### PR TITLE
test: add BDD scenarios and docs for MetadataWriter

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -18,6 +18,21 @@ serialisation. go-audit can send the same event to multiple outputs
 at once — a local file for long-term retention, a syslog server for
 your SIEM, and a webhook for real-time alerting, all simultaneously.
 
+### Optional Interfaces
+
+Output implementations may satisfy additional optional interfaces:
+
+| Interface | Purpose |
+|-----------|---------|
+| `DestinationKeyer` | Duplicate destination detection at construction |
+| `DeliveryReporter` | Output handles its own delivery metrics |
+| `MetadataWriter` | Receives structured event metadata (event type, severity, category, timestamp) alongside pre-serialised bytes |
+
+`MetadataWriter` is used by outputs that need structured access to
+per-event fields — for example, Loki uses event_type and severity as
+stream labels. Outputs that don't implement it receive plain `Write()`
+calls with no overhead.
+
 ## ❓ Why Multiple Outputs?
 
 Different teams need audit events in different places, in different

--- a/tests/bdd/features/metadata_writer.feature
+++ b/tests/bdd/features/metadata_writer.feature
@@ -1,0 +1,42 @@
+@core @metadata
+Feature: MetadataWriter Interface
+  As an output backend developer, I want to receive structured event
+  metadata (event type, severity, category, timestamp) alongside
+  pre-serialised bytes so that I can build Loki labels, Elasticsearch
+  index routes, or similar metadata-driven features without parsing
+  the serialised output.
+
+  Background:
+    Given a standard test taxonomy
+
+  Scenario: MetadataWriter output receives correct event_type
+    Given a logger with a MetadataWriter output
+    When I audit event "user_create" with fields:
+      | field    | value   |
+      | outcome  | success |
+      | actor_id | alice   |
+    Then the MetadataWriter should have received event_type "user_create"
+
+  Scenario: MetadataWriter output receives correct severity
+    Given a logger with a MetadataWriter output
+    When I audit event "user_create" with fields:
+      | field    | value   |
+      | outcome  | success |
+      | actor_id | alice   |
+    Then the MetadataWriter should have received severity 5
+
+  Scenario: MetadataWriter output receives delivery-specific category
+    Given a logger with a MetadataWriter output
+    When I audit event "user_create" with fields:
+      | field    | value   |
+      | outcome  | success |
+      | actor_id | alice   |
+    Then the MetadataWriter should have received category "write"
+
+  Scenario: Non-MetadataWriter output still receives events
+    Given a logger with stdout output
+    When I audit event "user_create" with fields:
+      | field    | value   |
+      | outcome  | success |
+      | actor_id | alice   |
+    Then the event should be delivered successfully

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -66,6 +66,9 @@ type AuditTestContext struct { //nolint:govet // fieldalignment: readability pre
 	CaptureOutput  *captureOutput            // raw event bytes for HMAC verification
 	CaptureOutputs map[string]*captureOutput // named outputs for multi-output HMAC tests
 
+	// MetadataWriter capture.
+	MetadataMock *MetadataWriterMock
+
 	// Metrics capture.
 	MockMetrics    *MockMetrics
 	WebhookMetrics *MockWebhookMetrics
@@ -179,4 +182,5 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerSensitivitySteps(ctx, tc)
 	registerBuilderSteps(ctx, tc)
 	registerHMACSteps(ctx, tc)
+	registerMetadataWriterSteps(ctx, tc)
 }

--- a/tests/bdd/steps/metadata_writer_steps.go
+++ b/tests/bdd/steps/metadata_writer_steps.go
@@ -1,0 +1,148 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cucumber/godog"
+
+	audit "github.com/axonops/go-audit"
+)
+
+// MetadataWriterMock implements both audit.Output and audit.MetadataWriter
+// for BDD testing.
+type MetadataWriterMock struct { //nolint:govet // fieldalignment: test mock
+	mu       sync.Mutex
+	name     string
+	lastMeta audit.EventMetadata
+	lastData []byte
+	called   bool
+	closed   bool
+}
+
+// Write implements audit.Output.
+func (m *MetadataWriterMock) Write(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	m.lastData = cp
+	return nil
+}
+
+// WriteWithMetadata implements audit.MetadataWriter.
+func (m *MetadataWriterMock) WriteWithMetadata(data []byte, meta audit.EventMetadata) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	m.lastData = cp
+	m.lastMeta = meta
+	m.called = true
+	return nil
+}
+
+// Close implements audit.Output.
+func (m *MetadataWriterMock) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+// Name implements audit.Output.
+func (m *MetadataWriterMock) Name() string { return m.name }
+
+func (m *MetadataWriterMock) getMeta() (audit.EventMetadata, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastMeta, m.called
+}
+
+func registerMetadataWriterSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
+	registerMetadataWriterGivenSteps(ctx, tc)
+	registerMetadataWriterThenSteps(ctx, tc)
+}
+
+func registerMetadataWriterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
+	ctx.Step(`^a logger with a MetadataWriter output$`, func() error {
+		mock := &MetadataWriterMock{name: "bdd-metadata-writer"}
+		tc.MetadataMock = mock
+
+		opts := []audit.Option{
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithNamedOutput(mock, nil, nil),
+		}
+		opts = append(opts, tc.Options...)
+
+		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		if err != nil {
+			return fmt.Errorf("create logger: %w", err)
+		}
+		tc.Logger = logger
+		tc.AddCleanup(func() { _ = logger.Close() })
+		return nil
+	})
+
+}
+
+// flushAndGetMeta closes the logger and returns the captured metadata.
+func flushAndGetMeta(tc *AuditTestContext) (audit.EventMetadata, error) {
+	if tc.Logger != nil {
+		_ = tc.Logger.Close()
+	}
+	meta, called := tc.MetadataMock.getMeta()
+	if !called {
+		return meta, fmt.Errorf("WriteWithMetadata was not called")
+	}
+	return meta, nil
+}
+
+func registerMetadataWriterThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
+	ctx.Step(`^the MetadataWriter should have received event_type "([^"]*)"$`, func(expected string) error {
+		meta, err := flushAndGetMeta(tc)
+		if err != nil {
+			return err
+		}
+		if meta.EventType != expected {
+			return fmt.Errorf("expected event_type %q, got %q", expected, meta.EventType)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the MetadataWriter should have received severity (\d+)$`, func(expected int) error {
+		meta, err := flushAndGetMeta(tc)
+		if err != nil {
+			return err
+		}
+		if meta.Severity != expected {
+			return fmt.Errorf("expected severity %d, got %d", expected, meta.Severity)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the MetadataWriter should have received category "([^"]*)"$`, func(expected string) error {
+		meta, err := flushAndGetMeta(tc)
+		if err != nil {
+			return err
+		}
+		if meta.Category != expected {
+			return fmt.Errorf("expected category %q, got %q", expected, meta.Category)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Adds the 4 BDD scenarios and docs/outputs.md entry that were missing when #250 was auto-closed.

- `metadata_writer.feature` — 4 scenarios: event_type, severity, category, non-implementing output
- `metadata_writer_steps.go` — MetadataWriterMock + step definitions
- `docs/outputs.md` — Optional Interfaces table with MetadataWriter

Closes #250.

394 BDD scenarios, all passing.