### PR TITLE
docs: progressive example improvements and doc gaps (#349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,12 @@ CEF:0|MyCompany|MyApp|1.0|user_create|A new user account was created|3|rt=... ac
 ```
 
 > `app_name`, `host`, and `pid` are **framework fields** — set once in your
-> outputs.yaml and automatically included in every event. SIEMs use the CEF
-> extension keys (`deviceProcessName`, `dvchost`, `dvcpid`) for automatic
-> host-level correlation.
+> outputs.yaml and automatically included in every event. The `host`,
+> `timezone`, and `pid` values reflect your system — they will differ
+> from the example above. `app_name` is set in `outputs.yaml` and stays
+> constant across deployments. SIEMs use the CEF extension keys
+> (`deviceProcessName`, `dvchost`, `dvcpid`) for automatic host-level
+> correlation.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,6 +5,7 @@
 - [What Is audittest?](#what-is-audittest)
 - [Why a Test Package?](#why-a-test-package)
 - [Quick Start](#quick-start)
+- [Dependency Injection](#dependency-injection)
 - [Two Constructor Patterns](#two-constructor-patterns)
 - [Recorded Event API](#recorded-event-api)
 - [Metrics Assertions](#metrics-assertions)
@@ -56,6 +57,41 @@ not have processed all events yet, and assertions on `events.Count()`
 or `events.Events()` without draining first produce racy results.
 `NewLogger` registers `t.Cleanup(logger.Close)` as a safety net
 against goroutine leaks, but your explicit Close MUST come first.
+
+## 💉 Dependency Injection
+
+The Quick Start above uses `NewUserService(logger)` — this is the
+correct pattern. Your service takes a `*audit.Logger` as a constructor
+parameter, not from a package-level global:
+
+```go
+// ✅ Correct: inject the logger
+type UserService struct {
+    audit *audit.Logger
+}
+
+func NewUserService(logger *audit.Logger) *UserService {
+    return &UserService{audit: logger}
+}
+```
+
+```go
+// ❌ Wrong: package-level global logger
+var logger *audit.Logger // data races in parallel tests
+
+type UserService struct{}
+```
+
+Why this matters for testing:
+
+- **Injected logger**: each test creates its own `audittest.NewLogger`,
+  passes it to the service, and asserts on its own events. Tests run in
+  parallel safely.
+- **Global logger**: all tests share the same logger. Events from one
+  test appear in another's assertions. `t.Parallel()` causes data races.
+
+Structure your code with constructor injection from the start — it is
+the only pattern that makes audit testing reliable.
 
 ## 🔧 Two Constructor Patterns
 

--- a/examples/02-code-generation/README.md
+++ b/examples/02-code-generation/README.md
@@ -194,14 +194,6 @@ so the entire taxonomy is type-safe. When sensitivity labels are
 defined, `FieldLabels` and `Label` constants are also generated — see
 the [Sensitivity Labels](../12-sensitivity-labels/) example.
 
-**Performance note:** Typed builders add one small heap allocation per
-event (the `Event` interface wrapper) compared to passing raw strings
-and maps. This is typically ~48 bytes per event — negligible compared
-to the cost of serialization and I/O. The trade-off is compile-time
-field safety in exchange for a minor allocation overhead. For
-extremely high-throughput paths where every allocation matters, the
-`audit.NewEvent()` escape hatch bypasses builders entirely.
-
 **Code generation is optional.** The basic example used raw strings and
 it worked fine. But once you have more than a handful of event types,
 generated constants are worth the small overhead of running

--- a/examples/03-standard-fields/README.md
+++ b/examples/03-standard-fields/README.md
@@ -121,6 +121,25 @@ outputs:
 - `standard_fields` maps reserved standard field names to default values.
   Environment variables are supported. Per-event values always override defaults.
 
+## Wiring Standard Field Defaults in Go
+
+The `standard_fields` YAML section produces a `map[string]string` in
+`result.StandardFields`. This is separate from `result.Options` — you
+must wire it explicitly:
+
+```go
+opts := []audit.Option{audit.WithTaxonomy(tax)}
+opts = append(opts, result.Options...)
+if result.StandardFields != nil {
+    opts = append(opts, audit.WithStandardFieldDefaults(result.StandardFields))
+}
+logger, err := audit.NewLogger(result.Config, opts...)
+```
+
+The `nil` guard is important: when `standard_fields:` is omitted from
+the YAML, `result.StandardFields` is `nil`. The guard keeps the wiring
+consistent whether or not standard fields are configured.
+
 ## Using Standard Field Setters
 
 The generated builders have setter methods for all 31 standard fields,

--- a/examples/08-loki-output/main.go
+++ b/examples/08-loki-output/main.go
@@ -62,10 +62,9 @@ func main() {
 	}
 
 	// Create the logger with the Loki output.
-	logger, err := audit.NewLogger(
-		result.Config,
-		append(result.Options, audit.WithTaxonomy(taxonomy))...,
-	)
+	opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
+	opts = append(opts, result.Options...)
+	logger, err := audit.NewLogger(result.Config, opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/10-tls-policy/README.md
+++ b/examples/10-tls-policy/README.md
@@ -21,7 +21,10 @@ HTTPS, loki HTTPS).
 ## Prerequisites
 
 None — this example uses stdout output to demonstrate the TLS policy
-configuration without requiring actual TLS connections.
+configuration without requiring actual TLS connections. This example is
+most useful after reading [06 — Syslog Output](../06-syslog-output/) or
+[07 — Webhook Output](../07-webhook-output/), which show the outputs
+that TLS policy applies to.
 
 ## Files
 


### PR DESCRIPTION
## Summary

Addresses 6 improvements from the user-guide-reviewer audit. Polish items (WARN severity) that improve the developer's learning flow.

Closes #349.

## Changes

| Item | Change |
|------|--------|
| Example 02 | Remove premature performance note (6 lines about heap allocs that interrupt the code-gen decision flow) |
| Example 03 | Add `WithStandardFieldDefaults` wiring subsection with code snippet and nil guard explanation |
| Example 08 | Standardize opts pattern to match 02-07 (was using inline append with reversed argument order) |
| Example 10 | Add TLS signpost noting prerequisite examples 06/07 |
| docs/testing.md | Add dependency injection section: constructor injection vs global logger anti-pattern |
| README | Add note that host/timezone/pid values vary by system |

## Test plan

- [x] `make test-examples` — all 17 examples compile
- [x] `make test-all` — all 12 modules pass
- [x] `make lint` — clean
- [ ] CI pipeline passes