### PR TITLE
fix: address review findings after taxonomy move to core

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -24,7 +24,7 @@
 // Output backends live in separate Go modules so consumers import only
 // what they need:
 //
-//   - github.com/axonops/go-audit — core (this package, stdlib only)
+//   - github.com/axonops/go-audit — core (this package; depends on gopkg.in/yaml.v3 for [ParseTaxonomyYAML])
 //   - github.com/axonops/go-audit/file — file output with rotation
 //   - github.com/axonops/go-audit/syslog — RFC 5424 syslog (TCP/UDP/TLS)
 //   - github.com/axonops/go-audit/webhook — batched HTTP webhook

--- a/taxonomy_yaml.go
+++ b/taxonomy_yaml.go
@@ -79,15 +79,15 @@ func ParseTaxonomyYAML(data []byte) (Taxonomy, error) {
 
 	var yt yamlTaxonomy
 	if err := dec.Decode(&yt); err != nil {
-		return Taxonomy{}, fmt.Errorf("%w: %w", ErrInvalidInput, err)
+		return Taxonomy{}, fmt.Errorf("%w: %v", ErrInvalidInput, err) //nolint:errorlint // intentionally not wrapping yaml.v3 error to avoid leaking third-party types into the public error chain
 	}
 
 	// Reject multi-document YAML and trailing content.
-	var discard yaml.Node
+	var discard any
 	if err := dec.Decode(&discard); err == nil {
 		return Taxonomy{}, fmt.Errorf("%w: input contains multiple YAML documents", ErrInvalidInput)
 	} else if !errors.Is(err, io.EOF) {
-		return Taxonomy{}, fmt.Errorf("%w: trailing content after YAML document: %w", ErrInvalidInput, err)
+		return Taxonomy{}, fmt.Errorf("%w: trailing content after YAML document: %v", ErrInvalidInput, err) //nolint:errorlint // intentionally not wrapping yaml.v3 error
 	}
 
 	tax := convertYAMLTaxonomy(yt)


### PR DESCRIPTION
## Summary

Post-move cleanup from review agents after moving taxonomy YAML parsing into the core package.

## Changes

- Remove "stdlib only" claim from doc.go — core now depends on yaml.v3
- Use `%v` instead of `%w` for yaml.v3 errors to prevent leaking third-party types through the error chain
- Use `var discard any` instead of `yaml.Node` for multi-document detection
- Add `nolint:errorlint` directives with justification

## Test plan

- [x] `make check` passes locally
- [x] `make lint` passes (0 issues with nolint directives)