### PR TITLE
chore: enable gosec linter and set issue caps to zero

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ linters:
     - cyclop        # alternative complexity checker
     - noctx         # http.NewRequest without context
     - rowserrcheck  # sql.Rows.Err() checked
+    - gosec         # security checks (crypto, file permissions, etc.)
     # Note: contextcheck is not a standard golangci-lint v2 linter
     # and is omitted. Context propagation is enforced by noctx and
     # manual review.
@@ -128,6 +129,20 @@ linters:
         linters:
           - revive
         text: "exported"
+
+      # Test files and internal helpers use file paths and TLS configs
+      # that gosec flags as unsafe — these are controlled test fixtures.
+      - path: _test\.go
+        linters:
+          - gosec
+
+      - path: internal/testhelper/
+        linters:
+          - gosec
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
 formatters:
   enable:

--- a/file/internal/rotate/compress.go
+++ b/file/internal/rotate/compress.go
@@ -26,7 +26,7 @@ import (
 func gzipCopy(dst io.Writer, src io.Reader) error {
 	gz := gzip.NewWriter(dst)
 	if _, err := io.Copy(gz, src); err != nil {
-		gz.Close() //nolint:errcheck // error path
+		gz.Close() //nolint:errcheck,gosec // error path
 		return fmt.Errorf("rotate: compress copy: %w", err)
 	}
 	if err := gz.Close(); err != nil {
@@ -59,13 +59,13 @@ func compressFile(src, dst string, mode os.FileMode) error {
 	}
 
 	if copyErr := gzipCopy(out, in); copyErr != nil {
-		out.Close()    //nolint:errcheck // error path
-		os.Remove(dst) //nolint:errcheck // best-effort cleanup of partial dest on error path
+		out.Close()    //nolint:errcheck,gosec // error path
+		os.Remove(dst) //nolint:errcheck,gosec // best-effort cleanup of partial dest on error path
 		return copyErr
 	}
 
 	if closeErr := out.Close(); closeErr != nil {
-		os.Remove(dst) //nolint:errcheck // best-effort cleanup of partial dest on error path
+		os.Remove(dst) //nolint:errcheck,gosec // best-effort cleanup of partial dest on error path
 		return fmt.Errorf("rotate: compress close dest: %w", closeErr)
 	}
 

--- a/file/internal/rotate/open_unix.go
+++ b/file/internal/rotate/open_unix.go
@@ -26,7 +26,7 @@ import (
 // then enforces the configured permissions via Chmod on the file
 // descriptor.
 func safeOpen(name string, flag int, mode os.FileMode) (*os.File, error) {
-	f, err := os.OpenFile(name, flag|syscall.O_NOFOLLOW, mode)
+	f, err := os.OpenFile(name, flag|syscall.O_NOFOLLOW, mode) //nolint:gosec // G304: path is controlled by the FileOutput config, not user input
 	if err != nil {
 		return nil, fmt.Errorf("rotate: open %q: %w", name, err)
 	}

--- a/tls_policy.go
+++ b/tls_policy.go
@@ -42,7 +42,7 @@ type TLSPolicy struct {
 // security-sensitive configurations (e.g. weak ciphers enabled).
 func (p *TLSPolicy) Apply(cfg *tls.Config) (result *tls.Config, warnings []string) {
 	if cfg == nil {
-		cfg = &tls.Config{}
+		cfg = &tls.Config{} //nolint:gosec // G402: MinVersion is set immediately below based on policy
 	}
 
 	// Nil receiver = zero value = TLS 1.3 only.


### PR DESCRIPTION
## Summary

- Enable `gosec` in golangci-lint for static application security testing
- Set `max-issues-per-linter: 0` and `max-same-issues: 0` to prevent silent suppression

## Gosec findings addressed

- `tls_policy.go:45` G402 — false positive, MinVersion set immediately after `tls.Config{}` creation. Suppressed with nolint + justification.
- `file/internal/rotate/compress.go` G104 — overlaps with existing errcheck suppressions on error-path cleanup. Added gosec to existing nolint directives.
- `file/internal/rotate/open_unix.go:29` G304 — `safeOpen` uses config-controlled paths with `O_NOFOLLOW`. Suppressed with nolint + justification.
- Test files and internal helpers excluded from gosec (controlled fixtures).

## Test plan

- [x] `make lint` passes across all 4 modules with 0 issues