### PR TITLE
feat: add global tls_policy to output configuration YAML

### DIFF
--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -24,6 +24,15 @@ logger:
   validation_mode: strict          # "strict" (default), "warn", "permissive"
   omit_empty: false                # default: false
 
+# ── Global TLS Policy (optional) ──────────────────────────
+# Applies to all TLS-enabled outputs (syslog tcp+tls, webhook https)
+# that don't specify their own tls_policy. Per-output tls_policy
+# overrides this global setting.
+
+tls_policy:
+  allow_tls12: false               # default: false (TLS 1.3 only)
+  allow_weak_ciphers: false        # default: false
+
 # ── Default Formatter (optional) ───────────────────────────
 # Applies to all outputs that don't specify their own formatter.
 # If omitted, JSON with RFC 3339 nanosecond timestamps is used.
@@ -128,6 +137,7 @@ outputs:
 |-------|----------|-------------|
 | `version` | Yes | Must be `1`. Schema version for future migration. |
 | `logger` | No | Logger configuration. All fields optional; defaults applied if omitted. |
+| `tls_policy` | No | Global TLS policy for all TLS-enabled outputs. Per-output `tls_policy` overrides. |
 | `default_formatter` | No | Default formatter for all outputs. JSON if omitted. |
 | `outputs` | Yes | Map of named outputs. At least one must be defined. Maximum: 100. |
 
@@ -152,6 +162,27 @@ logger:
   drain_timeout: "${AUDIT_DRAIN_TIMEOUT:-5s}"
   enabled: ${AUDIT_ENABLED:-true}
 ```
+
+## 🔒 Global TLS Policy
+
+The optional `tls_policy:` section sets the default TLS version and
+cipher suite policy for all TLS-enabled outputs (syslog with
+`network: tcp+tls`, webhook with `https://`). If an output defines its own `tls_policy`, the global `tls_policy`
+is ignored entirely for that output — fields are not merged. The
+per-output block stands alone, with any omitted fields taking their
+defaults (`false`).
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `allow_tls12` | `false` | Allow TLS 1.2 connections in addition to TLS 1.3. When `false` (default), only TLS 1.3 is accepted. Set `true` when connecting to legacy infrastructure that does not support TLS 1.3. |
+| `allow_weak_ciphers` | `false` | Allow weaker cipher suites when TLS 1.2 is enabled. Has no effect when `allow_tls12` is `false`. SHOULD NOT be enabled unless required by a specific server. |
+
+> ⚠️ **Security:** The default policy (TLS 1.3 only, no weak ciphers)
+> is the most secure configuration. Only relax these settings when
+> connecting to infrastructure that cannot be upgraded.
+
+Outputs that do not use TLS (file, stdout, syslog with `network: tcp`
+or `network: udp`) ignore the global TLS policy.
 
 ## 📦 Output Block
 

--- a/outputconfig/doc.go
+++ b/outputconfig/doc.go
@@ -35,7 +35,7 @@
 //
 // # YAML Schema
 //
-// The configuration document has four top-level keys:
+// The configuration document has the following top-level keys:
 //
 //	version: 1                      # required, must be 1
 //	logger:                         # optional, core logger settings
@@ -44,6 +44,9 @@
 //	  drain_timeout: "5s"           # default: "5s" (max: "60s")
 //	  validation_mode: strict       # "strict" (default), "warn", "permissive"
 //	  omit_empty: false             # default: false
+//	tls_policy:                     # optional, global TLS policy
+//	  allow_tls12: false            # default: false (TLS 1.3 only)
+//	  allow_weak_ciphers: false     # default: false
 //	default_formatter:              # optional, applies to all outputs
 //	  type: json                    # "json" or "cef"
 //	  timestamp: rfc3339nano        # "rfc3339nano" or "unix_ms"

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -205,7 +205,7 @@ func Load(data []byte, taxonomy *audit.Taxonomy, coreMetrics audit.Metrics) (*Lo
 		}
 		seen[name] = struct{}{}
 
-		no, err := buildOutput(name, valueNode, taxonomy, coreMetrics)
+		no, err := buildOutput(name, valueNode, taxonomy, top.tlsPolicyNode, coreMetrics)
 		if err != nil {
 			closeAll(outputs)
 			return nil, fmt.Errorf("%w: %w", ErrOutputConfigInvalid, err)
@@ -241,9 +241,10 @@ func Load(data []byte, taxonomy *audit.Taxonomy, coreMetrics audit.Metrics) (*Lo
 
 // topLevel holds parsed top-level YAML fields.
 type topLevel struct {
-	outputsNode *yaml.Node
-	defaultFmt  audit.Formatter
-	config      audit.Config
+	outputsNode   *yaml.Node
+	tlsPolicyNode *yaml.Node // global tls_policy, injected into outputs that don't specify their own
+	defaultFmt    audit.Formatter
+	config        audit.Config
 }
 
 // parseLoggerConfig parses the logger: YAML node into an audit.Config.
@@ -385,6 +386,8 @@ func parseTopLevel(doc *yaml.Node) (*topLevel, error) { //nolint:gocyclo,cyclop,
 			defaultFmtNode = val
 		case "logger":
 			loggerNode = val
+		case "tls_policy":
+			result.tlsPolicyNode = val
 		case "outputs":
 			result.outputsNode = val
 		default:
@@ -408,6 +411,26 @@ func parseTopLevel(doc *yaml.Node) (*topLevel, error) { //nolint:gocyclo,cyclop,
 		result.config = cfg
 	} else {
 		result.config = defaultLoggerConfig()
+	}
+
+	// Expand env vars and validate global TLS policy eagerly so that
+	// typos and unknown fields are caught at startup, not deferred to
+	// individual output factory invocations.
+	if result.tlsPolicyNode != nil {
+		if err := expandEnvInNode(result.tlsPolicyNode, "tls_policy"); err != nil {
+			return nil, fmt.Errorf("%w: tls_policy: %w", ErrOutputConfigInvalid, err)
+		}
+		// Validate structure — reject unknown fields like typos.
+		tlsBytes, err := yaml.Marshal(result.tlsPolicyNode)
+		if err != nil {
+			return nil, fmt.Errorf("%w: tls_policy: %w", ErrOutputConfigInvalid, err)
+		}
+		dec := yaml.NewDecoder(bytes.NewReader(tlsBytes))
+		dec.KnownFields(true)
+		var validated yamlTLSPolicy
+		if err := dec.Decode(&validated); err != nil {
+			return nil, fmt.Errorf("%w: tls_policy: %w", ErrOutputConfigInvalid, err)
+		}
 	}
 
 	if defaultFmtNode != nil {
@@ -450,7 +473,7 @@ type outputFields struct { //nolint:govet // fieldalignment: readability preferr
 
 // buildOutput constructs a single named output from its YAML node.
 // Returns nil (not error) when the output is disabled (enabled: false).
-func buildOutput(name string, node *yaml.Node, taxonomy *audit.Taxonomy, coreMetrics audit.Metrics) (*NamedOutput, error) {
+func buildOutput(name string, node *yaml.Node, taxonomy *audit.Taxonomy, globalTLSNode *yaml.Node, coreMetrics audit.Metrics) (*NamedOutput, error) {
 	fields, err := extractOutputFields(name, node)
 	if err != nil {
 		return nil, err
@@ -461,7 +484,7 @@ func buildOutput(name string, node *yaml.Node, taxonomy *audit.Taxonomy, coreMet
 	if expandErr := expandOutputEnvVars(name, fields); expandErr != nil {
 		return nil, expandErr
 	}
-	output, err := invokeFactory(name, fields, coreMetrics)
+	output, err := invokeFactory(name, fields, globalTLSNode, coreMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -551,13 +574,64 @@ func expandOutputEnvVars(name string, f *outputFields) error {
 	return nil
 }
 
-func invokeFactory(name string, f *outputFields, coreMetrics audit.Metrics) (audit.Output, error) {
+// deepCopyNode creates a deep copy of a YAML node tree so that
+// mutations in one consumer do not affect others.
+func deepCopyNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	cp := *n
+	if len(n.Content) > 0 {
+		cp.Content = make([]*yaml.Node, len(n.Content))
+		for i, child := range n.Content {
+			cp.Content[i] = deepCopyNode(child)
+		}
+	}
+	return &cp
+}
+
+// injectGlobalTLSPolicy adds the global tls_policy to an output's
+// type-specific config node if the output does not already define one.
+// A deep copy of the global node is injected so that per-output env
+// var expansion does not mutate the shared original.
+func injectGlobalTLSPolicy(typeNode, globalNode *yaml.Node) {
+	if typeNode == nil || globalNode == nil || typeNode.Kind != yaml.MappingNode {
+		return
+	}
+	// Check if the output already has a tls_policy key.
+	for i := 0; i+1 < len(typeNode.Content); i += 2 {
+		if typeNode.Content[i].Value == "tls_policy" {
+			return // per-output policy exists — do not override
+		}
+	}
+	// Inject a deep copy so mutations don't affect other outputs.
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "tls_policy", Tag: "!!str"}
+	typeNode.Content = append(typeNode.Content, keyNode, deepCopyNode(globalNode))
+}
+
+// yamlTLSPolicy is used for eager validation of the global tls_policy.
+type yamlTLSPolicy struct {
+	AllowTLS12       bool `yaml:"allow_tls12"`
+	AllowWeakCiphers bool `yaml:"allow_weak_ciphers"`
+}
+
+func invokeFactory(name string, f *outputFields, globalTLSNode *yaml.Node, coreMetrics audit.Metrics) (audit.Output, error) {
 	factory := audit.LookupOutputFactory(f.typeName)
 	if factory == nil {
 		registered := audit.RegisteredOutputTypes()
 		return nil, fmt.Errorf("output %q: unknown output type %q (registered: [%s]); did you import _ \"github.com/axonops/go-audit/%s\"?",
 			name, f.typeName, strings.Join(registered, ", "), f.typeName)
 	}
+	// Inject global TLS policy for output types that support it.
+	// Only syslog and webhook parse tls_policy — injecting into other
+	// types (file, stdout) would cause unknown-field errors.
+	if f.typeConfigNode != nil && globalTLSNode != nil {
+		switch f.typeName {
+		case "syslog", "webhook":
+			injectGlobalTLSPolicy(f.typeConfigNode, globalTLSNode)
+		}
+	}
+
 	var rawConfig []byte
 	if f.typeConfigNode != nil {
 		var err error

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -1226,3 +1226,179 @@ outputs:
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Global TLS policy (#220)
+// ---------------------------------------------------------------------------
+
+func TestLoad_GlobalTLSPolicy_AcceptedAtTopLevel(t *testing.T) {
+	t.Parallel()
+	// Global tls_policy with allow_tls12. The stdout output doesn't use
+	// TLS, but the config should still parse without error.
+	data := []byte(`
+version: 1
+tls_policy:
+  allow_tls12: true
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+}
+
+func TestLoad_GlobalTLSPolicy_NoGlobal(t *testing.T) {
+	t.Parallel()
+	// No global tls_policy — outputs should still work.
+	data := []byte(`
+version: 1
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+}
+
+func TestLoad_GlobalTLSPolicy_NotInjectedIntoFileOutput(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Global tls_policy should NOT be injected into file outputs
+	// (file doesn't support TLS), so this must succeed.
+	data := []byte(`
+version: 1
+tls_policy:
+  allow_tls12: true
+outputs:
+  audit_file:
+    type: file
+    file:
+      path: "` + dir + `/audit.log"
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+	for _, o := range result.Outputs {
+		_ = o.Output.Close()
+	}
+}
+
+// testOutput is a minimal audit.Output for testing factory injection.
+type testOutput struct{ name string }
+
+func (o *testOutput) Write([]byte) error { return nil }
+func (o *testOutput) Close() error       { return nil }
+func (o *testOutput) Name() string       { return o.name }
+
+func TestLoad_GlobalTLSPolicy_InjectedViaFactory(t *testing.T) {
+	t.Parallel()
+	// Register a test factory under the "webhook" type name so
+	// the injection logic recognises it as TLS-capable.
+	var captured atomic.Value
+	audit.RegisterOutputFactory("webhook", func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
+		captured.Store(string(rawConfig))
+		return &testOutput{name: name}, nil
+	})
+
+	data := []byte(`
+version: 1
+tls_policy:
+  allow_tls12: true
+outputs:
+  alerts:
+    type: webhook
+    webhook:
+      url: "https://example.com"
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+
+	raw, ok := captured.Load().(string)
+	require.True(t, ok, "factory should have been called")
+	assert.Contains(t, raw, "tls_policy")
+	assert.Contains(t, raw, "allow_tls12")
+
+	for _, o := range result.Outputs {
+		_ = o.Output.Close()
+	}
+}
+
+func TestLoad_GlobalTLSPolicy_PerOutputOverride(t *testing.T) {
+	t.Parallel()
+	var captured atomic.Value
+	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
+		captured.Store(string(rawConfig))
+		return &testOutput{name: name}, nil
+	})
+
+	data := []byte(`
+version: 1
+tls_policy:
+  allow_tls12: false
+outputs:
+  siem:
+    type: syslog
+    syslog:
+      network: "tcp+tls"
+      address: "localhost:6514"
+      tls_policy:
+        allow_tls12: true
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(data, &tax, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+
+	raw, ok := captured.Load().(string)
+	require.True(t, ok)
+	// Per-output override should be present, NOT the global one.
+	assert.Contains(t, raw, "allow_tls12: true")
+
+	for _, o := range result.Outputs {
+		_ = o.Output.Close()
+	}
+}
+
+func TestLoad_GlobalTLSPolicy_UnknownField(t *testing.T) {
+	t.Parallel()
+	// The global tls_policy is validated eagerly by parseTopLevel using
+	// KnownFields(true), regardless of output type. An unknown field
+	// must be rejected at parse time.
+	data := []byte(`
+version: 1
+tls_policy:
+  allow_tls12: true
+  bogus_field: true
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "tls_policy")
+}
+
+func TestLoad_GlobalTLSPolicy_MissingEnvVar(t *testing.T) {
+	data := []byte(`
+version: 1
+tls_policy:
+  allow_tls12: ${TOTALLY_MISSING_TLS_VAR}
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(data, &tax, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "tls_policy")
+}


### PR DESCRIPTION
## Summary

Add optional top-level `tls_policy:` section to the output configuration YAML:

```yaml
version: 1
tls_policy:
  allow_tls12: false
  allow_weak_ciphers: false
outputs:
  siem:
    type: syslog
    syslog:
      network: "tcp+tls"
      address: "syslog.example.com:6514"
      # inherits global tls_policy
```

Per-output `tls_policy` overrides the global setting entirely (no field merging). Only syslog and webhook outputs receive injection — file and stdout are unaffected.

**Security measures:**
- Env var expansion on tls_policy at parse time
- Eager validation with KnownFields catches typos at startup
- Deep copy prevents shared-pointer mutation across outputs

**Documentation updated:**
- `docs/output-configuration.md` — schema, reference table, dedicated section with security warning
- `outputconfig/doc.go` — YAML schema in godoc

Closes #220

## Test plan

- [x] `make check` passes (93.2% coverage)
- [x] 7 new tests: accepted at top level, no global, not injected into file, injected via webhook factory, per-output override via syslog factory, unknown field rejected, missing env var rejected
- [x] All 4 agents reviewed (code-reviewer, security-reviewer, user-guide-reviewer, go-quality)
- [x] All findings addressed