### PR TITLE
fix(security): prevent panic in isZeroValue from killing audit pipeline

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -33,7 +33,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -349,7 +348,7 @@ func (l *Logger) drainLoop(ctx context.Context) {
 		select {
 		case entry := <-l.ch:
 			if entry != nil {
-				l.processEntry(entry)
+				l.processEntrySafely(entry)
 			}
 		case <-ctx.Done():
 			l.drainRemaining()
@@ -365,12 +364,26 @@ func (l *Logger) drainRemaining() {
 		select {
 		case entry := <-l.ch:
 			if entry != nil {
-				l.processEntry(entry)
+				l.processEntrySafely(entry)
 			}
 		default:
 			return
 		}
 	}
+}
+
+// processEntrySafely ensures a malformed event cannot terminate the
+// drain goroutine.
+func (l *Logger) processEntrySafely(entry *auditEntry) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("audit: recovered panic in drain loop",
+				"event_type", entry.eventType,
+				"panic", r)
+		}
+	}()
+
+	l.processEntry(entry)
 }
 
 // processEntry serialises an audit entry and writes it to all outputs.
@@ -517,5 +530,39 @@ func isZeroValue(v interface{}) bool {
 	if v == nil {
 		return true
 	}
-	return reflect.ValueOf(v).IsZero()
+
+	switch x := v.(type) {
+	case string:
+		return x == ""
+	case bool:
+		return !x
+	case int:
+		return x == 0
+	case int8:
+		return x == 0
+	case int16:
+		return x == 0
+	case int32:
+		return x == 0
+	case int64:
+		return x == 0
+	case uint:
+		return x == 0
+	case uint8:
+		return x == 0
+	case uint16:
+		return x == 0
+	case uint32:
+		return x == 0
+	case uint64:
+		return x == 0
+	case uintptr:
+		return x == 0
+	case float32:
+		return x == 0
+	case float64:
+		return x == 0
+	default:
+		return false
+	}
 }

--- a/audit_test.go
+++ b/audit_test.go
@@ -1071,6 +1071,24 @@ func TestLogger_Audit_OmitEmptyZeroInt(t *testing.T) {
 	assert.False(t, hasActive, "OmitEmpty should omit false bool")
 }
 
+func TestLogger_Audit_OmitEmptyUnknownTypeIncluded(t *testing.T) {
+
+	out := newMockOutput("test")
+	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true, OmitEmpty: true, ValidationMode: audit.ValidationPermissive}, out)
+
+	err := logger.Audit("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "bob",
+		"meta":     struct{}{},
+	})
+	require.NoError(t, err)
+	require.True(t, out.waitForEvents(1, 2*time.Second))
+
+	ev := out.getEvent(0)
+	_, hasMeta := ev["meta"]
+	assert.True(t, hasMeta, "unknown types should be included when OmitEmpty is enabled")
+}
+
 // ---------------------------------------------------------------------------
 // Shutdown with nil app_name stored
 // ---------------------------------------------------------------------------
@@ -1131,6 +1149,41 @@ func TestLogger_Audit_SerializationFailure(t *testing.T) {
 
 	// Only the valid event should have been delivered.
 	assert.Equal(t, 1, out.eventCount())
+}
+
+type panicMarshaler struct{}
+
+func (panicMarshaler) MarshalJSON() ([]byte, error) {
+	panic("boom")
+}
+
+func TestLogger_Audit_DrainLoopRecoversFromPanic(t *testing.T) {
+
+	out := newMockOutput("test")
+	logger := newTestLogger(t, audit.Config{
+		Version:        1,
+		Enabled:        true,
+		ValidationMode: audit.ValidationPermissive,
+	}, out)
+
+	// This field panics during JSON marshaling. The logger should recover
+	// and continue processing subsequent events.
+	err := logger.Audit("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "bob",
+		"bad":      panicMarshaler{},
+	})
+	require.NoError(t, err)
+
+	err = logger.Audit("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "sentinel",
+	})
+	require.NoError(t, err)
+	require.True(t, out.waitForEvents(1, 2*time.Second))
+
+	assert.Equal(t, 1, out.eventCount())
+	assert.Equal(t, "sentinel", out.getEvent(0)["actor_id"])
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR fixes a security/reliability issue where a panic in `isZeroValue()` could terminate the audit drain goroutine and permanently disable the audit pipeline.

### Root Cause

The previous implementation of `isZeroValue()` used:

```
reflect.ValueOf(v).IsZero()
```

Reflection can panic for certain values or edge-case types. When this panic occurred during serialization with `OmitEmpty: true`, it propagated into the drain goroutine. Because the panic was not recovered, the goroutine exited permanently and the audit pipeline stopped processing events. Subsequent calls to `Audit()` would eventually return `ErrBufferFull` with no indication that the pipeline had failed.

### Changes

* Replaced the reflection-based zero-value check with a **safe primitive type switch** for common JSON types (`nil`, `string`, `bool`, integer types, unsigned integers, floats).
* Unknown types now return **false** (field included), avoiding unsafe reflection behavior.
* Added a **panic recovery wrapper** in the drain path to ensure a malformed entry cannot kill the pipeline.
* Updated both `drainLoop` and `drainRemaining` to use the safe processing wrapper.

### Tests

Added regression tests to validate the fix:

* `TestLogger_Audit_OmitEmptyUnknownTypeIncluded`
  Ensures unknown types are safely included when `OmitEmpty` is enabled.

* `TestLogger_Audit_DrainLoopRecoversFromPanic`
  Uses a custom type that panics in `MarshalJSON` to verify the drain loop recovers and continues processing subsequent entries.

### Validation

The fix was verified locally with:

```
go test ./...
go test -race ./...
```

Both passed successfully.

### Notes

This change ensures that malformed field values or serialization panics cannot permanently break the audit pipeline, aligning with the project guideline that library code should not allow panics to escape package boundaries.

Fixes #32
