### PR TITLE
refactor: replace time.Sleep with require.Eventually in TLS wrong CA test (#66)

### DIFF
--- a/webhook_external_test.go
+++ b/webhook_external_test.go
@@ -808,12 +808,16 @@ func TestWebhookOutput_TLS_WrongCA_Rejected(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, out.Write([]byte(`{"event":"wrong_ca"}`+"\n")))
-	time.Sleep(1 * time.Second)
-	require.NoError(t, out.Close())
 
-	// The TLS handshake fails — events are dropped.
-	assert.Greater(t, metrics.getWebhookDrops(), 0,
+	// Poll for the TLS failure to be recorded as a webhook drop.
+	// This replaces time.Sleep synchronisation with an observable
+	// condition, per CLAUDE.md requirements.
+	require.Eventually(t, func() bool {
+		return metrics.getWebhookDrops() > 0
+	}, 5*time.Second, 50*time.Millisecond,
 		"wrong CA should cause TLS failure and event drop")
+
+	require.NoError(t, out.Close())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace `time.Sleep(1 * time.Second)` synchronisation in `TestWebhookOutput_TLS_WrongCA_Rejected` with `require.Eventually` polling `metrics.getWebhookDrops() > 0`
- Test execution time reduced from ~1s to ~50ms
- Other `time.Sleep` calls in the file are intentional test infrastructure (slow server simulation) and are unchanged

## Test plan

- [x] `go test -race -count=10 -run TestWebhookOutput_TLS_WrongCA_Rejected ./...` passes 10/10
- [x] `go test -race -count=1 -run TestWebhookOutput ./...` passes
- [x] `go test -race -count=1 ./...` full suite passes
- [x] Test completes in under 5 seconds

Closes #66