### PR TITLE
feat: add Loki output config, validation, and YAML factory (#251)

### DIFF
--- a/loki/config.go
+++ b/loki/config.go
@@ -1,0 +1,372 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	audit "github.com/axonops/go-audit"
+)
+
+// Default values for [Config] fields.
+const (
+	DefaultBatchSize     = 100
+	DefaultMaxBatchBytes = 1 << 20 // 1 MiB
+	DefaultFlushInterval = 5 * time.Second
+	DefaultTimeout       = 10 * time.Second
+	DefaultMaxRetries    = 3
+	DefaultBufferSize    = 10_000
+)
+
+// Upper bounds for [Config] fields.
+const (
+	MaxBatchSize     = 10_000
+	MaxMaxBatchBytes = 10 << 20 // 10 MiB
+	MaxFlushInterval = 5 * time.Minute
+	MaxTimeout       = 5 * time.Minute
+	MaxMaxRetries    = 20
+	MaxBufferSize    = 1_000_000
+)
+
+// Lower bounds for [Config] fields.
+const (
+	MinMaxBatchBytes = 1024
+	MinFlushInterval = 100 * time.Millisecond
+	MinTimeout       = 1 * time.Second
+	MinBufferSize    = 100
+)
+
+// Metrics is an optional interface for recording Loki output
+// operational metrics. Pass nil to disable metrics collection.
+type Metrics interface {
+	// RecordLokiDrop is called when an event is dropped (buffer full
+	// or retries exhausted).
+	RecordLokiDrop()
+
+	// RecordLokiFlush is called after each successful push to Loki.
+	RecordLokiFlush(batchSize int, dur time.Duration)
+}
+
+// validLabelName matches Loki's label name requirement.
+var validLabelName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// validDynamicLabels is the set of allowed dynamic label names.
+var validDynamicLabels = map[string]struct{}{
+	"app_name":       {},
+	"host":           {},
+	"pid":            {},
+	"event_type":     {},
+	"event_category": {},
+	"severity":       {},
+}
+
+// BasicAuth holds HTTP basic authentication credentials.
+type BasicAuth struct {
+	Username string
+	Password string
+}
+
+// LabelConfig controls which fields become Loki stream labels.
+type LabelConfig struct {
+	// Static labels are constant across all events from this output.
+	// Keys must match [a-zA-Z_][a-zA-Z0-9_]* (Loki requirement).
+	Static map[string]string
+
+	// Dynamic controls which per-event fields become labels.
+	// Zero value means all dynamic labels are included.
+	Dynamic DynamicLabels
+}
+
+// DynamicLabels toggles which per-event fields become Loki stream
+// labels. All fields default to included (zero value = include).
+// Set Exclude* to true to remove a field from labels.
+type DynamicLabels struct {
+	ExcludeAppName       bool
+	ExcludeHost          bool
+	ExcludePID           bool
+	ExcludeEventType     bool
+	ExcludeEventCategory bool
+	ExcludeSeverity      bool
+}
+
+// Config holds configuration for the Loki [Output].
+type Config struct { //nolint:govet // fieldalignment: readability preferred
+	// URL is the full Loki push API endpoint, including path.
+	// Example: "https://loki:3100/loki/api/v1/push"
+	// REQUIRED; must be https unless AllowInsecureHTTP is true.
+	URL string
+
+	// BasicAuth configures HTTP basic authentication. Mutually
+	// exclusive with BearerToken.
+	BasicAuth *BasicAuth
+
+	// BearerToken sets the Authorization: Bearer header. Mutually
+	// exclusive with BasicAuth.
+	BearerToken string
+
+	// TenantID sets the X-Scope-OrgID header for Loki multi-tenancy.
+	TenantID string
+
+	// Headers are additional HTTP headers sent with every push request.
+	Headers map[string]string
+
+	// Labels controls stream label configuration.
+	Labels LabelConfig
+
+	// TLS configuration.
+	TLSCA     string
+	TLSCert   string
+	TLSKey    string
+	TLSPolicy *audit.TLSPolicy
+
+	// Batching.
+	BatchSize     int           // Max events per push (default 100, max 10000)
+	MaxBatchBytes int           // Max uncompressed bytes per push (default 1MB, max 10MB)
+	FlushInterval time.Duration // Max time between pushes (default 5s)
+	BufferSize    int           // Internal event buffer capacity (default 10000)
+	Timeout       time.Duration // HTTP request timeout (default 10s)
+	MaxRetries    int           // Retry count for 429/5xx (default 3, max 20)
+
+	// Compress enables gzip compression of push requests (default true).
+	Compress bool
+
+	// AllowInsecureHTTP permits http:// URLs. MUST NOT be true in
+	// production.
+	AllowInsecureHTTP bool
+
+	// AllowPrivateRanges permits connections to RFC 1918 private
+	// addresses. Intended for testing and private deployments.
+	AllowPrivateRanges bool
+}
+
+// String returns a safe representation of the config without credentials.
+func (c *Config) String() string {
+	auth := "none"
+	if c.BasicAuth != nil {
+		auth = "basic_auth"
+	} else if c.BearerToken != "" {
+		auth = "bearer_token"
+	}
+	return fmt.Sprintf("LokiConfig{url=%q, auth=%s, compress=%t, batch_size=%d}",
+		c.URL, auth, c.Compress, c.BatchSize)
+}
+
+// GoString implements [fmt.GoStringer] to prevent credential leakage via %#v.
+func (c *Config) GoString() string { return c.String() }
+
+// Format implements [fmt.Formatter] to prevent credential leakage via %+v.
+func (c *Config) Format(f fmt.State, _ rune) {
+	_, _ = fmt.Fprint(f, c.String())
+}
+
+// GoString implements [fmt.GoStringer] to prevent credential leakage via %#v.
+func (ba BasicAuth) GoString() string { return "BasicAuth{REDACTED}" }
+
+// validateLokiConfig validates the config and applies defaults.
+// It modifies cfg in place (applying defaults) and returns an error
+// if any field is invalid.
+func validateLokiConfig(cfg *Config) error {
+	if err := validateLokiURL(cfg); err != nil {
+		return err
+	}
+
+	if cfg.BasicAuth != nil && cfg.BearerToken != "" {
+		return fmt.Errorf("%w: loki: basic_auth and bearer_token are mutually exclusive", audit.ErrConfigInvalid)
+	}
+
+	if cfg.BasicAuth != nil && cfg.BasicAuth.Username == "" {
+		return fmt.Errorf("%w: loki: basic_auth.username must not be empty", audit.ErrConfigInvalid)
+	}
+
+	if (cfg.TLSCert != "") != (cfg.TLSKey != "") {
+		return fmt.Errorf("%w: loki: tls_cert and tls_key must both be set or both empty", audit.ErrConfigInvalid)
+	}
+
+	if err := validateStaticLabels(cfg.Labels.Static); err != nil {
+		return err
+	}
+
+	applyLokiDefaults(cfg)
+
+	if err := validateLokiBounds(cfg); err != nil {
+		return err
+	}
+
+	return validateHeaders(cfg.Headers)
+}
+
+// validateLokiURL checks the URL field for presence, scheme, and credentials.
+func validateLokiURL(cfg *Config) error {
+	if cfg.URL == "" {
+		return fmt.Errorf("%w: loki: url must not be empty", audit.ErrConfigInvalid)
+	}
+
+	u, err := url.Parse(cfg.URL)
+	if err != nil {
+		return fmt.Errorf("%w: loki: invalid url: %w", audit.ErrConfigInvalid, err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%w: loki: url scheme must be http or https, got %q", audit.ErrConfigInvalid, u.Scheme)
+	}
+
+	if u.Scheme == "http" && !cfg.AllowInsecureHTTP {
+		return fmt.Errorf("%w: loki: url must be https (got %q); set allow_insecure_http for testing", audit.ErrConfigInvalid, u.Scheme)
+	}
+
+	if u.User != nil {
+		return fmt.Errorf("%w: loki: url must not contain credentials; use basic_auth for authentication", audit.ErrConfigInvalid)
+	}
+
+	return nil
+}
+
+// validateStaticLabels checks that all static label names match the Loki
+// label name pattern and have non-empty values.
+func validateStaticLabels(labels map[string]string) error {
+	for name, val := range labels {
+		if !validLabelName.MatchString(name) {
+			return fmt.Errorf("%w: loki: static label name %q is invalid: must match [a-zA-Z_][a-zA-Z0-9_]*", audit.ErrConfigInvalid, name)
+		}
+		if val == "" {
+			return fmt.Errorf("%w: loki: static label %q has empty value", audit.ErrConfigInvalid, name)
+		}
+	}
+	return nil
+}
+
+// applyLokiDefaults fills zero-value fields with documented defaults.
+func applyLokiDefaults(cfg *Config) {
+	if cfg.BatchSize == 0 {
+		cfg.BatchSize = DefaultBatchSize
+	}
+	if cfg.MaxBatchBytes == 0 {
+		cfg.MaxBatchBytes = DefaultMaxBatchBytes
+	}
+	if cfg.FlushInterval == 0 {
+		cfg.FlushInterval = DefaultFlushInterval
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.MaxRetries == 0 {
+		cfg.MaxRetries = DefaultMaxRetries
+	}
+	if cfg.BufferSize == 0 {
+		cfg.BufferSize = DefaultBufferSize
+	}
+}
+
+// validateLokiBounds checks that all numeric/duration fields are within
+// documented bounds. Must be called after applyLokiDefaults.
+func validateLokiBounds(cfg *Config) error {
+	if err := checkIntBound("batch_size", cfg.BatchSize, 1, MaxBatchSize); err != nil {
+		return err
+	}
+	if err := checkIntBound("max_batch_bytes", cfg.MaxBatchBytes, MinMaxBatchBytes, MaxMaxBatchBytes); err != nil {
+		return err
+	}
+	if err := checkDurBound("flush_interval", cfg.FlushInterval, MinFlushInterval, MaxFlushInterval); err != nil {
+		return err
+	}
+	if err := checkDurBound("timeout", cfg.Timeout, MinTimeout, MaxTimeout); err != nil {
+		return err
+	}
+	if err := checkIntBound("max_retries", cfg.MaxRetries, 1, MaxMaxRetries); err != nil {
+		return err
+	}
+	return checkIntBound("buffer_size", cfg.BufferSize, MinBufferSize, MaxBufferSize)
+}
+
+func checkIntBound(name string, val, lo, hi int) error {
+	if val < lo || val > hi {
+		return fmt.Errorf("%w: loki: %s %d out of range [%d, %d]", audit.ErrConfigInvalid, name, val, lo, hi)
+	}
+	return nil
+}
+
+func checkDurBound(name string, val, lo, hi time.Duration) error {
+	if val < lo || val > hi {
+		return fmt.Errorf("%w: loki: %s %s out of range [%s, %s]", audit.ErrConfigInvalid, name, val, lo, hi)
+	}
+	return nil
+}
+
+// restrictedHeaders are header names managed by the library. Consumers
+// must use the dedicated Config fields (BasicAuth, BearerToken, TenantID)
+// instead of setting these via the Headers map.
+var restrictedHeaders = map[string]struct{}{
+	"authorization":    {},
+	"x-scope-orgid":    {},
+	"content-type":     {},
+	"content-encoding": {},
+	"host":             {},
+}
+
+// validateHeaders checks for CRLF injection and restricted header names.
+func validateHeaders(headers map[string]string) error {
+	for k, v := range headers {
+		if strings.ContainsAny(k, "\r\n") || strings.ContainsAny(v, "\r\n") {
+			return fmt.Errorf("%w: loki: header %q contains CR/LF", audit.ErrConfigInvalid, k)
+		}
+		if _, blocked := restrictedHeaders[strings.ToLower(k)]; blocked {
+			return fmt.Errorf("%w: loki: header %q is managed by the library; use the dedicated config field", audit.ErrConfigInvalid, k)
+		}
+	}
+	return nil
+}
+
+// buildLokiTLSConfig creates a TLS configuration from the Loki config.
+// Warnings from TLS policy application are returned for the caller to log.
+func buildLokiTLSConfig(cfg *Config) (*tls.Config, []string, error) {
+	var tlsCfg *tls.Config
+	var warnings []string
+	if cfg.TLSPolicy != nil {
+		tlsCfg, warnings = cfg.TLSPolicy.Apply(nil)
+	}
+
+	if tlsCfg == nil {
+		tlsCfg = &tls.Config{MinVersion: tls.VersionTLS13}
+	}
+
+	if cfg.TLSCert != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("audit: loki: load client certificate: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	if cfg.TLSCA != "" {
+		caPEM, err := os.ReadFile(cfg.TLSCA)
+		if err != nil {
+			return nil, nil, fmt.Errorf("audit: loki: read CA certificate: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, nil, fmt.Errorf("audit: loki: CA certificate contains no valid PEM blocks")
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	return tlsCfg, warnings, nil
+}

--- a/loki/config_test.go
+++ b/loki/config_test.go
@@ -1,0 +1,721 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	audit "github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/loki"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// TestValidateConfig — exhaustive table-driven validation cases
+// ---------------------------------------------------------------------------
+
+func TestValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct { //nolint:govet // fieldalignment: readability preferred
+		name    string
+		cfg     loki.Config
+		wantErr string // substring that must appear in err.Error(); empty means no error expected
+	}{
+		// --- URL presence and form ----------------------------------------
+		{
+			name:    "empty URL rejected",
+			cfg:     loki.Config{},
+			wantErr: "url must not be empty",
+		},
+		{
+			name:    "unparseable URL rejected",
+			cfg:     loki.Config{URL: "://not-a-url"},
+			wantErr: "invalid url",
+		},
+		{
+			name:    "ftp scheme rejected",
+			cfg:     loki.Config{URL: "ftp://logs.example.com/push"},
+			wantErr: "scheme must be http or https",
+		},
+		{
+			name:    "ws scheme rejected",
+			cfg:     loki.Config{URL: "ws://logs.example.com/push"},
+			wantErr: "scheme must be http or https",
+		},
+
+		// --- HTTP / HTTPS flag --------------------------------------------
+		{
+			name:    "http without AllowInsecureHTTP rejected",
+			cfg:     loki.Config{URL: "http://loki.internal:3100/loki/api/v1/push"},
+			wantErr: "must be https",
+		},
+		{
+			name: "http with AllowInsecureHTTP accepted",
+			cfg: loki.Config{
+				URL:               "http://loki.internal:3100/loki/api/v1/push",
+				AllowInsecureHTTP: true,
+			},
+		},
+		{
+			name: "https accepted without flag",
+			cfg:  loki.Config{URL: "https://loki.example.com/loki/api/v1/push"},
+		},
+
+		// --- Credentials in URL -------------------------------------------
+		{
+			name:    "credentials embedded in URL rejected",
+			cfg:     loki.Config{URL: "https://user:pass@loki.example.com/loki/api/v1/push"},
+			wantErr: "url must not contain credentials",
+		},
+		{
+			name:    "username-only in URL rejected",
+			cfg:     loki.Config{URL: "https://user@loki.example.com/loki/api/v1/push"},
+			wantErr: "url must not contain credentials",
+		},
+
+		// --- Auth mutual exclusivity --------------------------------------
+		{
+			name: "basic_auth and bearer_token mutually exclusive",
+			cfg: loki.Config{
+				URL:         "https://loki.example.com/loki/api/v1/push",
+				BasicAuth:   &loki.BasicAuth{Username: "alice", Password: "secret"},
+				BearerToken: "tok-abc123",
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "basic_auth with empty username rejected",
+			cfg: loki.Config{
+				URL:       "https://loki.example.com/loki/api/v1/push",
+				BasicAuth: &loki.BasicAuth{Username: "", Password: "secret"},
+			},
+			wantErr: "basic_auth.username must not be empty",
+		},
+		{
+			name: "basic_auth alone accepted",
+			cfg: loki.Config{
+				URL:       "https://loki.example.com/loki/api/v1/push",
+				BasicAuth: &loki.BasicAuth{Username: "alice", Password: "secret"},
+			},
+		},
+		{
+			name: "bearer_token alone accepted",
+			cfg: loki.Config{
+				URL:         "https://loki.example.com/loki/api/v1/push",
+				BearerToken: "tok-abc123",
+			},
+		},
+
+		// --- TLS cert/key pairing ----------------------------------------
+		{
+			name: "tls_cert without tls_key rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				TLSCert: "/tmp/client.crt",
+			},
+			wantErr: "tls_cert and tls_key must both be set or both empty",
+		},
+		{
+			name: "tls_key without tls_cert rejected",
+			cfg: loki.Config{
+				URL:    "https://loki.example.com/loki/api/v1/push",
+				TLSKey: "/tmp/client.key",
+			},
+			wantErr: "tls_cert and tls_key must both be set or both empty",
+		},
+		{
+			name: "tls_cert and tls_key both set accepted at validation stage",
+			// Note: file loading happens in buildLokiTLSConfig, not here.
+			// validateLokiConfig only checks that both are present together.
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				TLSCert: "/tmp/client.crt",
+				TLSKey:  "/tmp/client.key",
+			},
+		},
+
+		// --- Static label name validation --------------------------------
+		{
+			name: "static label name with hyphen rejected",
+			cfg: loki.Config{
+				URL: "https://loki.example.com/loki/api/v1/push",
+				Labels: loki.LabelConfig{
+					Static: map[string]string{"my-label": "prod"},
+				},
+			},
+			wantErr: "invalid",
+		},
+		{
+			name: "static label name starting with digit rejected",
+			cfg: loki.Config{
+				URL: "https://loki.example.com/loki/api/v1/push",
+				Labels: loki.LabelConfig{
+					Static: map[string]string{"1bad": "prod"},
+				},
+			},
+			wantErr: "invalid",
+		},
+		{
+			name: "static label name with space rejected",
+			cfg: loki.Config{
+				URL: "https://loki.example.com/loki/api/v1/push",
+				Labels: loki.LabelConfig{
+					Static: map[string]string{"bad name": "prod"},
+				},
+			},
+			wantErr: "invalid",
+		},
+		{
+			name: "static label with empty value rejected",
+			cfg: loki.Config{
+				URL: "https://loki.example.com/loki/api/v1/push",
+				Labels: loki.LabelConfig{
+					Static: map[string]string{"environment": ""},
+				},
+			},
+			wantErr: "empty value",
+		},
+		{
+			name: "static label name with underscore prefix accepted",
+			cfg: loki.Config{
+				URL: "https://loki.example.com/loki/api/v1/push",
+				Labels: loki.LabelConfig{
+					Static: map[string]string{"_private": "value"},
+				},
+			},
+		},
+		{
+			name: "static label name alphanumeric with underscores accepted",
+			cfg: loki.Config{
+				URL: "https://loki.example.com/loki/api/v1/push",
+				Labels: loki.LabelConfig{
+					Static: map[string]string{"env_name_2": "prod"},
+				},
+			},
+		},
+
+		// --- Batch size bounds -------------------------------------------
+		{
+			name: "batch_size below minimum rejected",
+			cfg: loki.Config{
+				URL:       "https://loki.example.com/loki/api/v1/push",
+				BatchSize: -1, // non-zero so default is not applied
+			},
+			wantErr: "batch_size",
+		},
+		{
+			name: "batch_size above maximum rejected",
+			cfg: loki.Config{
+				URL:       "https://loki.example.com/loki/api/v1/push",
+				BatchSize: loki.MaxBatchSize + 1,
+			},
+			wantErr: "batch_size",
+		},
+		{
+			name: "batch_size at maximum accepted",
+			cfg: loki.Config{
+				URL:       "https://loki.example.com/loki/api/v1/push",
+				BatchSize: loki.MaxBatchSize,
+			},
+		},
+
+		// --- MaxBatchBytes bounds ----------------------------------------
+		{
+			name: "max_batch_bytes below minimum rejected",
+			cfg: loki.Config{
+				URL:           "https://loki.example.com/loki/api/v1/push",
+				MaxBatchBytes: loki.MinMaxBatchBytes - 1,
+			},
+			wantErr: "max_batch_bytes",
+		},
+		{
+			name: "max_batch_bytes above maximum rejected",
+			cfg: loki.Config{
+				URL:           "https://loki.example.com/loki/api/v1/push",
+				MaxBatchBytes: loki.MaxMaxBatchBytes + 1,
+			},
+			wantErr: "max_batch_bytes",
+		},
+
+		// --- FlushInterval bounds ----------------------------------------
+		{
+			name: "flush_interval below minimum rejected",
+			cfg: loki.Config{
+				URL:           "https://loki.example.com/loki/api/v1/push",
+				FlushInterval: loki.MinFlushInterval - time.Millisecond,
+			},
+			wantErr: "flush_interval",
+		},
+		{
+			name: "flush_interval above maximum rejected",
+			cfg: loki.Config{
+				URL:           "https://loki.example.com/loki/api/v1/push",
+				FlushInterval: loki.MaxFlushInterval + time.Second,
+			},
+			wantErr: "flush_interval",
+		},
+
+		// --- Timeout bounds ----------------------------------------------
+		{
+			name: "timeout below minimum rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Timeout: loki.MinTimeout - time.Millisecond,
+			},
+			wantErr: "timeout",
+		},
+		{
+			name: "timeout above maximum rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Timeout: loki.MaxTimeout + time.Second,
+			},
+			wantErr: "timeout",
+		},
+
+		// --- MaxRetries bounds -------------------------------------------
+		// Note: MaxRetries == 0 triggers the default (3), so the minimum
+		// effective value a caller can force is 1 by setting it explicitly.
+		// Negative values are out of range.
+		{
+			name: "max_retries negative rejected",
+			cfg: loki.Config{
+				URL:        "https://loki.example.com/loki/api/v1/push",
+				MaxRetries: -1,
+			},
+			wantErr: "max_retries",
+		},
+		{
+			name: "max_retries above maximum rejected",
+			cfg: loki.Config{
+				URL:        "https://loki.example.com/loki/api/v1/push",
+				MaxRetries: loki.MaxMaxRetries + 1,
+			},
+			wantErr: "max_retries",
+		},
+		{
+			name: "max_retries at maximum accepted",
+			cfg: loki.Config{
+				URL:        "https://loki.example.com/loki/api/v1/push",
+				MaxRetries: loki.MaxMaxRetries,
+			},
+		},
+
+		// --- BufferSize bounds -------------------------------------------
+		{
+			name: "buffer_size below minimum rejected",
+			cfg: loki.Config{
+				URL:        "https://loki.example.com/loki/api/v1/push",
+				BufferSize: loki.MinBufferSize - 1,
+			},
+			wantErr: "buffer_size",
+		},
+		{
+			name: "buffer_size above maximum rejected",
+			cfg: loki.Config{
+				URL:        "https://loki.example.com/loki/api/v1/push",
+				BufferSize: loki.MaxBufferSize + 1,
+			},
+			wantErr: "buffer_size",
+		},
+		{
+			name: "buffer_size at maximum accepted",
+			cfg: loki.Config{
+				URL:        "https://loki.example.com/loki/api/v1/push",
+				BufferSize: loki.MaxBufferSize,
+			},
+		},
+		{
+			name: "buffer_size at minimum accepted",
+			cfg: loki.Config{
+				URL:        "https://loki.example.com/loki/api/v1/push",
+				BufferSize: loki.MinBufferSize,
+			},
+		},
+
+		// --- Header CRLF injection ---------------------------------------
+		{
+			name: "CRLF in header name rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Headers: map[string]string{"X-Bad\r\nHeader": "value"},
+			},
+			wantErr: "CR/LF",
+		},
+		{
+			name: "LF in header name rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Headers: map[string]string{"X-Bad\nHeader": "value"},
+			},
+			wantErr: "CR/LF",
+		},
+		{
+			name: "CRLF in header value rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Headers: map[string]string{"X-Good-Name": "injected\r\nX-Extra: evil"},
+			},
+			wantErr: "CR/LF",
+		},
+		// --- Restricted header names ----------------------------------
+		{
+			name: "Authorization header rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Headers: map[string]string{"Authorization": "Bearer evil"},
+			},
+			wantErr: "managed by the library",
+		},
+		{
+			name: "X-Scope-OrgID header rejected (case insensitive)",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Headers: map[string]string{"x-scope-orgid": "attacker-tenant"},
+			},
+			wantErr: "managed by the library",
+		},
+		{
+			name: "Content-Type header rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Headers: map[string]string{"Content-Type": "text/plain"},
+			},
+			wantErr: "managed by the library",
+		},
+		{
+			name: "Host header rejected",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Headers: map[string]string{"Host": "evil.com"},
+			},
+			wantErr: "managed by the library",
+		},
+		{
+			name: "clean header accepted",
+			cfg: loki.Config{
+				URL:     "https://loki.example.com/loki/api/v1/push",
+				Headers: map[string]string{"X-Tenant": "team-alpha"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Work on a copy so parallel subtests do not share the same struct.
+			cfg := tt.cfg
+			err := loki.ValidateLokiConfig(&cfg)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err, "expected no error for %q", tt.name)
+			} else {
+				require.Error(t, err, "expected an error containing %q for %q", tt.wantErr, tt.name)
+				assert.ErrorIs(t, err, audit.ErrConfigInvalid,
+					"validation errors must wrap audit.ErrConfigInvalid")
+				assert.Contains(t, err.Error(), tt.wantErr,
+					"error message should contain %q, got: %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestValidateConfig_Defaults — zero-value fields receive documented defaults
+// ---------------------------------------------------------------------------
+
+func TestValidateConfig_Defaults(t *testing.T) {
+	t.Parallel()
+
+	// A minimal valid config: only URL is set, all numeric/duration fields
+	// are their zero values. validateLokiConfig must fill them in.
+	cfg := loki.Config{URL: "https://loki.example.com/loki/api/v1/push"}
+
+	require.NoError(t, loki.ValidateLokiConfig(&cfg))
+
+	assert.Equal(t, loki.DefaultBatchSize, cfg.BatchSize,
+		"zero BatchSize should become loki.DefaultBatchSize")
+	assert.Equal(t, loki.DefaultMaxBatchBytes, cfg.MaxBatchBytes,
+		"zero MaxBatchBytes should become loki.DefaultMaxBatchBytes")
+	assert.Equal(t, loki.DefaultFlushInterval, cfg.FlushInterval,
+		"zero FlushInterval should become loki.DefaultFlushInterval")
+	assert.Equal(t, loki.DefaultTimeout, cfg.Timeout,
+		"zero Timeout should become loki.DefaultTimeout")
+	assert.Equal(t, loki.DefaultMaxRetries, cfg.MaxRetries,
+		"zero MaxRetries should become loki.DefaultMaxRetries")
+	assert.Equal(t, loki.DefaultBufferSize, cfg.BufferSize,
+		"zero BufferSize should become loki.DefaultBufferSize")
+}
+
+// ---------------------------------------------------------------------------
+// TestValidateConfig_BoundaryValues — all fields at documented limits pass
+// ---------------------------------------------------------------------------
+
+func TestValidateConfig_BoundaryValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all fields at maximum", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loki.Config{
+			URL:           "https://loki.example.com/loki/api/v1/push",
+			BatchSize:     loki.MaxBatchSize,
+			MaxBatchBytes: loki.MaxMaxBatchBytes,
+			FlushInterval: loki.MaxFlushInterval,
+			Timeout:       loki.MaxTimeout,
+			MaxRetries:    loki.MaxMaxRetries,
+			BufferSize:    loki.MaxBufferSize,
+		}
+		require.NoError(t, loki.ValidateLokiConfig(&cfg),
+			"all fields at documented maximum should be accepted")
+	})
+
+	t.Run("all fields at minimum", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loki.Config{
+			URL:           "https://loki.example.com/loki/api/v1/push",
+			BatchSize:     1, // minimum batch_size (zero triggers default)
+			MaxBatchBytes: loki.MinMaxBatchBytes,
+			FlushInterval: loki.MinFlushInterval,
+			Timeout:       loki.MinTimeout,
+			MaxRetries:    1, // zero triggers default; 1 is the minimum explicit value
+			BufferSize:    loki.MinBufferSize,
+		}
+		require.NoError(t, loki.ValidateLokiConfig(&cfg),
+			"all fields at documented minimum should be accepted")
+	})
+
+	t.Run("one above batch_size maximum rejected", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loki.Config{
+			URL:       "https://loki.example.com/loki/api/v1/push",
+			BatchSize: loki.MaxBatchSize + 1,
+		}
+		err := loki.ValidateLokiConfig(&cfg)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, audit.ErrConfigInvalid)
+		assert.Contains(t, err.Error(), "batch_size")
+	})
+
+	t.Run("one below max_batch_bytes minimum rejected", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loki.Config{
+			URL:           "https://loki.example.com/loki/api/v1/push",
+			MaxBatchBytes: loki.MinMaxBatchBytes - 1,
+		}
+		err := loki.ValidateLokiConfig(&cfg)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, audit.ErrConfigInvalid)
+		assert.Contains(t, err.Error(), "max_batch_bytes")
+	})
+
+	t.Run("one above buffer_size maximum rejected", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loki.Config{
+			URL:        "https://loki.example.com/loki/api/v1/push",
+			BufferSize: loki.MaxBufferSize + 1,
+		}
+		err := loki.ValidateLokiConfig(&cfg)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, audit.ErrConfigInvalid)
+		assert.Contains(t, err.Error(), "buffer_size")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestConfigString_Redaction — String() must not expose credentials
+// ---------------------------------------------------------------------------
+
+func TestConfigString_Redaction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no auth shows none", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &loki.Config{URL: "https://loki.example.com/loki/api/v1/push", BatchSize: 50}
+		s := cfg.String()
+
+		assert.Contains(t, s, "https://loki.example.com/loki/api/v1/push",
+			"String() must include the URL")
+		assert.Contains(t, s, "none",
+			"String() must show auth=none when no credentials are set")
+	})
+
+	t.Run("basic auth hides both username and password", func(t *testing.T) {
+		t.Parallel()
+
+		const username = "alice"
+		const password = "super-secret-pass"
+
+		cfg := &loki.Config{
+			URL:       "https://loki.example.com/loki/api/v1/push",
+			BasicAuth: &loki.BasicAuth{Username: username, Password: password},
+			BatchSize: 50,
+		}
+		s := cfg.String()
+
+		assert.NotContains(t, s, username,
+			"String() must NOT expose the basic auth username")
+		assert.NotContains(t, s, password,
+			"String() must NOT expose the basic auth password")
+		assert.Contains(t, s, "basic_auth",
+			"String() must indicate the auth type is basic_auth")
+	})
+
+	t.Run("bearer token hides token value", func(t *testing.T) {
+		t.Parallel()
+
+		const secret = "eyJhbGciOiJSUzI1NiJ9.super-secret-jwt-payload"
+
+		cfg := &loki.Config{
+			URL:         "https://loki.example.com/loki/api/v1/push",
+			BearerToken: secret,
+			BatchSize:   50,
+		}
+		s := cfg.String()
+
+		assert.NotContains(t, s, secret,
+			"String() must NOT expose the bearer token value")
+		assert.True(t, strings.Contains(s, "bearer_token"),
+			"String() must indicate the auth type is bearer_token")
+	})
+
+	t.Run("Format prevents credential leak via %+v", func(t *testing.T) {
+		t.Parallel()
+
+		const password = "format-leak-secret"
+		cfg := &loki.Config{
+			URL:       "https://loki.example.com/loki/api/v1/push",
+			BasicAuth: &loki.BasicAuth{Username: "user", Password: password},
+		}
+		s := fmt.Sprintf("%+v", cfg)
+		assert.NotContains(t, s, password,
+			"%%+v must NOT expose credentials; Format() should intercept all verbs")
+	})
+
+	t.Run("GoString prevents credential leak via %#v", func(t *testing.T) {
+		t.Parallel()
+
+		const token = "gosstring-leak-token"
+		cfg := &loki.Config{
+			URL:         "https://loki.example.com/loki/api/v1/push",
+			BearerToken: token,
+		}
+		s := fmt.Sprintf("%#v", cfg)
+		assert.NotContains(t, s, token,
+			"%%#v must NOT expose credentials; GoString() should intercept")
+	})
+
+	t.Run("BasicAuth GoString redacts credentials", func(t *testing.T) {
+		t.Parallel()
+
+		ba := loki.BasicAuth{Username: "alice", Password: "secret-password"}
+		s := fmt.Sprintf("%#v", ba)
+		assert.NotContains(t, s, "alice",
+			"BasicAuth GoString must not expose username")
+		assert.NotContains(t, s, "secret-password",
+			"BasicAuth GoString must not expose password")
+		assert.Contains(t, s, "REDACTED")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestBuildLokiTLSConfig — TLS configuration building
+// ---------------------------------------------------------------------------
+
+func TestBuildLokiTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil TLSPolicy defaults to TLS 1.3", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &loki.Config{URL: "https://loki.example.com/push"}
+		tlsCfg, warnings, err := loki.BuildLokiTLSConfig(cfg)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+		assert.Equal(t, uint16(tls.VersionTLS13), tlsCfg.MinVersion,
+			"default TLS config must require TLS 1.3")
+		assert.Empty(t, tlsCfg.Certificates)
+		assert.Nil(t, tlsCfg.RootCAs)
+	})
+
+	t.Run("TLSPolicy applies overrides", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &loki.Config{
+			URL:       "https://loki.example.com/push",
+			TLSPolicy: &audit.TLSPolicy{AllowTLS12: true},
+		}
+		tlsCfg, _, err := loki.BuildLokiTLSConfig(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, uint16(tls.VersionTLS12), tlsCfg.MinVersion,
+			"AllowTLS12 should set minimum to TLS 1.2")
+	})
+
+	t.Run("invalid cert path returns error", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &loki.Config{
+			URL:     "https://loki.example.com/push",
+			TLSCert: "/nonexistent/client.crt",
+			TLSKey:  "/nonexistent/client.key",
+		}
+		_, _, err := loki.BuildLokiTLSConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "load client certificate")
+	})
+
+	t.Run("invalid CA path returns error", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &loki.Config{
+			URL:   "https://loki.example.com/push",
+			TLSCA: "/nonexistent/ca.pem",
+		}
+		_, _, err := loki.BuildLokiTLSConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read CA certificate")
+	})
+
+	t.Run("invalid CA PEM returns error", func(t *testing.T) {
+		t.Parallel()
+
+		// Write a temporary file that is not valid PEM.
+		dir := t.TempDir()
+		caFile := filepath.Join(dir, "bad-ca.pem")
+		require.NoError(t, os.WriteFile(caFile, []byte("not-pem-data"), 0o600))
+
+		cfg := &loki.Config{
+			URL:   "https://loki.example.com/push",
+			TLSCA: caFile,
+		}
+		_, _, err := loki.BuildLokiTLSConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no valid PEM blocks")
+	})
+}

--- a/loki/doc.go
+++ b/loki/doc.go
@@ -1,0 +1,48 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package loki provides a Grafana Loki output for the go-audit library.
+//
+// The output pushes audit events to a Loki instance via the HTTP Push
+// API (POST /loki/api/v1/push). Events are batched and delivered as
+// JSON-encoded push requests with configurable stream labels, gzip
+// compression, multi-tenant support, and TLS.
+//
+// # Stream Labels
+//
+// Users control which fields become Loki stream labels via the Labels
+// configuration. Static labels (e.g., job, environment) are constant
+// across all events. Dynamic labels (event_type, severity,
+// event_category, app_name, host, pid) are derived per-event from
+// [audit.EventMetadata] via the [audit.MetadataWriter] interface.
+//
+// Custom user-defined fields are never labels — they stay in the log
+// line and are queryable via LogQL JSON parsing:
+//
+//	{event_type="auth_failure"} | json | actor_id="alice"
+//
+// # Batching
+//
+// Events are buffered internally and flushed when the batch reaches
+// [Config.BatchSize] events, [Config.MaxBatchBytes] total payload
+// bytes, or [Config.FlushInterval] elapses — whichever comes first.
+// The [Output.Close] method flushes any remaining events.
+//
+// # Import
+//
+// Import this package for its side effect of registering the "loki"
+// output type with the audit output registry:
+//
+//	import _ "github.com/axonops/go-audit/loki"
+package loki

--- a/loki/export_test.go
+++ b/loki/export_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki
+
+// Exported aliases for internal functions needed by black-box tests.
+var (
+	ValidateLokiConfig = validateLokiConfig
+	BuildLokiTLSConfig = buildLokiTLSConfig
+)

--- a/loki/go.mod
+++ b/loki/go.mod
@@ -1,0 +1,17 @@
+module github.com/axonops/go-audit/loki
+
+go 1.26.1
+
+require (
+	github.com/axonops/go-audit v0.0.0
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rgooding/go-syncmap v1.0.1 // indirect
+)
+
+replace github.com/axonops/go-audit => ..

--- a/loki/go.sum
+++ b/loki/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rgooding/go-syncmap v1.0.1 h1:FNG1ers6J1Y/IGHLd8Su8xrp0mVLNW1pxQhpvhJPFGE=
+github.com/rgooding/go-syncmap v1.0.1/go.mod h1:2A4vkLQnpUge7GRBXTMpu77N5JIV1yFPM4RdrY0e754=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/loki/register.go
+++ b/loki/register.go
@@ -1,0 +1,201 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	audit "github.com/axonops/go-audit"
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	audit.RegisterOutputFactory("loki", defaultFactory)
+}
+
+// defaultFactory creates a Loki output from YAML config. Core metrics
+// are forwarded (Loki needs them for delivery reporting). Loki-specific
+// metrics are nil — consumers who want them should register via
+// [NewFactory] before calling the config loader.
+func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
+	return buildOutput(name, rawConfig, coreMetrics, nil)
+}
+
+// NewFactory returns an [audit.OutputFactory] that creates Loki outputs
+// from YAML configuration with the provided Loki-specific metrics
+// captured in the closure. Pass nil to disable Loki metrics.
+func NewFactory(lokiMetrics Metrics) audit.OutputFactory {
+	return func(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
+		return buildOutput(name, rawConfig, coreMetrics, lokiMetrics)
+	}
+}
+
+// yamlLokiConfig is the YAML-specific representation of Loki output
+// configuration. Maps snake_case YAML fields to the Go Config struct.
+type yamlLokiConfig struct { //nolint:govet // fieldalignment: readability preferred
+	URL        string            `yaml:"url"`
+	BasicAuth  *yamlBasicAuth    `yaml:"basic_auth"`
+	BearerTkn  string            `yaml:"bearer_token"`
+	TenantID   string            `yaml:"tenant_id"`
+	Headers    map[string]string `yaml:"headers"`
+	Labels     *yamlLabelConfig  `yaml:"labels"`
+	TLSCA      string            `yaml:"tls_ca"`
+	TLSCert    string            `yaml:"tls_cert"`
+	TLSKey     string            `yaml:"tls_key"`
+	TLSPolicy  *yamlTLSPolicy    `yaml:"tls_policy"`
+	BatchSize  int               `yaml:"batch_size"`
+	MaxBatchB  int               `yaml:"max_batch_bytes"`
+	FlushIvl   yamlDuration      `yaml:"flush_interval"`
+	BufferSize int               `yaml:"buffer_size"`
+	Timeout    yamlDuration      `yaml:"timeout"`
+	MaxRetries int               `yaml:"max_retries"`
+	Compress   *bool             `yaml:"gzip"` // YAML key is "gzip" for user clarity; maps to Compress
+	AllowHTTP  bool              `yaml:"allow_insecure_http"`
+	AllowPriv  bool              `yaml:"allow_private_ranges"`
+}
+
+type yamlBasicAuth struct {
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}
+
+type yamlLabelConfig struct {
+	Static  map[string]string `yaml:"static"`
+	Dynamic map[string]bool   `yaml:"dynamic"`
+}
+
+type yamlTLSPolicy struct {
+	AllowTLS12       bool `yaml:"allow_tls12"`
+	AllowWeakCiphers bool `yaml:"allow_weak_ciphers"`
+}
+
+// yamlDuration is a time.Duration that unmarshals from a YAML string.
+type yamlDuration time.Duration
+
+func (d *yamlDuration) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return fmt.Errorf("decode duration: %w", err)
+	}
+	parsed, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	*d = yamlDuration(parsed)
+	return nil
+}
+
+func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics, lokiMetrics Metrics) (audit.Output, error) {
+	if len(rawConfig) == 0 {
+		return nil, fmt.Errorf("audit: loki output %q: config is required", name)
+	}
+
+	var yc yamlLokiConfig
+	dec := yaml.NewDecoder(bytes.NewReader(rawConfig))
+	dec.KnownFields(true)
+	if err := dec.Decode(&yc); err != nil {
+		return nil, fmt.Errorf("audit: loki output %q: %w", name, err)
+	}
+
+	cfg := &Config{
+		URL:                yc.URL,
+		BearerToken:        yc.BearerTkn,
+		TenantID:           yc.TenantID,
+		Headers:            yc.Headers,
+		TLSCA:              yc.TLSCA,
+		TLSCert:            yc.TLSCert,
+		TLSKey:             yc.TLSKey,
+		BatchSize:          yc.BatchSize,
+		MaxBatchBytes:      yc.MaxBatchB,
+		FlushInterval:      time.Duration(yc.FlushIvl),
+		BufferSize:         yc.BufferSize,
+		Timeout:            time.Duration(yc.Timeout),
+		MaxRetries:         yc.MaxRetries,
+		AllowInsecureHTTP:  yc.AllowHTTP,
+		AllowPrivateRanges: yc.AllowPriv,
+	}
+
+	// Basic auth.
+	if yc.BasicAuth != nil {
+		cfg.BasicAuth = &BasicAuth{
+			Username: yc.BasicAuth.Username,
+			Password: yc.BasicAuth.Password,
+		}
+	}
+
+	// TLS policy.
+	if yc.TLSPolicy != nil {
+		cfg.TLSPolicy = &audit.TLSPolicy{
+			AllowTLS12:       yc.TLSPolicy.AllowTLS12,
+			AllowWeakCiphers: yc.TLSPolicy.AllowWeakCiphers,
+		}
+	}
+
+	// Gzip: default true, explicit false overrides.
+	if yc.Compress != nil {
+		cfg.Compress = *yc.Compress
+	} else {
+		cfg.Compress = true
+	}
+
+	// Labels.
+	if yc.Labels != nil {
+		cfg.Labels.Static = yc.Labels.Static
+		if yc.Labels.Dynamic != nil {
+			if err := parseDynamicLabels(yc.Labels.Dynamic, &cfg.Labels.Dynamic); err != nil {
+				return nil, fmt.Errorf("audit: loki output %q: %w", name, err)
+			}
+		}
+	}
+
+	// Validate config.
+	if err := validateLokiConfig(cfg); err != nil {
+		return nil, fmt.Errorf("audit: loki output %q: %w", name, err)
+	}
+
+	// New() not yet implemented — Phase 2 of #251 adds the Output constructor.
+	_ = coreMetrics
+	_ = lokiMetrics
+	return nil, fmt.Errorf("audit: loki output %q: not yet implemented", name)
+}
+
+// parseDynamicLabels converts the YAML dynamic labels map into the
+// DynamicLabels struct. Unknown label names are rejected.
+func parseDynamicLabels(m map[string]bool, dl *DynamicLabels) error {
+	for name, enabled := range m {
+		if _, ok := validDynamicLabels[name]; !ok {
+			return fmt.Errorf("%w: loki: unknown dynamic label %q: valid labels are app_name, host, pid, event_type, event_category, severity", audit.ErrConfigInvalid, name)
+		}
+		if !enabled {
+			switch name {
+			case "app_name":
+				dl.ExcludeAppName = true
+			case "host":
+				dl.ExcludeHost = true
+			case "pid":
+				dl.ExcludePID = true
+			case "event_type":
+				dl.ExcludeEventType = true
+			case "event_category":
+				dl.ExcludeEventCategory = true
+			case "severity":
+				dl.ExcludeSeverity = true
+			}
+		}
+	}
+	return nil
+}

--- a/loki/register_test.go
+++ b/loki/register_test.go
@@ -1,0 +1,477 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	audit "github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/loki"
+)
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_RegisteredByInit verifies that importing the loki package
+// (for its side effect) registers a factory under the "loki" key. This is the
+// fundamental contract of the package: blank-import registers the output type.
+func TestLokiFactory_RegisteredByInit(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory, "loki factory must be registered by init(); import _ \"github.com/axonops/go-audit/loki\" was performed")
+}
+
+// ---------------------------------------------------------------------------
+// Basic factory error paths
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_EmptyConfig verifies that passing nil config bytes returns
+// a clear error indicating that a config block is required.
+func TestLokiFactory_EmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	_, err := factory("my_loki", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config is required",
+		"empty config should produce 'config is required' error, got: %q", err.Error())
+}
+
+// TestLokiFactory_UnknownField verifies that the YAML decoder runs in strict
+// mode (KnownFields(true)), so an unrecognised field causes a clear decode
+// error. This prevents silent misconfiguration.
+func TestLokiFactory_UnknownField(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\nunknown_field: oops\n")
+	_, err := factory("strict_loki", rawYAML, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown_field",
+		"strict YAML decode should name the unexpected field, got: %q", err.Error())
+}
+
+// ---------------------------------------------------------------------------
+// Duration field parsing
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_DurationParsing exercises the custom yamlDuration type for
+// flush_interval and timeout. Valid Go duration strings are accepted; bare
+// integers and non-duration strings are rejected at decode time.
+func TestLokiFactory_DurationParsing(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name:    "seconds suffix accepted",
+			yaml:    "url: https://loki.example.com/loki/api/v1/push\nflush_interval: 5s\n",
+			wantErr: false,
+		},
+		{
+			name:    "milliseconds suffix accepted",
+			yaml:    "url: https://loki.example.com/loki/api/v1/push\ntimeout: 100ms\n",
+			wantErr: false,
+		},
+		{
+			name:    "minutes suffix accepted",
+			yaml:    "url: https://loki.example.com/loki/api/v1/push\nflush_interval: 1m\n",
+			wantErr: false,
+		},
+		{
+			name: "zero duration string accepted",
+			// 0s is a valid Go duration; validateLokiConfig replaces zero
+			// flush_interval with the default, so this should not error.
+			yaml:    "url: https://loki.example.com/loki/api/v1/push\nflush_interval: 0s\n",
+			wantErr: false,
+		},
+		{
+			name:    "non-duration string rejected",
+			yaml:    "url: https://loki.example.com/loki/api/v1/push\nflush_interval: banana\n",
+			wantErr: true,
+		},
+		{
+			name: "bare integer without suffix rejected",
+			// Go time.ParseDuration requires a unit suffix; "5" is not valid.
+			yaml:    "url: https://loki.example.com/loki/api/v1/push\nflush_interval: 5\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := factory("dur_test", []byte(tt.yaml), nil)
+			if tt.wantErr {
+				require.Error(t, err, "expected a parse error for YAML: %s", tt.yaml)
+				// The error must mention duration, not something unrelated.
+				assert.Contains(t, err.Error(), "duration",
+					"error for invalid duration should mention 'duration', got: %q", err.Error())
+			} else if err != nil {
+				// A valid config may still return "not yet implemented" — that is
+				// acceptable here. What must NOT happen is a duration-parse error.
+				assert.NotContains(t, err.Error(), "duration",
+					"a valid duration string must not produce a duration parse error; got: %q", err.Error())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth mutual exclusivity
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_BasicAuthAndBearerToken_Rejected verifies that the factory
+// rejects configurations that set both basic_auth and bearer_token. These are
+// mutually exclusive authentication mechanisms.
+func TestLokiFactory_BasicAuthAndBearerToken_Rejected(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	rawYAML := []byte(`
+url: https://loki.example.com/loki/api/v1/push
+basic_auth:
+  username: alice
+  password: secret
+bearer_token: tok-should-not-coexist
+`)
+	_, err := factory("conflict_auth", rawYAML, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid,
+		"auth conflict must wrap audit.ErrConfigInvalid")
+	assert.Contains(t, err.Error(), "mutually exclusive",
+		"basic_auth + bearer_token must be rejected with 'mutually exclusive', got: %q", err.Error())
+}
+
+// ---------------------------------------------------------------------------
+// Gzip / compress defaults
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_GzipDefaultTrue verifies that omitting the "gzip" field
+// from the YAML config results in compression being enabled. This is the
+// documented default (Compress: true) and must be preserved by the factory.
+// The config passes validation and reaches the "not yet implemented" gate.
+func TestLokiFactory_GzipDefaultTrue(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\n")
+	_, err := factory("gzip_default", rawYAML, nil)
+
+	// Phase 1: a valid config is rejected only by the "not yet implemented"
+	// sentinel — the gzip field itself must not cause an error.
+	require.Error(t, err, "factory should return error in Phase 1")
+	assert.Contains(t, err.Error(), "not yet implemented",
+		"a valid config with no gzip field must reach Phase 1 sentinel, got: %q", err.Error())
+}
+
+// TestLokiFactory_GzipExplicitFalse verifies that explicitly setting
+// "gzip: false" is accepted by the factory. The field exists and its false
+// value is a valid override of the default.
+func TestLokiFactory_GzipExplicitFalse(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\ngzip: false\n")
+	_, err := factory("gzip_explicit_false", rawYAML, nil)
+
+	require.Error(t, err, "factory should return error in Phase 1")
+	assert.Contains(t, err.Error(), "not yet implemented",
+		"gzip: false must be accepted and reach Phase 1 sentinel, got: %q", err.Error())
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic label validation
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_DynamicLabels_UnknownName verifies that unknown dynamic
+// label names are rejected. The set of valid dynamic labels is fixed:
+// app_name, host, pid, event_type, event_category, severity.
+func TestLokiFactory_DynamicLabels_UnknownName(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	rawYAML := []byte(`
+url: https://loki.example.com/loki/api/v1/push
+labels:
+  dynamic:
+    actor_id: true
+`)
+	_, err := factory("bad_dynamic_label", rawYAML, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid,
+		"unknown dynamic label must wrap audit.ErrConfigInvalid")
+	assert.Contains(t, err.Error(), "unknown dynamic label",
+		"unrecognised dynamic label name must produce 'unknown dynamic label' error, got: %q", err.Error())
+}
+
+// ---------------------------------------------------------------------------
+// Static label validation
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_StaticLabels_InvalidName verifies that static label names
+// that do not match the Loki label name pattern [a-zA-Z_][a-zA-Z0-9_]* are
+// rejected. Hyphens, dots, and spaces are not valid.
+func TestLokiFactory_StaticLabels_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	tests := []struct {
+		name      string
+		labelName string
+	}{
+		{"hyphen in name", "my-label"},
+		{"dot in name", "my.label"},
+		{"starts with digit", "2bad"},
+		{"space in name", "bad name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\nlabels:\n  static:\n    " + tt.labelName + ": somevalue\n")
+			_, err := factory("invalid_label_"+tt.name, rawYAML, nil)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrConfigInvalid,
+				"invalid static label must wrap audit.ErrConfigInvalid")
+			assert.Contains(t, err.Error(), "invalid",
+				"static label name %q must be rejected as invalid, got: %q", tt.labelName, err.Error())
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 sentinel — valid configs reach "not yet implemented"
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_ValidConfig_ReturnsNotYetImplemented documents the current
+// Phase 1 state: the factory validates config correctly but returns a
+// "not yet implemented" error because the output constructor is not yet built.
+// This test MUST be updated when Phase 2 (New()) is implemented.
+func TestLokiFactory_ValidConfig_ReturnsNotYetImplemented(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	rawYAML := []byte(`
+url: https://loki.example.com/loki/api/v1/push
+batch_size: 50
+flush_interval: 10s
+timeout: 5s
+max_retries: 2
+buffer_size: 500
+`)
+	_, err := factory("phase1", rawYAML, nil)
+	require.Error(t, err, "Phase 1 factory must return an error")
+	assert.Contains(t, err.Error(), "not yet implemented",
+		"Phase 1 factory must return 'not yet implemented' for a valid config, got: %q", err.Error())
+}
+
+// TestLokiFactory_ValidConfig_WithAllAuthOptions verifies that each auth
+// variant (none, basic, bearer) passes validation in isolation.
+func TestLokiFactory_ValidConfig_WithAllAuthOptions(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "no auth",
+			yaml: "url: https://loki.example.com/loki/api/v1/push\n",
+		},
+		{
+			name: "basic auth",
+			yaml: "url: https://loki.example.com/loki/api/v1/push\nbasic_auth:\n  username: alice\n  password: s3cr3t\n",
+		},
+		{
+			name: "bearer token",
+			yaml: "url: https://loki.example.com/loki/api/v1/push\nbearer_token: tok-abc123\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := factory("auth_test", []byte(tt.yaml), nil)
+			// Each auth variant must pass validation and reach the Phase 1 gate.
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not yet implemented",
+				"%s auth variant should reach Phase 1 sentinel, got: %q", tt.name, err.Error())
+		})
+	}
+}
+
+// TestLokiFactory_NewFactory_NilMetrics verifies that NewFactory(nil) returns
+// a working factory function. Nil metrics is an explicitly supported path
+// (disables Loki-specific metric collection).
+func TestLokiFactory_NewFactory_NilMetrics(t *testing.T) {
+	t.Parallel()
+
+	// Import the loki package has already registered the default factory.
+	// NewFactory returns a separate factory with custom metrics wiring.
+	// We call it directly here via the loki package (external test).
+	// Since register_test.go is in package loki_test, we cannot call
+	// loki.NewFactory without importing it by name — which we can do
+	// through the side-effect import above.
+	//
+	// We exercise this path indirectly: the default factory (registered by
+	// init) uses nil lokiMetrics internally. A valid config must still reach
+	// the Phase 1 sentinel rather than panicking on nil metrics.
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	_, err := factory("nil_metrics_path", []byte("url: https://loki.example.com/loki/api/v1/push\n"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not yet implemented",
+		"nil coreMetrics must not panic; got: %q", err.Error())
+}
+
+// TestLokiFactory_NewFactory_WithMetrics verifies that NewFactory with a
+// non-nil Metrics implementation returns a factory that behaves identically
+// to the default factory in terms of config validation and Phase 1 status.
+func TestLokiFactory_NewFactory_WithMetrics(t *testing.T) {
+	t.Parallel()
+
+	metrics := &mockLokiMetrics{}
+	factory := loki.NewFactory(metrics)
+	require.NotNil(t, factory, "NewFactory must return a non-nil factory")
+
+	_, err := factory("custom_metrics", []byte("url: https://loki.example.com/loki/api/v1/push\n"), nil)
+	require.Error(t, err, "Phase 1: factory must return error")
+	assert.Contains(t, err.Error(), "not yet implemented",
+		"valid config with custom metrics must reach Phase 1 sentinel, got: %q", err.Error())
+}
+
+// TestLokiFactory_NewFactory_WithMetrics_InvalidConfig verifies that a
+// factory created with NewFactory still validates config — invalid configs
+// must not reach the Phase 1 gate.
+func TestLokiFactory_NewFactory_WithMetrics_InvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	factory := loki.NewFactory(nil)
+
+	_, err := factory("bad_cfg", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config is required",
+		"NewFactory factory must enforce config-required check, got: %q", err.Error())
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic label parsing — success paths
+// ---------------------------------------------------------------------------
+
+// TestLokiFactory_DynamicLabels_ExcludeFields verifies that setting a known
+// dynamic label to false correctly excludes it from the stream labels. This
+// exercises the full parseDynamicLabels success path for each valid name.
+func TestLokiFactory_DynamicLabels_ExcludeFields(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	// Each valid dynamic label name disabled (false) must be accepted and
+	// reach the Phase 1 gate.
+	validLabels := []string{
+		"app_name",
+		"host",
+		"pid",
+		"event_type",
+		"event_category",
+		"severity",
+	}
+
+	for _, labelName := range validLabels {
+		t.Run("exclude_"+labelName, func(t *testing.T) {
+			t.Parallel()
+
+			rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\nlabels:\n  dynamic:\n    " + labelName + ": false\n")
+			_, err := factory("dyn_"+labelName, rawYAML, nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not yet implemented",
+				"disabling dynamic label %q must reach Phase 1 sentinel, got: %q", labelName, err.Error())
+		})
+	}
+}
+
+// TestLokiFactory_DynamicLabels_IncludeFields verifies that setting a known
+// dynamic label to true (explicitly included) is also accepted.
+func TestLokiFactory_DynamicLabels_IncludeFields(t *testing.T) {
+	t.Parallel()
+
+	factory := audit.LookupOutputFactory("loki")
+	require.NotNil(t, factory)
+
+	rawYAML := []byte(`
+url: https://loki.example.com/loki/api/v1/push
+labels:
+  dynamic:
+    app_name: true
+    event_type: true
+    severity: false
+`)
+	_, err := factory("mixed_dynamic", rawYAML, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not yet implemented",
+		"mixed include/exclude dynamic labels must reach Phase 1 sentinel, got: %q", err.Error())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Ensure the mock satisfies the loki.Metrics interface at compile time.
+var _ loki.Metrics = (*mockLokiMetrics)(nil)
+
+type mockLokiMetrics struct {
+	drops   int
+	flushes int
+}
+
+func (m *mockLokiMetrics) RecordLokiDrop()                        { m.drops++ }
+func (m *mockLokiMetrics) RecordLokiFlush(_ int, _ time.Duration) { m.flushes++ }


### PR DESCRIPTION
## Summary

Phase 1 of the Grafana Loki output backend (issue #251). Adds the `loki/` sub-module with:

- **Config struct** — URL, BasicAuth/BearerToken, TLS (cert/key/CA/policy), batching (size, bytes, interval), buffer, timeout, retries, compression, labels (static + dynamic), custom headers
- **Validation** — all errors wrap `audit.ErrConfigInvalid`; URL scheme enforcement, credential mutual exclusivity, static label name regex, bounds checking, CRLF header injection, restricted header blocking (Authorization, X-Scope-OrgID, Content-Type, Host)
- **YAML factory** — `init()` registration with `KnownFields(true)` strict decoding, `yamlDuration` for Go-style duration strings, `NewFactory(Metrics)` for custom metrics injection
- **Security** — `fmt.Formatter`/`GoString` on Config and BasicAuth prevent credential leakage via `%+v`/`%#v`; TLS 1.3 default; library code returns warnings instead of calling `slog.Warn`
- **Tests** — 96.6% coverage, black-box tests (`package loki_test`) with `export_test.go` pattern, table-driven validation (50+ cases), boundary values, credential redaction, TLS config builder

## Test plan

- [x] `go test -race -count=1 ./loki/...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make check` — all checks passed
- [x] Coverage ≥ 90% (96.6%)
- [x] Code reviewer: 0 BLOCKING findings
- [x] Security reviewer: 0 CRITICAL findings, all HIGH/MEDIUM addressed
- [x] Go quality: all automated checks pass

## Next steps

Phase 2: Output struct, lifecycle, batch loop (PR 2 of 7 for #251)