### PR TITLE
perf: cache parsed host in webhook Output.Name() (#113)

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -99,6 +99,7 @@ type Output struct {
 	cancel         context.CancelFunc
 	client         *http.Client
 	url            string
+	name           string // cached from url.Parse at construction
 	batchSize      int
 	maxRetries     int
 	flushIvl       time.Duration
@@ -166,6 +167,7 @@ func New(cfg *Config, metrics audit.Metrics, webhookMetrics Metrics) (*Output, e
 	w := &Output{
 		client:         client,
 		url:            cfg.URL,
+		name:           webhookName(cfg.URL),
 		headers:        headers,
 		metrics:        metrics,
 		webhookMetrics: webhookMetrics,
@@ -246,8 +248,15 @@ func (w *Output) Close() error {
 func (w *Output) ReportsDelivery() bool { return true }
 
 // Name returns the human-readable identifier for this output.
+// The name is cached at construction time to avoid per-call url.Parse.
 func (w *Output) Name() string {
-	if u, err := url.Parse(w.url); err == nil {
+	return w.name
+}
+
+// webhookName parses the URL and returns "webhook:<host>" or "webhook"
+// if parsing fails.
+func webhookName(rawURL string) string {
+	if u, err := url.Parse(rawURL); err == nil {
 		return "webhook:" + u.Host
 	}
 	return "webhook"


### PR DESCRIPTION
## Summary

Compute the webhook name (`"webhook:<host>"`) once at construction time instead of calling `url.Parse` on every `Name()` invocation. `Name()` is called from `recordSuccess` and `recordDrop` in per-batch metric recording.

Small, focused change — 10 lines.

## Test plan

- [x] `make check` passes
- [x] All webhook tests pass (Name() returns same value as before)