### PR TITLE
feat: parse core logger config from YAML

### DIFF
--- a/docs/async-delivery.md
+++ b/docs/async-delivery.md
@@ -73,21 +73,32 @@ outputs can write them.
 
 ### Configuration
 
-Buffer and drain settings are configured in the Go `Config` struct
-(not in YAML):
+Buffer and drain settings are configured in the `logger:` section of
+your output YAML:
+
+```yaml
+logger:
+  buffer_size: 50000         # default: 10,000, max: 1,000,000
+  drain_timeout: "30s"       # default: "5s", max: "60s"
+```
+
+Or programmatically via the `Config` struct:
 
 ```go
 logger, err := audit.NewLogger(
     audit.Config{
         Version:      1,
         Enabled:      true,
-        BufferSize:   10_000,        // channel capacity (default: 10,000, max: 1,000,000)
-        DrainTimeout: 5 * time.Second, // shutdown flush deadline (default: 5s, max: 60s)
+        BufferSize:   50_000,
+        DrainTimeout: 30 * time.Second,
     },
     audit.WithTaxonomy(tax),
     audit.WithOutputs(out),
 )
 ```
+
+When using `outputconfig.Load`, the parsed `result.Config` contains
+these values from your YAML — pass it directly to `NewLogger`.
 
 | Field | Default | Max | What It Does |
 |-------|---------|-----|-------------|

--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -14,6 +14,16 @@ This is a complete reference for everything that can go in an
 ```yaml
 version: 1
 
+# ── Logger Configuration (optional) ────────────────────────
+# Core logger settings. If omitted, sensible defaults are used.
+
+logger:
+  enabled: true                    # default: true (set false to disable auditing)
+  buffer_size: 10000               # default: 10,000 (max: 1,000,000)
+  drain_timeout: "5s"              # default: "5s" (max: "60s")
+  validation_mode: strict          # "strict" (default), "warn", "permissive"
+  omit_empty: false                # default: false
+
 # ── Default Formatter (optional) ───────────────────────────
 # Applies to all outputs that don't specify their own formatter.
 # If omitted, JSON with RFC 3339 nanosecond timestamps is used.
@@ -117,8 +127,31 @@ outputs:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `version` | Yes | Must be `1`. Schema version for future migration. |
+| `logger` | No | Logger configuration. All fields optional; defaults applied if omitted. |
 | `default_formatter` | No | Default formatter for all outputs. JSON if omitted. |
 | `outputs` | Yes | Map of named outputs. At least one must be defined. Maximum: 100. |
+
+## ⚙️ Logger Configuration
+
+The optional `logger:` section configures the core audit logger. All
+fields are optional — omitted fields use sensible defaults.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Set `false` to disable audit logging entirely (no-op logger). |
+| `buffer_size` | `10000` | Async channel capacity. Events dropped when full. Maximum: 1,000,000. |
+| `drain_timeout` | `"5s"` | How long `Close()` waits for pending events to flush. Maximum: `"60s"`. |
+| `validation_mode` | `"strict"` | `"strict"` rejects unknown fields, `"warn"` logs them, `"permissive"` accepts all. |
+| `omit_empty` | `false` | `true` to skip zero-value fields in output. Consumers under compliance regimes that require all registered fields SHOULD leave this `false`. Only applies when no `default_formatter` or per-output `formatter` is configured — when an explicit formatter is present, the formatter's own `omit_empty` takes precedence. |
+
+All values support environment variable substitution:
+
+```yaml
+logger:
+  buffer_size: ${AUDIT_BUFFER_SIZE:-10000}
+  drain_timeout: "${AUDIT_DRAIN_TIMEOUT:-5s}"
+  enabled: ${AUDIT_ENABLED:-true}
+```
 
 ## 📦 Output Block
 
@@ -310,12 +343,12 @@ var outputsYAML []byte
 
 result, err := outputconfig.Load(outputsYAML, &taxonomy, metrics)
 if err != nil {
-    log.Fatal(err)  // fail hard — partial configs are never returned
+    return fmt.Errorf("audit config: %w", err)
 }
 
 opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
 opts = append(opts, result.Options...)
-logger, err := audit.NewLogger(cfg, opts...)
+logger, err := audit.NewLogger(result.Config, opts...)
 ```
 
 ## 📚 Further Reading

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -51,7 +51,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(result.Config, opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/03-file-output/main.go
+++ b/examples/03-file-output/main.go
@@ -50,7 +50,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(result.Config, opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/04-multi-output/main.go
+++ b/examples/04-multi-output/main.go
@@ -50,7 +50,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(result.Config, opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/05-event-routing/main.go
+++ b/examples/05-event-routing/main.go
@@ -50,7 +50,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(result.Config, opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/06-sensitivity-labels/main.go
+++ b/examples/06-sensitivity-labels/main.go
@@ -62,7 +62,7 @@ func createLogger() *audit.Logger {
 	}
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(result.Config, opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/07-formatters/main.go
+++ b/examples/07-formatters/main.go
@@ -50,7 +50,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(result.Config, opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/09-crud-api/audit_setup.go
+++ b/examples/09-crud-api/audit_setup.go
@@ -64,8 +64,5 @@ func setupAuditLogger(tax audit.Taxonomy, m *auditMetrics) (*audit.Logger, error
 	}
 	opts = append(opts, result.Options...)
 
-	return audit.NewLogger(audit.Config{
-		Version: 1,
-		Enabled: true,
-	}, opts...)
+	return audit.NewLogger(result.Config, opts...)
 }

--- a/examples/09-crud-api/outputs.yaml
+++ b/examples/09-crud-api/outputs.yaml
@@ -1,4 +1,7 @@
 version: 1
+logger:
+  buffer_size: ${AUDIT_BUFFER_SIZE:-10000}
+  drain_timeout: "${AUDIT_DRAIN_TIMEOUT:-5s}"
 outputs:
   console:
     type: stdout

--- a/examples/10-testing/main.go
+++ b/examples/10-testing/main.go
@@ -77,7 +77,7 @@ func main() {
 
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(result.Config, opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/outputconfig/doc.go
+++ b/outputconfig/doc.go
@@ -35,12 +35,19 @@
 //
 // # YAML Schema
 //
-// The configuration document has three top-level keys:
+// The configuration document has four top-level keys:
 //
 //	version: 1                      # required, must be 1
+//	logger:                         # optional, core logger settings
+//	  enabled: true                 # default: true
+//	  buffer_size: 10000            # default: 10,000 (max: 1,000,000)
+//	  drain_timeout: "5s"           # default: "5s" (max: "60s")
+//	  validation_mode: strict       # "strict" (default), "warn", "permissive"
+//	  omit_empty: false             # default: false
 //	default_formatter:              # optional, applies to all outputs
 //	  type: json                    # "json" or "cef"
 //	  timestamp: rfc3339nano        # "rfc3339nano" or "unix_ms"
+//	  omit_empty: false             # default: false
 //	outputs:                        # required, map of named outputs
 //	  audit_log:
 //	    type: file                  # registered output type
@@ -66,14 +73,12 @@
 //
 //	result, err := outputconfig.Load(yamlData, &taxonomy, metrics)
 //	if err != nil {
-//	    log.Fatal(err)
+//	    return fmt.Errorf("audit config: %w", err)
 //	}
 //
-//	logger, err := audit.NewLogger(
-//	    audit.Config{Version: 1, Enabled: true},
-//	    audit.WithTaxonomy(taxonomy),
-//	    result.Options...,
-//	)
+//	opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
+//	opts = append(opts, result.Options...)
+//	logger, err := audit.NewLogger(result.Config, opts...)
 //
 // [Load] fails hard on any configuration error — partial configurations
 // are never returned. This ensures that a misconfigured output does not

--- a/outputconfig/go.mod
+++ b/outputconfig/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/axonops/go-audit/file v0.1.0
 	github.com/cucumber/godog v0.15.1
 	github.com/stretchr/testify v1.11.1
+	go.uber.org/goleak v1.3.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -19,7 +19,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
+	"time"
 
 	audit "github.com/axonops/go-audit"
 	"gopkg.in/yaml.v3"
@@ -35,9 +37,17 @@ const MaxOutputConfigSize = 1 << 20 // 1 MiB
 // MaxOutputCount is the maximum number of outputs in a single config.
 const MaxOutputCount = 100
 
-// LoadResult holds the outputs and options produced by [Load], ready
-// to be passed to [audit.NewLogger].
+// LoadResult holds the outputs, options, and logger configuration
+// produced by [Load], ready to be passed to [audit.NewLogger].
 type LoadResult struct { //nolint:govet // fieldalignment: readability preferred
+	// Config is the logger configuration parsed from the optional
+	// top-level `logger:` section. If the section is omitted, Config
+	// contains Version: 1 and Enabled: true; other fields are zero-valued
+	// and will be filled with sensible defaults by [audit.NewLogger]
+	// (BufferSize: 10,000, DrainTimeout: 5s, ValidationMode: strict).
+	// Pass this directly to [audit.NewLogger] as the first argument.
+	Config audit.Config
+
 	// Options contains one [audit.WithNamedOutput] per configured
 	// output, plus an optional [audit.WithFormatter] for the default
 	// formatter. Pass these directly to [audit.NewLogger].
@@ -55,9 +65,16 @@ type LoadResult struct { //nolint:govet // fieldalignment: readability preferred
 // NamedOutput pairs a constructed output with its config-level name
 // and resolved formatter and route.
 type NamedOutput struct {
-	Name      string
-	Output    audit.Output
-	Route     *audit.EventRoute
+	// Name is the config-level name of the output, as declared in the
+	// YAML outputs map key.
+	Name string
+	// Output is the constructed output instance, ready for use.
+	Output audit.Output
+	// Route is the optional per-output event filter. Nil means all
+	// events are delivered to this output.
+	Route *audit.EventRoute
+	// Formatter is the optional per-output formatter override. Nil
+	// means the logger's default formatter is used.
 	Formatter audit.Formatter
 	// ExcludeLabels lists sensitivity label names whose fields are
 	// stripped from events before delivery to this output. Nil or
@@ -207,6 +224,7 @@ func Load(data []byte, taxonomy *audit.Taxonomy, coreMetrics audit.Metrics) (*Lo
 
 	// Phase 8: Build Options slice.
 	result := &LoadResult{
+		Config:           top.config,
 		Outputs:          outputs,
 		DefaultFormatter: top.defaultFmt,
 	}
@@ -225,10 +243,122 @@ func Load(data []byte, taxonomy *audit.Taxonomy, coreMetrics audit.Metrics) (*Lo
 type topLevel struct {
 	outputsNode *yaml.Node
 	defaultFmt  audit.Formatter
+	config      audit.Config
+}
+
+// parseLoggerConfig parses the logger: YAML node into an audit.Config.
+// It walks the mapping manually (like parseTopLevel) so that env-var-
+// expanded string values are correctly handled for numeric fields.
+func parseLoggerConfig(node *yaml.Node) (audit.Config, error) { //nolint:gocyclo,gocognit,cyclop // YAML field dispatch
+	if node.Kind != yaml.MappingNode {
+		return audit.Config{}, fmt.Errorf("expected mapping, got %v", node.Kind)
+	}
+	cfg := audit.Config{
+		Version: 1,
+		Enabled: true,
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		val := node.Content[i+1]
+		switch key {
+		case "enabled":
+			var v bool
+			if err := val.Decode(&v); err != nil {
+				var s string
+				if sErr := val.Decode(&s); sErr != nil {
+					return cfg, fmt.Errorf("enabled: %w", err)
+				}
+				parsed, pErr := strconv.ParseBool(s)
+				if pErr != nil {
+					return cfg, fmt.Errorf("enabled: invalid boolean %q: %w", s, pErr)
+				}
+				v = parsed
+			}
+			cfg.Enabled = v
+		case "buffer_size":
+			var v int
+			if err := val.Decode(&v); err != nil {
+				// After env expansion, the value may be a string.
+				var s string
+				if sErr := val.Decode(&s); sErr != nil {
+					return cfg, fmt.Errorf("buffer_size: %w", err)
+				}
+				n, pErr := strconv.Atoi(s)
+				if pErr != nil {
+					return cfg, fmt.Errorf("buffer_size: invalid integer %q: %w", s, pErr)
+				}
+				v = n
+			}
+			if v < 0 {
+				return cfg, fmt.Errorf("buffer_size: must be non-negative, got %d", v)
+			}
+			if v > audit.MaxBufferSize {
+				return cfg, fmt.Errorf("buffer_size: %d exceeds maximum %d", v, audit.MaxBufferSize)
+			}
+			cfg.BufferSize = v
+		case "drain_timeout":
+			var s string
+			if err := val.Decode(&s); err != nil {
+				return cfg, fmt.Errorf("drain_timeout: %w", err)
+			}
+			if s != "" {
+				d, err := time.ParseDuration(s)
+				if err != nil {
+					return cfg, fmt.Errorf("drain_timeout: invalid duration %q: %w", s, err)
+				}
+				if d < 0 {
+					return cfg, fmt.Errorf("drain_timeout: must be non-negative, got %s", s)
+				}
+				if d > audit.MaxDrainTimeout {
+					return cfg, fmt.Errorf("drain_timeout: %s exceeds maximum %s", d, audit.MaxDrainTimeout)
+				}
+				cfg.DrainTimeout = d
+			}
+		case "validation_mode":
+			var s string
+			if err := val.Decode(&s); err != nil {
+				return cfg, fmt.Errorf("validation_mode: %w", err)
+			}
+			if s != "" {
+				switch audit.ValidationMode(s) {
+				case audit.ValidationStrict, audit.ValidationWarn, audit.ValidationPermissive:
+					cfg.ValidationMode = audit.ValidationMode(s)
+				default:
+					return cfg, fmt.Errorf("validation_mode: unknown mode %q (valid: strict, warn, permissive)", s)
+				}
+			}
+		case "omit_empty":
+			var v bool
+			if err := val.Decode(&v); err != nil {
+				var s string
+				if sErr := val.Decode(&s); sErr != nil {
+					return cfg, fmt.Errorf("omit_empty: %w", err)
+				}
+				parsed, pErr := strconv.ParseBool(s)
+				if pErr != nil {
+					return cfg, fmt.Errorf("omit_empty: invalid boolean %q: %w", s, pErr)
+				}
+				v = parsed
+			}
+			cfg.OmitEmpty = v
+		default:
+			return cfg, fmt.Errorf("unknown field %q", key)
+		}
+	}
+	return cfg, nil
+}
+
+// defaultLoggerConfig returns an audit.Config with sensible defaults
+// for when the logger: section is omitted from YAML.
+func defaultLoggerConfig() audit.Config {
+	return audit.Config{
+		Version: 1,
+		Enabled: true,
+	}
 }
 
 // parseTopLevel extracts and validates top-level YAML fields.
-func parseTopLevel(doc *yaml.Node) (*topLevel, error) { //nolint:gocyclo,cyclop // YAML field dispatch
+func parseTopLevel(doc *yaml.Node) (*topLevel, error) { //nolint:gocyclo,cyclop,gocognit // YAML field dispatch
 	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
 		return nil, fmt.Errorf("%w: empty document", ErrOutputConfigInvalid)
 	}
@@ -240,6 +370,7 @@ func parseTopLevel(doc *yaml.Node) (*topLevel, error) { //nolint:gocyclo,cyclop 
 	var (
 		version        int
 		defaultFmtNode *yaml.Node
+		loggerNode     *yaml.Node
 		result         topLevel
 	)
 	for i := 0; i+1 < len(root.Content); i += 2 {
@@ -252,6 +383,8 @@ func parseTopLevel(doc *yaml.Node) (*topLevel, error) { //nolint:gocyclo,cyclop 
 			}
 		case "default_formatter":
 			defaultFmtNode = val
+		case "logger":
+			loggerNode = val
 		case "outputs":
 			result.outputsNode = val
 		default:
@@ -262,6 +395,19 @@ func parseTopLevel(doc *yaml.Node) (*topLevel, error) { //nolint:gocyclo,cyclop 
 	if version != 1 {
 		return nil, fmt.Errorf("%w: unsupported version %d (expected 1)",
 			ErrOutputConfigInvalid, version)
+	}
+
+	if loggerNode != nil {
+		if err := expandEnvInNode(loggerNode, "logger"); err != nil {
+			return nil, fmt.Errorf("%w: logger: %w", ErrOutputConfigInvalid, err)
+		}
+		cfg, err := parseLoggerConfig(loggerNode)
+		if err != nil {
+			return nil, fmt.Errorf("%w: logger: %w", ErrOutputConfigInvalid, err)
+		}
+		result.config = cfg
+	} else {
+		result.config = defaultLoggerConfig()
 	}
 
 	if defaultFmtNode != nil {

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -15,10 +15,12 @@
 package outputconfig_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +28,7 @@ import (
 	audit "github.com/axonops/go-audit"
 	_ "github.com/axonops/go-audit/file" // register file factory
 	"github.com/axonops/go-audit/outputconfig"
+	"go.uber.org/goleak"
 )
 
 func testTaxonomy(t *testing.T) audit.Taxonomy {
@@ -439,6 +442,7 @@ outputs:
 }
 
 func TestLoad_OptionsContainWithNamedOutput(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	yaml := []byte(`
 version: 1
 outputs:
@@ -586,6 +590,7 @@ func TestLoad_MissingEnvVarInRoute(t *testing.T) {
 }
 
 func TestLoad_EndToEnd_EventsFlowThrough(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	dir := t.TempDir()
 	yamlCfg := []byte(`
 version: 1
@@ -935,4 +940,289 @@ outputs:
 	// Verify the labels are stored and will be passed through.
 	require.Len(t, result.Outputs, 1)
 	assert.Equal(t, []string{"pii"}, result.Outputs[0].ExcludeLabels)
+}
+
+// ---------------------------------------------------------------------------
+// Logger config from YAML (#183)
+// ---------------------------------------------------------------------------
+
+func TestLoad_LoggerConfig_Defaults(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Config.Version)
+	assert.True(t, result.Config.Enabled)
+	assert.Equal(t, 0, result.Config.BufferSize, "zero means applyDefaults will set 10000")
+	assert.Equal(t, time.Duration(0), result.Config.DrainTimeout, "zero means applyDefaults will set 5s")
+	assert.Equal(t, audit.ValidationMode(""), result.Config.ValidationMode, "empty means applyDefaults will set strict")
+	assert.False(t, result.Config.OmitEmpty)
+}
+
+func TestLoad_LoggerConfig_AllFields(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  enabled: true
+  buffer_size: 50000
+  drain_timeout: "30s"
+  validation_mode: warn
+  omit_empty: true
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Config.Version)
+	assert.True(t, result.Config.Enabled)
+	assert.Equal(t, 50000, result.Config.BufferSize)
+	assert.Equal(t, 30*time.Second, result.Config.DrainTimeout)
+	assert.Equal(t, audit.ValidationMode("warn"), result.Config.ValidationMode)
+	assert.True(t, result.Config.OmitEmpty)
+}
+
+func TestLoad_LoggerConfig_PartialFields(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  buffer_size: 25000
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 25000, result.Config.BufferSize)
+	assert.True(t, result.Config.Enabled, "default enabled")
+	assert.Equal(t, time.Duration(0), result.Config.DrainTimeout, "default drain timeout")
+}
+
+func TestLoad_LoggerConfig_EnabledFalse(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  enabled: false
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+
+	assert.False(t, result.Config.Enabled)
+}
+
+func TestLoad_LoggerConfig_EnvVars(t *testing.T) {
+	t.Setenv("TEST_BUFFER_SIZE", "75000")
+	t.Setenv("TEST_DRAIN_TIMEOUT", "15s")
+
+	data := []byte(`
+version: 1
+logger:
+  buffer_size: ${TEST_BUFFER_SIZE}
+  drain_timeout: "${TEST_DRAIN_TIMEOUT}"
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 75000, result.Config.BufferSize)
+	assert.Equal(t, 15*time.Second, result.Config.DrainTimeout)
+}
+
+func TestLoad_LoggerConfig_EnvVars_Boolean(t *testing.T) {
+	t.Setenv("TEST_ENABLED", "false")
+	t.Setenv("TEST_OMIT_EMPTY", "true")
+
+	data := []byte(`
+version: 1
+logger:
+  enabled: ${TEST_ENABLED}
+  omit_empty: ${TEST_OMIT_EMPTY}
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+
+	assert.False(t, result.Config.Enabled)
+	assert.True(t, result.Config.OmitEmpty)
+}
+
+func TestLoad_LoggerConfig_NotAMapping(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger: "not a mapping"
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "logger")
+}
+
+func TestLoad_LoggerConfig_UnknownField(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  enabled: true
+  bogus_field: 42
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "logger")
+}
+
+func TestLoad_LoggerConfig_NegativeBufferSize(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  buffer_size: -1
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "non-negative")
+}
+
+func TestLoad_LoggerConfig_BufferSizeExceedsMax(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  buffer_size: 2000000
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestLoad_LoggerConfig_NegativeDrainTimeout(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  drain_timeout: "-5s"
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "non-negative")
+}
+
+func TestLoad_LoggerConfig_DrainTimeoutExceedsMax(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  drain_timeout: "120s"
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestLoad_LoggerConfig_InvalidDrainTimeout(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  drain_timeout: "not-a-duration"
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "duration")
+}
+
+func TestLoad_LoggerConfig_InvalidValidationMode(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+logger:
+  validation_mode: invalid
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "unknown mode")
+}
+
+func TestLoad_LoggerConfig_ValidationModes(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"strict", "warn", "permissive"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			data := []byte(fmt.Sprintf(`
+version: 1
+logger:
+  validation_mode: %s
+outputs:
+  console:
+    type: stdout
+`, mode))
+			tax := testTaxonomy(t)
+			result, err := outputconfig.Load(data, &tax, nil)
+			require.NoError(t, err)
+			assert.Equal(t, audit.ValidationMode(mode), result.Config.ValidationMode)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Add optional `logger:` section to output configuration YAML for configuring core audit.Config fields without recompiling:

```yaml
version: 1
logger:
  enabled: true               # default: true
  buffer_size: 10000           # default: 10,000, max: 1,000,000
  drain_timeout: "5s"          # default: "5s", max: "60s"
  validation_mode: strict      # "strict", "warn", "permissive"
  omit_empty: false            # default: false
outputs:
  console:
    type: stdout
```

`LoadResult.Config` is populated from the YAML — pass it directly to `NewLogger`. All fields optional. Environment variable substitution works on all types (integers, booleans, durations).

- Validation mode validated at parse time (fail-fast)
- Unknown fields in logger: section rejected
- Boolean and integer env var expansion handled (YAML tag coercion)
- All 8 examples updated to use `result.Config`
- CRUD API example shows `logger:` section with env vars
- Docs updated: output-configuration.md, async-delivery.md, outputconfig/doc.go

Closes #183, closes #219

## Test plan

- [x] `make check` passes
- [x] 11 new tests: all fields, defaults, partial, env vars (int + bool), unknown field, invalid duration, invalid validation mode, enabled=false, all three validation modes
- [x] All examples compile (`make test-examples`)
- [x] Code reviewer: all findings addressed
- [x] User-guide-reviewer: all findings addressed