### PR TITLE
test: fill integration test gaps from schema-registry gap analysis (#30)

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -1893,6 +1893,113 @@ func TestFormatCache_NilData(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Field completeness tests
+// ---------------------------------------------------------------------------
+
+func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
+	tax := audit.Taxonomy{
+		Version: 1,
+		Categories: map[string][]string{
+			"security": {"auth_check"},
+		},
+		Events: map[string]*audit.EventDef{
+			"auth_check": {
+				Category: "security",
+				Required: []string{"outcome", "actor_id", "actor_type"},
+				Optional: []string{"target_type", "target_id", "reason", "source_ip", "user_agent", "request_id"},
+			},
+		},
+		DefaultEnabled: []string{"security"},
+	}
+
+	out := testhelper.NewMockOutput("field-test")
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true},
+		audit.WithTaxonomy(tax),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+
+	fields := audit.Fields{
+		"outcome":     "success",
+		"actor_id":    "alice",
+		"actor_type":  "user",
+		"target_type": "schema",
+		"target_id":   "my-topic-value",
+		"reason":      "valid_credentials",
+		"source_ip":   "192.168.1.100",
+		"user_agent":  "test-client/1.0",
+		"request_id":  "req-12345",
+	}
+	require.NoError(t, logger.Audit("auth_check", fields))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	record := out.GetEvent(0)
+
+	// Auto-populated fields.
+	assert.Contains(t, record, "timestamp")
+	assert.NotEmpty(t, record["timestamp"], "timestamp must not be empty")
+	assert.Equal(t, "auth_check", record["event_type"])
+
+	// All required fields present with correct values.
+	for _, f := range tax.Events["auth_check"].Required {
+		assert.Contains(t, record, f, "required field %q must be present", f)
+	}
+
+	// All optional fields we provided present with correct values.
+	for _, f := range tax.Events["auth_check"].Optional {
+		assert.Contains(t, record, f, "provided optional field %q must be present", f)
+		assert.Equal(t, fields[f], record[f], "field %q value mismatch", f)
+	}
+}
+
+func TestLogger_Audit_FieldCompleteness_OmittedOptionalFieldsAbsent(t *testing.T) {
+	tax := audit.Taxonomy{
+		Version: 1,
+		Categories: map[string][]string{
+			"security": {"auth_check"},
+		},
+		Events: map[string]*audit.EventDef{
+			"auth_check": {
+				Category: "security",
+				Required: []string{"outcome", "actor_id"},
+				Optional: []string{"reason", "source_ip", "user_agent"},
+			},
+		},
+		DefaultEnabled: []string{"security"},
+	}
+
+	out := testhelper.NewMockOutput("field-test")
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true, OmitEmpty: true},
+		audit.WithTaxonomy(tax),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+
+	// Send event with only required fields — optional fields omitted.
+	require.NoError(t, logger.Audit("auth_check", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	}))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	record := out.GetEvent(0)
+
+	// Required fields must be present.
+	assert.Equal(t, "success", record["outcome"])
+	assert.Equal(t, "alice", record["actor_id"])
+
+	// Optional fields not provided should be absent (OmitEmpty=true).
+	for _, f := range tax.Events["auth_check"].Optional {
+		assert.NotContains(t, record, f,
+			"omitted optional field %q should not appear in output", f)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Benchmarks
 // ---------------------------------------------------------------------------
 

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -69,6 +69,18 @@ func resetWebhook(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
+// configureWebhook sets the webhook receiver's response behaviour.
+func configureWebhook(t *testing.T, statusCode int, delayMS int) {
+	t.Helper()
+	body := fmt.Sprintf(`{"status_code":%d,"delay_ms":%d}`, statusCode, delayMS)
+	resp, err := http.Post(webhookURL+"/configure", "application/json",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"configure endpoint should accept the configuration")
+}
+
 // getWebhookEvents returns stored webhook events.
 func getWebhookEvents(t *testing.T) []map[string]any {
 	t.Helper()
@@ -283,6 +295,63 @@ func TestFanOut_EventRouting(t *testing.T) {
 			"webhook should NOT receive write events")
 	}
 	assert.True(t, found, "webhook should receive the security event")
+}
+
+func TestFanOut_PartialFailure(t *testing.T) {
+	resetWebhook(t)
+	configureWebhook(t, 503, 0) // webhook returns 503
+	m := marker(t)
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "audit.log")
+
+	fileOut, err := file.New(file.Config{Path: filePath}, nil)
+	require.NoError(t, err)
+
+	syslogOut, err := syslog.New(&syslog.Config{
+		Network:  "tcp",
+		Address:  "localhost:5514",
+		Facility: "local0",
+		AppName:  "fanout-partial",
+	}, nil)
+	require.NoError(t, err)
+
+	webhookOut, err := webhook.New(&webhook.Config{
+		URL:                webhookURL + "/events",
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      100 * time.Millisecond,
+		Timeout:            5 * time.Second,
+		MaxRetries:         1,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true},
+		audit.WithTaxonomy(testTaxonomy()),
+		audit.WithNamedOutput(fileOut, nil, nil),
+		audit.WithNamedOutput(syslogOut, nil, nil),
+		audit.WithNamedOutput(webhookOut, nil, nil),
+	)
+	require.NoError(t, err)
+
+	// Send event while webhook is failing.
+	err = logger.Audit("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+		"marker":   m,
+	})
+	require.NoError(t, err)
+
+	// Close flushes file and syslog despite webhook failure.
+	require.NoError(t, logger.Close())
+
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), m, "file should receive event despite webhook failure")
+
+	assert.True(t, waitForSyslogMarker(t, m, 10*time.Second),
+		"syslog should receive event despite webhook failure")
 }
 
 func TestFanOut_MixedFormatters(t *testing.T) {

--- a/webhook/tests/integration/webhook_test.go
+++ b/webhook/tests/integration/webhook_test.go
@@ -60,7 +60,9 @@ func configureReceiver(t *testing.T, statusCode int, delayMS int) {
 	resp, err := http.Post(receiverURL+"/configure", "application/json",
 		strings.NewReader(body))
 	require.NoError(t, err)
-	resp.Body.Close()
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"configure endpoint should accept the configuration")
 }
 
 // getEvents returns the events stored in the webhook receiver.
@@ -198,6 +200,43 @@ func TestWebhook_CustomHeaders(t *testing.T) {
 	require.True(t, ok, "event should have headers")
 	assert.Equal(t, "integration-test", headers["X-Audit-Source"],
 		"custom header should be received")
+
+	require.NoError(t, out.Close())
+}
+
+func TestWebhook_NoRetryOn4xx(t *testing.T) {
+	resetReceiver(t)
+	configureReceiver(t, 400, 0) // return 400 Bad Request
+
+	out := newWebhookOutput(t, func(c *webhook.Config) {
+		c.BatchSize = 1
+		c.MaxRetries = 5 // high retry count — should NOT be used for 4xx
+	})
+
+	require.NoError(t, out.Write([]byte(`{"event":"no_retry_4xx","marker":"first"}`)))
+
+	// Wait for the single delivery attempt.
+	assert.True(t, waitForEvents(t, 1, 5*time.Second),
+		"receiver should store the initial attempt")
+
+	// Verify the received event is ours.
+	events := getEvents(t)
+	require.GreaterOrEqual(t, len(events), 1)
+
+	// Switch to 200 and send a sentinel event. When the sentinel arrives,
+	// we know the output has processed the 4xx response fully. If retries
+	// had occurred, additional events would appear before the sentinel.
+	configureReceiver(t, 200, 0)
+	require.NoError(t, out.Write([]byte(`{"event":"sentinel","marker":"second"}`)))
+
+	// Wait for the sentinel event to arrive.
+	assert.True(t, waitForEvents(t, 2, 5*time.Second),
+		"sentinel event should arrive")
+
+	// Exactly 2 events: the 4xx attempt + the sentinel. No retries.
+	finalEvents := getEvents(t)
+	assert.Equal(t, 2, len(finalEvents),
+		"expected exactly 2 events (initial 4xx attempt + sentinel), got %d", len(finalEvents))
 
 	require.NoError(t, out.Close())
 }


### PR DESCRIPTION
## Summary

Gap analysis of axonops-schema-registry's 104 unit tests and 49 BDD scenarios against go-audit's 586+ existing tests confirmed the unit test coverage is a **superset**. Three minor integration test gaps were identified and filled:

- **TestFanOut_PartialFailure** — webhook returning 503 does not block file or syslog delivery
- **TestWebhook_NoRetryOn4xx** — 400 responses are not retried (uses sentinel event pattern)
- **TestLogger_Audit_FieldCompleteness** — all taxonomy-defined fields (required + optional) appear in JSON output; omitted optional fields absent when OmitEmpty=true

Also fixes `configureReceiver` in webhook integration tests to assert HTTP status code.

## Test plan

- [x] `make check` passes (fmt, vet, lint, test, tidy, security)
- [x] `make test-integration` passes with Docker infrastructure
- [x] New unit tests pass: `go test -run TestLogger_Audit_FieldCompleteness .`
- [x] Code reviewer, security reviewer, go-quality, test-writer agents reviewed