### PR TITLE
refactor: extract SSRF dial control to core audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - JSON post-serialisation append reduced from 6 to 1 allocs/op (#229)
 - HMAC drain-loop: hash reuse via Reset() + pre-allocated buffers, 8 → 1 extra alloc per event (#230)
+- SSRF dial control extracted from webhook/internal/ssrf to core audit package (#256)
 
 ### Added
 

--- a/ssrf.go
+++ b/ssrf.go
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ssrf provides a net.Dialer Control function that prevents
-// server-side request forgery by blocking connections to private,
-// loopback, link-local, and cloud metadata IP addresses.
-package ssrf
+package audit
 
 import (
 	"fmt"
@@ -23,36 +20,36 @@ import (
 	"syscall"
 )
 
-// config holds SSRF protection options.
-type config struct {
+// SSRFOption configures SSRF protection behaviour for
+// [NewSSRFDialControl].
+type SSRFOption func(*ssrfConfig)
+
+type ssrfConfig struct {
 	allowPrivate bool
 }
-
-// Option configures SSRF protection behaviour.
-type Option func(*config)
 
 // AllowPrivateRanges permits connections to RFC 1918 private address
 // ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), IPv6 ULA
 // (fc00::/7), and loopback (127.0.0.0/8, ::1). This is intended for
-// private network deployments where webhook receivers run on internal
+// private network deployments where output receivers run on internal
 // infrastructure, and for testing with [net/http/httptest] which binds
 // to 127.0.0.1.
 //
 // Cloud metadata addresses (169.254.169.254) remain blocked even when
 // private ranges are allowed.
-func AllowPrivateRanges() Option {
-	return func(c *config) {
+func AllowPrivateRanges() SSRFOption {
+	return func(c *ssrfConfig) {
 		c.allowPrivate = true
 	}
 }
 
-// NewDialControl returns a [net.Dialer] Control function that checks
-// every resolved IP address before a connection is established. Use it
-// with [net/http.Transport]:
+// NewSSRFDialControl returns a [net.Dialer] Control function that
+// checks every resolved IP address before a connection is established.
+// Use it with [net/http.Transport]:
 //
 //	transport := &http.Transport{
 //	    DialContext: (&net.Dialer{
-//	        Control: ssrf.NewDialControl(),
+//	        Control: audit.NewSSRFDialControl(),
 //	    }).DialContext,
 //	}
 //
@@ -66,64 +63,63 @@ func AllowPrivateRanges() Option {
 //   - Unspecified addresses (0.0.0.0, ::)
 //
 // Use [AllowPrivateRanges] to permit private and loopback addresses.
-func NewDialControl(opts ...Option) func(string, string, syscall.RawConn) error {
-	cfg := &config{}
+func NewSSRFDialControl(opts ...SSRFOption) func(string, string, syscall.RawConn) error {
+	cfg := &ssrfConfig{}
 	for _, opt := range opts {
 		opt(cfg)
 	}
 	return func(_, address string, _ syscall.RawConn) error {
-		return CheckAddress(address, cfg.allowPrivate)
+		return CheckSSRFAddress(address, cfg.allowPrivate)
 	}
 }
 
-// CheckAddress validates that a resolved address is not blocked by
-// SSRF policy. The address must be in host:port format. This function
-// is exported for direct testing.
-func CheckAddress(address string, allowPrivate bool) error {
+// CheckSSRFAddress validates that a resolved address is not blocked by
+// SSRF policy. The address must be in host:port format.
+func CheckSSRFAddress(address string, allowPrivate bool) error {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
-		return fmt.Errorf("ssrf: invalid address %q: %w", address, err)
+		return fmt.Errorf("audit: ssrf: invalid address %q: %w", address, err)
 	}
 
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return fmt.Errorf("ssrf: could not parse IP %q", host)
+		return fmt.Errorf("audit: ssrf: could not parse IP %q", host)
 	}
 
-	return CheckIP(ip, allowPrivate)
+	return CheckSSRFIP(ip, allowPrivate)
 }
 
-// CheckIP validates that an IP address is not blocked by SSRF policy.
-// This function is exported for direct unit testing of IP classification.
-func CheckIP(ip net.IP, allowPrivate bool) error {
+// CheckSSRFIP validates that an IP address is not blocked by SSRF
+// policy. Exported for direct unit testing of IP classification.
+func CheckSSRFIP(ip net.IP, allowPrivate bool) error {
 	// Cloud metadata — ALWAYS blocked regardless of config.
 	// AWS, GCP, and Azure all use 169.254.169.254.
 	if ip.Equal(net.IPv4(169, 254, 169, 254)) {
-		return fmt.Errorf("ssrf: cloud metadata address %s blocked", ip)
+		return fmt.Errorf("audit: ssrf: cloud metadata address %s blocked", ip)
 	}
 
 	// Link-local — always blocked (includes metadata range).
 	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-		return fmt.Errorf("ssrf: link-local address %s blocked", ip)
+		return fmt.Errorf("audit: ssrf: link-local address %s blocked", ip)
 	}
 
 	// Multicast — always blocked.
 	if ip.IsMulticast() {
-		return fmt.Errorf("ssrf: multicast address %s blocked", ip)
+		return fmt.Errorf("audit: ssrf: multicast address %s blocked", ip)
 	}
 
 	// Unspecified (0.0.0.0, ::) — always blocked.
 	if ip.IsUnspecified() {
-		return fmt.Errorf("ssrf: unspecified address %s blocked", ip)
+		return fmt.Errorf("audit: ssrf: unspecified address %s blocked", ip)
 	}
 
 	// Private and loopback — blocked unless AllowPrivateRanges.
 	if !allowPrivate {
 		if ip.IsLoopback() {
-			return fmt.Errorf("ssrf: loopback address %s blocked", ip)
+			return fmt.Errorf("audit: ssrf: loopback address %s blocked", ip)
 		}
 		if ip.IsPrivate() {
-			return fmt.Errorf("ssrf: private address %s blocked", ip)
+			return fmt.Errorf("audit: ssrf: private address %s blocked", ip)
 		}
 	}
 

--- a/ssrf_test.go
+++ b/ssrf_test.go
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ssrf_test
+package audit_test
 
 import (
 	"net"
 	"testing"
 
-	"github.com/axonops/go-audit/webhook/internal/ssrf"
+	audit "github.com/axonops/go-audit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheckIP_Blocked(t *testing.T) {
+func TestCheckSSRFIP_Blocked(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		ip   string
@@ -48,15 +49,17 @@ func TestCheckIP_Blocked(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ip := net.ParseIP(tt.ip)
 			require.NotNil(t, ip, "failed to parse %q", tt.ip)
-			err := ssrf.CheckIP(ip, false)
+			err := audit.CheckSSRFIP(ip, false)
 			assert.Error(t, err, "IP %s should be blocked", tt.ip)
 		})
 	}
 }
 
-func TestCheckIP_Allowed(t *testing.T) {
+func TestCheckSSRFIP_Allowed(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		ip   string
@@ -69,15 +72,17 @@ func TestCheckIP_Allowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ip := net.ParseIP(tt.ip)
 			require.NotNil(t, ip, "failed to parse %q", tt.ip)
-			err := ssrf.CheckIP(ip, false)
+			err := audit.CheckSSRFIP(ip, false)
 			assert.NoError(t, err, "IP %s should be allowed", tt.ip)
 		})
 	}
 }
 
-func TestCheckIP_AllowPrivateRanges(t *testing.T) {
+func TestCheckSSRFIP_AllowPrivateRanges(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		ip      string
@@ -96,9 +101,10 @@ func TestCheckIP_AllowPrivateRanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ip := net.ParseIP(tt.ip)
 			require.NotNil(t, ip)
-			err := ssrf.CheckIP(ip, true)
+			err := audit.CheckSSRFIP(ip, true)
 			if tt.blocked {
 				assert.Error(t, err, "%s should be blocked", tt.ip)
 			} else {
@@ -108,7 +114,8 @@ func TestCheckIP_AllowPrivateRanges(t *testing.T) {
 	}
 }
 
-func TestCheckIP_IPv4MappedIPv6(t *testing.T) {
+func TestCheckSSRFIP_IPv4MappedIPv6(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		ip      string
@@ -122,9 +129,10 @@ func TestCheckIP_IPv4MappedIPv6(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ip := net.ParseIP(tt.ip)
 			require.NotNil(t, ip)
-			err := ssrf.CheckIP(ip, false)
+			err := audit.CheckSSRFIP(ip, false)
 			if tt.blocked {
 				assert.Error(t, err, "%s should be blocked", tt.ip)
 			} else {
@@ -134,27 +142,29 @@ func TestCheckIP_IPv4MappedIPv6(t *testing.T) {
 	}
 }
 
-func TestCheckAddress(t *testing.T) {
-	err := ssrf.CheckAddress("127.0.0.1:443", false)
+func TestCheckSSRFAddress(t *testing.T) {
+	t.Parallel()
+	err := audit.CheckSSRFAddress("127.0.0.1:443", false)
 	assert.Error(t, err, "loopback should be blocked")
 
-	err = ssrf.CheckAddress("8.8.8.8:443", false)
+	err = audit.CheckSSRFAddress("8.8.8.8:443", false)
 	assert.NoError(t, err, "public IP should be allowed")
 }
 
-func TestCheckAddress_Invalid(t *testing.T) {
-	err := ssrf.CheckAddress("not-valid", false)
+func TestCheckSSRFAddress_Invalid(t *testing.T) {
+	t.Parallel()
+	err := audit.CheckSSRFAddress("not-valid", false)
 	assert.Error(t, err, "invalid address should error")
 
-	err = ssrf.CheckAddress("not-an-ip:443", false)
+	err = audit.CheckSSRFAddress("not-an-ip:443", false)
 	assert.Error(t, err, "non-IP host should error")
 }
 
-func TestNewDialControl_ReturnsFunction(t *testing.T) {
-	// Verify the returned function has the correct signature.
-	fn := ssrf.NewDialControl()
+func TestNewSSRFDialControl_ReturnsFunction(t *testing.T) {
+	t.Parallel()
+	fn := audit.NewSSRFDialControl()
 	require.NotNil(t, fn)
 
-	fn2 := ssrf.NewDialControl(ssrf.AllowPrivateRanges())
+	fn2 := audit.NewSSRFDialControl(audit.AllowPrivateRanges())
 	require.NotNil(t, fn2)
 }

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -39,7 +39,6 @@ import (
 	"time"
 
 	audit "github.com/axonops/go-audit"
-	"github.com/axonops/go-audit/webhook/internal/ssrf"
 )
 
 // Compile-time assertions.
@@ -82,7 +81,7 @@ var errRedirectBlocked = errors.New("audit: webhook redirects are not followed")
 //
 // # SSRF Prevention
 //
-// The HTTP client uses [internal/ssrf.NewDialControl] to block
+// The HTTP client uses [audit.NewSSRFDialControl] to block
 // connections to private, loopback, link-local, and cloud metadata
 // addresses. Redirects are rejected entirely. Keep-alives are disabled
 // to force fresh DNS resolution per request, preventing DNS rebinding.
@@ -129,15 +128,15 @@ func New(cfg *Config, metrics audit.Metrics, webhookMetrics Metrics) (*Output, e
 		return nil, fmt.Errorf("audit: webhook tls: %w", err)
 	}
 
-	var ssrfOpts []ssrf.Option
+	var ssrfOpts []audit.SSRFOption
 	if cfg.AllowPrivateRanges {
-		ssrfOpts = append(ssrfOpts, ssrf.AllowPrivateRanges())
+		ssrfOpts = append(ssrfOpts, audit.AllowPrivateRanges())
 	}
 
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout: 30 * time.Second,
-			Control: ssrf.NewDialControl(ssrfOpts...),
+			Control: audit.NewSSRFDialControl(ssrfOpts...),
 		}).DialContext,
 		TLSClientConfig:     tlsCfg,
 		DisableKeepAlives:   true, // force fresh dial per request (DNS rebinding)


### PR DESCRIPTION
## Summary

Move SSRF dial-control from `webhook/internal/ssrf/` to the core `audit` package. Enables the Loki output (#251) and future HTTP outputs to share SSRF protection without duplicating security-critical code.

Closes #256.

## Changes

- `ssrf.go` — `NewSSRFDialControl`, `CheckSSRFAddress`, `CheckSSRFIP`, `AllowPrivateRanges` exported from core
- `ssrf_test.go` — 7 test functions relocated with t.Parallel()
- `webhook/webhook.go` — imports SSRF from core instead of internal package
- `webhook/internal/ssrf/` — deleted
- `CHANGELOG.md` — Changed entry

## Agent review status

- security-reviewer: approved (0 findings, IP blocking logic identical)
- commit-message-reviewer: approved (shortened subject)
- issue-writer: issue #256 updated with complete spec

## Test plan

- [x] `make check` passes
- [x] All 7 SSRF tests pass in core
- [x] All webhook tests pass (no regression)
- [x] 394 BDD scenarios pass
- [x] Cloud metadata always blocked (even with AllowPrivateRanges)
- [x] go test -race clean