### PR TITLE
docs: add ACKNOWLEDGEMENTS.md and NOTICE file

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,35 @@
+# Acknowledgements
+
+go-audit builds on the work of these open-source projects. We are
+grateful to their authors and contributors.
+
+## Runtime Dependencies
+
+| Project | License | Copyright | Used For |
+|---------|---------|-----------|----------|
+| [gopkg.in/yaml.v3](https://github.com/go-yaml/yaml) | MIT / Apache-2.0 | 2011-2016 Canonical Ltd. | YAML parsing for taxonomy and output configuration |
+| [github.com/axonops/srslog](https://github.com/axonops/srslog) | BSD-3-Clause | 2015 Rackspace | RFC 5424 syslog client (fork of [gravwell/srslog](https://github.com/gravwell/srslog)) |
+| [github.com/rgooding/go-syncmap](https://github.com/rgooding/go-syncmap) | Apache-2.0 | Richard Gooding | Generic `sync.Map` for lock-free category lookups |
+
+## Test Dependencies
+
+| Project | License | Copyright | Used For |
+|---------|---------|-----------|----------|
+| [github.com/stretchr/testify](https://github.com/stretchr/testify) | MIT | 2012-2020 Mat Ryer, Tyler Bunnell and contributors | Test assertions |
+| [go.uber.org/goleak](https://github.com/uber-go/goleak) | MIT | 2018 Uber Technologies, Inc. | Goroutine leak detection in tests |
+| [github.com/cucumber/godog](https://github.com/cucumber/godog) | MIT | SmartBear | BDD test framework |
+
+## Build and CI Tools
+
+| Tool | License | Used For |
+|------|---------|----------|
+| [golangci-lint](https://github.com/golangci/golangci-lint) | GPL-3.0 | Static analysis and linting |
+| [GoReleaser](https://github.com/goreleaser/goreleaser) | MIT | Release automation |
+| [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | BSD-3-Clause | Vulnerability scanning |
+
+## License Compatibility
+
+All runtime and test dependencies use licenses compatible with
+Apache 2.0 (MIT, BSD-3-Clause, Apache-2.0). No GPL-licensed code is
+linked into the go-audit binary — `golangci-lint` is a build tool
+only, not a library dependency.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,24 @@
+go-audit
+Copyright 2026 AxonOps Limited
+
+This product includes software developed by third parties.
+See ACKNOWLEDGEMENTS.md for full attribution.
+
+---
+
+This product includes software from gopkg.in/yaml.v3,
+which includes the following notice:
+
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -258,11 +258,13 @@ minor versions until v1.0.0. Pin your dependency version.
 
 ## 🙏 Acknowledgements
 
-go-audit builds on the work of these open-source projects:
+go-audit builds on excellent open-source projects. See
+[ACKNOWLEDGEMENTS.md](ACKNOWLEDGEMENTS.md) for full attribution and
+license details.
 
-- [gopkg.in/yaml.v3](https://github.com/go-yaml/yaml) — YAML parsing for taxonomy and output configuration
-- [github.com/axonops/srslog](https://github.com/axonops/srslog) — RFC 5424 syslog client (fork of [gravwell/srslog](https://github.com/gravwell/srslog))
-- [github.com/rgooding/go-syncmap](https://github.com/rgooding/go-syncmap) — Generic sync.Map for lock-free category lookups
+- [gopkg.in/yaml.v3](https://github.com/go-yaml/yaml) — YAML parsing (MIT / Apache-2.0)
+- [github.com/axonops/srslog](https://github.com/axonops/srslog) — RFC 5424 syslog (BSD-3-Clause)
+- [github.com/rgooding/go-syncmap](https://github.com/rgooding/go-syncmap) — Generic sync.Map (Apache-2.0)
 
 ---
 


### PR DESCRIPTION
## Summary

- `ACKNOWLEDGEMENTS.md` — all runtime, test, and build dependencies with license types, copyright holders, and what we use them for
- `NOTICE` — aggregates upstream Apache 2.0 NOTICE content (yaml.v3 has a NOTICE file that Apache 2.0 §4.4 requires us to include)
- README updated to link to ACKNOWLEDGEMENTS.md with license types shown

All dependency licenses verified as Apache 2.0 compatible (MIT, BSD-3-Clause, Apache-2.0). No GPL code linked into the binary.

Closes #27

## Test plan

- [x] Docs-only, `make check` not needed
- [x] All links resolve
- [x] License types verified against upstream repos