### PR TITLE
fix: resolve flaky TestSyslogOutput_RapidFireTCP (#189)

### DIFF
--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -1263,8 +1263,13 @@ func TestSyslogOutput_RapidFireTCP(t *testing.T) {
 		require.NoError(t, out.Write(data))
 	}
 
-	require.True(t, srv.waitForData(5*time.Second), "server should receive data")
 	require.NoError(t, out.Close())
+
+	// Wait for the last event to arrive — verifies all data was delivered.
+	// Close() flushes the connection, so all data should be receivable.
+	lastEvent := fmt.Sprintf(`"n":%d`, count-1)
+	require.True(t, srv.waitForContent([]string{lastEvent}, 10*time.Second),
+		"server should receive all %d events (last event not found)", count)
 
 	// Verify all events arrived by checking the concatenated content.
 	all := strings.Join(srv.getMessages(), "")


### PR DESCRIPTION
## Summary

Wait for the last event via `waitForContent` instead of `waitForData` (which only waits for the first chunk). Close the output before asserting to ensure all data is flushed. Increase timeout to 10s for CI.

## Test plan

- [x] `-count=100` passes locally
- [x] `make test-syslog` passes