### PR TITLE
fix: RecordEvent fires on delivery, not enqueue, for async outputs (#53)

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -546,19 +546,35 @@ func (l *Logger) formatCached(oe *outputEntry, entry *auditEntry, ts time.Time, 
 }
 
 // writeToOutput sends data to a single output and records metrics.
+// deliveryReporter is an optional interface that async outputs (like
+// [WebhookOutput]) implement to indicate they report their own delivery
+// metrics. When an output implements this interface and ReportsDelivery
+// returns true, writeToOutput skips its RecordEvent calls — the output
+// is responsible for calling them from its delivery goroutine after
+// actual delivery (not just enqueue).
+type deliveryReporter interface {
+	ReportsDelivery() bool
+}
+
 func (l *Logger) writeToOutput(o Output, data []byte, eventType string) {
+	// Check if this output reports its own delivery metrics.
+	selfReports := false
+	if dr, ok := o.(deliveryReporter); ok {
+		selfReports = dr.ReportsDelivery()
+	}
+
 	if writeErr := o.Write(data); writeErr != nil {
 		slog.Error("audit: output write failed",
 			"output", o.Name(),
 			"event_type", eventType,
 			"error", writeErr)
-		if l.metrics != nil {
+		if l.metrics != nil && !selfReports {
 			l.metrics.RecordOutputError(o.Name())
 			l.metrics.RecordEvent(o.Name(), "error")
 		}
 		return
 	}
-	if l.metrics != nil {
+	if l.metrics != nil && !selfReports {
 		l.metrics.RecordEvent(o.Name(), "success")
 	}
 }

--- a/audit_test.go
+++ b/audit_test.go
@@ -209,6 +209,12 @@ func (m *mockMetrics) getOutputFiltered(output string) int {
 	return m.filteredCount[output]
 }
 
+func (m *mockMetrics) getEventCount(output, status string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.events[output+":"+status]
+}
+
 func (m *mockMetrics) getWebhookDrops() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/webhook.go
+++ b/webhook.go
@@ -177,6 +177,7 @@ func (w *WebhookOutput) Write(data []byte) error {
 			"buffer_size", cap(w.ch))
 		if w.metrics != nil {
 			w.metrics.RecordWebhookDrop()
+			w.metrics.RecordEvent(w.Name(), "error")
 		}
 		return nil // non-blocking — do not return error to drain goroutine
 	}
@@ -208,6 +209,11 @@ func (w *WebhookOutput) Close() error {
 	w.client.CloseIdleConnections()
 	return nil
 }
+
+// ReportsDelivery returns true, indicating that WebhookOutput reports
+// its own delivery metrics from the batch goroutine after actual HTTP
+// delivery, not from the Write enqueue path.
+func (w *WebhookOutput) ReportsDelivery() bool { return true }
 
 // Name returns the human-readable identifier for this output.
 func (w *WebhookOutput) Name() string {

--- a/webhook_external_test.go
+++ b/webhook_external_test.go
@@ -815,3 +815,142 @@ func TestWebhookOutput_TLS_WrongCA_Rejected(t *testing.T) {
 	assert.Greater(t, metrics.getWebhookDrops(), 0,
 		"wrong CA should cause TLS failure and event drop")
 }
+
+// ---------------------------------------------------------------------------
+// Delivery metrics tests (#53)
+// ---------------------------------------------------------------------------
+
+func TestWebhookOutput_DeliveryMetrics_SuccessOnHTTP200(t *testing.T) {
+	srv := newWebhookTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	})
+	metrics := newMockMetrics()
+	out, err := audit.NewWebhookOutput(&audit.WebhookConfig{
+		URL:                srv.url(),
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          3,
+		FlushInterval:      50 * time.Millisecond,
+		Timeout:            5 * time.Second,
+		BufferSize:         100,
+	}, metrics)
+	require.NoError(t, err)
+
+	for range 3 {
+		require.NoError(t, out.Write([]byte(`{"event":"metric_test"}`+"\n")))
+	}
+	// Wait for the batch to be delivered — server MUST receive the
+	// request BEFORE we Close() (which cancels the context).
+	require.True(t, srv.waitForRequests(1, 5*time.Second),
+		"server should receive at least 1 request")
+
+	// Small delay to ensure the batch goroutine has processed the
+	// response and recorded metrics before Close cancels the context.
+	time.Sleep(50 * time.Millisecond) // deliberate: wait for response processing
+
+	require.NoError(t, out.Close())
+
+	// RecordEvent should be called with "success" for each event in the batch.
+	name := out.Name()
+	assert.Equal(t, 3, metrics.getEventCount(name, "success"),
+		"RecordEvent(success) should be called once per delivered event")
+	assert.Equal(t, 0, metrics.getEventCount(name, "error"),
+		"RecordEvent(error) should not be called on success")
+}
+
+func TestWebhookOutput_DeliveryMetrics_ErrorOnRetryExhausted(t *testing.T) {
+	srv := newWebhookTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+	})
+	metrics := newMockMetrics()
+	out, err := audit.NewWebhookOutput(&audit.WebhookConfig{
+		URL:                srv.url(),
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          2,
+		FlushInterval:      50 * time.Millisecond,
+		Timeout:            5 * time.Second,
+		MaxRetries:         2,
+		BufferSize:         100,
+	}, metrics)
+	require.NoError(t, err)
+
+	for range 2 {
+		require.NoError(t, out.Write([]byte(`{"event":"drop_test"}`+"\n")))
+	}
+	require.NoError(t, out.Close())
+
+	name := out.Name()
+	assert.Equal(t, 2, metrics.getEventCount(name, "error"),
+		"RecordEvent(error) should be called once per dropped event")
+	assert.Equal(t, 0, metrics.getEventCount(name, "success"),
+		"RecordEvent(success) should not be called when retries exhausted")
+}
+
+func TestWebhookOutput_DeliveryMetrics_ErrorOnBufferOverflow(t *testing.T) {
+	// Slow server to keep batch goroutine busy.
+	srv := newWebhookTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(1 * time.Second)
+		w.WriteHeader(200)
+	})
+	metrics := newMockMetrics()
+	out, err := audit.NewWebhookOutput(&audit.WebhookConfig{
+		URL:                srv.url(),
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      50 * time.Millisecond,
+		Timeout:            5 * time.Second,
+		MaxRetries:         1,
+		BufferSize:         3,
+	}, metrics)
+	require.NoError(t, err)
+
+	// Fill buffer — overflow events get RecordEvent(error).
+	for range 15 {
+		_ = out.Write([]byte(`{"event":"overflow"}` + "\n"))
+	}
+	require.NoError(t, out.Close())
+
+	name := out.Name()
+	assert.Greater(t, metrics.getEventCount(name, "error"), 0,
+		"RecordEvent(error) should be called for buffer overflow drops")
+}
+
+func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
+	// Verify that the core writeToOutput does NOT call RecordEvent
+	// for webhook outputs (they report their own delivery).
+	srv := newWebhookTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	})
+	metrics := newMockMetrics()
+
+	webhookOut, err := audit.NewWebhookOutput(&audit.WebhookConfig{
+		URL:                srv.url(),
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      50 * time.Millisecond,
+		Timeout:            5 * time.Second,
+		BufferSize:         100,
+	}, metrics)
+	require.NoError(t, err)
+
+	// Create a logger with the webhook output and metrics.
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithTaxonomy(testTaxonomy()),
+		audit.WithNamedOutput(webhookOut, &audit.EventRoute{}, nil),
+		audit.WithMetrics(metrics),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, logger.Audit("user_create", audit.Fields{"outcome": "success"}))
+	require.True(t, srv.waitForRequests(1, 2*time.Second))
+	require.NoError(t, logger.Close())
+
+	name := webhookOut.Name()
+	// The webhook should report its OWN success metrics (from the delivery goroutine).
+	assert.Equal(t, 1, metrics.getEventCount(name, "success"),
+		"webhook should report delivery success from batch goroutine")
+}

--- a/webhook_http.go
+++ b/webhook_http.go
@@ -45,10 +45,7 @@ func (w *WebhookOutput) doPostWithRetry(ctx context.Context, batch [][]byte) {
 
 		retryable, err := w.doPost(ctx, body)
 		if err == nil {
-			// Success — record metrics.
-			if w.metrics != nil {
-				w.metrics.RecordWebhookFlush(len(batch), time.Since(start))
-			}
+			w.recordSuccess(len(batch), time.Since(start))
 			return
 		}
 
@@ -118,13 +115,28 @@ func (w *WebhookOutput) doPost(ctx context.Context, body []byte) (bool, error) {
 	return false, fmt.Errorf("audit: webhook client error %d", resp.StatusCode)
 }
 
-// recordDrop records dropped events in metrics.
+// recordSuccess records successful delivery metrics for a batch.
+func (w *WebhookOutput) recordSuccess(batchSize int, dur time.Duration) {
+	if w.metrics == nil {
+		return
+	}
+	w.metrics.RecordWebhookFlush(batchSize, dur)
+	name := w.Name()
+	for range batchSize {
+		w.metrics.RecordEvent(name, "success")
+	}
+}
+
+// recordDrop records dropped events in metrics. Both RecordWebhookDrop
+// and RecordEvent(name, "error") are called per dropped event.
 func (w *WebhookOutput) recordDrop(count int) {
 	if w.metrics == nil {
 		return
 	}
+	name := w.Name()
 	for range count {
 		w.metrics.RecordWebhookDrop()
+		w.metrics.RecordEvent(name, "error")
 	}
 }
 


### PR DESCRIPTION
## Summary

Add internal `deliveryReporter` interface. `writeToOutput` skips its `RecordEvent` calls for outputs that report their own delivery. WebhookOutput implements it and calls `RecordEvent` from the batch goroutine after actual HTTP delivery.

- `RecordEvent(name, "success")` per event on HTTP 2xx
- `RecordEvent(name, "error")` per event on retry exhaustion or buffer overflow

Synchronous outputs unchanged.

## Test plan

- [x] `go test -race -count=1 ./...` — all pass
- [x] TestWebhookOutput_DeliveryMetrics_SuccessOnHTTP200
- [x] TestWebhookOutput_DeliveryMetrics_ErrorOnRetryExhausted
- [x] TestWebhookOutput_DeliveryMetrics_ErrorOnBufferOverflow
- [x] TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter
- [x] All existing tests pass without modification

Closes #53