### PR TITLE
fix: eliminate mutable global and reduce CEF allocations (#38, #39)

### DIFF
--- a/format_cef.go
+++ b/format_cef.go
@@ -168,6 +168,7 @@ func (cf *CEFFormatter) Format(ts time.Time, eventType string, fields Fields, de
 		if k == "timestamp" || k == "event_type" {
 			continue
 		}
+		// Allow non-Duration duration_ms values through as regular fields.
 		if k == "duration_ms" {
 			if _, isDuration := fields[k].(time.Duration); isDuration {
 				continue
@@ -185,6 +186,7 @@ func (cf *CEFFormatter) Format(ts time.Time, eventType string, fields Fields, de
 	}
 
 	buf.WriteByte('\n')
+	// Safe: buf is local and not reused; Bytes() is the sole reference.
 	return buf.Bytes(), nil
 }
 

--- a/format_test.go
+++ b/format_test.go
@@ -829,7 +829,6 @@ func TestCEFFormatter_ConcurrentFormat_NoRace(t *testing.T) {
 		Category: "write",
 		Required: []string{"outcome"},
 	}
-	fields := audit.Fields{"outcome": "ok"}
 	ts := time.Now()
 
 	var wg sync.WaitGroup
@@ -837,9 +836,20 @@ func TestCEFFormatter_ConcurrentFormat_NoRace(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := cf.Format(ts, "ev", fields, def)
+			// Each goroutine gets its own fields map to avoid relying
+			// on Format never writing to the map.
+			f := audit.Fields{"outcome": "ok"}
+			data, err := cf.Format(ts, "ev", f, def)
 			if err != nil {
 				t.Errorf("Format failed: %v", err)
+				return
+			}
+			s := string(data)
+			if !strings.HasPrefix(s, "CEF:0|V|P|1|") {
+				t.Errorf("unexpected output prefix: %s", s[:40])
+			}
+			if !strings.HasSuffix(s, "\n") {
+				t.Errorf("output missing newline terminator")
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary

Two targeted fixes to `format_cef.go`:

### Issue #38: Eliminate mutable global defaultCEFFieldMapping (security)

Replace the package-level `var defaultCEFFieldMapping = map[string]string{...}` (a mutable global) with `defaultCEFFieldMappingEntries()` which returns a fresh map literal on each call. No package-level mutable state remains. This is a security hardening change for a library used in security-conscious settings.

### Issue #39: Reduce CEFFormatter allocations (performance)

Replace the double `strings.Builder` pattern (one for extensions, one for the full CEF line) with a single `bytes.Buffer`. Header and extensions are written directly into the same buffer.

**Benchmark results:**

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| ns/op | 827 | 707 | -14.5% faster |
| B/op | 792 | 384 | -51.5% less memory |
| allocs/op | 11 | 5 | -54.5% fewer allocs |

## Test plan

- [x] `go test -race -count=1 ./...` -- all pass
- [x] Coverage: 95.3%
- [x] `go vet ./...` -- clean
- [x] `gofmt -l .` -- no diff
- [x] New: `TestDefaultCEFFieldMapping_IndependentCopies` -- verifies no shared mutable state
- [x] New: `TestCEFFormatter_ConcurrentFormat_NoRace` -- 50 goroutines, validates output correctness
- [x] All existing CEF tests pass unchanged (byte-identical output)
- [x] `grep -n '^var.*map\[' format_cef.go` returns nothing (no global map vars)

Fixes #38
Fixes #39