### PR TITLE
feat: add admin settings, data export, and bulk delete (#350)

### DIFF
--- a/examples/16-crud-api/admin.go
+++ b/examples/16-crud-api/admin.go
@@ -1,0 +1,204 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	audit "github.com/axonops/go-audit"
+)
+
+// settingsStore holds application settings in memory. In production,
+// use a database or configuration service.
+type settingsStore struct { //nolint:govet // fieldalignment: readability preferred
+	mu       sync.RWMutex
+	settings map[string]string
+}
+
+func newSettingsStore() *settingsStore {
+	return &settingsStore{
+		settings: map[string]string{
+			"rate_limit_threshold":    "5",
+			"session_timeout_minutes": "30",
+			"maintenance_mode":        "false",
+		},
+	}
+}
+
+func (s *settingsStore) getAll() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cp := make(map[string]string, len(s.settings))
+	for k, v := range s.settings {
+		cp[k] = v
+	}
+	return cp
+}
+
+func (s *settingsStore) update(key, value string) (old string, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	old, ok = s.settings[key]
+	if !ok {
+		return "", false
+	}
+	s.settings[key] = value
+	return old, true
+}
+
+// --- Admin authorization ---
+
+const adminUser = "admin"
+
+// requireAdmin checks that the authenticated user is the admin.
+// Returns true if authorized; writes 403 and sets audit hints on failure.
+func requireAdmin(w http.ResponseWriter, r *http.Request) bool {
+	hints := audit.HintsFromContext(r.Context())
+	if hints == nil || hints.ActorID != adminUser {
+		if hints != nil {
+			hints.EventType = EventAuthorizationFailure
+			hints.Outcome = "failure"
+			hints.Reason = "admin access required"
+		}
+		http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+// --- Admin handlers ---
+
+// adminHandlers serve admin and compliance endpoints. These go through
+// the audit middleware but override hints.EventType because their
+// routes don't match the simple resource/{id} pattern in routeTable.
+type adminHandlers struct {
+	db       *sql.DB
+	settings *settingsStore
+}
+
+func (a *adminHandlers) getSettings(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	writeJSON(w, http.StatusOK, a.settings.getAll())
+}
+
+func (a *adminHandlers) updateSettings(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	// Set event type early so error paths are audited.
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.EventType = EventConfigChange
+	}
+
+	var req struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+	// Production: use http.MaxBytesReader to bound request size.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Key == "" {
+		writeError(w, r, http.StatusBadRequest, "key is required")
+		return
+	}
+
+	oldVal, ok := a.settings.update(req.Key, req.Value)
+	if !ok {
+		writeError(w, r, http.StatusBadRequest, "unknown setting key")
+		return
+	}
+
+	// Override event type — admin routes bypass the routeTable.
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.EventType = EventConfigChange
+		if hints.Extra == nil {
+			hints.Extra = make(map[string]any)
+		}
+		hints.Extra[FieldSettingKey] = req.Key
+		hints.Extra[FieldOldValue] = oldVal
+		hints.Extra[FieldNewValue] = req.Value
+	}
+	writeJSON(w, http.StatusOK, a.settings.getAll())
+}
+
+// exportUsers returns all users including PII (email, phone).
+// Production: paginate results, enforce export rate limits, and
+// consider a redacted view or async export with download link.
+func (a *adminHandlers) exportUsers(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	// Set event type early so error paths are audited.
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.EventType = EventDataExport
+	}
+
+	users, err := queryUsers(a.db)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "export failed")
+		return
+	}
+
+	// Override event type — compliance routes bypass the routeTable.
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.EventType = EventDataExport
+		if hints.Extra == nil {
+			hints.Extra = make(map[string]any)
+		}
+		hints.Extra[FieldRecordCount] = len(users)
+	}
+	writeJSON(w, http.StatusOK, users)
+}
+
+func (a *adminHandlers) bulkDeleteItems(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	// Set event type early so error paths are audited.
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.EventType = EventBulkDelete
+	}
+
+	result, err := a.db.Exec("DELETE FROM items WHERE id NOT IN (SELECT DISTINCT item_id FROM orders)")
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "bulk delete failed")
+		return
+	}
+	affected, rowsErr := result.RowsAffected()
+	if rowsErr != nil {
+		writeError(w, r, http.StatusInternalServerError, "bulk delete failed")
+		return
+	}
+
+	// Override event type — compliance routes bypass the routeTable.
+	if hints := audit.HintsFromContext(r.Context()); hints != nil {
+		hints.EventType = EventBulkDelete
+		if hints.Extra == nil {
+			hints.Extra = make(map[string]any)
+		}
+		hints.Extra[FieldAffectedCount] = affected
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": affected})
+}

--- a/examples/16-crud-api/audit_generated.go
+++ b/examples/16-crud-api/audit_generated.go
@@ -68,39 +68,44 @@ const (
 // Field name constants — use in audit.Fields maps for
 // compile-time typo prevention.
 const (
-	FieldAction     = "action"
-	FieldActorID    = "actor_id"
-	FieldActorUID   = "actor_uid"
-	FieldDestHost   = "dest_host"
-	FieldDestIP     = "dest_ip"
-	FieldDestPort   = "dest_port"
-	FieldEmail      = "email"
-	FieldEndTime    = "end_time"
-	FieldFileHash   = "file_hash"
-	FieldFileName   = "file_name"
-	FieldFilePath   = "file_path"
-	FieldFileSize   = "file_size"
-	FieldMessage    = "message"
-	FieldMethod     = "method"
-	FieldOutcome    = "outcome"
-	FieldPath       = "path"
-	FieldPhone      = "phone"
-	FieldProtocol   = "protocol"
-	FieldReason     = "reason"
-	FieldReferrer   = "referrer"
-	FieldRequestID  = "request_id"
-	FieldRole       = "role"
-	FieldSessionID  = "session_id"
-	FieldSourceHost = "source_host"
-	FieldSourceIP   = "source_ip"
-	FieldSourcePort = "source_port"
-	FieldStartTime  = "start_time"
-	FieldTargetID   = "target_id"
-	FieldTargetRole = "target_role"
-	FieldTargetType = "target_type"
-	FieldTargetUID  = "target_uid"
-	FieldTransport  = "transport"
-	FieldUserAgent  = "user_agent"
+	FieldAction        = "action"
+	FieldActorID       = "actor_id"
+	FieldActorUID      = "actor_uid"
+	FieldAffectedCount = "affected_count"
+	FieldDestHost      = "dest_host"
+	FieldDestIP        = "dest_ip"
+	FieldDestPort      = "dest_port"
+	FieldEmail         = "email"
+	FieldEndTime       = "end_time"
+	FieldFileHash      = "file_hash"
+	FieldFileName      = "file_name"
+	FieldFilePath      = "file_path"
+	FieldFileSize      = "file_size"
+	FieldMessage       = "message"
+	FieldMethod        = "method"
+	FieldNewValue      = "new_value"
+	FieldOldValue      = "old_value"
+	FieldOutcome       = "outcome"
+	FieldPath          = "path"
+	FieldPhone         = "phone"
+	FieldProtocol      = "protocol"
+	FieldReason        = "reason"
+	FieldRecordCount   = "record_count"
+	FieldReferrer      = "referrer"
+	FieldRequestID     = "request_id"
+	FieldRole          = "role"
+	FieldSessionID     = "session_id"
+	FieldSettingKey    = "setting_key"
+	FieldSourceHost    = "source_host"
+	FieldSourceIP      = "source_ip"
+	FieldSourcePort    = "source_port"
+	FieldStartTime     = "start_time"
+	FieldTargetID      = "target_id"
+	FieldTargetRole    = "target_role"
+	FieldTargetType    = "target_type"
+	FieldTargetUID     = "target_uid"
+	FieldTransport     = "transport"
+	FieldUserAgent     = "user_agent"
 )
 
 // Sensitivity label constants — use with exclude_labels
@@ -143,15 +148,15 @@ var EventFields = map[string]struct {
 	},
 	EventBulkDelete: {
 		Required: []string{FieldActorID, FieldOutcome},
-		Optional: []string{},
+		Optional: []string{FieldAffectedCount},
 	},
 	EventConfigChange: {
 		Required: []string{FieldActorID, FieldOutcome},
-		Optional: []string{},
+		Optional: []string{FieldNewValue, FieldOldValue, FieldSettingKey},
 	},
 	EventDataExport: {
 		Required: []string{FieldActorID, FieldOutcome},
-		Optional: []string{},
+		Optional: []string{FieldRecordCount},
 	},
 	EventItemCreate: {
 		Required: []string{FieldActorID, FieldOutcome},
@@ -1339,37 +1344,38 @@ func (e *AuthorizationFailureEvent) Categories() []audit.CategoryInfo {
 
 // BulkDeleteFields describes every field on [EventBulkDelete] events.
 type BulkDeleteFields struct {
-	ActorID    audit.FieldInfo // required
-	Outcome    audit.FieldInfo // required
-	Action     audit.FieldInfo // reserved standard
-	ActorUID   audit.FieldInfo // reserved standard
-	DestHost   audit.FieldInfo // reserved standard
-	DestIP     audit.FieldInfo // reserved standard
-	DestPort   audit.FieldInfo // reserved standard
-	EndTime    audit.FieldInfo // reserved standard
-	FileHash   audit.FieldInfo // reserved standard
-	FileName   audit.FieldInfo // reserved standard
-	FilePath   audit.FieldInfo // reserved standard
-	FileSize   audit.FieldInfo // reserved standard
-	Message    audit.FieldInfo // reserved standard
-	Method     audit.FieldInfo // reserved standard
-	Path       audit.FieldInfo // reserved standard
-	Protocol   audit.FieldInfo // reserved standard
-	Reason     audit.FieldInfo // reserved standard
-	Referrer   audit.FieldInfo // reserved standard
-	RequestID  audit.FieldInfo // reserved standard
-	Role       audit.FieldInfo // reserved standard
-	SessionID  audit.FieldInfo // reserved standard
-	SourceHost audit.FieldInfo // reserved standard
-	SourceIP   audit.FieldInfo // reserved standard
-	SourcePort audit.FieldInfo // reserved standard
-	StartTime  audit.FieldInfo // reserved standard
-	TargetID   audit.FieldInfo // reserved standard
-	TargetRole audit.FieldInfo // reserved standard
-	TargetType audit.FieldInfo // reserved standard
-	TargetUID  audit.FieldInfo // reserved standard
-	Transport  audit.FieldInfo // reserved standard
-	UserAgent  audit.FieldInfo // reserved standard
+	ActorID       audit.FieldInfo // required
+	Outcome       audit.FieldInfo // required
+	AffectedCount audit.FieldInfo // optional
+	Action        audit.FieldInfo // reserved standard
+	ActorUID      audit.FieldInfo // reserved standard
+	DestHost      audit.FieldInfo // reserved standard
+	DestIP        audit.FieldInfo // reserved standard
+	DestPort      audit.FieldInfo // reserved standard
+	EndTime       audit.FieldInfo // reserved standard
+	FileHash      audit.FieldInfo // reserved standard
+	FileName      audit.FieldInfo // reserved standard
+	FilePath      audit.FieldInfo // reserved standard
+	FileSize      audit.FieldInfo // reserved standard
+	Message       audit.FieldInfo // reserved standard
+	Method        audit.FieldInfo // reserved standard
+	Path          audit.FieldInfo // reserved standard
+	Protocol      audit.FieldInfo // reserved standard
+	Reason        audit.FieldInfo // reserved standard
+	Referrer      audit.FieldInfo // reserved standard
+	RequestID     audit.FieldInfo // reserved standard
+	Role          audit.FieldInfo // reserved standard
+	SessionID     audit.FieldInfo // reserved standard
+	SourceHost    audit.FieldInfo // reserved standard
+	SourceIP      audit.FieldInfo // reserved standard
+	SourcePort    audit.FieldInfo // reserved standard
+	StartTime     audit.FieldInfo // reserved standard
+	TargetID      audit.FieldInfo // reserved standard
+	TargetRole    audit.FieldInfo // reserved standard
+	TargetType    audit.FieldInfo // reserved standard
+	TargetUID     audit.FieldInfo // reserved standard
+	Transport     audit.FieldInfo // reserved standard
+	UserAgent     audit.FieldInfo // reserved standard
 }
 
 // BulkDeleteEvent builds a type-safe audit event: A bulk deletion was performed.
@@ -1385,6 +1391,12 @@ func NewBulkDeleteEvent(actorID any, outcome any) *BulkDeleteEvent {
 		FieldActorID: actorID,
 		FieldOutcome: outcome,
 	}}
+}
+
+// SetAffectedCount sets the FieldAffectedCount field.
+func (e *BulkDeleteEvent) SetAffectedCount(v any) *BulkDeleteEvent {
+	e.fields[FieldAffectedCount] = v
+	return e
 }
 
 // SetAction sets the reserved standard field "action".
@@ -1573,37 +1585,38 @@ func (e *BulkDeleteEvent) Description() string { return "A bulk deletion was per
 // FieldInfo returns typed descriptors for every field on this event.
 func (e *BulkDeleteEvent) FieldInfo() BulkDeleteFields {
 	return BulkDeleteFields{
-		ActorID:    audit.FieldInfo{Name: FieldActorID, Required: true},
-		Outcome:    audit.FieldInfo{Name: FieldOutcome, Required: true},
-		Action:     audit.FieldInfo{Name: FieldAction},
-		ActorUID:   audit.FieldInfo{Name: FieldActorUID},
-		DestHost:   audit.FieldInfo{Name: FieldDestHost},
-		DestIP:     audit.FieldInfo{Name: FieldDestIP},
-		DestPort:   audit.FieldInfo{Name: FieldDestPort},
-		EndTime:    audit.FieldInfo{Name: FieldEndTime},
-		FileHash:   audit.FieldInfo{Name: FieldFileHash},
-		FileName:   audit.FieldInfo{Name: FieldFileName},
-		FilePath:   audit.FieldInfo{Name: FieldFilePath},
-		FileSize:   audit.FieldInfo{Name: FieldFileSize},
-		Message:    audit.FieldInfo{Name: FieldMessage},
-		Method:     audit.FieldInfo{Name: FieldMethod},
-		Path:       audit.FieldInfo{Name: FieldPath},
-		Protocol:   audit.FieldInfo{Name: FieldProtocol},
-		Reason:     audit.FieldInfo{Name: FieldReason},
-		Referrer:   audit.FieldInfo{Name: FieldReferrer},
-		RequestID:  audit.FieldInfo{Name: FieldRequestID},
-		Role:       audit.FieldInfo{Name: FieldRole},
-		SessionID:  audit.FieldInfo{Name: FieldSessionID},
-		SourceHost: audit.FieldInfo{Name: FieldSourceHost},
-		SourceIP:   audit.FieldInfo{Name: FieldSourceIP},
-		SourcePort: audit.FieldInfo{Name: FieldSourcePort},
-		StartTime:  audit.FieldInfo{Name: FieldStartTime},
-		TargetID:   audit.FieldInfo{Name: FieldTargetID},
-		TargetRole: audit.FieldInfo{Name: FieldTargetRole},
-		TargetType: audit.FieldInfo{Name: FieldTargetType},
-		TargetUID:  audit.FieldInfo{Name: FieldTargetUID},
-		Transport:  audit.FieldInfo{Name: FieldTransport},
-		UserAgent:  audit.FieldInfo{Name: FieldUserAgent},
+		ActorID:       audit.FieldInfo{Name: FieldActorID, Required: true},
+		Outcome:       audit.FieldInfo{Name: FieldOutcome, Required: true},
+		AffectedCount: audit.FieldInfo{Name: FieldAffectedCount},
+		Action:        audit.FieldInfo{Name: FieldAction},
+		ActorUID:      audit.FieldInfo{Name: FieldActorUID},
+		DestHost:      audit.FieldInfo{Name: FieldDestHost},
+		DestIP:        audit.FieldInfo{Name: FieldDestIP},
+		DestPort:      audit.FieldInfo{Name: FieldDestPort},
+		EndTime:       audit.FieldInfo{Name: FieldEndTime},
+		FileHash:      audit.FieldInfo{Name: FieldFileHash},
+		FileName:      audit.FieldInfo{Name: FieldFileName},
+		FilePath:      audit.FieldInfo{Name: FieldFilePath},
+		FileSize:      audit.FieldInfo{Name: FieldFileSize},
+		Message:       audit.FieldInfo{Name: FieldMessage},
+		Method:        audit.FieldInfo{Name: FieldMethod},
+		Path:          audit.FieldInfo{Name: FieldPath},
+		Protocol:      audit.FieldInfo{Name: FieldProtocol},
+		Reason:        audit.FieldInfo{Name: FieldReason},
+		Referrer:      audit.FieldInfo{Name: FieldReferrer},
+		RequestID:     audit.FieldInfo{Name: FieldRequestID},
+		Role:          audit.FieldInfo{Name: FieldRole},
+		SessionID:     audit.FieldInfo{Name: FieldSessionID},
+		SourceHost:    audit.FieldInfo{Name: FieldSourceHost},
+		SourceIP:      audit.FieldInfo{Name: FieldSourceIP},
+		SourcePort:    audit.FieldInfo{Name: FieldSourcePort},
+		StartTime:     audit.FieldInfo{Name: FieldStartTime},
+		TargetID:      audit.FieldInfo{Name: FieldTargetID},
+		TargetRole:    audit.FieldInfo{Name: FieldTargetRole},
+		TargetType:    audit.FieldInfo{Name: FieldTargetType},
+		TargetUID:     audit.FieldInfo{Name: FieldTargetUID},
+		Transport:     audit.FieldInfo{Name: FieldTransport},
+		UserAgent:     audit.FieldInfo{Name: FieldUserAgent},
 	}
 }
 
@@ -1618,6 +1631,9 @@ func (e *BulkDeleteEvent) Categories() []audit.CategoryInfo {
 type ConfigChangeFields struct {
 	ActorID    audit.FieldInfo // required
 	Outcome    audit.FieldInfo // required
+	NewValue   audit.FieldInfo // optional
+	OldValue   audit.FieldInfo // optional
+	SettingKey audit.FieldInfo // optional
 	Action     audit.FieldInfo // reserved standard
 	ActorUID   audit.FieldInfo // reserved standard
 	DestHost   audit.FieldInfo // reserved standard
@@ -1662,6 +1678,24 @@ func NewConfigChangeEvent(actorID any, outcome any) *ConfigChangeEvent {
 		FieldActorID: actorID,
 		FieldOutcome: outcome,
 	}}
+}
+
+// SetNewValue sets the FieldNewValue field.
+func (e *ConfigChangeEvent) SetNewValue(v any) *ConfigChangeEvent {
+	e.fields[FieldNewValue] = v
+	return e
+}
+
+// SetOldValue sets the FieldOldValue field.
+func (e *ConfigChangeEvent) SetOldValue(v any) *ConfigChangeEvent {
+	e.fields[FieldOldValue] = v
+	return e
+}
+
+// SetSettingKey sets the FieldSettingKey field.
+func (e *ConfigChangeEvent) SetSettingKey(v any) *ConfigChangeEvent {
+	e.fields[FieldSettingKey] = v
+	return e
 }
 
 // SetAction sets the reserved standard field "action".
@@ -1852,6 +1886,9 @@ func (e *ConfigChangeEvent) FieldInfo() ConfigChangeFields {
 	return ConfigChangeFields{
 		ActorID:    audit.FieldInfo{Name: FieldActorID, Required: true},
 		Outcome:    audit.FieldInfo{Name: FieldOutcome, Required: true},
+		NewValue:   audit.FieldInfo{Name: FieldNewValue},
+		OldValue:   audit.FieldInfo{Name: FieldOldValue},
+		SettingKey: audit.FieldInfo{Name: FieldSettingKey},
 		Action:     audit.FieldInfo{Name: FieldAction},
 		ActorUID:   audit.FieldInfo{Name: FieldActorUID},
 		DestHost:   audit.FieldInfo{Name: FieldDestHost},
@@ -1893,37 +1930,38 @@ func (e *ConfigChangeEvent) Categories() []audit.CategoryInfo {
 
 // DataExportFields describes every field on [EventDataExport] events.
 type DataExportFields struct {
-	ActorID    audit.FieldInfo // required
-	Outcome    audit.FieldInfo // required
-	Action     audit.FieldInfo // reserved standard
-	ActorUID   audit.FieldInfo // reserved standard
-	DestHost   audit.FieldInfo // reserved standard
-	DestIP     audit.FieldInfo // reserved standard
-	DestPort   audit.FieldInfo // reserved standard
-	EndTime    audit.FieldInfo // reserved standard
-	FileHash   audit.FieldInfo // reserved standard
-	FileName   audit.FieldInfo // reserved standard
-	FilePath   audit.FieldInfo // reserved standard
-	FileSize   audit.FieldInfo // reserved standard
-	Message    audit.FieldInfo // reserved standard
-	Method     audit.FieldInfo // reserved standard
-	Path       audit.FieldInfo // reserved standard
-	Protocol   audit.FieldInfo // reserved standard
-	Reason     audit.FieldInfo // reserved standard
-	Referrer   audit.FieldInfo // reserved standard
-	RequestID  audit.FieldInfo // reserved standard
-	Role       audit.FieldInfo // reserved standard
-	SessionID  audit.FieldInfo // reserved standard
-	SourceHost audit.FieldInfo // reserved standard
-	SourceIP   audit.FieldInfo // reserved standard
-	SourcePort audit.FieldInfo // reserved standard
-	StartTime  audit.FieldInfo // reserved standard
-	TargetID   audit.FieldInfo // reserved standard
-	TargetRole audit.FieldInfo // reserved standard
-	TargetType audit.FieldInfo // reserved standard
-	TargetUID  audit.FieldInfo // reserved standard
-	Transport  audit.FieldInfo // reserved standard
-	UserAgent  audit.FieldInfo // reserved standard
+	ActorID     audit.FieldInfo // required
+	Outcome     audit.FieldInfo // required
+	RecordCount audit.FieldInfo // optional
+	Action      audit.FieldInfo // reserved standard
+	ActorUID    audit.FieldInfo // reserved standard
+	DestHost    audit.FieldInfo // reserved standard
+	DestIP      audit.FieldInfo // reserved standard
+	DestPort    audit.FieldInfo // reserved standard
+	EndTime     audit.FieldInfo // reserved standard
+	FileHash    audit.FieldInfo // reserved standard
+	FileName    audit.FieldInfo // reserved standard
+	FilePath    audit.FieldInfo // reserved standard
+	FileSize    audit.FieldInfo // reserved standard
+	Message     audit.FieldInfo // reserved standard
+	Method      audit.FieldInfo // reserved standard
+	Path        audit.FieldInfo // reserved standard
+	Protocol    audit.FieldInfo // reserved standard
+	Reason      audit.FieldInfo // reserved standard
+	Referrer    audit.FieldInfo // reserved standard
+	RequestID   audit.FieldInfo // reserved standard
+	Role        audit.FieldInfo // reserved standard
+	SessionID   audit.FieldInfo // reserved standard
+	SourceHost  audit.FieldInfo // reserved standard
+	SourceIP    audit.FieldInfo // reserved standard
+	SourcePort  audit.FieldInfo // reserved standard
+	StartTime   audit.FieldInfo // reserved standard
+	TargetID    audit.FieldInfo // reserved standard
+	TargetRole  audit.FieldInfo // reserved standard
+	TargetType  audit.FieldInfo // reserved standard
+	TargetUID   audit.FieldInfo // reserved standard
+	Transport   audit.FieldInfo // reserved standard
+	UserAgent   audit.FieldInfo // reserved standard
 }
 
 // DataExportEvent builds a type-safe audit event: User data was exported for compliance.
@@ -1939,6 +1977,12 @@ func NewDataExportEvent(actorID any, outcome any) *DataExportEvent {
 		FieldActorID: actorID,
 		FieldOutcome: outcome,
 	}}
+}
+
+// SetRecordCount sets the FieldRecordCount field.
+func (e *DataExportEvent) SetRecordCount(v any) *DataExportEvent {
+	e.fields[FieldRecordCount] = v
+	return e
 }
 
 // SetAction sets the reserved standard field "action".
@@ -2127,37 +2171,38 @@ func (e *DataExportEvent) Description() string { return "User data was exported 
 // FieldInfo returns typed descriptors for every field on this event.
 func (e *DataExportEvent) FieldInfo() DataExportFields {
 	return DataExportFields{
-		ActorID:    audit.FieldInfo{Name: FieldActorID, Required: true},
-		Outcome:    audit.FieldInfo{Name: FieldOutcome, Required: true},
-		Action:     audit.FieldInfo{Name: FieldAction},
-		ActorUID:   audit.FieldInfo{Name: FieldActorUID},
-		DestHost:   audit.FieldInfo{Name: FieldDestHost},
-		DestIP:     audit.FieldInfo{Name: FieldDestIP},
-		DestPort:   audit.FieldInfo{Name: FieldDestPort},
-		EndTime:    audit.FieldInfo{Name: FieldEndTime},
-		FileHash:   audit.FieldInfo{Name: FieldFileHash},
-		FileName:   audit.FieldInfo{Name: FieldFileName},
-		FilePath:   audit.FieldInfo{Name: FieldFilePath},
-		FileSize:   audit.FieldInfo{Name: FieldFileSize},
-		Message:    audit.FieldInfo{Name: FieldMessage},
-		Method:     audit.FieldInfo{Name: FieldMethod},
-		Path:       audit.FieldInfo{Name: FieldPath},
-		Protocol:   audit.FieldInfo{Name: FieldProtocol},
-		Reason:     audit.FieldInfo{Name: FieldReason},
-		Referrer:   audit.FieldInfo{Name: FieldReferrer},
-		RequestID:  audit.FieldInfo{Name: FieldRequestID},
-		Role:       audit.FieldInfo{Name: FieldRole},
-		SessionID:  audit.FieldInfo{Name: FieldSessionID},
-		SourceHost: audit.FieldInfo{Name: FieldSourceHost},
-		SourceIP:   audit.FieldInfo{Name: FieldSourceIP},
-		SourcePort: audit.FieldInfo{Name: FieldSourcePort},
-		StartTime:  audit.FieldInfo{Name: FieldStartTime},
-		TargetID:   audit.FieldInfo{Name: FieldTargetID},
-		TargetRole: audit.FieldInfo{Name: FieldTargetRole},
-		TargetType: audit.FieldInfo{Name: FieldTargetType},
-		TargetUID:  audit.FieldInfo{Name: FieldTargetUID},
-		Transport:  audit.FieldInfo{Name: FieldTransport},
-		UserAgent:  audit.FieldInfo{Name: FieldUserAgent},
+		ActorID:     audit.FieldInfo{Name: FieldActorID, Required: true},
+		Outcome:     audit.FieldInfo{Name: FieldOutcome, Required: true},
+		RecordCount: audit.FieldInfo{Name: FieldRecordCount},
+		Action:      audit.FieldInfo{Name: FieldAction},
+		ActorUID:    audit.FieldInfo{Name: FieldActorUID},
+		DestHost:    audit.FieldInfo{Name: FieldDestHost},
+		DestIP:      audit.FieldInfo{Name: FieldDestIP},
+		DestPort:    audit.FieldInfo{Name: FieldDestPort},
+		EndTime:     audit.FieldInfo{Name: FieldEndTime},
+		FileHash:    audit.FieldInfo{Name: FieldFileHash},
+		FileName:    audit.FieldInfo{Name: FieldFileName},
+		FilePath:    audit.FieldInfo{Name: FieldFilePath},
+		FileSize:    audit.FieldInfo{Name: FieldFileSize},
+		Message:     audit.FieldInfo{Name: FieldMessage},
+		Method:      audit.FieldInfo{Name: FieldMethod},
+		Path:        audit.FieldInfo{Name: FieldPath},
+		Protocol:    audit.FieldInfo{Name: FieldProtocol},
+		Reason:      audit.FieldInfo{Name: FieldReason},
+		Referrer:    audit.FieldInfo{Name: FieldReferrer},
+		RequestID:   audit.FieldInfo{Name: FieldRequestID},
+		Role:        audit.FieldInfo{Name: FieldRole},
+		SessionID:   audit.FieldInfo{Name: FieldSessionID},
+		SourceHost:  audit.FieldInfo{Name: FieldSourceHost},
+		SourceIP:    audit.FieldInfo{Name: FieldSourceIP},
+		SourcePort:  audit.FieldInfo{Name: FieldSourcePort},
+		StartTime:   audit.FieldInfo{Name: FieldStartTime},
+		TargetID:    audit.FieldInfo{Name: FieldTargetID},
+		TargetRole:  audit.FieldInfo{Name: FieldTargetRole},
+		TargetType:  audit.FieldInfo{Name: FieldTargetType},
+		TargetUID:   audit.FieldInfo{Name: FieldTargetUID},
+		Transport:   audit.FieldInfo{Name: FieldTransport},
+		UserAgent:   audit.FieldInfo{Name: FieldUserAgent},
 	}
 }
 

--- a/examples/16-crud-api/auth.go
+++ b/examples/16-crud-api/auth.go
@@ -33,7 +33,12 @@ import (
 	audit "github.com/axonops/go-audit"
 )
 
-var errTokenExpired = errors.New("token expired")
+var (
+	errTokenExpired    = errors.New("token expired")
+	errMalformedTok    = errors.New("malformed token")
+	errInvalidSig      = errors.New("invalid signature")
+	errSessionNotFound = errors.New("session not found")
+)
 
 // sessionStore holds active session tokens. Tokens are removed on
 // logout or when individually validated after expiry. Production apps
@@ -93,7 +98,7 @@ func (s *sessionStore) validate(token string) (string, error) {
 	// Verify HMAC signature.
 	lastPipe := strings.LastIndex(token, "|")
 	if lastPipe < 0 {
-		return "", fmt.Errorf("malformed token")
+		return "", errMalformedTok
 	}
 	payload := token[:lastPipe]
 	sig := token[lastPipe+1:]
@@ -102,7 +107,7 @@ func (s *sessionStore) validate(token string) (string, error) {
 	_, _ = mac.Write([]byte(payload)) // hash.Hash.Write never errors
 	expected := hex.EncodeToString(mac.Sum(nil))
 	if !hmac.Equal([]byte(sig), []byte(expected)) {
-		return "", fmt.Errorf("invalid signature")
+		return "", errInvalidSig
 	}
 
 	// Check store — token must be active (not logged out).
@@ -110,7 +115,7 @@ func (s *sessionStore) validate(token string) (string, error) {
 	info, ok := s.tokens[token]
 	s.mu.Unlock()
 	if !ok {
-		return "", fmt.Errorf("session not found")
+		return "", errSessionNotFound
 	}
 
 	// Check expiry.
@@ -133,8 +138,8 @@ func (s *sessionStore) revoke(token string) {
 
 // --- Credential store (demo) ---
 
-// credentials maps username → password. In production, use hashed
-// passwords in a database.
+// credentials maps username → password. Read-only after package init.
+// Production: use bcrypt-hashed passwords in a database.
 var credentials = map[string]string{
 	"alice": "password",
 	"bob":   "password",

--- a/examples/16-crud-api/main.go
+++ b/examples/16-crud-api/main.go
@@ -63,15 +63,16 @@ func main() {
 		log.Fatalf("create schema: %v", schemaErr) //nolint:gocritic // db.Close deferred above; Fatalf is acceptable for startup failures
 	}
 
-	// Set up session store and rate limiter for auth.
+	// Set up session store, rate limiter, and admin settings.
 	sessions := newSessionStore(30 * time.Minute)
 	rl := newRateLimiter(1*time.Minute, 5) // 5 failures per minute per IP
+	settings := newSettingsStore()
 
 	// Build HTTP server.
 	addr := envOr("LISTEN_ADDR", ":8080")
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           newServer(logger, db, sessions, rl),
+		Handler:           newServer(logger, db, sessions, rl, settings),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/examples/16-crud-api/server.go
+++ b/examples/16-crud-api/server.go
@@ -53,13 +53,15 @@ var routeTable = map[string]string{
 //
 // Login/logout emit audit events directly because they ARE the
 // security action. CRUD routes emit events via the audit middleware.
-func newServer(logger *audit.Logger, db *sql.DB, sessions *sessionStore, rl *rateLimiter) http.Handler {
-	// --- Inner mux: CRUD routes (auth + audit middleware) ---
+func newServer(logger *audit.Logger, db *sql.DB, sessions *sessionStore, rl *rateLimiter, settings *settingsStore) http.Handler {
+	// --- Inner mux: CRUD + admin routes (auth + audit middleware) ---
 	innerMux := http.NewServeMux()
 
 	h := &handlers{db: db}
+	adminH := &adminHandlers{db: db, settings: settings}
 	registerInfraRoutes(innerMux)
 	registerCRUDRoutes(innerMux, h)
+	registerAdminRoutes(innerMux, adminH)
 
 	// Apply middleware: auth first, then audit.
 	authed := authMiddleware(sessions)(innerMux)
@@ -109,6 +111,19 @@ func registerCRUDRoutes(mux *http.ServeMux, h *handlers) {
 	mux.HandleFunc("GET /orders/{id}", h.getOrder)
 	mux.HandleFunc("POST /orders", h.createOrder)
 	mux.HandleFunc("PUT /orders/{id}", h.updateOrder)
+}
+
+func registerAdminRoutes(mux *http.ServeMux, a *adminHandlers) {
+	// Admin settings — successful GET reads are not audited (low value);
+	// authorization failures are still captured via requireAdmin.
+	// PUT writes emit config_change via hints.EventType override.
+	mux.HandleFunc("GET /admin/settings", a.getSettings)
+	mux.HandleFunc("PUT /admin/settings", a.updateSettings)
+
+	// Compliance endpoints — emit data_export / bulk_delete via
+	// hints.EventType override (severity 9, compliance category).
+	mux.HandleFunc("GET /export/users", a.exportUsers)
+	mux.HandleFunc("DELETE /admin/bulk-delete/items", a.bulkDeleteItems)
 }
 
 // buildAuditEvent maps HTTP request metadata to audit events.

--- a/examples/16-crud-api/taxonomy.yaml
+++ b/examples/16-crud-api/taxonomy.yaml
@@ -144,6 +144,9 @@ events:
     fields:
       outcome: { required: true }
       actor_id: { required: true }
+      setting_key: {}
+      old_value: {}
+      new_value: {}
 
   # --- Read events ---
   user_list:
@@ -182,9 +185,11 @@ events:
     fields:
       outcome: { required: true }
       actor_id: { required: true }
+      record_count: {}
 
   bulk_delete:
     description: "A bulk deletion was performed"
     fields:
       outcome: { required: true }
       actor_id: { required: true }
+      affected_count: {}


### PR DESCRIPTION
## Summary

PR 4 of 6 for issue #350 (capstone example rewrite).

- `GET/PUT /admin/settings` — in-memory settings store with key validation, emits `config_change` (severity 7)
- `GET /export/users` — exports all users, emits `data_export` (compliance, severity 9)
- `DELETE /admin/bulk-delete/items` — bulk deletes unreferenced items, emits `bulk_delete` (severity 9)
- `requireAdmin` authorization guard emits `authorization_failure` on denial
- `hints.EventType` set early in each handler so error paths are audited (not just success)
- Settings key validation rejects unknown keys (prevents unbounded map growth)
- Sentinel errors for session validation (`errors.New` instead of `fmt.Errorf`)
- Optional taxonomy fields: `setting_key`, `old_value`, `new_value`, `record_count`, `affected_count`

Agent reviews completed BEFORE commit:
- **Code-reviewer**: 1 blocking (error paths not audited) + 2 important + 2 nits — all fixed
- **Security-reviewer**: 3 medium (export warning, body limit, key validation) — all fixed
- **Go-quality**: 2 important (RowsAffected, sentinel errors) + 5 minor — all fixed

## Test plan

- [ ] `go build ./examples/16-crud-api/...` compiles
- [ ] `make lint` passes with 0 issues
- [ ] `PUT /admin/settings` with admin key updates settings, emits config_change
- [ ] `PUT /admin/settings` with non-admin key returns 403, emits authorization_failure
- [ ] `PUT /admin/settings` with unknown key returns 400
- [ ] `GET /export/users` returns all users, emits data_export (severity 9)
- [ ] `DELETE /admin/bulk-delete/items` deletes unreferenced items, emits bulk_delete
- [ ] Compliance events (severity 9) appear in security.log with HMAC