### PR TITLE
chore: cache Go tools in CI to speed up install-tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, 'feature/**', 'fix/**', 'chore/**']
+    branches: [main, 'feature/**', 'fix/**', 'chore/**', 'refactor/**']
   pull_request:
     branches: [main]
   workflow_call: {}
@@ -32,6 +32,12 @@ jobs:
 
       - name: Set up go.work
         run: make workspace
+
+      - name: Cache Go tools
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/bin
+          key: go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
       - name: Install tools
         run: make install-tools
@@ -64,6 +70,12 @@ jobs:
 
       - name: Set up go.work
         run: make workspace
+
+      - name: Cache Go tools
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/bin
+          key: go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
       - name: Install tools
         run: make install-tools
@@ -171,6 +183,12 @@ jobs:
 
       - name: Set up go.work
         run: make workspace
+
+      - name: Cache Go tools
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/bin
+          key: go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
       - name: Install tools
         run: make install-tools


### PR DESCRIPTION
## Summary

Cache `~/go/bin` in CI jobs that run `make install-tools` (hygiene, lint, security). On cache hit the tools are already present and `make install-tools` completes in seconds instead of ~60s.

## Changes

- Add `actions/cache` step before `make install-tools` in hygiene, lint, and security jobs
- Cache key: `go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}` — busts when tool versions in the Makefile change
- Cache path: `~/go/bin`
- Also add `refactor/**` to branch triggers

## Test plan

- [x] First CI run: cache miss, tools install from source (same as before)
- [x] Subsequent runs: cache hit, install-tools is a no-op