### PR TITLE
test: add tests, benchmarks, and coverage for Loki output (#251)

### DIFF
--- a/loki/bench_test.go
+++ b/loki/bench_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	audit "github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/loki"
+)
+
+func BenchmarkWriteWithMetadata(b *testing.B) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	cfg := validConfigWithURL(srv.URL)
+	cfg.BufferSize = 100000 // large buffer to avoid drops during bench
+	out, err := loki.New(cfg, nil, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = out.Close() }()
+
+	data := []byte(`{"actor_id":"alice","action":"login","resource":"session"}`)
+	meta := audit.EventMetadata{
+		EventType: "user_login",
+		Severity:  6,
+		Category:  "authentication",
+		Timestamp: time.Now(),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_ = out.WriteWithMetadata(data, meta)
+	}
+}
+
+func BenchmarkLokiBackoff(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = loki.LokiBackoff(3)
+	}
+}
+
+func BenchmarkParseRetryAfter(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = loki.ParseRetryAfter("5")
+	}
+}

--- a/loki/export_test.go
+++ b/loki/export_test.go
@@ -25,6 +25,8 @@ import (
 var (
 	ValidateLokiConfig = validateLokiConfig
 	BuildLokiTLSConfig = buildLokiTLSConfig
+	LokiBackoff        = lokiBackoff
+	ParseRetryAfter    = parseRetryAfter
 )
 
 // TestEvent is a test-only event for building payloads.
@@ -72,13 +74,13 @@ func buildTestConfig(input TestPayloadInput) *Config { //nolint:gocritic // huge
 
 // buildTestOutput creates an Output from test input and returns it
 // along with a batch of lokiEntry values.
-func buildTestOutput(t *testing.T, input TestPayloadInput) (*Output, []lokiEntry) { //nolint:gocritic // hugeParam: test helper
-	t.Helper()
+func buildTestOutput(tb testing.TB, input TestPayloadInput) (*Output, []lokiEntry) { //nolint:gocritic // hugeParam: test helper
+	tb.Helper()
 
 	cfg := buildTestConfig(input)
 	o, err := New(cfg, nil, nil)
 	if err != nil {
-		t.Fatalf("New() failed: %v", err)
+		tb.Fatalf("New() failed: %v", err)
 	}
 
 	o.SetFrameworkFields(input.AppName, input.Host, input.PID)
@@ -93,10 +95,10 @@ func buildTestOutput(t *testing.T, input TestPayloadInput) (*Output, []lokiEntry
 // BuildTestPayload constructs a Loki push payload from test inputs.
 // It creates a temporary Output, sets framework fields, groups events,
 // builds the payload, and returns the raw (uncompressed) JSON bytes.
-func BuildTestPayload(t *testing.T, input TestPayloadInput) []byte { //nolint:gocritic // hugeParam: test helper, readability preferred
-	t.Helper()
+func BuildTestPayload(tb testing.TB, input TestPayloadInput) []byte { //nolint:gocritic // hugeParam: test helper, readability preferred
+	tb.Helper()
 
-	o, batch := buildTestOutput(t, input)
+	o, batch := buildTestOutput(tb, input)
 	defer func() { _ = o.Close() }()
 
 	o.groupByStream(batch)
@@ -106,10 +108,10 @@ func BuildTestPayload(t *testing.T, input TestPayloadInput) []byte { //nolint:go
 
 // BuildTestCompressedPayload is like BuildTestPayload but returns
 // gzip-compressed bytes.
-func BuildTestCompressedPayload(t *testing.T, input TestPayloadInput) []byte { //nolint:gocritic // hugeParam: test helper, readability preferred
-	t.Helper()
+func BuildTestCompressedPayload(tb testing.TB, input TestPayloadInput) []byte { //nolint:gocritic // hugeParam: test helper, readability preferred
+	tb.Helper()
 
-	o, batch := buildTestOutput(t, input)
+	o, batch := buildTestOutput(tb, input)
 	defer func() { _ = o.Close() }()
 
 	o.groupByStream(batch)

--- a/loki/http_test.go
+++ b/loki/http_test.go
@@ -15,14 +15,18 @@
 package loki_test
 
 import (
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	audit "github.com/axonops/go-audit"
 	"github.com/axonops/go-audit/loki"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -354,7 +358,7 @@ func TestHTTP_CompressedBody_ValidJSON(t *testing.T) {
 
 	// Decompress and verify valid JSON.
 	require.GreaterOrEqual(t, len(capturedBody), 2)
-	gr, err := gzip.NewReader(bytesReader(capturedBody))
+	gr, err := gzip.NewReader(bytes.NewReader(capturedBody))
 	require.NoError(t, err)
 	decompressed, err := io.ReadAll(gr)
 	require.NoError(t, err)
@@ -424,20 +428,241 @@ func TestHTTP_CustomHeaders(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// lokiBackoff
+// ---------------------------------------------------------------------------
+
+func TestLokiBackoff_Attempt0(t *testing.T) {
+	t.Parallel()
+
+	d := loki.LokiBackoff(0)
+	// 100ms base with [0.5, 1.0) jitter → [50ms, 100ms)
+	assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+	assert.Less(t, d, 100*time.Millisecond)
+}
+
+func TestLokiBackoff_Attempt1(t *testing.T) {
+	t.Parallel()
+
+	d := loki.LokiBackoff(1)
+	// 200ms with [0.5, 1.0) jitter → [100ms, 200ms)
+	assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+	assert.Less(t, d, 200*time.Millisecond)
+}
+
+func TestLokiBackoff_Cap(t *testing.T) {
+	t.Parallel()
+
+	d := loki.LokiBackoff(100)
+	assert.LessOrEqual(t, d, 5*time.Second,
+		"backoff must be capped at 5s")
+}
+
+func TestLokiBackoff_NonNegative(t *testing.T) {
+	t.Parallel()
+
+	for attempt := 0; attempt < 25; attempt++ {
+		d := loki.LokiBackoff(attempt)
+		assert.GreaterOrEqual(t, d, time.Duration(0),
+			"backoff must never be negative (attempt=%d)", attempt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseRetryAfter
+// ---------------------------------------------------------------------------
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		val  string
+		want time.Duration
+	}{
+		{"empty", "", 0},
+		{"valid 1s", "1", 1 * time.Second},
+		{"valid 5s", "5", 5 * time.Second},
+		{"zero", "0", 0},
+		{"negative", "-1", 0},
+		{"non-numeric", "banana", 0},
+		{"float", "1.5", 0},
+		{"capped at 30s", "60", 30 * time.Second},
+		{"large value capped", "86400", 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := loki.ParseRetryAfter(tt.val)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Core audit.Metrics integration
+// ---------------------------------------------------------------------------
+
+func TestHTTP_Success_RecordsCoreMetrics(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	coreMetrics := &mockCoreMetrics{}
+	cfg := validConfigWithURL(srv.URL)
+
+	out, err := loki.New(cfg, coreMetrics, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, out.Write([]byte(`{"event":"core_metrics"}`)))
+	require.NoError(t, out.Close())
+
+	assert.Greater(t, coreMetrics.successCount(), 0,
+		"core metrics RecordEvent should be called with success")
+}
+
+func TestHTTP_Drop_RecordsCoreMetrics(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest) // non-retryable
+	}))
+	t.Cleanup(srv.Close)
+
+	coreMetrics := &mockCoreMetrics{}
+	cfg := validConfigWithURL(srv.URL)
+
+	out, err := loki.New(cfg, coreMetrics, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, out.Write([]byte(`{"event":"core_drop"}`)))
+	require.NoError(t, out.Close())
+
+	assert.Greater(t, coreMetrics.errorCount(), 0,
+		"core metrics RecordEvent should be called with error on drop")
+}
+
+// ---------------------------------------------------------------------------
+// Context cancellation in doPost
+// ---------------------------------------------------------------------------
+
+func TestHTTP_ContextCancelled_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	// Server that delays, giving context time to cancel.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := validConfigWithURL(srv.URL)
+	cfg.MaxRetries = 1
+	cfg.Timeout = 2 * time.Second
+
+	out, err := loki.New(cfg, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, out.Write([]byte(`{"event":"cancel"}`)))
+
+	// Close immediately — cancels context, flushFinal creates a fresh
+	// short context. The important assertion is no panic or deadlock.
+	require.NoError(t, out.Close())
+}
+
+// ---------------------------------------------------------------------------
+// Redirect blocked
+// ---------------------------------------------------------------------------
+
+func TestHTTP_Redirect_NotRetried(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		http.Redirect(w, r, "http://evil.example.com/", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	metrics := &testLokiMetrics{}
+	cfg := validConfigWithURL(srv.URL)
+	cfg.MaxRetries = 3
+
+	out, err := loki.New(cfg, nil, metrics)
+	require.NoError(t, err)
+
+	require.NoError(t, out.Write([]byte(`{"event":"redirect"}`)))
+	require.NoError(t, out.Close())
+
+	assert.Greater(t, metrics.drops(), 0,
+		"redirect should cause a drop")
+	assert.Equal(t, int32(1), requestCount.Load(),
+		"redirect should not be retried")
+}
+
+// ---------------------------------------------------------------------------
+// Nil metrics — no panic
+// ---------------------------------------------------------------------------
+
+func TestHTTP_NilMetrics_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := validConfigWithURL(srv.URL)
+
+	// Both metrics nil — should not panic.
+	out, err := loki.New(cfg, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, out.Write([]byte(`{"event":"nil_metrics"}`)))
+	require.NoError(t, out.Close())
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-type bytesReaderHelper struct{ data []byte }
+// mockCoreMetrics implements audit.Metrics for testing the core metrics path.
+type mockCoreMetrics struct { //nolint:govet // fieldalignment: readability preferred
+	mu     sync.Mutex
+	events map[string]int // status → count
+}
 
-func (r *bytesReaderHelper) Read(p []byte) (int, error) {
-	n := copy(p, r.data)
-	r.data = r.data[n:]
-	if len(r.data) == 0 {
-		return n, io.EOF
+func (m *mockCoreMetrics) RecordEvent(_, status string) {
+	m.mu.Lock()
+	if m.events == nil {
+		m.events = make(map[string]int)
 	}
-	return n, nil
+	m.events[status]++
+	m.mu.Unlock()
 }
 
-func bytesReader(data []byte) io.Reader {
-	return &bytesReaderHelper{data: append([]byte(nil), data...)}
+func (m *mockCoreMetrics) successCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.events["success"]
 }
+
+func (m *mockCoreMetrics) errorCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.events["error"]
+}
+
+// Satisfy the full audit.Metrics interface with no-ops.
+func (m *mockCoreMetrics) RecordOutputError(_ string)        {}
+func (m *mockCoreMetrics) RecordOutputFiltered(_ string)     {}
+func (m *mockCoreMetrics) RecordValidationError(_ string)    {}
+func (m *mockCoreMetrics) RecordFiltered(_ string)           {}
+func (m *mockCoreMetrics) RecordSerializationError(_ string) {}
+func (m *mockCoreMetrics) RecordBufferDrop()                 {}
+
+// Verify interface satisfaction.
+var _ audit.Metrics = (*mockCoreMetrics)(nil)

--- a/loki/push_test.go
+++ b/loki/push_test.go
@@ -327,7 +327,7 @@ func TestBuildPayload_SpecialCharsInData(t *testing.T) {
 
 	ts := time.Date(2026, 4, 4, 12, 0, 0, 0, time.UTC)
 	// Event data with special chars: quotes, backslashes, newlines,
-	// Unicode (U+2028, U+2029), invalid UTF-8, and HTML chars.
+	// Unicode (U+2028), HTML chars.
 	payload := loki.BuildTestPayload(t, loki.TestPayloadInput{
 		Events: []loki.TestEvent{
 			{
@@ -343,6 +343,29 @@ func TestBuildPayload_SpecialCharsInData(t *testing.T) {
 	var p pushPayload
 	require.NoError(t, json.Unmarshal(payload, &p),
 		"payload with special chars must be valid JSON: %s", string(payload))
+	require.Len(t, p.Streams, 1)
+}
+
+func TestBuildPayload_InvalidUTF8InData(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 4, 4, 12, 0, 0, 0, time.UTC)
+	// Invalid UTF-8 bytes (0xFF, 0xFE) and U+2029 paragraph separator.
+	payload := loki.BuildTestPayload(t, loki.TestPayloadInput{
+		Events: []loki.TestEvent{
+			{
+				Data: []byte("{\"bad\":\"\xff\xfe\",\"para\":\"\xe2\x80\xa9\"}"),
+				Meta: audit.EventMetadata{EventType: "test", Severity: 1, Timestamp: ts},
+			},
+		},
+		AppName: "app",
+		Host:    "h1",
+		PID:     1,
+	})
+
+	var p pushPayload
+	require.NoError(t, json.Unmarshal(payload, &p),
+		"payload with invalid UTF-8 and U+2029 must be valid JSON: %s", string(payload))
 	require.Len(t, p.Streams, 1)
 }
 


### PR DESCRIPTION
## Summary

Address all agent review findings from Loki Phases 1-4. No production code changes — test-only.

- **Backoff/RetryAfter unit tests** — 4 `lokiBackoff` cases (bounds, cap, non-negative) + 9 `parseRetryAfter` cases (empty, valid, negative, non-numeric, capped)
- **Core metrics integration** — tests for `audit.Metrics` path in `recordSuccess`/`recordDrop` with `mockCoreMetrics`
- **Security paths** — redirect blocking (SSRF protection), context cancellation (no panic), nil metrics (no panic)
- **JSON escaping coverage** — invalid UTF-8 (`\xff\xfe`) and U+2029 for `writeJSONMultibyte`
- **Benchmarks** — `BenchmarkWriteWithMetadata`, `BenchmarkLokiBackoff`, `BenchmarkParseRetryAfter`
- **Cleanup** — replaced `bytesReaderHelper` with `bytes.NewReader`, fixed stale comments, fixed magic literals

Coverage: 91.5% → 94.9%

## Test plan

- [x] `go test -race -count=1 ./loki/...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make check` — all checks passed
- [x] Coverage ≥ 90% (94.9%)
- [x] Code reviewer: 0 BLOCKING — approved
- [x] Security reviewer: 0 findings — approved
- [x] Go quality: READY TO COMMIT