### PR TITLE
feat: expand capstone to users, items, and orders (#350)

### DIFF
--- a/examples/16-crud-api/audit_generated.go
+++ b/examples/16-crud-api/audit_generated.go
@@ -36,6 +36,8 @@ const (
 	EventOrderCreate = "order_create"
 	// EventOrderList — Orders were listed
 	EventOrderList = "order_list"
+	// EventOrderRead — An order was viewed
+	EventOrderRead = "order_read"
 	// EventOrderUpdate — An order was updated
 	EventOrderUpdate = "order_update"
 	// EventRateLimitExceeded — Too many failed authentication attempts
@@ -46,6 +48,8 @@ const (
 	EventUserCreate = "user_create"
 	// EventUserDelete — A user account was deleted
 	EventUserDelete = "user_delete"
+	// EventUserList — User accounts were listed
+	EventUserList = "user_list"
 	// EventUserRead — A user account was viewed
 	EventUserRead = "user_read"
 	// EventUserUpdate — A user account was updated
@@ -177,6 +181,10 @@ var EventFields = map[string]struct {
 		Required: []string{FieldOutcome},
 		Optional: []string{},
 	},
+	EventOrderRead: {
+		Required: []string{FieldOutcome},
+		Optional: []string{},
+	},
 	EventOrderUpdate: {
 		Required: []string{FieldActorID, FieldOutcome},
 		Optional: []string{},
@@ -197,6 +205,10 @@ var EventFields = map[string]struct {
 		Required: []string{FieldActorID, FieldOutcome},
 		Optional: []string{},
 	},
+	EventUserList: {
+		Required: []string{FieldOutcome},
+		Optional: []string{},
+	},
 	EventUserRead: {
 		Required: []string{FieldOutcome},
 		Optional: []string{},
@@ -210,7 +222,7 @@ var EventFields = map[string]struct {
 // CategoryEvents maps category names to their member event types.
 var CategoryEvents = map[string][]string{
 	CategoryCompliance: {EventBulkDelete, EventDataExport},
-	CategoryRead:       {EventItemList, EventItemRead, EventOrderList, EventUserRead},
+	CategoryRead:       {EventItemList, EventItemRead, EventOrderList, EventOrderRead, EventUserList, EventUserRead},
 	CategorySecurity:   {EventAuthFailure, EventAuthLogout, EventAuthSuccess, EventAuthorizationFailure, EventRateLimitExceeded, EventTokenExpired},
 	CategoryWrite:      {EventConfigChange, EventItemCreate, EventItemDelete, EventItemUpdate, EventOrderCreate, EventOrderUpdate, EventUserCreate, EventUserDelete, EventUserUpdate},
 }
@@ -4110,6 +4122,288 @@ func (e *OrderListEvent) Categories() []audit.CategoryInfo {
 	}
 }
 
+// OrderReadFields describes every field on [EventOrderRead] events.
+type OrderReadFields struct {
+	Outcome    audit.FieldInfo // required
+	Action     audit.FieldInfo // reserved standard
+	ActorID    audit.FieldInfo // reserved standard
+	ActorUID   audit.FieldInfo // reserved standard
+	DestHost   audit.FieldInfo // reserved standard
+	DestIP     audit.FieldInfo // reserved standard
+	DestPort   audit.FieldInfo // reserved standard
+	EndTime    audit.FieldInfo // reserved standard
+	FileHash   audit.FieldInfo // reserved standard
+	FileName   audit.FieldInfo // reserved standard
+	FilePath   audit.FieldInfo // reserved standard
+	FileSize   audit.FieldInfo // reserved standard
+	Message    audit.FieldInfo // reserved standard
+	Method     audit.FieldInfo // reserved standard
+	Path       audit.FieldInfo // reserved standard
+	Protocol   audit.FieldInfo // reserved standard
+	Reason     audit.FieldInfo // reserved standard
+	Referrer   audit.FieldInfo // reserved standard
+	RequestID  audit.FieldInfo // reserved standard
+	Role       audit.FieldInfo // reserved standard
+	SessionID  audit.FieldInfo // reserved standard
+	SourceHost audit.FieldInfo // reserved standard
+	SourceIP   audit.FieldInfo // reserved standard
+	SourcePort audit.FieldInfo // reserved standard
+	StartTime  audit.FieldInfo // reserved standard
+	TargetID   audit.FieldInfo // reserved standard
+	TargetRole audit.FieldInfo // reserved standard
+	TargetType audit.FieldInfo // reserved standard
+	TargetUID  audit.FieldInfo // reserved standard
+	Transport  audit.FieldInfo // reserved standard
+	UserAgent  audit.FieldInfo // reserved standard
+}
+
+// OrderReadEvent builds a type-safe audit event: An order was viewed.
+// A builder is not safe for concurrent use. Calling a setter
+// multiple times overwrites the previous value.
+type OrderReadEvent struct {
+	fields audit.Fields
+}
+
+// NewOrderReadEvent creates a EventOrderRead event with required fields.
+func NewOrderReadEvent(outcome any) *OrderReadEvent {
+	return &OrderReadEvent{fields: audit.Fields{
+		FieldOutcome: outcome,
+	}}
+}
+
+// SetAction sets the reserved standard field "action".
+func (e *OrderReadEvent) SetAction(v any) *OrderReadEvent {
+	e.fields[FieldAction] = v
+	return e
+}
+
+// SetActorID sets the reserved standard field "actor_id".
+func (e *OrderReadEvent) SetActorID(v any) *OrderReadEvent {
+	e.fields[FieldActorID] = v
+	return e
+}
+
+// SetActorUID sets the reserved standard field "actor_uid".
+func (e *OrderReadEvent) SetActorUID(v any) *OrderReadEvent {
+	e.fields[FieldActorUID] = v
+	return e
+}
+
+// SetDestHost sets the reserved standard field "dest_host".
+func (e *OrderReadEvent) SetDestHost(v any) *OrderReadEvent {
+	e.fields[FieldDestHost] = v
+	return e
+}
+
+// SetDestIP sets the reserved standard field "dest_ip".
+func (e *OrderReadEvent) SetDestIP(v any) *OrderReadEvent {
+	e.fields[FieldDestIP] = v
+	return e
+}
+
+// SetDestPort sets the reserved standard field "dest_port".
+func (e *OrderReadEvent) SetDestPort(v any) *OrderReadEvent {
+	e.fields[FieldDestPort] = v
+	return e
+}
+
+// SetEndTime sets the reserved standard field "end_time".
+func (e *OrderReadEvent) SetEndTime(v any) *OrderReadEvent {
+	e.fields[FieldEndTime] = v
+	return e
+}
+
+// SetFileHash sets the reserved standard field "file_hash".
+func (e *OrderReadEvent) SetFileHash(v any) *OrderReadEvent {
+	e.fields[FieldFileHash] = v
+	return e
+}
+
+// SetFileName sets the reserved standard field "file_name".
+func (e *OrderReadEvent) SetFileName(v any) *OrderReadEvent {
+	e.fields[FieldFileName] = v
+	return e
+}
+
+// SetFilePath sets the reserved standard field "file_path".
+func (e *OrderReadEvent) SetFilePath(v any) *OrderReadEvent {
+	e.fields[FieldFilePath] = v
+	return e
+}
+
+// SetFileSize sets the reserved standard field "file_size".
+func (e *OrderReadEvent) SetFileSize(v any) *OrderReadEvent {
+	e.fields[FieldFileSize] = v
+	return e
+}
+
+// SetMessage sets the reserved standard field "message".
+func (e *OrderReadEvent) SetMessage(v any) *OrderReadEvent {
+	e.fields[FieldMessage] = v
+	return e
+}
+
+// SetMethod sets the reserved standard field "method".
+func (e *OrderReadEvent) SetMethod(v any) *OrderReadEvent {
+	e.fields[FieldMethod] = v
+	return e
+}
+
+// SetPath sets the reserved standard field "path".
+func (e *OrderReadEvent) SetPath(v any) *OrderReadEvent {
+	e.fields[FieldPath] = v
+	return e
+}
+
+// SetProtocol sets the reserved standard field "protocol".
+func (e *OrderReadEvent) SetProtocol(v any) *OrderReadEvent {
+	e.fields[FieldProtocol] = v
+	return e
+}
+
+// SetReason sets the reserved standard field "reason".
+func (e *OrderReadEvent) SetReason(v any) *OrderReadEvent {
+	e.fields[FieldReason] = v
+	return e
+}
+
+// SetReferrer sets the reserved standard field "referrer".
+func (e *OrderReadEvent) SetReferrer(v any) *OrderReadEvent {
+	e.fields[FieldReferrer] = v
+	return e
+}
+
+// SetRequestID sets the reserved standard field "request_id".
+func (e *OrderReadEvent) SetRequestID(v any) *OrderReadEvent {
+	e.fields[FieldRequestID] = v
+	return e
+}
+
+// SetRole sets the reserved standard field "role".
+func (e *OrderReadEvent) SetRole(v any) *OrderReadEvent {
+	e.fields[FieldRole] = v
+	return e
+}
+
+// SetSessionID sets the reserved standard field "session_id".
+func (e *OrderReadEvent) SetSessionID(v any) *OrderReadEvent {
+	e.fields[FieldSessionID] = v
+	return e
+}
+
+// SetSourceHost sets the reserved standard field "source_host".
+func (e *OrderReadEvent) SetSourceHost(v any) *OrderReadEvent {
+	e.fields[FieldSourceHost] = v
+	return e
+}
+
+// SetSourceIP sets the reserved standard field "source_ip".
+func (e *OrderReadEvent) SetSourceIP(v any) *OrderReadEvent {
+	e.fields[FieldSourceIP] = v
+	return e
+}
+
+// SetSourcePort sets the reserved standard field "source_port".
+func (e *OrderReadEvent) SetSourcePort(v any) *OrderReadEvent {
+	e.fields[FieldSourcePort] = v
+	return e
+}
+
+// SetStartTime sets the reserved standard field "start_time".
+func (e *OrderReadEvent) SetStartTime(v any) *OrderReadEvent {
+	e.fields[FieldStartTime] = v
+	return e
+}
+
+// SetTargetID sets the reserved standard field "target_id".
+func (e *OrderReadEvent) SetTargetID(v any) *OrderReadEvent {
+	e.fields[FieldTargetID] = v
+	return e
+}
+
+// SetTargetRole sets the reserved standard field "target_role".
+func (e *OrderReadEvent) SetTargetRole(v any) *OrderReadEvent {
+	e.fields[FieldTargetRole] = v
+	return e
+}
+
+// SetTargetType sets the reserved standard field "target_type".
+func (e *OrderReadEvent) SetTargetType(v any) *OrderReadEvent {
+	e.fields[FieldTargetType] = v
+	return e
+}
+
+// SetTargetUID sets the reserved standard field "target_uid".
+func (e *OrderReadEvent) SetTargetUID(v any) *OrderReadEvent {
+	e.fields[FieldTargetUID] = v
+	return e
+}
+
+// SetTransport sets the reserved standard field "transport".
+func (e *OrderReadEvent) SetTransport(v any) *OrderReadEvent {
+	e.fields[FieldTransport] = v
+	return e
+}
+
+// SetUserAgent sets the reserved standard field "user_agent".
+func (e *OrderReadEvent) SetUserAgent(v any) *OrderReadEvent {
+	e.fields[FieldUserAgent] = v
+	return e
+}
+
+// EventType returns the event type name.
+func (e *OrderReadEvent) EventType() string { return EventOrderRead }
+
+// Fields returns the event fields for [audit.Logger.AuditEvent].
+func (e *OrderReadEvent) Fields() audit.Fields { return e.fields }
+
+// Description returns the taxonomy description.
+func (e *OrderReadEvent) Description() string { return "An order was viewed" }
+
+// FieldInfo returns typed descriptors for every field on this event.
+func (e *OrderReadEvent) FieldInfo() OrderReadFields {
+	return OrderReadFields{
+		Outcome:    audit.FieldInfo{Name: FieldOutcome, Required: true},
+		Action:     audit.FieldInfo{Name: FieldAction},
+		ActorID:    audit.FieldInfo{Name: FieldActorID},
+		ActorUID:   audit.FieldInfo{Name: FieldActorUID},
+		DestHost:   audit.FieldInfo{Name: FieldDestHost},
+		DestIP:     audit.FieldInfo{Name: FieldDestIP},
+		DestPort:   audit.FieldInfo{Name: FieldDestPort},
+		EndTime:    audit.FieldInfo{Name: FieldEndTime},
+		FileHash:   audit.FieldInfo{Name: FieldFileHash},
+		FileName:   audit.FieldInfo{Name: FieldFileName},
+		FilePath:   audit.FieldInfo{Name: FieldFilePath},
+		FileSize:   audit.FieldInfo{Name: FieldFileSize},
+		Message:    audit.FieldInfo{Name: FieldMessage},
+		Method:     audit.FieldInfo{Name: FieldMethod},
+		Path:       audit.FieldInfo{Name: FieldPath},
+		Protocol:   audit.FieldInfo{Name: FieldProtocol},
+		Reason:     audit.FieldInfo{Name: FieldReason},
+		Referrer:   audit.FieldInfo{Name: FieldReferrer},
+		RequestID:  audit.FieldInfo{Name: FieldRequestID},
+		Role:       audit.FieldInfo{Name: FieldRole},
+		SessionID:  audit.FieldInfo{Name: FieldSessionID},
+		SourceHost: audit.FieldInfo{Name: FieldSourceHost},
+		SourceIP:   audit.FieldInfo{Name: FieldSourceIP},
+		SourcePort: audit.FieldInfo{Name: FieldSourcePort},
+		StartTime:  audit.FieldInfo{Name: FieldStartTime},
+		TargetID:   audit.FieldInfo{Name: FieldTargetID},
+		TargetRole: audit.FieldInfo{Name: FieldTargetRole},
+		TargetType: audit.FieldInfo{Name: FieldTargetType},
+		TargetUID:  audit.FieldInfo{Name: FieldTargetUID},
+		Transport:  audit.FieldInfo{Name: FieldTransport},
+		UserAgent:  audit.FieldInfo{Name: FieldUserAgent},
+	}
+}
+
+// Categories returns the categories this event belongs to.
+func (e *OrderReadEvent) Categories() []audit.CategoryInfo {
+	return []audit.CategoryInfo{
+		{Name: CategoryRead, Severity: intPtr(3)},
+	}
+}
+
 // OrderUpdateFields describes every field on [EventOrderUpdate] events.
 type OrderUpdateFields struct {
 	ActorID    audit.FieldInfo // required
@@ -5517,6 +5811,288 @@ func (e *UserDeleteEvent) FieldInfo() UserDeleteFields {
 func (e *UserDeleteEvent) Categories() []audit.CategoryInfo {
 	return []audit.CategoryInfo{
 		{Name: CategoryWrite, Severity: intPtr(5)},
+	}
+}
+
+// UserListFields describes every field on [EventUserList] events.
+type UserListFields struct {
+	Outcome    audit.FieldInfo // required
+	Action     audit.FieldInfo // reserved standard
+	ActorID    audit.FieldInfo // reserved standard
+	ActorUID   audit.FieldInfo // reserved standard
+	DestHost   audit.FieldInfo // reserved standard
+	DestIP     audit.FieldInfo // reserved standard
+	DestPort   audit.FieldInfo // reserved standard
+	EndTime    audit.FieldInfo // reserved standard
+	FileHash   audit.FieldInfo // reserved standard
+	FileName   audit.FieldInfo // reserved standard
+	FilePath   audit.FieldInfo // reserved standard
+	FileSize   audit.FieldInfo // reserved standard
+	Message    audit.FieldInfo // reserved standard
+	Method     audit.FieldInfo // reserved standard
+	Path       audit.FieldInfo // reserved standard
+	Protocol   audit.FieldInfo // reserved standard
+	Reason     audit.FieldInfo // reserved standard
+	Referrer   audit.FieldInfo // reserved standard
+	RequestID  audit.FieldInfo // reserved standard
+	Role       audit.FieldInfo // reserved standard
+	SessionID  audit.FieldInfo // reserved standard
+	SourceHost audit.FieldInfo // reserved standard
+	SourceIP   audit.FieldInfo // reserved standard
+	SourcePort audit.FieldInfo // reserved standard
+	StartTime  audit.FieldInfo // reserved standard
+	TargetID   audit.FieldInfo // reserved standard
+	TargetRole audit.FieldInfo // reserved standard
+	TargetType audit.FieldInfo // reserved standard
+	TargetUID  audit.FieldInfo // reserved standard
+	Transport  audit.FieldInfo // reserved standard
+	UserAgent  audit.FieldInfo // reserved standard
+}
+
+// UserListEvent builds a type-safe audit event: User accounts were listed.
+// A builder is not safe for concurrent use. Calling a setter
+// multiple times overwrites the previous value.
+type UserListEvent struct {
+	fields audit.Fields
+}
+
+// NewUserListEvent creates a EventUserList event with required fields.
+func NewUserListEvent(outcome any) *UserListEvent {
+	return &UserListEvent{fields: audit.Fields{
+		FieldOutcome: outcome,
+	}}
+}
+
+// SetAction sets the reserved standard field "action".
+func (e *UserListEvent) SetAction(v any) *UserListEvent {
+	e.fields[FieldAction] = v
+	return e
+}
+
+// SetActorID sets the reserved standard field "actor_id".
+func (e *UserListEvent) SetActorID(v any) *UserListEvent {
+	e.fields[FieldActorID] = v
+	return e
+}
+
+// SetActorUID sets the reserved standard field "actor_uid".
+func (e *UserListEvent) SetActorUID(v any) *UserListEvent {
+	e.fields[FieldActorUID] = v
+	return e
+}
+
+// SetDestHost sets the reserved standard field "dest_host".
+func (e *UserListEvent) SetDestHost(v any) *UserListEvent {
+	e.fields[FieldDestHost] = v
+	return e
+}
+
+// SetDestIP sets the reserved standard field "dest_ip".
+func (e *UserListEvent) SetDestIP(v any) *UserListEvent {
+	e.fields[FieldDestIP] = v
+	return e
+}
+
+// SetDestPort sets the reserved standard field "dest_port".
+func (e *UserListEvent) SetDestPort(v any) *UserListEvent {
+	e.fields[FieldDestPort] = v
+	return e
+}
+
+// SetEndTime sets the reserved standard field "end_time".
+func (e *UserListEvent) SetEndTime(v any) *UserListEvent {
+	e.fields[FieldEndTime] = v
+	return e
+}
+
+// SetFileHash sets the reserved standard field "file_hash".
+func (e *UserListEvent) SetFileHash(v any) *UserListEvent {
+	e.fields[FieldFileHash] = v
+	return e
+}
+
+// SetFileName sets the reserved standard field "file_name".
+func (e *UserListEvent) SetFileName(v any) *UserListEvent {
+	e.fields[FieldFileName] = v
+	return e
+}
+
+// SetFilePath sets the reserved standard field "file_path".
+func (e *UserListEvent) SetFilePath(v any) *UserListEvent {
+	e.fields[FieldFilePath] = v
+	return e
+}
+
+// SetFileSize sets the reserved standard field "file_size".
+func (e *UserListEvent) SetFileSize(v any) *UserListEvent {
+	e.fields[FieldFileSize] = v
+	return e
+}
+
+// SetMessage sets the reserved standard field "message".
+func (e *UserListEvent) SetMessage(v any) *UserListEvent {
+	e.fields[FieldMessage] = v
+	return e
+}
+
+// SetMethod sets the reserved standard field "method".
+func (e *UserListEvent) SetMethod(v any) *UserListEvent {
+	e.fields[FieldMethod] = v
+	return e
+}
+
+// SetPath sets the reserved standard field "path".
+func (e *UserListEvent) SetPath(v any) *UserListEvent {
+	e.fields[FieldPath] = v
+	return e
+}
+
+// SetProtocol sets the reserved standard field "protocol".
+func (e *UserListEvent) SetProtocol(v any) *UserListEvent {
+	e.fields[FieldProtocol] = v
+	return e
+}
+
+// SetReason sets the reserved standard field "reason".
+func (e *UserListEvent) SetReason(v any) *UserListEvent {
+	e.fields[FieldReason] = v
+	return e
+}
+
+// SetReferrer sets the reserved standard field "referrer".
+func (e *UserListEvent) SetReferrer(v any) *UserListEvent {
+	e.fields[FieldReferrer] = v
+	return e
+}
+
+// SetRequestID sets the reserved standard field "request_id".
+func (e *UserListEvent) SetRequestID(v any) *UserListEvent {
+	e.fields[FieldRequestID] = v
+	return e
+}
+
+// SetRole sets the reserved standard field "role".
+func (e *UserListEvent) SetRole(v any) *UserListEvent {
+	e.fields[FieldRole] = v
+	return e
+}
+
+// SetSessionID sets the reserved standard field "session_id".
+func (e *UserListEvent) SetSessionID(v any) *UserListEvent {
+	e.fields[FieldSessionID] = v
+	return e
+}
+
+// SetSourceHost sets the reserved standard field "source_host".
+func (e *UserListEvent) SetSourceHost(v any) *UserListEvent {
+	e.fields[FieldSourceHost] = v
+	return e
+}
+
+// SetSourceIP sets the reserved standard field "source_ip".
+func (e *UserListEvent) SetSourceIP(v any) *UserListEvent {
+	e.fields[FieldSourceIP] = v
+	return e
+}
+
+// SetSourcePort sets the reserved standard field "source_port".
+func (e *UserListEvent) SetSourcePort(v any) *UserListEvent {
+	e.fields[FieldSourcePort] = v
+	return e
+}
+
+// SetStartTime sets the reserved standard field "start_time".
+func (e *UserListEvent) SetStartTime(v any) *UserListEvent {
+	e.fields[FieldStartTime] = v
+	return e
+}
+
+// SetTargetID sets the reserved standard field "target_id".
+func (e *UserListEvent) SetTargetID(v any) *UserListEvent {
+	e.fields[FieldTargetID] = v
+	return e
+}
+
+// SetTargetRole sets the reserved standard field "target_role".
+func (e *UserListEvent) SetTargetRole(v any) *UserListEvent {
+	e.fields[FieldTargetRole] = v
+	return e
+}
+
+// SetTargetType sets the reserved standard field "target_type".
+func (e *UserListEvent) SetTargetType(v any) *UserListEvent {
+	e.fields[FieldTargetType] = v
+	return e
+}
+
+// SetTargetUID sets the reserved standard field "target_uid".
+func (e *UserListEvent) SetTargetUID(v any) *UserListEvent {
+	e.fields[FieldTargetUID] = v
+	return e
+}
+
+// SetTransport sets the reserved standard field "transport".
+func (e *UserListEvent) SetTransport(v any) *UserListEvent {
+	e.fields[FieldTransport] = v
+	return e
+}
+
+// SetUserAgent sets the reserved standard field "user_agent".
+func (e *UserListEvent) SetUserAgent(v any) *UserListEvent {
+	e.fields[FieldUserAgent] = v
+	return e
+}
+
+// EventType returns the event type name.
+func (e *UserListEvent) EventType() string { return EventUserList }
+
+// Fields returns the event fields for [audit.Logger.AuditEvent].
+func (e *UserListEvent) Fields() audit.Fields { return e.fields }
+
+// Description returns the taxonomy description.
+func (e *UserListEvent) Description() string { return "User accounts were listed" }
+
+// FieldInfo returns typed descriptors for every field on this event.
+func (e *UserListEvent) FieldInfo() UserListFields {
+	return UserListFields{
+		Outcome:    audit.FieldInfo{Name: FieldOutcome, Required: true},
+		Action:     audit.FieldInfo{Name: FieldAction},
+		ActorID:    audit.FieldInfo{Name: FieldActorID},
+		ActorUID:   audit.FieldInfo{Name: FieldActorUID},
+		DestHost:   audit.FieldInfo{Name: FieldDestHost},
+		DestIP:     audit.FieldInfo{Name: FieldDestIP},
+		DestPort:   audit.FieldInfo{Name: FieldDestPort},
+		EndTime:    audit.FieldInfo{Name: FieldEndTime},
+		FileHash:   audit.FieldInfo{Name: FieldFileHash},
+		FileName:   audit.FieldInfo{Name: FieldFileName},
+		FilePath:   audit.FieldInfo{Name: FieldFilePath},
+		FileSize:   audit.FieldInfo{Name: FieldFileSize},
+		Message:    audit.FieldInfo{Name: FieldMessage},
+		Method:     audit.FieldInfo{Name: FieldMethod},
+		Path:       audit.FieldInfo{Name: FieldPath},
+		Protocol:   audit.FieldInfo{Name: FieldProtocol},
+		Reason:     audit.FieldInfo{Name: FieldReason},
+		Referrer:   audit.FieldInfo{Name: FieldReferrer},
+		RequestID:  audit.FieldInfo{Name: FieldRequestID},
+		Role:       audit.FieldInfo{Name: FieldRole},
+		SessionID:  audit.FieldInfo{Name: FieldSessionID},
+		SourceHost: audit.FieldInfo{Name: FieldSourceHost},
+		SourceIP:   audit.FieldInfo{Name: FieldSourceIP},
+		SourcePort: audit.FieldInfo{Name: FieldSourcePort},
+		StartTime:  audit.FieldInfo{Name: FieldStartTime},
+		TargetID:   audit.FieldInfo{Name: FieldTargetID},
+		TargetRole: audit.FieldInfo{Name: FieldTargetRole},
+		TargetType: audit.FieldInfo{Name: FieldTargetType},
+		TargetUID:  audit.FieldInfo{Name: FieldTargetUID},
+		Transport:  audit.FieldInfo{Name: FieldTransport},
+		UserAgent:  audit.FieldInfo{Name: FieldUserAgent},
+	}
+}
+
+// Categories returns the categories this event belongs to.
+func (e *UserListEvent) Categories() []audit.CategoryInfo {
+	return []audit.CategoryInfo{
+		{Name: CategoryRead, Severity: intPtr(3)},
 	}
 }
 

--- a/examples/16-crud-api/db.go
+++ b/examples/16-crud-api/db.go
@@ -22,7 +22,20 @@ import (
 	_ "github.com/lib/pq" // Postgres driver
 )
 
-// Item is the CRUD resource.
+// --- Model types ---
+
+// User is a registered user account. Email and phone carry the "pii"
+// sensitivity label in the taxonomy — they are stripped from Loki output.
+type User struct { //nolint:govet // fieldalignment: readability preferred
+	ID        string    `json:"id"`
+	Username  string    `json:"username"`
+	Email     string    `json:"email"`
+	Phone     string    `json:"phone,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Item is an inventory item.
 type Item struct { //nolint:govet // fieldalignment: readability preferred
 	ID          string    `json:"id"`
 	Name        string    `json:"name"`
@@ -30,6 +43,19 @@ type Item struct { //nolint:govet // fieldalignment: readability preferred
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }
+
+// Order links a user to an item with a quantity and status.
+type Order struct { //nolint:govet // fieldalignment: readability preferred
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	ItemID    string    `json:"item_id"`
+	Quantity  int       `json:"quantity"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// --- Connection ---
 
 func connectDB() (*sql.DB, error) {
 	// sslmode=disable is for local Docker development only — use sslmode=require in production.
@@ -47,8 +73,24 @@ func connectDB() (*sql.DB, error) {
 	return db, nil
 }
 
+// --- Schema ---
+
 func createSchema(db *sql.DB) error {
-	_, err := db.Exec(`
+	// Users first — orders reference users.
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS users (
+			id         TEXT PRIMARY KEY,
+			username   TEXT UNIQUE NOT NULL,
+			email      TEXT NOT NULL DEFAULT '',
+			phone      TEXT NOT NULL DEFAULT '',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		return fmt.Errorf("create users table: %w", err)
+	}
+
+	if _, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS items (
 			id          TEXT PRIMARY KEY,
 			name        TEXT NOT NULL,
@@ -56,77 +98,24 @@ func createSchema(db *sql.DB) error {
 			created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)
-	`)
-	return err
-}
+	`); err != nil {
+		return fmt.Errorf("create items table: %w", err)
+	}
 
-func queryItems(db *sql.DB) ([]Item, error) {
-	rows, err := db.Query("SELECT id, name, description, created_at, updated_at FROM items ORDER BY created_at")
-	if err != nil {
-		return nil, err
+	// Orders reference both users and items.
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS orders (
+			id         TEXT PRIMARY KEY,
+			user_id    TEXT NOT NULL REFERENCES users(id),
+			item_id    TEXT NOT NULL REFERENCES items(id),
+			quantity   INTEGER NOT NULL DEFAULT 1,
+			status     TEXT NOT NULL DEFAULT 'pending',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		return fmt.Errorf("create orders table: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
 
-	var items []Item
-	for rows.Next() {
-		var it Item
-		if err := rows.Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt); err != nil {
-			return nil, err
-		}
-		items = append(items, it)
-	}
-	if items == nil {
-		items = []Item{} // return empty array, not null
-	}
-	return items, rows.Err()
-}
-
-func queryItem(db *sql.DB, id string) (*Item, error) {
-	var it Item
-	err := db.QueryRow(
-		"SELECT id, name, description, created_at, updated_at FROM items WHERE id = $1", id,
-	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
-	if err != nil {
-		return nil, err
-	}
-	return &it, nil
-}
-
-func insertItem(db *sql.DB, id, name, description string) (*Item, error) {
-	var it Item
-	err := db.QueryRow(
-		"INSERT INTO items (id, name, description) VALUES ($1, $2, $3) RETURNING id, name, description, created_at, updated_at",
-		id, name, description,
-	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
-	if err != nil {
-		return nil, err
-	}
-	return &it, nil
-}
-
-func updateItemDB(db *sql.DB, id, name, description string) (*Item, error) {
-	var it Item
-	err := db.QueryRow(
-		"UPDATE items SET name = $2, description = $3, updated_at = NOW() WHERE id = $1 RETURNING id, name, description, created_at, updated_at",
-		id, name, description,
-	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
-	if err != nil {
-		return nil, err
-	}
-	return &it, nil
-}
-
-func deleteItemDB(db *sql.DB, id string) error {
-	result, err := db.Exec("DELETE FROM items WHERE id = $1", id)
-	if err != nil {
-		return err
-	}
-	n, rowsErr := result.RowsAffected()
-	if rowsErr != nil {
-		return fmt.Errorf("rows affected: %w", rowsErr)
-	}
-	if n == 0 {
-		return sql.ErrNoRows
-	}
 	return nil
 }

--- a/examples/16-crud-api/db_items.go
+++ b/examples/16-crud-api/db_items.go
@@ -22,7 +22,7 @@ import (
 func queryItems(db *sql.DB) ([]Item, error) {
 	rows, err := db.Query("SELECT id, name, description, created_at, updated_at FROM items ORDER BY created_at")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query items: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -30,7 +30,7 @@ func queryItems(db *sql.DB) ([]Item, error) {
 	for rows.Next() {
 		var it Item
 		if err := rows.Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan item: %w", err)
 		}
 		items = append(items, it)
 	}
@@ -46,7 +46,7 @@ func queryItem(db *sql.DB, id string) (*Item, error) {
 		"SELECT id, name, description, created_at, updated_at FROM items WHERE id = $1", id,
 	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query item %s: %w", id, err)
 	}
 	return &it, nil
 }
@@ -58,7 +58,7 @@ func insertItem(db *sql.DB, id, name, description string) (*Item, error) {
 		id, name, description,
 	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("insert item: %w", err)
 	}
 	return &it, nil
 }
@@ -70,7 +70,7 @@ func updateItemDB(db *sql.DB, id, name, description string) (*Item, error) {
 		id, name, description,
 	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("update item %s: %w", id, err)
 	}
 	return &it, nil
 }

--- a/examples/16-crud-api/db_items.go
+++ b/examples/16-crud-api/db_items.go
@@ -1,0 +1,91 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func queryItems(db *sql.DB) ([]Item, error) {
+	rows, err := db.Query("SELECT id, name, description, created_at, updated_at FROM items ORDER BY created_at")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var items []Item
+	for rows.Next() {
+		var it Item
+		if err := rows.Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, it)
+	}
+	if items == nil {
+		items = []Item{}
+	}
+	return items, rows.Err()
+}
+
+func queryItem(db *sql.DB, id string) (*Item, error) {
+	var it Item
+	err := db.QueryRow(
+		"SELECT id, name, description, created_at, updated_at FROM items WHERE id = $1", id,
+	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &it, nil
+}
+
+func insertItem(db *sql.DB, id, name, description string) (*Item, error) {
+	var it Item
+	err := db.QueryRow(
+		"INSERT INTO items (id, name, description) VALUES ($1, $2, $3) RETURNING id, name, description, created_at, updated_at",
+		id, name, description,
+	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &it, nil
+}
+
+func updateItemDB(db *sql.DB, id, name, description string) (*Item, error) {
+	var it Item
+	err := db.QueryRow(
+		"UPDATE items SET name = $2, description = $3, updated_at = NOW() WHERE id = $1 RETURNING id, name, description, created_at, updated_at",
+		id, name, description,
+	).Scan(&it.ID, &it.Name, &it.Description, &it.CreatedAt, &it.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &it, nil
+}
+
+func deleteItemDB(db *sql.DB, id string) error {
+	result, err := db.Exec("DELETE FROM items WHERE id = $1", id)
+	if err != nil {
+		return err
+	}
+	n, rowsErr := result.RowsAffected()
+	if rowsErr != nil {
+		return fmt.Errorf("rows affected: %w", rowsErr)
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/examples/16-crud-api/db_orders.go
+++ b/examples/16-crud-api/db_orders.go
@@ -14,12 +14,15 @@
 
 package main
 
-import "database/sql"
+import (
+	"database/sql"
+	"fmt"
+)
 
 func queryOrders(db *sql.DB) ([]Order, error) {
 	rows, err := db.Query("SELECT id, user_id, item_id, quantity, status, created_at, updated_at FROM orders ORDER BY created_at")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query orders: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -27,7 +30,7 @@ func queryOrders(db *sql.DB) ([]Order, error) {
 	for rows.Next() {
 		var o Order
 		if err := rows.Scan(&o.ID, &o.UserID, &o.ItemID, &o.Quantity, &o.Status, &o.CreatedAt, &o.UpdatedAt); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan order: %w", err)
 		}
 		orders = append(orders, o)
 	}
@@ -43,7 +46,7 @@ func queryOrder(db *sql.DB, id string) (*Order, error) {
 		"SELECT id, user_id, item_id, quantity, status, created_at, updated_at FROM orders WHERE id = $1", id,
 	).Scan(&o.ID, &o.UserID, &o.ItemID, &o.Quantity, &o.Status, &o.CreatedAt, &o.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query order %s: %w", id, err)
 	}
 	return &o, nil
 }
@@ -55,7 +58,7 @@ func insertOrder(db *sql.DB, id, userID, itemID string, quantity int) (*Order, e
 		id, userID, itemID, quantity,
 	).Scan(&o.ID, &o.UserID, &o.ItemID, &o.Quantity, &o.Status, &o.CreatedAt, &o.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("insert order: %w", err)
 	}
 	return &o, nil
 }
@@ -67,7 +70,7 @@ func updateOrderDB(db *sql.DB, id, status string) (*Order, error) {
 		id, status,
 	).Scan(&o.ID, &o.UserID, &o.ItemID, &o.Quantity, &o.Status, &o.CreatedAt, &o.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("update order %s: %w", id, err)
 	}
 	return &o, nil
 }

--- a/examples/16-crud-api/db_orders.go
+++ b/examples/16-crud-api/db_orders.go
@@ -1,0 +1,73 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "database/sql"
+
+func queryOrders(db *sql.DB) ([]Order, error) {
+	rows, err := db.Query("SELECT id, user_id, item_id, quantity, status, created_at, updated_at FROM orders ORDER BY created_at")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var orders []Order
+	for rows.Next() {
+		var o Order
+		if err := rows.Scan(&o.ID, &o.UserID, &o.ItemID, &o.Quantity, &o.Status, &o.CreatedAt, &o.UpdatedAt); err != nil {
+			return nil, err
+		}
+		orders = append(orders, o)
+	}
+	if orders == nil {
+		orders = []Order{}
+	}
+	return orders, rows.Err()
+}
+
+func queryOrder(db *sql.DB, id string) (*Order, error) {
+	var o Order
+	err := db.QueryRow(
+		"SELECT id, user_id, item_id, quantity, status, created_at, updated_at FROM orders WHERE id = $1", id,
+	).Scan(&o.ID, &o.UserID, &o.ItemID, &o.Quantity, &o.Status, &o.CreatedAt, &o.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &o, nil
+}
+
+func insertOrder(db *sql.DB, id, userID, itemID string, quantity int) (*Order, error) {
+	var o Order
+	err := db.QueryRow(
+		"INSERT INTO orders (id, user_id, item_id, quantity) VALUES ($1, $2, $3, $4) RETURNING id, user_id, item_id, quantity, status, created_at, updated_at",
+		id, userID, itemID, quantity,
+	).Scan(&o.ID, &o.UserID, &o.ItemID, &o.Quantity, &o.Status, &o.CreatedAt, &o.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &o, nil
+}
+
+func updateOrderDB(db *sql.DB, id, status string) (*Order, error) {
+	var o Order
+	err := db.QueryRow(
+		"UPDATE orders SET status = $2, updated_at = NOW() WHERE id = $1 RETURNING id, user_id, item_id, quantity, status, created_at, updated_at",
+		id, status,
+	).Scan(&o.ID, &o.UserID, &o.ItemID, &o.Quantity, &o.Status, &o.CreatedAt, &o.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &o, nil
+}

--- a/examples/16-crud-api/db_users.go
+++ b/examples/16-crud-api/db_users.go
@@ -22,7 +22,7 @@ import (
 func queryUsers(db *sql.DB) ([]User, error) {
 	rows, err := db.Query("SELECT id, username, email, phone, created_at, updated_at FROM users ORDER BY created_at")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query users: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -30,7 +30,7 @@ func queryUsers(db *sql.DB) ([]User, error) {
 	for rows.Next() {
 		var u User
 		if err := rows.Scan(&u.ID, &u.Username, &u.Email, &u.Phone, &u.CreatedAt, &u.UpdatedAt); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan user: %w", err)
 		}
 		users = append(users, u)
 	}
@@ -46,7 +46,7 @@ func queryUser(db *sql.DB, id string) (*User, error) {
 		"SELECT id, username, email, phone, created_at, updated_at FROM users WHERE id = $1", id,
 	).Scan(&u.ID, &u.Username, &u.Email, &u.Phone, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query user %s: %w", id, err)
 	}
 	return &u, nil
 }
@@ -58,7 +58,7 @@ func insertUser(db *sql.DB, id, username, email, phone string) (*User, error) {
 		id, username, email, phone,
 	).Scan(&u.ID, &u.Username, &u.Email, &u.Phone, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("insert user: %w", err)
 	}
 	return &u, nil
 }
@@ -70,7 +70,7 @@ func updateUserDB(db *sql.DB, id, username, email, phone string) (*User, error) 
 		id, username, email, phone,
 	).Scan(&u.ID, &u.Username, &u.Email, &u.Phone, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("update user %s: %w", id, err)
 	}
 	return &u, nil
 }

--- a/examples/16-crud-api/db_users.go
+++ b/examples/16-crud-api/db_users.go
@@ -1,0 +1,91 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func queryUsers(db *sql.DB) ([]User, error) {
+	rows, err := db.Query("SELECT id, username, email, phone, created_at, updated_at FROM users ORDER BY created_at")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var users []User
+	for rows.Next() {
+		var u User
+		if err := rows.Scan(&u.ID, &u.Username, &u.Email, &u.Phone, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	if users == nil {
+		users = []User{}
+	}
+	return users, rows.Err()
+}
+
+func queryUser(db *sql.DB, id string) (*User, error) {
+	var u User
+	err := db.QueryRow(
+		"SELECT id, username, email, phone, created_at, updated_at FROM users WHERE id = $1", id,
+	).Scan(&u.ID, &u.Username, &u.Email, &u.Phone, &u.CreatedAt, &u.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func insertUser(db *sql.DB, id, username, email, phone string) (*User, error) {
+	var u User
+	err := db.QueryRow(
+		"INSERT INTO users (id, username, email, phone) VALUES ($1, $2, $3, $4) RETURNING id, username, email, phone, created_at, updated_at",
+		id, username, email, phone,
+	).Scan(&u.ID, &u.Username, &u.Email, &u.Phone, &u.CreatedAt, &u.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func updateUserDB(db *sql.DB, id, username, email, phone string) (*User, error) {
+	var u User
+	err := db.QueryRow(
+		"UPDATE users SET username = $2, email = $3, phone = $4, updated_at = NOW() WHERE id = $1 RETURNING id, username, email, phone, created_at, updated_at",
+		id, username, email, phone,
+	).Scan(&u.ID, &u.Username, &u.Email, &u.Phone, &u.CreatedAt, &u.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func deleteUserDB(db *sql.DB, id string) error {
+	result, err := db.Exec("DELETE FROM users WHERE id = $1", id)
+	if err != nil {
+		return err
+	}
+	n, rowsErr := result.RowsAffected()
+	if rowsErr != nil {
+		return fmt.Errorf("rows affected: %w", rowsErr)
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/examples/16-crud-api/handlers.go
+++ b/examples/16-crud-api/handlers.go
@@ -34,6 +34,22 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+// populatePIIHints adds PII fields (email, phone) to hints.Extra so they
+// flow through sensitivity filtering. On Loki (exclude_labels: [pii]),
+// these fields are stripped. On stdout and audit.log, they appear in full.
+func populatePIIHints(hints *audit.Hints, email, phone string) {
+	if hints == nil {
+		return
+	}
+	if hints.Extra == nil {
+		hints.Extra = make(map[string]any)
+	}
+	hints.Extra[FieldEmail] = email
+	if phone != "" {
+		hints.Extra[FieldPhone] = phone
+	}
+}
+
 // writeError records a failure in audit hints and writes an error response.
 func writeError(w http.ResponseWriter, r *http.Request, status int, msg string) {
 	if hints := audit.HintsFromContext(r.Context()); hints != nil {

--- a/examples/16-crud-api/handlers.go
+++ b/examples/16-crud-api/handlers.go
@@ -20,108 +20,21 @@ import (
 	"net/http"
 
 	audit "github.com/axonops/go-audit"
-	"github.com/google/uuid"
 )
 
+// handlers holds dependencies shared across all HTTP handlers.
 type handlers struct {
 	db *sql.DB
 }
 
-func (h *handlers) listItems(w http.ResponseWriter, r *http.Request) {
-	items, err := queryItems(h.db)
-	if err != nil {
-		writeError(w, r, http.StatusInternalServerError, "list items failed")
-		return
-	}
-	writeJSON(w, http.StatusOK, items)
-}
-
-func (h *handlers) getItem(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	if hints := audit.HintsFromContext(r.Context()); hints != nil {
-		hints.TargetID = id
-	}
-
-	item, err := queryItem(h.db, id)
-	if err != nil {
-		writeError(w, r, http.StatusNotFound, "item not found")
-		return
-	}
-	writeJSON(w, http.StatusOK, item)
-}
-
-func (h *handlers) createItem(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-	}
-	// Production apps should wrap r.Body with http.MaxBytesReader
-	// to bound request size: r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
-		return
-	}
-	if req.Name == "" {
-		writeError(w, r, http.StatusBadRequest, "name is required")
-		return
-	}
-
-	id := uuid.New().String()
-	item, err := insertItem(h.db, id, req.Name, req.Description)
-	if err != nil {
-		writeError(w, r, http.StatusInternalServerError, "create item failed")
-		return
-	}
-
-	if hints := audit.HintsFromContext(r.Context()); hints != nil {
-		hints.TargetID = id
-	}
-	writeJSON(w, http.StatusCreated, item)
-}
-
-func (h *handlers) updateItem(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	if hints := audit.HintsFromContext(r.Context()); hints != nil {
-		hints.TargetID = id
-	}
-
-	var req struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-	}
-	// Production: use http.MaxBytesReader to bound request size.
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
-		return
-	}
-
-	item, err := updateItemDB(h.db, id, req.Name, req.Description)
-	if err != nil {
-		writeError(w, r, http.StatusNotFound, "item not found")
-		return
-	}
-	writeJSON(w, http.StatusOK, item)
-}
-
-func (h *handlers) deleteItem(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	if hints := audit.HintsFromContext(r.Context()); hints != nil {
-		hints.TargetID = id
-	}
-
-	if err := deleteItemDB(h.db, id); err != nil {
-		writeError(w, r, http.StatusNotFound, "item not found")
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
-
+// writeJSON encodes v as JSON and writes it with the given status code.
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+// writeError records a failure in audit hints and writes an error response.
 func writeError(w http.ResponseWriter, r *http.Request, status int, msg string) {
 	if hints := audit.HintsFromContext(r.Context()); hints != nil {
 		hints.Outcome = "failure"

--- a/examples/16-crud-api/handlers_items.go
+++ b/examples/16-crud-api/handlers_items.go
@@ -1,0 +1,118 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	audit "github.com/axonops/go-audit"
+	"github.com/google/uuid"
+)
+
+func (h *handlers) listItems(w http.ResponseWriter, r *http.Request) {
+	items, err := queryItems(h.db)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "list items failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, items)
+}
+
+func (h *handlers) getItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+
+	item, err := queryItem(h.db, id)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "item not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, item)
+}
+
+func (h *handlers) createItem(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	// Production: use http.MaxBytesReader to bound request size.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, r, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	id := uuid.New().String()
+	item, err := insertItem(h.db, id, req.Name, req.Description)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "create item failed")
+		return
+	}
+
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+	writeJSON(w, http.StatusCreated, item)
+}
+
+func (h *handlers) updateItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	// Production: use http.MaxBytesReader to bound request size.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	item, err := updateItemDB(h.db, id, req.Name, req.Description)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "item not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, item)
+}
+
+func (h *handlers) deleteItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+
+	if err := deleteItemDB(h.db, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "item not found")
+		} else {
+			// Foreign key violation — item has dependent orders.
+			writeError(w, r, http.StatusConflict, "item has dependent orders")
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/examples/16-crud-api/handlers_orders.go
+++ b/examples/16-crud-api/handlers_orders.go
@@ -1,0 +1,107 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	audit "github.com/axonops/go-audit"
+	"github.com/google/uuid"
+)
+
+func (h *handlers) listOrders(w http.ResponseWriter, r *http.Request) {
+	orders, err := queryOrders(h.db)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "list orders failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, orders)
+}
+
+func (h *handlers) getOrder(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+
+	order, err := queryOrder(h.db, id)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "order not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, order)
+}
+
+func (h *handlers) createOrder(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		UserID   string `json:"user_id"`
+		ItemID   string `json:"item_id"`
+		Quantity int    `json:"quantity"`
+	}
+	// Production: use http.MaxBytesReader to bound request size.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.UserID == "" || req.ItemID == "" {
+		writeError(w, r, http.StatusBadRequest, "user_id and item_id are required")
+		return
+	}
+	if req.Quantity <= 0 {
+		req.Quantity = 1 // default to 1 for convenience in the demo
+	}
+
+	id := uuid.New().String()
+	order, err := insertOrder(h.db, id, req.UserID, req.ItemID, req.Quantity)
+	if err != nil {
+		// Foreign key violations (invalid user_id or item_id) produce
+		// a Postgres error here — the audit event captures the failure.
+		writeError(w, r, http.StatusBadRequest, "create order failed: check user_id and item_id exist")
+		return
+	}
+
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+	writeJSON(w, http.StatusCreated, order)
+}
+
+func (h *handlers) updateOrder(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+
+	var req struct {
+		Status string `json:"status"`
+	}
+	// Production: use http.MaxBytesReader to bound request size.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Status == "" {
+		writeError(w, r, http.StatusBadRequest, "status is required")
+		return
+	}
+
+	order, err := updateOrderDB(h.db, id, req.Status)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "order not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, order)
+}

--- a/examples/16-crud-api/handlers_users.go
+++ b/examples/16-crud-api/handlers_users.go
@@ -1,0 +1,154 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	audit "github.com/axonops/go-audit"
+	"github.com/google/uuid"
+)
+
+func (h *handlers) listUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := queryUsers(h.db)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "list users failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, users)
+}
+
+func (h *handlers) getUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+
+	user, err := queryUser(h.db, id)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "user not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, user)
+}
+
+func (h *handlers) createUser(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Username string `json:"username"`
+		Email    string `json:"email"`
+		Phone    string `json:"phone"`
+	}
+	// Production: use http.MaxBytesReader to bound request size.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Username == "" {
+		writeError(w, r, http.StatusBadRequest, "username is required")
+		return
+	}
+	if req.Email == "" {
+		writeError(w, r, http.StatusBadRequest, "email is required")
+		return
+	}
+
+	id := uuid.New().String()
+	user, err := insertUser(h.db, id, req.Username, req.Email, req.Phone)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "create user failed")
+		return
+	}
+
+	// Pass PII fields via hints.Extra so they flow through sensitivity
+	// filtering. On Loki (exclude_labels: [pii]), email and phone are
+	// stripped. On stdout and audit.log, they appear in full.
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+		if hints.Extra == nil {
+			hints.Extra = make(map[string]any)
+		}
+		hints.Extra[FieldEmail] = req.Email
+		if req.Phone != "" {
+			hints.Extra[FieldPhone] = req.Phone
+		}
+	}
+	writeJSON(w, http.StatusCreated, user)
+}
+
+func (h *handlers) updateUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+
+	var req struct {
+		Username string `json:"username"`
+		Email    string `json:"email"`
+		Phone    string `json:"phone"`
+	}
+	// Production: use http.MaxBytesReader to bound request size.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.Username == "" {
+		writeError(w, r, http.StatusBadRequest, "username is required")
+		return
+	}
+	if req.Email == "" {
+		writeError(w, r, http.StatusBadRequest, "email is required")
+		return
+	}
+
+	user, err := updateUserDB(h.db, id, req.Username, req.Email, req.Phone)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "user not found")
+		return
+	}
+
+	// Pass PII fields via hints.Extra for sensitivity filtering.
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		if hints.Extra == nil {
+			hints.Extra = make(map[string]any)
+		}
+		hints.Extra[FieldEmail] = req.Email
+		if req.Phone != "" {
+			hints.Extra[FieldPhone] = req.Phone
+		}
+	}
+	writeJSON(w, http.StatusOK, user)
+}
+
+func (h *handlers) deleteUser(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.TargetID = id
+	}
+
+	if err := deleteUserDB(h.db, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "user not found")
+		} else {
+			// Foreign key violation — user has dependent orders.
+			writeError(w, r, http.StatusConflict, "user has dependent orders")
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/examples/16-crud-api/handlers_users.go
+++ b/examples/16-crud-api/handlers_users.go
@@ -74,18 +74,9 @@ func (h *handlers) createUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Pass PII fields via hints.Extra so they flow through sensitivity
-	// filtering. On Loki (exclude_labels: [pii]), email and phone are
-	// stripped. On stdout and audit.log, they appear in full.
 	if hints := audit.HintsFromContext(r.Context()); hints != nil {
 		hints.TargetID = id
-		if hints.Extra == nil {
-			hints.Extra = make(map[string]any)
-		}
-		hints.Extra[FieldEmail] = req.Email
-		if req.Phone != "" {
-			hints.Extra[FieldPhone] = req.Phone
-		}
+		populatePIIHints(hints, req.Email, req.Phone)
 	}
 	writeJSON(w, http.StatusCreated, user)
 }
@@ -122,15 +113,8 @@ func (h *handlers) updateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Pass PII fields via hints.Extra for sensitivity filtering.
 	if hints := audit.HintsFromContext(r.Context()); hints != nil {
-		if hints.Extra == nil {
-			hints.Extra = make(map[string]any)
-		}
-		hints.Extra[FieldEmail] = req.Email
-		if req.Phone != "" {
-			hints.Extra[FieldPhone] = req.Phone
-		}
+		populatePIIHints(hints, req.Email, req.Phone)
 	}
 	writeJSON(w, http.StatusOK, user)
 }

--- a/examples/16-crud-api/server.go
+++ b/examples/16-crud-api/server.go
@@ -24,8 +24,8 @@ import (
 )
 
 // routeTable maps "METHOD resource" or "METHOD resource/{id}" to audit
-// event types. IMPORTANT: when adding routes below, also add the event
-// mapping here.
+// event types. Read-only after initialization. IMPORTANT: when adding
+// routes below, also add the event mapping here.
 var routeTable = map[string]string{
 	// Items
 	"GET items":         EventItemList,
@@ -39,7 +39,7 @@ var routeTable = map[string]string{
 	"POST users":        EventUserCreate,
 	"PUT users/{id}":    EventUserUpdate,
 	"DELETE users/{id}": EventUserDelete,
-	// Orders
+	// Orders — no DELETE: orders are immutable once placed; use status updates.
 	"GET orders":      EventOrderList,
 	"GET orders/{id}": EventOrderRead,
 	"POST orders":     EventOrderCreate,
@@ -136,8 +136,12 @@ func collectFields(hints *audit.Hints, transport *audit.TransportMetadata) audit
 
 	// Copy Extra fields (e.g., PII fields like email, phone) so they
 	// flow through sensitivity filtering in the output pipeline.
+	// Guard: framework fields take precedence over Extra to prevent
+	// audit log spoofing via hints.Extra["outcome"] = "success".
 	for k, v := range hints.Extra {
-		fields[k] = v
+		if _, isFramework := fields[k]; !isFramework {
+			fields[k] = v
+		}
 	}
 
 	return fields

--- a/examples/16-crud-api/server.go
+++ b/examples/16-crud-api/server.go
@@ -17,10 +17,34 @@ package main
 import (
 	"database/sql"
 	"net/http"
+	"strings"
 
 	audit "github.com/axonops/go-audit"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// routeTable maps "METHOD resource" or "METHOD resource/{id}" to audit
+// event types. IMPORTANT: when adding routes below, also add the event
+// mapping here.
+var routeTable = map[string]string{
+	// Items
+	"GET items":         EventItemList,
+	"GET items/{id}":    EventItemRead,
+	"POST items":        EventItemCreate,
+	"PUT items/{id}":    EventItemUpdate,
+	"DELETE items/{id}": EventItemDelete,
+	// Users
+	"GET users":         EventUserList,
+	"GET users/{id}":    EventUserRead,
+	"POST users":        EventUserCreate,
+	"PUT users/{id}":    EventUserUpdate,
+	"DELETE users/{id}": EventUserDelete,
+	// Orders
+	"GET orders":      EventOrderList,
+	"GET orders/{id}": EventOrderRead,
+	"POST orders":     EventOrderCreate,
+	"PUT orders/{id}": EventOrderUpdate,
+}
 
 // newServer builds the HTTP mux with auth middleware, audit middleware,
 // CRUD routes, health check, and Prometheus metrics endpoint.
@@ -38,16 +62,27 @@ func newServer(logger *audit.Logger, db *sql.DB, m *auditMetrics) http.Handler {
 	// Prometheus metrics — no auth, no audit.
 	mux.Handle("GET /metrics", promhttp.Handler())
 
-	// CRUD routes — require auth.
+	// Item routes.
 	mux.HandleFunc("GET /items", h.listItems)
 	mux.HandleFunc("GET /items/{id}", h.getItem)
 	mux.HandleFunc("POST /items", h.createItem)
 	mux.HandleFunc("PUT /items/{id}", h.updateItem)
 	mux.HandleFunc("DELETE /items/{id}", h.deleteItem)
 
+	// User routes.
+	mux.HandleFunc("GET /users", h.listUsers)
+	mux.HandleFunc("GET /users/{id}", h.getUser)
+	mux.HandleFunc("POST /users", h.createUser)
+	mux.HandleFunc("PUT /users/{id}", h.updateUser)
+	mux.HandleFunc("DELETE /users/{id}", h.deleteUser)
+
+	// Order routes.
+	mux.HandleFunc("GET /orders", h.listOrders)
+	mux.HandleFunc("GET /orders/{id}", h.getOrder)
+	mux.HandleFunc("POST /orders", h.createOrder)
+	mux.HandleFunc("PUT /orders/{id}", h.updateOrder)
+
 	// Apply middleware: auth first, then audit.
-	// Audit middleware wraps the auth+route handler so it captures
-	// the authenticated actor from hints.
 	authed := authMiddleware()(mux)
 	audited := audit.Middleware(logger, buildAuditEvent)(authed)
 
@@ -73,7 +108,12 @@ func buildAuditEvent(hints *audit.Hints, transport *audit.TransportMetadata) (ev
 		return "", nil, true
 	}
 
-	fields = audit.Fields{
+	return eventType, collectFields(hints, transport), false
+}
+
+// collectFields builds the audit Fields map from hints and transport metadata.
+func collectFields(hints *audit.Hints, transport *audit.TransportMetadata) audit.Fields {
+	fields := audit.Fields{
 		FieldOutcome: hints.Outcome,
 	}
 
@@ -94,24 +134,37 @@ func buildAuditEvent(hints *audit.Hints, transport *audit.TransportMetadata) (ev
 		fields[FieldSourceIP] = transport.ClientIP
 	}
 
-	return eventType, fields, false
+	// Copy Extra fields (e.g., PII fields like email, phone) so they
+	// flow through sensitivity filtering in the output pipeline.
+	for k, v := range hints.Extra {
+		fields[k] = v
+	}
+
+	return fields
 }
 
-// mapHTTPToEvent maps HTTP method + path patterns to audit event types.
-// Returns empty string for unrecognised routes (skipped by buildAuditEvent).
+// mapHTTPToEvent maps HTTP method + resolved path to an audit event type
+// using the routeTable. Returns empty string for unrecognised routes.
 func mapHTTPToEvent(method, path string) string {
-	switch {
-	case method == "GET" && path == "/items":
-		return EventItemList
-	case method == "GET":
-		return EventItemRead
-	case method == "POST":
-		return EventItemCreate
-	case method == "PUT":
-		return EventItemUpdate
-	case method == "DELETE":
-		return EventItemDelete
-	default:
-		return "" // unknown route — buildAuditEvent will still emit with empty type
+	resource, hasID := parseResource(path)
+	if resource == "" {
+		return ""
 	}
+
+	key := method + " " + resource
+	if hasID {
+		key += "/{id}"
+	}
+	return routeTable[key]
+}
+
+// parseResource extracts the resource name and whether an ID segment is
+// present from a URL path. "/users" → ("users", false),
+// "/users/abc-123" → ("users", true).
+func parseResource(path string) (resource string, hasID bool) {
+	parts := strings.SplitN(strings.TrimPrefix(path, "/"), "/", 3)
+	if len(parts) == 0 || parts[0] == "" {
+		return "", false
+	}
+	return parts[0], len(parts) >= 2 && parts[1] != ""
 }

--- a/examples/16-crud-api/taxonomy.yaml
+++ b/examples/16-crud-api/taxonomy.yaml
@@ -34,10 +34,12 @@ categories:
   read:
     severity: 3
     events:
+      - user_list
       - user_read
       - item_list
       - item_read
       - order_list
+      - order_read
   compliance:
     severity: 9
     events:
@@ -144,6 +146,11 @@ events:
       actor_id: { required: true }
 
   # --- Read events ---
+  user_list:
+    description: "User accounts were listed"
+    fields:
+      outcome: { required: true }
+
   user_read:
     description: "A user account was viewed"
     fields:
@@ -161,6 +168,11 @@ events:
 
   order_list:
     description: "Orders were listed"
+    fields:
+      outcome: { required: true }
+
+  order_read:
+    description: "An order was viewed"
     fields:
       outcome: { required: true }
 


### PR DESCRIPTION
## Summary

PR 2 of 6 for issue #350 (capstone example rewrite).

- Adds users resource (5 endpoints) with email/phone PII fields flowing through `hints.Extra` for sensitivity label demonstration
- Adds orders resource (4 endpoints) with foreign keys to users and items
- Keeps existing items resource (5 endpoints), split into separate file
- Replaces switch-based event mapping with declarative `routeTable` map
- Extracts `collectFields` helper from `buildAuditEvent` to keep cyclomatic complexity under 10
- Adds `user_list` and `order_read` events to taxonomy (now 23 types)
- FK-aware delete handlers return 409 Conflict for dependent records

## Test plan

- [ ] `go build ./examples/16-crud-api/...` compiles
- [ ] `make lint` passes with 0 issues
- [ ] All 14 CRUD routes respond correctly via curl
- [ ] `POST /users` with email/phone → fields appear on stdout, stripped from Loki
- [ ] `DELETE /users/{id}` with dependent order → returns 409 Conflict
- [ ] `POST /orders` with invalid user_id → returns 400