### PR TITLE
feat: add login/logout, session tokens, and rate limiting (#350)

### DIFF
--- a/examples/16-crud-api/auth.go
+++ b/examples/16-crud-api/auth.go
@@ -15,18 +15,229 @@
 package main
 
 import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
 	"net/http"
+	"strings"
+	"sync"
+	"time"
 
 	audit "github.com/axonops/go-audit"
 )
 
-// authMiddleware validates the X-API-Key header and populates audit
-// hints with the authenticated identity. Unauthenticated requests to
-// protected endpoints receive 401 and emit an auth_failure event via
-// the audit middleware's Hints mechanism — no direct logger.AuditEvent call.
-func authMiddleware() func(http.Handler) http.Handler {
-	// In production this would be backed by a database or identity provider.
-	users := map[string]string{
+var errTokenExpired = errors.New("token expired")
+
+// sessionStore holds active session tokens. Tokens are removed on
+// logout or when individually validated after expiry. Production apps
+// should add a periodic background reaper to evict expired tokens
+// that are never presented again (memory leak under sustained load).
+// In production, use a database or Redis.
+type sessionStore struct { //nolint:govet // fieldalignment: readability preferred
+	mu       sync.Mutex
+	tokens   map[string]sessionInfo // token → info
+	secret   []byte                 // HMAC-SHA256 signing key
+	lifetime time.Duration
+}
+
+type sessionInfo struct { //nolint:govet // fieldalignment: readability preferred
+	username string
+	expiry   time.Time
+}
+
+func newSessionStore(lifetime time.Duration) *sessionStore {
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		panic("crypto/rand: " + err.Error())
+	}
+	return &sessionStore{
+		tokens:   make(map[string]sessionInfo),
+		secret:   secret,
+		lifetime: lifetime,
+	}
+}
+
+// createToken generates an HMAC-signed session token for the given user.
+// The username must not contain "|" (used as a delimiter in the token
+// format). Production apps should use a non-ambiguous encoding (JWT).
+func (s *sessionStore) createToken(username string) string {
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		panic("crypto/rand: " + err.Error())
+	}
+
+	expiry := time.Now().Add(s.lifetime)
+	payload := fmt.Sprintf("%s|%d|%s", username, expiry.Unix(), hex.EncodeToString(nonce))
+
+	mac := hmac.New(sha256.New, s.secret)
+	_, _ = mac.Write([]byte(payload)) // hash.Hash.Write never errors
+	sig := hex.EncodeToString(mac.Sum(nil))
+	token := payload + "|" + sig
+
+	s.mu.Lock()
+	s.tokens[token] = sessionInfo{username: username, expiry: expiry}
+	s.mu.Unlock()
+
+	return token
+}
+
+// validate checks a session token. Returns the username if valid.
+func (s *sessionStore) validate(token string) (string, error) {
+	// Verify HMAC signature.
+	lastPipe := strings.LastIndex(token, "|")
+	if lastPipe < 0 {
+		return "", fmt.Errorf("malformed token")
+	}
+	payload := token[:lastPipe]
+	sig := token[lastPipe+1:]
+
+	mac := hmac.New(sha256.New, s.secret)
+	_, _ = mac.Write([]byte(payload)) // hash.Hash.Write never errors
+	expected := hex.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return "", fmt.Errorf("invalid signature")
+	}
+
+	// Check store — token must be active (not logged out).
+	s.mu.Lock()
+	info, ok := s.tokens[token]
+	s.mu.Unlock()
+	if !ok {
+		return "", fmt.Errorf("session not found")
+	}
+
+	// Check expiry.
+	if time.Now().After(info.expiry) {
+		s.mu.Lock()
+		delete(s.tokens, token)
+		s.mu.Unlock()
+		return info.username, errTokenExpired
+	}
+
+	return info.username, nil
+}
+
+// revoke invalidates a session token (logout).
+func (s *sessionStore) revoke(token string) {
+	s.mu.Lock()
+	delete(s.tokens, token)
+	s.mu.Unlock()
+}
+
+// --- Credential store (demo) ---
+
+// credentials maps username → password. In production, use hashed
+// passwords in a database.
+var credentials = map[string]string{
+	"alice": "password",
+	"bob":   "password",
+	"admin": "admin123",
+}
+
+// --- Auth handlers (emit events directly, outside middleware) ---
+
+// authHandlers handles login/logout. These endpoints are NOT wrapped
+// by the audit middleware — they emit audit events directly because
+// they ARE the security action, not a business action that happens
+// to need auth.
+type authHandlers struct {
+	logger   *audit.Logger
+	sessions *sessionStore
+	rl       *rateLimiter
+}
+
+func (a *authHandlers) login(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	// Production: use http.MaxBytesReader to bound request size.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		a.rl.record(clientIP(r))
+		a.emitAuthEvent(EventAuthFailure, "anonymous", "failure",
+			"invalid request body", r)
+		writeLoginError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Constant-time comparison prevents timing attacks that leak
+	// password content. Production: use bcrypt, never plaintext.
+	expected, exists := credentials[req.Username]
+	got := sha256.Sum256([]byte(req.Password))
+	want := sha256.Sum256([]byte(expected))
+	if !exists || subtle.ConstantTimeCompare(got[:], want[:]) != 1 {
+		a.rl.record(clientIP(r))
+		a.emitAuthEvent(EventAuthFailure, req.Username, "failure",
+			"invalid credentials", r)
+		writeLoginError(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+
+	token := a.sessions.createToken(req.Username)
+	a.emitAuthEvent(EventAuthSuccess, req.Username, "success", "", r)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"token": token})
+}
+
+func (a *authHandlers) logout(w http.ResponseWriter, r *http.Request) {
+	token := extractBearerToken(r)
+	if token == "" {
+		writeLoginError(w, http.StatusBadRequest, "missing bearer token")
+		return
+	}
+
+	username, err := a.sessions.validate(token)
+	if err != nil {
+		eventType := EventAuthFailure
+		if errors.Is(err, errTokenExpired) {
+			eventType = EventTokenExpired
+		}
+		a.emitAuthEvent(eventType, username, "failure", "invalid session", r)
+		writeLoginError(w, http.StatusUnauthorized, "invalid session")
+		return
+	}
+
+	a.sessions.revoke(token)
+	a.emitAuthEvent(EventAuthLogout, username, "success", "", r)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// emitAuthEvent directly emits a security audit event. This is used
+// by login/logout handlers which are outside the audit middleware.
+func (a *authHandlers) emitAuthEvent(eventType, actorID, outcome, reason string, r *http.Request) {
+	fields := audit.Fields{
+		FieldActorID: actorID,
+		FieldOutcome: outcome,
+	}
+	if reason != "" {
+		fields[FieldReason] = reason
+	}
+	if ip := clientIP(r); ip != "" {
+		fields[FieldSourceIP] = ip
+	}
+	if err := a.logger.AuditEvent(audit.NewEvent(eventType, fields)); err != nil {
+		// Log but don't fail — audit should not block auth.
+		log.Printf("audit error: %v", err)
+	}
+}
+
+// --- Auth middleware for CRUD routes ---
+
+// authMiddleware validates the X-API-Key header or Bearer token and
+// populates audit hints with the authenticated identity.
+func authMiddleware(sessions *sessionStore) func(http.Handler) http.Handler {
+	// API key → user ID mapping. In production, use a database.
+	apiKeys := map[string]string{
 		"key-alice": "alice",
 		"key-bob":   "bob",
 		"key-admin": "admin",
@@ -41,35 +252,95 @@ func authMiddleware() func(http.Handler) http.Handler {
 			}
 
 			hints := audit.HintsFromContext(r.Context())
-			apiKey := r.Header.Get("X-API-Key")
 
-			userID, ok := users[apiKey]
-			if !ok {
-				// Record auth failure in hints for the audit middleware.
-				if hints != nil {
-					hints.EventType = EventAuthFailure
-					hints.Outcome = "failure"
-					// Log only a prefix — never record the full credential
-					// in audit output. Production apps should hash the key.
-					actorID := "anonymous"
-					if apiKey != "" {
-						actorID = apiKey[:min(4, len(apiKey))] + "..."
-					}
-					hints.ActorID = actorID
-					hints.Reason = "invalid API key"
+			// Try Bearer token first, then API key.
+			if token := extractBearerToken(r); token != "" {
+				if authenticateBearer(sessions, token, hints, w) {
+					next.ServeHTTP(w, r)
 				}
-				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 				return
 			}
 
-			// Populate hints with authenticated identity.
-			if hints != nil {
-				hints.ActorID = userID
-				hints.AuthMethod = "api_key"
-				hints.Outcome = "success"
+			// Fall back to API key.
+			apiKey := r.Header.Get("X-API-Key")
+			if userID, ok := apiKeys[apiKey]; ok {
+				if hints != nil {
+					hints.ActorID = userID
+					hints.AuthMethod = "api_key"
+					hints.Outcome = "success"
+				}
+				next.ServeHTTP(w, r)
+				return
 			}
 
-			next.ServeHTTP(w, r)
+			// No valid auth.
+			if hints != nil {
+				hints.EventType = EventAuthFailure
+				hints.Outcome = "failure"
+				actorID := "anonymous"
+				if apiKey != "" {
+					actorID = apiKey[:min(4, len(apiKey))] + "..."
+				}
+				hints.ActorID = actorID
+				hints.Reason = "invalid credentials"
+			}
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 		})
 	}
+}
+
+// authenticateBearer validates a Bearer token and populates hints.
+// Returns true if authentication succeeded (caller should proceed).
+func authenticateBearer(sessions *sessionStore, token string, hints *audit.Hints, w http.ResponseWriter) bool {
+	username, err := sessions.validate(token)
+	if err != nil {
+		eventType := EventAuthFailure
+		reason := "invalid session token"
+		if errors.Is(err, errTokenExpired) {
+			eventType = EventTokenExpired
+			reason = "session token expired"
+		}
+		if hints != nil {
+			hints.EventType = eventType
+			hints.Outcome = "failure"
+			hints.ActorID = username
+			hints.Reason = reason
+		}
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return false
+	}
+	if hints != nil {
+		hints.ActorID = username
+		hints.AuthMethod = "bearer"
+		hints.Outcome = "success"
+	}
+	return true
+}
+
+// --- Helpers ---
+
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	return ""
+}
+
+func clientIP(r *http.Request) string {
+	// WARNING: X-Forwarded-For is trivially spoofable by direct clients.
+	// Only trust this header when behind a reverse proxy that overwrites it.
+	// For this demo we use RemoteAddr as the safe default. Production apps
+	// behind a proxy should use the rightmost-untrusted IP.
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+func writeLoginError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }

--- a/examples/16-crud-api/main.go
+++ b/examples/16-crud-api/main.go
@@ -63,11 +63,15 @@ func main() {
 		log.Fatalf("create schema: %v", schemaErr) //nolint:gocritic // db.Close deferred above; Fatalf is acceptable for startup failures
 	}
 
+	// Set up session store and rate limiter for auth.
+	sessions := newSessionStore(30 * time.Minute)
+	rl := newRateLimiter(1*time.Minute, 5) // 5 failures per minute per IP
+
 	// Build HTTP server.
 	addr := envOr("LISTEN_ADDR", ":8080")
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           newServer(logger, db, metrics),
+		Handler:           newServer(logger, db, sessions, rl),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/examples/16-crud-api/ratelimit.go
+++ b/examples/16-crud-api/ratelimit.go
@@ -1,0 +1,104 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	audit "github.com/axonops/go-audit"
+)
+
+// rateLimiter tracks failed auth attempts per source IP using a
+// sliding window. Cleanup happens inline on each allow() call.
+// Production apps should add periodic background cleanup for
+// memory bounds under high IP cardinality.
+type rateLimiter struct { //nolint:govet // fieldalignment: readability preferred
+	mu        sync.Mutex
+	attempts  map[string][]time.Time
+	window    time.Duration
+	threshold int
+}
+
+func newRateLimiter(window time.Duration, threshold int) *rateLimiter {
+	return &rateLimiter{
+		attempts:  make(map[string][]time.Time),
+		window:    window,
+		threshold: threshold,
+	}
+}
+
+// record adds a failed attempt for the given IP.
+func (rl *rateLimiter) record(ip string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.attempts[ip] = append(rl.attempts[ip], time.Now())
+}
+
+// allow checks whether the IP is within the rate limit. It prunes
+// expired entries inline to bound memory.
+func (rl *rateLimiter) allow(ip string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	cutoff := time.Now().Add(-rl.window)
+	attempts := rl.attempts[ip]
+
+	// Prune expired entries in-place.
+	n := 0
+	for _, t := range attempts {
+		if t.After(cutoff) {
+			attempts[n] = t
+			n++
+		}
+	}
+	rl.attempts[ip] = attempts[:n]
+
+	return n < rl.threshold
+}
+
+// rateLimitMiddleware wraps a handler (typically /login) and blocks
+// requests from IPs that have exceeded the auth failure threshold.
+// When blocked, it emits a rate_limit_exceeded audit event directly.
+func rateLimitMiddleware(logger *audit.Logger, rl *rateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := clientIP(r)
+			if !rl.allow(ip) {
+				// Emit rate limit event directly.
+				fields := audit.Fields{
+					FieldOutcome: "failure",
+					FieldReason:  "too many failed authentication attempts",
+				}
+				if ip != "" {
+					fields[FieldSourceIP] = ip
+				}
+				if err := logger.AuditEvent(audit.NewEvent(EventRateLimitExceeded, fields)); err != nil {
+					log.Printf("audit error: %v", err)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Retry-After", "60")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = fmt.Fprintf(w, `{"error":"too many requests, try again later"}`)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/examples/16-crud-api/server.go
+++ b/examples/16-crud-api/server.go
@@ -46,47 +46,69 @@ var routeTable = map[string]string{
 	"PUT orders/{id}": EventOrderUpdate,
 }
 
-// newServer builds the HTTP mux with auth middleware, audit middleware,
-// CRUD routes, health check, and Prometheus metrics endpoint.
-func newServer(logger *audit.Logger, db *sql.DB, m *auditMetrics) http.Handler {
-	mux := http.NewServeMux()
+// newServer builds the HTTP handler with two layers:
+//
+//   - outerMux: login/logout (self-auditing, outside middleware chain)
+//   - innerMux: CRUD routes (wrapped by auth + audit middleware)
+//
+// Login/logout emit audit events directly because they ARE the
+// security action. CRUD routes emit events via the audit middleware.
+func newServer(logger *audit.Logger, db *sql.DB, sessions *sessionStore, rl *rateLimiter) http.Handler {
+	// --- Inner mux: CRUD routes (auth + audit middleware) ---
+	innerMux := http.NewServeMux()
 
 	h := &handlers{db: db}
+	registerInfraRoutes(innerMux)
+	registerCRUDRoutes(innerMux, h)
 
-	// Health check — no auth, no audit.
+	// Apply middleware: auth first, then audit.
+	authed := authMiddleware(sessions)(innerMux)
+	audited := audit.Middleware(logger, buildAuditEvent)(authed)
+
+	// --- Outer mux: auth endpoints (self-auditing, no middleware) ---
+	outerMux := http.NewServeMux()
+
+	authH := &authHandlers{logger: logger, sessions: sessions, rl: rl}
+
+	// Login is wrapped by rate limiter. Logout is not.
+	outerMux.Handle("POST /login",
+		rateLimitMiddleware(logger, rl)(http.HandlerFunc(authH.login)))
+	outerMux.HandleFunc("POST /logout", authH.logout)
+
+	// Everything else goes through the middleware chain.
+	outerMux.Handle("/", audited)
+
+	return outerMux
+}
+
+func registerInfraRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
-
-	// Prometheus metrics — no auth, no audit.
 	mux.Handle("GET /metrics", promhttp.Handler())
+}
 
-	// Item routes.
+func registerCRUDRoutes(mux *http.ServeMux, h *handlers) {
+	// Items
 	mux.HandleFunc("GET /items", h.listItems)
 	mux.HandleFunc("GET /items/{id}", h.getItem)
 	mux.HandleFunc("POST /items", h.createItem)
 	mux.HandleFunc("PUT /items/{id}", h.updateItem)
 	mux.HandleFunc("DELETE /items/{id}", h.deleteItem)
 
-	// User routes.
+	// Users
 	mux.HandleFunc("GET /users", h.listUsers)
 	mux.HandleFunc("GET /users/{id}", h.getUser)
 	mux.HandleFunc("POST /users", h.createUser)
 	mux.HandleFunc("PUT /users/{id}", h.updateUser)
 	mux.HandleFunc("DELETE /users/{id}", h.deleteUser)
 
-	// Order routes.
+	// Orders
 	mux.HandleFunc("GET /orders", h.listOrders)
 	mux.HandleFunc("GET /orders/{id}", h.getOrder)
 	mux.HandleFunc("POST /orders", h.createOrder)
 	mux.HandleFunc("PUT /orders/{id}", h.updateOrder)
-
-	// Apply middleware: auth first, then audit.
-	authed := authMiddleware()(mux)
-	audited := audit.Middleware(logger, buildAuditEvent)(authed)
-
-	return audited
 }
 
 // buildAuditEvent maps HTTP request metadata to audit events.


### PR DESCRIPTION
## Summary

PR 3 of 6 for issue #350 (capstone example rewrite).

- Adds `POST /login` with HMAC-SHA256 session tokens (crypto/rand secret, 30-min lifetime)
- Adds `POST /logout` with session revocation and failure auditing
- Dual auth on CRUD routes: `Authorization: Bearer <token>` and `X-API-Key` both accepted
- In-memory rate limiter on `/login` (5 failures per minute per IP)
- Constant-time password comparison via `crypto/subtle.ConstantTimeCompare`
- Login/logout registered outside the audit middleware chain (outerMux pattern) — they emit security events directly via `logger.AuditEvent()`, no double-emit
- Rate limiter wraps only `/login`, emits `rate_limit_exceeded` directly
- Token expiry detected via sentinel error (`errors.Is(err, errTokenExpired)`)
- All 6 security event types wired: `auth_success`, `auth_failure`, `auth_logout`, `token_expired`, `rate_limit_exceeded`, `authorization_failure`

Agent reviews completed BEFORE commit:
- **Code-reviewer**: 1 blocking + 3 important + 4 nits — all addressed
- **Security-reviewer**: 2 HIGH + 4 MEDIUM — all addressed
- **Go-quality**: 2 important + 4 nits — all addressed

## Test plan

- [ ] `go build ./examples/16-crud-api/...` compiles
- [ ] `make lint` passes with 0 issues
- [ ] `POST /login {"username":"alice","password":"password"}` returns token
- [ ] Bearer token accepted on CRUD routes
- [ ] API key auth still works on CRUD routes
- [ ] `POST /logout` with valid token returns 204
- [ ] Expired token returns 401 with `token_expired` audit event
- [ ] 5+ failed logins from same IP returns 429
- [ ] All security events appear in security.log with HMAC