### PR TITLE
feat: add WithStandardFieldDefaults for deployment-wide defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `app_name`, `host`, `timezone` top-level keys in outputs YAML with env var support (#237)
 - `standard_fields` YAML section for deployment-wide reserved field defaults (#237)
 - Syslog `hostname` auto-injected from top-level `host` when not set per-output (#237)
+- `WithStandardFieldDefaults` option for deployment-wide reserved field defaults (#237)
 - Syslog `hostname` config field overrides `os.Hostname()` in RFC 5424 header (#237)
 - 31 reserved standard fields always accepted without taxonomy declaration (#237)
 - Expanded default CEF field mapping from 7 to 28 ArcSight extension keys (#237)

--- a/audit.go
+++ b/audit.go
@@ -109,6 +109,11 @@ type Logger struct {
 	host     string
 	timezone string
 	pid      int
+	// standardFieldDefaults holds deployment-wide default values for
+	// reserved standard fields. Set once via WithStandardFieldDefaults;
+	// read-only after construction. Applied in auditInternal before
+	// validation so that defaults satisfy required: true constraints.
+	standardFieldDefaults map[string]string
 }
 
 // NewLogger creates a new audit [Logger] with the given configuration
@@ -215,6 +220,8 @@ func (l *Logger) auditInternal(eventType string, fields Fields) error {
 		}
 		return fmt.Errorf("audit: unknown event type %q", eventType)
 	}
+
+	fields = l.applyStandardFieldDefaults(fields)
 
 	if err := l.validateFields(eventType, def, fields); err != nil {
 		if l.metrics != nil {
@@ -847,6 +854,25 @@ func (l *Logger) writeToOutput(o Output, data []byte, eventType string) {
 
 // validateFields checks that all required fields are present and no
 // unknown fields are included (behavior depends on validation mode).
+// applyStandardFieldDefaults merges deployment-wide defaults into the
+// event fields. Per-event values take precedence (key existence check,
+// not zero value — an empty string counts as "set"). Returns the
+// possibly-initialised fields map.
+func (l *Logger) applyStandardFieldDefaults(fields Fields) Fields {
+	if len(l.standardFieldDefaults) == 0 {
+		return fields
+	}
+	if fields == nil {
+		fields = make(Fields, len(l.standardFieldDefaults))
+	}
+	for k, v := range l.standardFieldDefaults {
+		if _, exists := fields[k]; !exists {
+			fields[k] = v
+		}
+	}
+	return fields
+}
+
 func (l *Logger) validateFields(eventType string, def *EventDef, fields Fields) error {
 	if err := checkRequiredFields(eventType, def, fields); err != nil {
 		return err

--- a/audit_test.go
+++ b/audit_test.go
@@ -298,6 +298,115 @@ func TestLogger_FrameworkFields_InOutput(t *testing.T) {
 	assert.NotNil(t, record["pid"], "pid should always be present")
 }
 
+// ---------------------------------------------------------------------------
+// Standard field defaults (#237)
+// ---------------------------------------------------------------------------
+
+func TestWithStandardFieldDefaults_Applied(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true},
+		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithOutputs(out),
+		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+
+	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	})))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	record := out.GetEvent(0)
+	assert.Equal(t, "10.0.0.1", record["source_ip"], "default should be applied")
+}
+
+func TestWithStandardFieldDefaults_PerEventOverride(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true},
+		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithOutputs(out),
+		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+
+	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":   "success",
+		"actor_id":  "alice",
+		"source_ip": "192.168.1.1",
+	})))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	record := out.GetEvent(0)
+	assert.Equal(t, "192.168.1.1", record["source_ip"], "per-event value should override default")
+}
+
+func TestWithStandardFieldDefaults_EmptyStringOverride(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true},
+		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithOutputs(out),
+		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+
+	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":   "success",
+		"actor_id":  "alice",
+		"source_ip": "",
+	})))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	record := out.GetEvent(0)
+	assert.Equal(t, "", record["source_ip"], "empty string counts as set -- no default applied")
+}
+
+func TestWithStandardFieldDefaults_SetOnce(t *testing.T) {
+	t.Parallel()
+	_, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true},
+		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "a"}),
+		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "b"}),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "standard field defaults already set")
+}
+
+func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {
+	t.Parallel()
+	// Taxonomy with source_ip as required.
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
+		Events: map[string]*audit.EventDef{
+			"ev1": {Required: []string{"outcome", "source_ip"}},
+		},
+	}
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.Config{Version: 1, Enabled: true, ValidationMode: "strict"},
+		audit.WithTaxonomy(tax),
+		audit.WithOutputs(out),
+		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+
+	// Event only provides outcome — source_ip should come from defaults.
+	err = logger.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
+	assert.NoError(t, err, "default should satisfy required field")
+}
+
 func TestLogger_Audit_NilFields(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")

--- a/options.go
+++ b/options.go
@@ -98,6 +98,22 @@ func WithTimezone(tz string) Option {
 	}
 }
 
+// WithStandardFieldDefaults sets deployment-wide default values for
+// reserved standard fields. Defaults are applied in [Logger.AuditEvent]
+// before validation — a default satisfies required: true constraints.
+// Per-event values always override defaults (key existence check, not
+// zero value). This option may be called at most once; a second call
+// returns an error.
+func WithStandardFieldDefaults(defaults map[string]string) Option {
+	return func(l *Logger) error {
+		if l.standardFieldDefaults != nil {
+			return fmt.Errorf("audit: standard field defaults already set -- cannot be overridden")
+		}
+		l.standardFieldDefaults = defaults
+		return nil
+	}
+}
+
 // WithFormatter sets the event serialisation formatter. If not
 // provided, a [JSONFormatter] is created from the [Config]. Use this
 // to configure a [CEFFormatter] or a custom [Formatter] implementation.


### PR DESCRIPTION
## Summary

- `WithStandardFieldDefaults(map[string]string)` option for deployment-wide reserved field defaults
- Defaults applied in `auditInternal()` before validation — satisfies `required: true` constraints
- Per-event values override defaults (key existence check, not zero value)
- Set-once semantics prevent double-configuration from YAML + programmatic paths
- Part 6 of #237

## Changes (4 files)

- `audit.go` — `standardFieldDefaults` on Logger, `applyStandardFieldDefaults()` helper
- `options.go` — `WithStandardFieldDefaults()` with set-once check
- `audit_test.go` — 5 new tests (applied, per-event override, empty string, set-once, satisfies required)
- `CHANGELOG.md`

## Test plan

- [x] `make check` passes
- [x] Default applied when event doesn't set field
- [x] Per-event value overrides default
- [x] Empty string per-event overrides default
- [x] Set-once: second call returns error
- [x] Default satisfies required: true validation