### PR TITLE
feat: add hostname config to syslog output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `pid` framework field auto-captured via `os.Getpid()` at construction (#237)
 - JSON output: `app_name`, `host`, `timezone`, `pid` after `duration_ms`, before user fields (#237)
 - CEF output: `deviceProcessName`, `dvchost`, `dtz`, `dvcpid` framework extensions (#237)
+- Syslog `hostname` config field overrides `os.Hostname()` in RFC 5424 header (#237)
 - 31 reserved standard fields always accepted without taxonomy declaration (#237)
 - Expanded default CEF field mapping from 7 to 28 ArcSight extension keys (#237)
 - Per-output HMAC integrity verification with 6 NIST-approved algorithms (#216)

--- a/syslog/register.go
+++ b/syslog/register.go
@@ -49,7 +49,7 @@ type yamlTLSPolicy struct {
 // yamlSyslogConfig is the YAML-specific representation of syslog
 // output configuration. Maps snake_case YAML fields to the Go
 // Config struct.
-type yamlSyslogConfig struct { //nolint:govet // fieldalignment: readability preferred
+type yamlSyslogConfig struct {
 	Network    string         `yaml:"network"`
 	Address    string         `yaml:"address"`
 	AppName    string         `yaml:"app_name"`
@@ -58,6 +58,7 @@ type yamlSyslogConfig struct { //nolint:govet // fieldalignment: readability pre
 	TLSKey     string         `yaml:"tls_key"`
 	TLSCA      string         `yaml:"tls_ca"`
 	TLSPolicy  *yamlTLSPolicy `yaml:"tls_policy"`
+	Hostname   string         `yaml:"hostname"`
 	MaxRetries int            `yaml:"max_retries"`
 }
 
@@ -81,6 +82,7 @@ func buildOutput(name string, rawConfig []byte, syslogMetrics Metrics) (audit.Ou
 		TLSCert:    yc.TLSCert,
 		TLSKey:     yc.TLSKey,
 		TLSCA:      yc.TLSCA,
+		Hostname:   yc.Hostname,
 		MaxRetries: yc.MaxRetries,
 	}
 	if yc.TLSPolicy != nil {

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -73,7 +73,7 @@ const (
 )
 
 // Config holds configuration for [Output].
-type Config struct { //nolint:govet // fieldalignment: pointer field TLSPolicy extends scan region by 8 bytes; readability preferred
+type Config struct {
 	// Network is the transport protocol: "tcp", "udp", or "tcp+tls".
 	// Empty defaults to "tcp". Note: UDP syslog may silently truncate
 	// or drop messages larger than ~2048 bytes (RFC 5424 §6.1).
@@ -112,6 +112,11 @@ type Config struct { //nolint:govet // fieldalignment: pointer field TLSPolicy e
 	// the default policy (TLS 1.3 only) is used. See [audit.TLSPolicy]
 	// for details on enabling TLS 1.2 fallback.
 	TLSPolicy *audit.TLSPolicy
+
+	// Hostname overrides the hostname in the syslog RFC 5424 header.
+	// When empty, [os.Hostname] is used at construction time. Set this
+	// to match the logger-wide host value from [audit.WithHost].
+	Hostname string
 
 	// MaxRetries is the maximum number of consecutive reconnection
 	// attempts before giving up. Zero defaults to
@@ -185,12 +190,16 @@ func New(cfg *Config, syslogMetrics Metrics) (*Output, error) {
 		return nil, fmt.Errorf("audit: syslog facility %q: %w", cfg.Facility, err)
 	}
 
-	// Hostname failure is non-fatal; an empty hostname is acceptable
-	// in the RFC 5424 header (NILVALUE "-" per §6.2.4).
+	// Use explicit hostname from config if provided; otherwise fall
+	// back to os.Hostname(). Failure is non-fatal; an empty hostname
+	// is acceptable in the RFC 5424 header (NILVALUE "-" per §6.2.4).
 	// Note: both hostname and ProcID (set by srslog via os.Getpid())
 	// are cached at construction time and not updated if the process
 	// forks or the hostname changes during the process lifetime.
-	hostname, _ := os.Hostname()
+	hostname := cfg.Hostname
+	if hostname == "" {
+		hostname, _ = os.Hostname()
+	}
 
 	var tlsCfg *tls.Config
 	if cfg.Network == "tcp+tls" {

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -467,6 +467,48 @@ func TestSyslogOutput_Write(t *testing.T) {
 	assert.Contains(t, msgs[0], "user_create")
 }
 
+func TestSyslogOutput_Hostname_Override(t *testing.T) {
+	srv := newMockSyslogServer(t)
+	defer srv.close()
+
+	out, err := syslog.New(&syslog.Config{
+		Network:  "tcp",
+		Address:  srv.addr(),
+		Hostname: "custom-host",
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, out.Write([]byte(`{"event_type":"test"}`)))
+	require.True(t, srv.waitForData(2*time.Second))
+	require.NoError(t, out.Close())
+
+	msgs := srv.getMessages()
+	require.NotEmpty(t, msgs)
+	assert.Contains(t, msgs[0], "custom-host",
+		"syslog message should contain the overridden hostname")
+}
+
+func TestSyslogOutput_Hostname_DefaultFallback(t *testing.T) {
+	srv := newMockSyslogServer(t)
+	defer srv.close()
+
+	out, err := syslog.New(&syslog.Config{
+		Network: "tcp",
+		Address: srv.addr(),
+		// Hostname intentionally omitted — should fall back to os.Hostname.
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, out.Write([]byte(`{"event_type":"test"}`)))
+	require.True(t, srv.waitForData(2*time.Second))
+	require.NoError(t, out.Close())
+
+	msgs := srv.getMessages()
+	require.NotEmpty(t, msgs)
+	// Cannot assert the exact hostname, but the message should be non-empty.
+	assert.NotEmpty(t, msgs[0])
+}
+
 func TestSyslogOutput_WriteMultiple(t *testing.T) {
 	srv := newMockSyslogServer(t)
 	defer srv.close()


### PR DESCRIPTION
## Summary

- Add `Hostname` field to syslog `Config` struct — overrides `os.Hostname()` in RFC 5424 header
- Add `hostname` YAML key to syslog output configuration
- Consumers can align syslog hostname with the logger-wide `host` value from `WithHost`
- Part 4 of #237

## Changes (4 files)

- `syslog/syslog.go` — `Hostname` field in Config, updated `New()` to prefer it over `os.Hostname()`
- `syslog/register.go` — `hostname` YAML field in `yamlSyslogConfig`, passed to Config
- `syslog/syslog_test.go` — 2 new tests (hostname override, default fallback)
- `CHANGELOG.md` — Added entry

## Test plan

- [x] `make check` passes
- [x] Hostname override test verifies value flows to syslog message
- [x] Default fallback test verifies backward compatibility
- [x] commit-message-reviewer approved