### PR TITLE
docs: clarify two-level buffering architecture (#318)

### DIFF
--- a/docs/async-delivery.md
+++ b/docs/async-delivery.md
@@ -5,6 +5,7 @@
 - [How Events Flow](#how-events-flow)
 - [Why Async?](#why-async)
 - [Buffering and Backpressure](#buffering-and-backpressure)
+- [Two-Level Buffering](#two-level-buffering)
 - [Delivery Guarantee](#delivery-guarantee)
 - [Graceful Shutdown](#graceful-shutdown)
 - [Thread Safety](#thread-safety)
@@ -118,6 +119,154 @@ events continuously with no timeout.
 
 Monitor `RecordBufferDrop()` — if it fires, your buffer is too small
 or your outputs are too slow.
+
+## 🏗️ Two-Level Buffering
+
+go-audit has a two-level buffering architecture. Understanding it is
+essential for tuning performance and diagnosing event drops.
+
+### Level 1: Core Logger Buffer
+
+Every `AuditEvent()` call validates the event and enqueues it into a
+buffered Go channel. A single drain goroutine reads from this channel,
+serialises each event, and delivers it to every configured output in
+sequence.
+
+```
+AuditEvent()
+  → validate against taxonomy
+  → enqueue to channel (capacity: Config.BufferSize, default 10,000)
+  → return immediately (sub-microsecond)
+
+Drain goroutine (single, runs continuously)
+  → dequeue entry
+  → set timestamp
+  → serialise (JSON or CEF, cached per format)
+  → deliver to output 1, then output 2, then output 3, ...
+  → return entry to sync.Pool for reuse
+```
+
+If the channel is full, `AuditEvent()` returns `ErrBufferFull` and the
+event is lost. The `RecordBufferDrop()` metric fires on every drop.
+
+### Level 2: Per-Output Buffer (Loki and Webhook Only)
+
+Loki and webhook outputs have their own internal buffered channel and
+a background goroutine that accumulates events into batches before
+sending them as HTTP requests. File, syslog, and stdout outputs do
+**not** have this second level — they write synchronously from the
+drain goroutine.
+
+```
+Drain goroutine                        Output goroutine
+───────────────                        ────────────────
+  delivers to Loki/Webhook output        reads from output channel
+    → WriteWithMetadata() /                → accumulates into batch
+      Write()                              → flushes when:
+    → copies event bytes                       batch_size reached
+    → enqueues to output channel               max_batch_bytes reached (Loki)
+      (capacity: output buffer_size,           flush_interval elapsed
+       default 10,000)                         shutdown
+    → returns immediately                  → HTTP POST to destination
+                                           → retry on 429/5xx
+```
+
+If the output's channel is full (e.g., the destination is down and
+retries are consuming time), new events are dropped. The output-specific
+metric (`RecordLokiDrop()` or `RecordWebhookDrop()`) fires on every
+drop, and `audit.Metrics.RecordEvent(outputName, "error")` is also
+called on the core metrics interface. A rate-limited `slog.Warn`
+diagnostic fires at most once per 10 seconds. Consumers monitoring
+core metrics may see error counts for a webhook or Loki output name
+that represent buffer drops, not HTTP delivery failures.
+
+### The Complete Pipeline
+
+```
+                    Level 1                              Level 2
+                    ───────                              ───────
+AuditEvent() ──► core channel ──► drain goroutine ─┬──► File.Write()                  [synchronous]
+                 (10,000)          (single)        ├──► Syslog.WriteWithMetadata()     [synchronous]
+                                                   ├──► Stdout.Write()                 [synchronous]
+                                                   ├──► Webhook.Write() ──────────────► batchLoop ──► HTTP POST
+                                                   │    (10,000)
+                                                   └──► Loki.WriteWithMetadata() ─────► batchLoop ──► HTTP POST
+                                                        (10,000)
+```
+
+Outputs that implement `MetadataWriter` (Loki, Syslog) receive
+per-event metadata (event type, severity, category, timestamp)
+alongside the serialised bytes. Loki uses this for stream labels;
+Syslog uses it for RFC 5424 severity mapping.
+
+### Key Implications
+
+**A slow synchronous output blocks all outputs.** The drain goroutine
+delivers to outputs sequentially. If a syslog TCP write blocks for 30
+seconds (server unreachable), no events reach file, webhook, or Loki
+during that time. Monitor output errors. You SHOULD use async outputs
+(webhook, Loki) for unreliable destinations to avoid blocking the
+drain goroutine.
+
+**Async output drops are isolated.** If Loki's buffer fills because
+Loki is down, Loki drops events but the core buffer and all other
+outputs are unaffected.
+
+**Two different `buffer_size` configs exist.** `logger.buffer_size`
+(or `Config.BufferSize`) is the Level 1 core channel.
+`buffer_size` on a Loki or webhook output is that output's Level 2
+channel. They are independent. Both default to 10,000 but they are
+not the same thing.
+
+**`batch_size` is not `buffer_size`.** `batch_size` controls how many
+events are grouped into a single HTTP request. `buffer_size` controls
+how many events can queue up waiting to be batched. With the defaults
+(`buffer_size: 10000`, `batch_size: 100`), up to 100 batches of
+events can be queued before drops begin.
+
+### Memory Sizing
+
+The core library uses a package-level `sync.Pool` shared across all
+`Logger` instances to reuse `auditEntry` structs, reducing GC pressure
+on the hot path. Pool entries are returned after the drain goroutine
+finishes processing each event. The channel holds pointers to
+pool-allocated structs, not copies.
+
+For Level 2 buffers (Loki, webhook), each entry is a byte slice copy
+of the serialised event. Typical sizes:
+
+| Event Complexity | Approximate Serialised Size |
+|------------------|-----------------------------|
+| Minimal (3 fields + framework) | ~200 bytes |
+| Typical (8–10 fields + framework) | ~500 bytes |
+| Large (20+ fields + framework) | ~1,200 bytes |
+
+Memory per Level 2 buffer at default 10,000 capacity:
+
+| Event Size | Buffer Memory |
+|------------|---------------|
+| 200 bytes | ~2 MB |
+| 500 bytes | ~5 MB |
+| 1,200 bytes | ~12 MB |
+
+The Loki Level 2 buffer holds `lokiEntry` structs, not raw byte
+slices. Each entry carries the serialised bytes plus an
+`EventMetadata` value (event type, severity, category, timestamp) —
+add approximately 80–120 bytes per entry for the metadata overhead.
+
+With the core buffer + one Loki buffer + one webhook buffer, worst
+case with large events: ~36 MB of buffered events. This is usually
+negligible, but relevant when tuning buffer sizes for
+memory-constrained environments.
+
+### Tuning Guidance
+
+| Symptom | Diagnosis | Fix |
+|---------|-----------|-----|
+| `ErrBufferFull` from `AuditEvent()` | Core buffer (Level 1) full — drain goroutine can't keep up | Increase `logger.buffer_size`, or check if a synchronous output is blocking the drain |
+| `RecordLokiDrop` / `RecordWebhookDrop` firing | Output buffer (Level 2) full — destination too slow or down | Increase output `buffer_size`, decrease `flush_interval`, check destination health |
+| High event latency | Events queued too long before flushing | Decrease `flush_interval` or `batch_size` for faster delivery |
+| Excessive memory | Large buffers with large events | Decrease `buffer_size` on outputs you can afford to drop from |
 
 ## 📤 Delivery Guarantee
 

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -43,7 +43,7 @@ audit: buffer full
 | **When** | `AuditEvent()` is called but the async buffer channel is at capacity |
 | **Meaning** | The event was **dropped** — it will not be delivered to any output |
 | **Transient?** | Yes — resolves when the drain goroutine catches up |
-| **What to do** | Log a warning, increment a metric (`RecordBufferDrop` fires automatically). Do NOT retry immediately — the buffer is full and retrying worsens the backlog. If this happens frequently, increase `Config.BufferSize` or investigate slow outputs. |
+| **What to do** | Log a warning, increment a metric (`RecordBufferDrop` fires automatically). Do NOT retry immediately — the buffer is full and retrying worsens the backlog. If this happens frequently, increase `Config.BufferSize` or investigate slow outputs. See [Two-Level Buffering](async-delivery.md#two-level-buffering) for the pipeline architecture. |
 
 ### `ErrClosed`
 

--- a/docs/file-output.md
+++ b/docs/file-output.md
@@ -88,6 +88,22 @@ flowchart LR
    - Backups exceeding `max_backups` count or `max_age_days` are deleted
    - A new active file is opened
 
+## Delivery Model
+
+The file output writes **synchronously** from the core drain
+goroutine. It has no internal buffer or batching — each event is
+written directly to the underlying file as soon as the drain goroutine
+processes it.
+
+This means file write latency directly affects the drain loop
+throughput and delivery to all other outputs. In practice, local file
+writes are fast (microseconds with OS-level buffering), so this is
+rarely a bottleneck. However, if the filesystem is slow (network
+mount, full disk), it will delay delivery to every output.
+
+See [Two-Level Buffering](async-delivery.md#two-level-buffering) for
+the complete pipeline architecture.
+
 ## Complete Configuration Reference
 
 | Field | Type | Default | Range | Description |

--- a/docs/loki-output.md
+++ b/docs/loki-output.md
@@ -10,6 +10,7 @@ retry.
 - [Why Loki for Audit Logging?](#why-loki-for-audit-logging)
 - [Quick Start](#quick-start)
 - [How It Works](#how-it-works)
+- [Buffering Architecture](#buffering-architecture)
 - [Stream Labels](#stream-labels)
 - [Complete Configuration Reference](#complete-configuration-reference)
 - [Authentication](#authentication)
@@ -95,6 +96,64 @@ The Loki output runs its own goroutine (`batchLoop`) that:
 4. Builds the Loki push API JSON payload
 5. Gzip-compresses it
 6. POSTs it to Loki with retry on failure
+
+---
+
+## Buffering Architecture
+
+The Loki output has its own internal buffer separate from the core
+logger buffer. This is [Level 2](async-delivery.md#two-level-buffering)
+in the pipeline:
+
+```
+Core drain goroutine ──► WriteWithMetadata()
+                            → copies event bytes
+                            → enqueues to Loki channel (capacity: buffer_size, default 10,000)
+                            → returns immediately (non-blocking)
+
+Loki batchLoop goroutine
+  → reads from channel
+  → accumulates into batch
+  → flushes on: batch_size (100) | max_batch_bytes (1 MiB) | flush_interval (5s) | shutdown
+  → groups events by stream labels
+  → gzip compresses
+  → HTTP POST to Loki
+  → retries on 429/5xx
+```
+
+### `buffer_size` vs `batch_size`
+
+These are different things:
+
+| Config | Default | What It Controls |
+|--------|---------|------------------|
+| `buffer_size` | 10,000 | How many events can **queue up** waiting to be sent. This is the channel capacity. |
+| `batch_size` | 100 | How many events are grouped into a **single HTTP POST**. This is the flush threshold. |
+
+With the defaults, up to 100 batches of events (10,000 ÷ 100) can be
+queued before drops begin. Increasing `buffer_size` absorbs longer
+outages; decreasing `batch_size` or `flush_interval` drains the buffer
+faster.
+
+### Drop Behaviour
+
+If the internal buffer fills (e.g., Loki is down and retries are
+consuming time), new events are **dropped silently** — the
+`WriteWithMetadata()` call returns `nil` to avoid blocking the core
+drain goroutine. This isolation ensures that a Loki outage does not
+affect delivery to other outputs.
+
+A rate-limited `slog.Warn` fires at most once per 10 seconds during
+sustained drops. The `RecordLokiDrop()` metric fires on **every**
+drop — use metrics, not log lines, for precise monitoring.
+
+### Relationship to Core Buffer
+
+The Loki `buffer_size` is independent of the core `logger.buffer_size`
+(`Config.BufferSize`). Both default to 10,000 but they serve different
+pipeline stages. See
+[Two-Level Buffering](async-delivery.md#two-level-buffering) for the
+full architecture diagram and memory sizing guidance.
 
 ---
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -207,6 +207,37 @@ Every output supports these optional features:
 | **Sensitivity labels** | `exclude_labels:` on each output | [Sensitivity Labels](sensitivity-labels.md) |
 | **Enable/disable** | `enabled: false` on each output | Toggle without removing config |
 
+## 🏗️ Buffering and Delivery Model
+
+Outputs fall into two categories based on how they receive events from
+the core drain goroutine:
+
+| Output | Internal Buffer | Batching | Delivery Model |
+|--------|----------------|----------|----------------|
+| **Stdout** | No | No | Synchronous — blocks drain goroutine until write to `os.Stdout` completes |
+| **File** | No | No | Synchronous — blocks drain goroutine until file write completes (with OS-level file buffering) |
+| **Syslog** | No | No | Synchronous — blocks drain goroutine until TCP/UDP write completes |
+| **Webhook** | Yes (`buffer_size`, default 10,000) | Yes (`batch_size`, `flush_interval`) | Async — own goroutine, batched HTTP POST |
+| **Loki** | Yes (`buffer_size`, default 10,000) | Yes (`batch_size`, `max_batch_bytes`, `flush_interval`) | Async — own goroutine, batched HTTP POST with gzip |
+
+**Synchronous outputs** (file, syslog, stdout) write directly from the
+core drain goroutine. If a synchronous output blocks (e.g., syslog
+server unreachable, disk full), it delays delivery to **all** outputs
+because the drain goroutine delivers sequentially. Monitor output
+errors and consider using async outputs (webhook, Loki) for unreliable
+destinations.
+
+**Async outputs** (webhook, Loki) copy the event bytes into their own
+internal buffer and return immediately. A background goroutine reads
+from this buffer, accumulates events into batches, and delivers them
+via HTTP. If the internal buffer fills, events are dropped.
+`RecordLokiDrop()` or `RecordWebhookDrop()` fires on every drop, and
+a rate-limited `slog.Warn` fires at most once per 10 seconds. Drops
+in one async output's buffer do not affect other outputs.
+
+See [Two-Level Buffering](async-delivery.md#two-level-buffering) for
+the complete pipeline architecture, memory sizing, and tuning guidance.
+
 ## 📡 Fan-Out Architecture
 
 ```mermaid
@@ -221,8 +252,11 @@ flowchart TD
 ```
 
 The drain goroutine serialises each event once per unique format and
-delivers to all outputs in sequence. Each output is independent —
-a failure in one output does not block or affect delivery to others.
+delivers to all outputs in sequence. An error returned by one output
+does not prevent delivery to others — the drain loop continues.
+However, a synchronous output that blocks (e.g., during syslog
+reconnection) delays all subsequent outputs for that event. See
+[Buffering and Delivery Model](#-buffering-and-delivery-model) above.
 
 ## 📚 Further Reading
 

--- a/docs/stdout-output.md
+++ b/docs/stdout-output.md
@@ -89,6 +89,23 @@ guards against concurrent `Close()` calls.
 exits. Close drains the internal buffer and flushes all pending events.
 Without it, events still in the buffer are lost silently.
 
+## Delivery Model
+
+The stdout output writes **synchronously** from the core drain
+goroutine. It has no internal buffer or batching — each event is
+written directly to `os.Stdout` as soon as the drain goroutine
+processes it.
+
+In practice, stdout writes are very fast and rarely a bottleneck.
+`StdoutOutput.Write()` acquires a mutex internally to guard against
+concurrent `Close()` calls, but since the drain goroutine is the sole
+writer, this mutex never contends during normal operation. If stdout
+is piped to a slow consumer or a full pipe buffer, it will delay
+delivery to all other outputs.
+
+See [Two-Level Buffering](async-delivery.md#two-level-buffering) for
+the complete pipeline architecture.
+
 ## Configuration
 
 The stdout output accepts **no type-specific configuration**:

--- a/docs/syslog-output.md
+++ b/docs/syslog-output.md
@@ -279,6 +279,25 @@ enforced by default (configurable via `tls_policy`). Supports:
 
 See [TLS and mTLS Configuration](#tls-and-mtls-configuration) below.
 
+## Delivery Model
+
+The syslog output writes **synchronously** from the core drain
+goroutine via `WriteWithMetadata()`, which carries per-event metadata
+(event type, severity, category, timestamp) used for severity mapping
+into the RFC 5424 PRIORITY field. It has no internal buffer or
+batching — each event is sent directly to the syslog server as soon
+as the drain goroutine processes it.
+
+This means syslog write latency directly affects the drain loop
+throughput and delivery to all other outputs. If the syslog server is
+slow or unreachable, the reconnection backoff (100ms to 30s) will
+delay delivery to every configured output. For unreliable syslog
+servers, you SHOULD pair with an async output (webhook or Loki) to
+ensure other destinations are not blocked.
+
+See [Two-Level Buffering](async-delivery.md#two-level-buffering) for
+the complete pipeline architecture.
+
 ## Complete Configuration Reference
 
 | Field | Type | Default | Description |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,7 +51,9 @@ than the drain goroutine can write them to outputs.
 | **Output error loop** | If an output is failing on every write, the drain goroutine spends time on error handling instead of processing events. Check `RecordOutputError` metrics. |
 
 Monitor `RecordBufferDrop()` in your metrics to catch this before
-users notice. See [Metrics & Monitoring](metrics-monitoring.md).
+users notice. See [Metrics & Monitoring](metrics-monitoring.md) and
+[Two-Level Buffering](async-delivery.md#two-level-buffering) for the
+complete pipeline architecture and tuning guidance.
 
 ---
 

--- a/docs/webhook-output.md
+++ b/docs/webhook-output.md
@@ -11,6 +11,7 @@ by default (SSRF protection).
 - [Why Webhook for Audit Logging?](#why-webhook-for-audit-logging)
 - [Quick Start](#quick-start)
 - [How It Works](#how-it-works)
+- [Buffering Architecture](#buffering-architecture)
 - [NDJSON Format](#ndjson-format)
 - [Complete Configuration Reference](#complete-configuration-reference)
 - [Authentication](#authentication)
@@ -84,6 +85,61 @@ flowchart LR
 5. On transient failure (5xx, 429), the batch is retried with
    exponential backoff
 6. On permanent failure (4xx), the batch is dropped
+
+## Buffering Architecture
+
+The webhook output has its own internal buffer separate from the core
+logger buffer. This is [Level 2](async-delivery.md#two-level-buffering)
+in the pipeline:
+
+```
+Core drain goroutine ──► Write()
+                            → copies event bytes
+                            → enqueues to webhook channel (capacity: buffer_size, default 10,000)
+                            → returns immediately (non-blocking)
+
+Webhook batchLoop goroutine
+  → reads from channel
+  → accumulates into batch
+  → flushes on: batch_size (100) | flush_interval (5s) | shutdown
+  → joins events as NDJSON
+  → HTTP POST to endpoint
+  → retries on 429/5xx
+```
+
+### `buffer_size` vs `batch_size`
+
+These are different things:
+
+| Config | Default | What It Controls |
+|--------|---------|------------------|
+| `buffer_size` | 10,000 | How many events can **queue up** waiting to be sent. This is the channel capacity. |
+| `batch_size` | 100 | How many events are grouped into a **single HTTP POST**. This is the flush threshold. |
+
+With the defaults, up to 100 batches of events (10,000 / 100) can be
+queued before drops begin. Increasing `buffer_size` absorbs longer
+outages; decreasing `batch_size` or `flush_interval` drains the buffer
+faster.
+
+### Drop Behaviour
+
+If the internal buffer fills (e.g., the endpoint is down and retries
+are consuming time), new events are **dropped silently** — the
+`Write()` call returns `nil` to avoid blocking the core drain
+goroutine. This isolation ensures that a webhook outage does not
+affect delivery to other outputs.
+
+A rate-limited `slog.Warn` fires at most once per 10 seconds during
+sustained drops. The `RecordWebhookDrop()` metric fires on **every**
+drop — use metrics, not log lines, for precise monitoring.
+
+### Relationship to Core Buffer
+
+The webhook `buffer_size` is independent of the core
+`logger.buffer_size` (`Config.BufferSize`). Both default to 10,000
+but they serve different pipeline stages. See
+[Two-Level Buffering](async-delivery.md#two-level-buffering) for the
+full architecture diagram and memory sizing guidance.
 
 ## NDJSON Format
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,17 @@ The **basic** example uses the programmatic API to show how the library
 works. Every example after that uses YAML files for configuration —
 that's how you'd use go-audit in a real application.
 
+### Buffering and Performance
+
+Examples 7 (webhook) and 8 (Loki) use outputs with internal buffers
+and batching. Examples 5 (file), 6 (syslog), and 4 (stdout) use
+synchronous outputs that write directly from the drain goroutine.
+Example 9 (multi-output) demonstrates both synchronous and async
+outputs in a single configuration — the most direct illustration of
+the two-level buffering model. See
+[Two-Level Buffering](../docs/async-delivery.md#two-level-buffering)
+for the architecture explanation, memory sizing, and tuning guidance.
+
 ## Getting Started
 
 From a fresh clone:


### PR DESCRIPTION
## Summary

- Adds "Two-Level Buffering" section to `docs/async-delivery.md` with complete pipeline diagram, `buffer_size` vs `batch_size` definitions, memory sizing guidance, `sync.Pool` details, and tuning table
- Adds "Buffering and Delivery Model" comparison table to `docs/outputs.md` showing sync vs async delivery per output type
- Adds "Buffering Architecture" sections to `docs/loki-output.md` and `docs/webhook-output.md` explaining the per-output buffer/batch relationship
- Adds "Delivery Model" sections to `docs/file-output.md`, `docs/syslog-output.md`, and `docs/stdout-output.md` noting synchronous writes from the drain goroutine
- Fixes contradiction in `docs/outputs.md` fan-out prose (error isolation vs latency blocking)
- Adds cross-references from `docs/troubleshooting.md` and `docs/error-reference.md` to the two-level buffering section
- Adds buffering cross-reference paragraph to `examples/README.md`

Closes #318 (items 1-5, 7). Item 6 (new progressive example) will be a separate PR.

## Test plan

- [ ] All markdown renders correctly on GitHub (tables, code blocks, ASCII diagrams)
- [ ] Cross-reference links resolve correctly (`async-delivery.md#two-level-buffering`)
- [ ] No broken links in the 10 changed files
- [ ] Technical claims verified against source code (sync.Pool, sequential delivery, WriteWithMetadata dispatch, non-blocking drop with nil return)