### PR TITLE
feat: add optional description field to taxonomy event definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,5 @@ bench.txt
 CLAUDE.md
 .claude/
 mem.prof
-audit-gen
+# Built audit-gen binary (not the source directory)
+/audit-gen

--- a/cmd/audit-gen/generate.go
+++ b/cmd/audit-gen/generate.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"text/template"
 
 	audit "github.com/axonops/go-audit"
@@ -45,6 +46,7 @@ type constantDef struct {
 	Name        string // Go identifier, e.g. EventSchemaRegister
 	Value       string // Original string, e.g. "schema_register"
 	QuotedValue string // Go string literal, e.g. `"schema_register"`
+	Comment     string // Non-empty → emitted as // comment above the constant
 }
 
 // templateData is the data passed to the Go template.
@@ -69,7 +71,8 @@ package {{ .Package }}
 // to get compile-time safety.
 const (
 {{- range .Events }}
-	{{ .Name }} = {{ .QuotedValue }}
+{{ if .Comment }}	// {{ .Comment }}
+{{ end }}	{{ .Name }} = {{ .QuotedValue }}
 {{- end }}
 )
 {{ end }}{{ if .HasCategories }}
@@ -127,7 +130,7 @@ func buildTemplateData(tax audit.Taxonomy, opts generateOptions) (templateData, 
 
 	if opts.Types {
 		var err error
-		data.Events, err = buildConstants("Event", sortedKeys(tax.Events))
+		data.Events, err = buildEventConstants(tax)
 		if err != nil {
 			return templateData{}, err
 		}
@@ -153,6 +156,44 @@ func buildTemplateData(tax audit.Taxonomy, opts generateOptions) (templateData, 
 	}
 
 	return data, nil
+}
+
+// buildEventConstants creates event constant entries with optional
+// description comments from the taxonomy.
+func buildEventConstants(tax audit.Taxonomy) ([]constantDef, error) {
+	keys := sortedKeys(tax.Events)
+	nameToKey := make(map[string]string, len(keys))
+	defs := make([]constantDef, 0, len(keys))
+	for _, k := range keys {
+		if !validKey.MatchString(k) {
+			return nil, fmt.Errorf("taxonomy key %q contains characters unsafe for code generation", k)
+		}
+		name := "Event" + toPascalCase(k)
+		if prev, ok := nameToKey[name]; ok {
+			return nil, fmt.Errorf("naming collision: %q and %q both produce constant %q", prev, k, name)
+		}
+		nameToKey[name] = k
+
+		comment := sanitiseComment(tax.Events[k].Description)
+		if comment != "" {
+			comment = name + " — " + comment
+		}
+
+		defs = append(defs, constantDef{
+			Name:        name,
+			Value:       k,
+			QuotedValue: strconv.Quote(k),
+			Comment:     comment,
+		})
+	}
+	return defs, nil
+}
+
+// sanitiseComment collapses newlines and trims whitespace from a
+// description for use as a single-line Go comment.
+func sanitiseComment(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	return strings.TrimSpace(s)
 }
 
 // buildConstants creates constantDef entries from sorted keys with a

--- a/cmd/audit-gen/generate_test.go
+++ b/cmd/audit-gen/generate_test.go
@@ -507,3 +507,100 @@ func TestWriteFileAtomic_RenameFailure(t *testing.T) {
 	// On most systems this fails at CreateTemp (can't create in read-only dir).
 	assert.Error(t, err)
 }
+
+// --- Description comment tests ---
+
+func TestGenerate_DescriptionAsComment(t *testing.T) {
+	t.Parallel()
+	tax := loadTestTaxonomy(t, "testdata/valid_taxonomy.yaml")
+	out := generateToString(t, tax, defaultOpts())
+
+	// Events with descriptions should have comments.
+	assert.Contains(t, out, "// EventSchemaRegister — A new schema version was registered in the registry")
+	assert.Contains(t, out, "// EventAuthFailure — An authentication attempt failed")
+
+	// Events without descriptions should NOT have comments.
+	assert.NotContains(t, out, "// EventSchemaRead")
+	assert.NotContains(t, out, "// EventConfigRead")
+
+	// Must still compile.
+	fset := token.NewFileSet()
+	_, err := parser.ParseFile(fset, "generated.go", out, parser.AllErrors)
+	assert.NoError(t, err)
+}
+
+func TestGenerate_NoCommentWhenEmpty(t *testing.T) {
+	t.Parallel()
+	tax := loadTestTaxonomy(t, "testdata/minimal_taxonomy.yaml")
+	out := generateToString(t, tax, defaultOpts())
+
+	// The health_check event has no description — should have no comment.
+	// Lifecycle events (startup/shutdown) get descriptions from InjectLifecycleEvents,
+	// so they will have comments. Only check user-defined events.
+	assert.NotContains(t, out, "// EventHealthCheck")
+}
+
+func TestGenerate_MultiLineDescription(t *testing.T) {
+	t.Parallel()
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string][]string{"test": {"multi_line"}},
+		Events: map[string]*audit.EventDef{
+			"multi_line": {
+				Category:    "test",
+				Description: "First line\nSecond line\n\tTabbed",
+				Required:    []string{"outcome"},
+			},
+		},
+		DefaultEnabled: []string{"test"},
+	}
+
+	out := generateToString(t, tax, defaultOpts())
+
+	// Multi-line should be collapsed to single line.
+	assert.Contains(t, out, "// EventMultiLine — First line Second line Tabbed")
+	assert.NotContains(t, out, "Second line\n")
+}
+
+func TestGenerate_WhitespaceOnlyDescription(t *testing.T) {
+	t.Parallel()
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string][]string{"test": {"blank_desc"}},
+		Events: map[string]*audit.EventDef{
+			"blank_desc": {
+				Category:    "test",
+				Description: "   \t\n  ",
+				Required:    []string{"outcome"},
+			},
+		},
+		DefaultEnabled: []string{"test"},
+	}
+
+	out := generateToString(t, tax, defaultOpts())
+
+	// Whitespace-only treated as empty — no comment.
+	assert.NotContains(t, out, "// EventBlankDesc")
+}
+
+func TestSanitiseComment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple", "A schema was registered", "A schema was registered"},
+		{"newlines", "First\nSecond\nThird", "First Second Third"},
+		{"tabs", "Has\ttabs", "Has tabs"},
+		{"whitespace only", "   \t\n  ", ""},
+		{"empty", "", ""},
+		{"leading trailing", "  hello world  ", "hello world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, sanitiseComment(tt.input))
+		})
+	}
+}

--- a/cmd/audit-gen/testdata/valid_taxonomy.yaml
+++ b/cmd/audit-gen/testdata/valid_taxonomy.yaml
@@ -24,6 +24,7 @@ events:
       - outcome
   schema_register:
     category: write
+    description: "A new schema version was registered in the registry"
     required:
       - outcome
       - actor_id
@@ -32,12 +33,14 @@ events:
       - schema_type
   schema_delete:
     category: write
+    description: "A schema was permanently deleted"
     required:
       - outcome
       - actor_id
       - subject
   auth_failure:
     category: security
+    description: "An authentication attempt failed"
     required:
       - outcome
       - actor_id

--- a/taxonomy.go
+++ b/taxonomy.go
@@ -33,6 +33,13 @@ type EventDef struct {
 	// [Taxonomy.Categories].
 	Category string
 
+	// Description is an optional human-readable explanation of what
+	// this event type represents. It is informational metadata only
+	// — it has no effect on validation, routing, or serialisation.
+	// When present, [audit-gen] emits it as a Go comment above the
+	// generated constant.
+	Description string
+
 	// Required lists field names that must be present in every
 	// [Logger.Audit] call for this event type. Missing required
 	// fields always produce an error regardless of validation mode.
@@ -134,9 +141,10 @@ func InjectLifecycleEvents(t *Taxonomy) {
 	// Inject startup if not already defined.
 	if _, ok := t.Events["startup"]; !ok {
 		t.Events["startup"] = &EventDef{
-			Category: lifecycleCategory,
-			Required: []string{"app_name"},
-			Optional: []string{"version", "config"},
+			Category:    lifecycleCategory,
+			Description: "Application started",
+			Required:    []string{"app_name"},
+			Optional:    []string{"version", "config"},
 		}
 		if !slices.Contains(t.Categories[lifecycleCategory], "startup") {
 			t.Categories[lifecycleCategory] = append(t.Categories[lifecycleCategory], "startup")
@@ -146,9 +154,10 @@ func InjectLifecycleEvents(t *Taxonomy) {
 	// Inject shutdown if not already defined.
 	if _, ok := t.Events["shutdown"]; !ok {
 		t.Events["shutdown"] = &EventDef{
-			Category: lifecycleCategory,
-			Required: []string{"app_name"},
-			Optional: []string{"reason", "uptime_ms"},
+			Category:    lifecycleCategory,
+			Description: "Application shutting down",
+			Required:    []string{"app_name"},
+			Optional:    []string{"reason", "uptime_ms"},
 		}
 		if !slices.Contains(t.Categories[lifecycleCategory], "shutdown") {
 			t.Categories[lifecycleCategory] = append(t.Categories[lifecycleCategory], "shutdown")

--- a/taxonomy_yaml.go
+++ b/taxonomy_yaml.go
@@ -46,9 +46,10 @@ type yamlTaxonomy struct {
 // yamlEventDef is the intermediate representation of a single event
 // definition within the YAML taxonomy.
 type yamlEventDef struct {
-	Category string   `yaml:"category"`
-	Required []string `yaml:"required"`
-	Optional []string `yaml:"optional"`
+	Category    string   `yaml:"category"`
+	Description string   `yaml:"description"`
+	Required    []string `yaml:"required"`
+	Optional    []string `yaml:"optional"`
 }
 
 // ParseTaxonomyYAML parses a YAML document into a [Taxonomy].
@@ -118,9 +119,10 @@ func convertYAMLTaxonomy(yt yamlTaxonomy) Taxonomy {
 	events := make(map[string]*EventDef, len(yt.Events))
 	for name, def := range yt.Events {
 		events[name] = &EventDef{
-			Category: def.Category,
-			Required: copyStrings(def.Required),
-			Optional: copyStrings(def.Optional),
+			Category:    def.Category,
+			Description: def.Description,
+			Required:    copyStrings(def.Required),
+			Optional:    copyStrings(def.Optional),
 		}
 	}
 

--- a/taxonomy_yaml_test.go
+++ b/taxonomy_yaml_test.go
@@ -728,6 +728,89 @@ func TestParseTaxonomyYAML_AllValidationErrorsWrapSentinel(t *testing.T) {
 
 // --- Benchmarks ---
 
+func TestParseTaxonomyYAML_WithDescription(t *testing.T) {
+	yaml := `
+version: 1
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    category: write
+    description: "A new user account was created"
+    required: [outcome]
+default_enabled: [write]
+`
+	tax, err := audit.ParseTaxonomyYAML([]byte(yaml))
+	require.NoError(t, err)
+	assert.Equal(t, "A new user account was created", tax.Events["user_create"].Description)
+}
+
+func TestParseTaxonomyYAML_WithoutDescription(t *testing.T) {
+	yaml := `
+version: 1
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    category: write
+    required: [outcome]
+default_enabled: [write]
+`
+	tax, err := audit.ParseTaxonomyYAML([]byte(yaml))
+	require.NoError(t, err)
+	assert.Equal(t, "", tax.Events["user_create"].Description)
+}
+
+func TestInjectLifecycleEvents_SetsDescriptions(t *testing.T) {
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string][]string{"write": {"user_create"}},
+		Events: map[string]*audit.EventDef{
+			"user_create": {Category: "write", Required: []string{"outcome"}},
+		},
+		DefaultEnabled: []string{"write"},
+	}
+	audit.InjectLifecycleEvents(&tax)
+	assert.Equal(t, "Application started", tax.Events["startup"].Description)
+	assert.Equal(t, "Application shutting down", tax.Events["shutdown"].Description)
+}
+
+func TestPrecomputeTaxonomy_DescriptionNotInKnownFields(t *testing.T) {
+	yaml := `
+version: 1
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    category: write
+    description: "Should not appear in knownFields"
+    required: [outcome]
+    optional: [actor_id]
+default_enabled: [write]
+`
+	tax, err := audit.ParseTaxonomyYAML([]byte(yaml))
+	require.NoError(t, err)
+
+	// Create a logger and audit an event — the description should not
+	// be treated as a field name. An event with only outcome + actor_id
+	// should pass strict validation (no unknown fields).
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true, ValidationMode: "strict"},
+		audit.WithTaxonomy(tax),
+	)
+	require.NoError(t, err)
+	defer func() { _ = logger.Close() }()
+
+	err = logger.Audit("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	})
+	assert.NoError(t, err, "description should not be in knownFields set")
+}
+
 func BenchmarkParseTaxonomyYAML(b *testing.B) {
 	data := []byte(validYAML)
 	for b.Loop() {


### PR DESCRIPTION
## Summary

- Add `Description string` field to `EventDef` for documenting event purpose in the taxonomy
- Populated from YAML `description` key (optional, backwards compatible)
- `audit-gen` emits descriptions as Go comments above generated constants
- Lifecycle events get built-in descriptions
- Informational metadata only — no effect on validation, routing, or serialisation

Closes #161

## Test plan

- [ ] `make check` passes
- [ ] YAML with descriptions parses correctly
- [ ] YAML without descriptions still parses (backwards compatible)
- [ ] `audit-gen` output shows comments for events with descriptions
- [ ] `audit-gen` output has no comments for events without descriptions
- [ ] Multi-line descriptions collapsed to single comment line
- [ ] Description not in precomputed knownFields