### PR TITLE
fix: correct progressive example defects (#348)

### DIFF
--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -185,7 +185,7 @@ INFO audit: logger created buffer_size=10000 drain_timeout=5s validation_mode=st
 --- Invalid event (missing required field) ---
 Validation error: audit: event "user_create" missing required fields: [actor_id]
 INFO audit: shutdown started
-{"timestamp":"...","event_type":"user_create","severity":5,"pid":...,"actor_id":"alice","outcome":"success"}
+{"timestamp":"...","event_type":"user_create","severity":5,"timezone":"Local","pid":...,"actor_id":"alice","outcome":"success"}
 INFO audit: shutdown complete duration=...
 ```
 

--- a/examples/08-loki-output/main.go
+++ b/examples/08-loki-output/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Example 13: Loki Output
+// Example 08: Loki Output
 //
 // Demonstrates sending audit events to Grafana Loki with stream labels,
 // gzip compression, and multi-tenant support.
@@ -76,6 +76,8 @@ func main() {
 	}()
 
 	// Audit some events — these will appear in Loki with stream labels.
+	// In production, use generated typed builders from audit-gen instead
+	// of raw event types and Fields maps (see example 02-code-generation).
 	type auditEvent struct {
 		fields    audit.Fields
 		eventType string

--- a/examples/15-middleware/main.go
+++ b/examples/15-middleware/main.go
@@ -52,6 +52,8 @@ func buildEvent(hints *audit.Hints, transport *audit.TransportMetadata) (eventTy
 	if hints.TargetID != "" {
 		fields["target_id"] = hints.TargetID
 	}
+	// In production, use a generated constant from audit-gen instead of
+	// the raw string (see example 02-code-generation for the full pattern).
 	return "http_request", fields, false
 }
 

--- a/examples/17-testing/main.go
+++ b/examples/17-testing/main.go
@@ -32,6 +32,9 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
+//go:embed outputs.yaml
+var outputsYAML []byte
+
 // UserService is a simple service that emits audit events.
 // It takes a *audit.Logger as a dependency — making it testable.
 type UserService struct {
@@ -71,7 +74,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: testing-demo\nhost: localhost\noutputs:\n  console:\n    type: stdout\n"), &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/17-testing/outputs.yaml
+++ b/examples/17-testing/outputs.yaml
@@ -1,0 +1,6 @@
+version: 1
+app_name: testing-demo
+host: localhost
+outputs:
+  console:
+    type: stdout


### PR DESCRIPTION
## Summary

Fixes 4 defects in progressive examples found by the user-guide-reviewer audit.

Closes #348.

## Changes

| Example | Fix |
|---------|-----|
| 01 (Basic) | Add missing `"timezone":"Local"` to expected output in README |
| 08 (Loki) | Fix stale "Example 13" → "Example 08" comment, add note about generated code pattern |
| 15 (Middleware) | Add comment showing production pattern with audit-gen constants |
| 17 (Testing) | Replace inline YAML string with `//go:embed outputs.yaml` |

## Test plan

- [x] `make test-examples` — all 17 examples compile
- [x] `make test-all` — all 12 modules pass
- [x] `make lint` — clean
- [ ] CI pipeline passes