### PR TITLE
refactor: config zero value and options-only NewLogger (#388)

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -85,6 +85,11 @@ type Logger struct {
 	// usedWithOutputs is set during construction when WithOutputs is
 	// applied; prevents mixing WithOutputs and WithNamedOutput.
 	usedWithOutputs bool
+	// disabled is set by WithDisabled to create a no-op logger that
+	// discards all events without validation or delivery. Replaces
+	// the former Config.Enabled field (inverted: disabled=true means
+	// the logger does nothing).
+	disabled bool
 	// Framework fields set via WithAppName, WithHost, WithTimezone.
 	// PID is captured once at construction via os.Getpid().
 	appName  string
@@ -99,31 +104,34 @@ type Logger struct {
 	drops                 dropLimiter // rate-limits buffer-full slog.Warn
 }
 
-// NewLogger creates a new audit [Logger] with the given configuration
-// and options. A taxonomy MUST be provided via [WithTaxonomy];
-// NewLogger returns an error if none is supplied.
+// NewLogger creates a new audit [Logger] from the given options.
+// A taxonomy MUST be provided via [WithTaxonomy]; NewLogger returns
+// an error if none is supplied.
 //
-// When [Config.Enabled] is false, NewLogger returns a valid no-op
+// The zero-value [Config] is valid: buffer=10,000, drain=5s,
+// validation=strict. Pass tuning options like [WithBufferSize] or
+// [WithDrainTimeout] to override defaults, or [WithConfig] to apply
+// a struct.
+//
+// When [WithDisabled] is applied, NewLogger returns a valid no-op
 // logger. All [Logger.AuditEvent] calls return nil immediately without
 // validation or delivery.
-//
-// NewLogger MUST NOT return a non-nil *Logger when cfg or the taxonomy
-// is invalid. Config version migration runs before validation; a zero
-// [Config.Version] returns an error wrapping [ErrConfigInvalid].
-func NewLogger(cfg Config, opts ...Option) (*Logger, error) {
-	if err := migrateConfig(&cfg); err != nil {
-		return nil, err
-	}
-	if err := validateConfig(&cfg); err != nil {
-		return nil, err
-	}
-
-	l := &Logger{cfg: cfg}
+func NewLogger(opts ...Option) (*Logger, error) {
+	l := &Logger{}
 
 	for _, opt := range opts {
 		if err := opt(l); err != nil {
 			return nil, err
 		}
+	}
+
+	// validateConfig calls applyDefaults internally, then validates.
+	// migrateConfig runs after defaults so version is always set.
+	if err := validateConfig(&l.cfg); err != nil {
+		return nil, err
+	}
+	if err := migrateConfig(&l.cfg); err != nil {
+		return nil, err
 	}
 
 	// Release construction-only state.
@@ -141,7 +149,7 @@ func NewLogger(cfg Config, opts ...Option) (*Logger, error) {
 
 	// Default formatter if WithFormatter was not called.
 	if l.formatter == nil {
-		l.formatter = &JSONFormatter{OmitEmpty: cfg.OmitEmpty}
+		l.formatter = &JSONFormatter{OmitEmpty: l.cfg.OmitEmpty}
 	}
 
 	// Capture PID and timezone once at construction.
@@ -153,20 +161,20 @@ func NewLogger(cfg Config, opts ...Option) (*Logger, error) {
 	// Propagate framework fields to all formatters that support them.
 	l.propagateFrameworkFields()
 
-	if !cfg.Enabled {
+	if l.disabled {
 		return l, nil
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	l.cancel = cancel
-	l.ch = make(chan *auditEntry, cfg.BufferSize)
+	l.ch = make(chan *auditEntry, l.cfg.BufferSize)
 	l.drainDone = make(chan struct{})
 	go l.drainLoop(ctx)
 
 	slog.Info("audit: logger created",
-		"buffer_size", cfg.BufferSize,
-		"drain_timeout", cfg.DrainTimeout,
-		"validation_mode", string(cfg.ValidationMode),
+		"buffer_size", l.cfg.BufferSize,
+		"drain_timeout", l.cfg.DrainTimeout,
+		"validation_mode", string(l.cfg.ValidationMode),
 		"outputs", len(l.entries),
 	)
 
@@ -192,7 +200,7 @@ func (l *Logger) AuditEvent(evt Event) error {
 // auditInternal is the shared validation-and-enqueue path used by
 // both [Logger.AuditEvent] and internal callers.
 func (l *Logger) auditInternal(eventType string, fields Fields) error {
-	if !l.cfg.Enabled {
+	if l.disabled {
 		return nil
 	}
 	if l.closed.Load() {
@@ -274,7 +282,7 @@ func (l *Logger) Close() error {
 	l.closeOnce.Do(func() {
 		l.closed.Store(true)
 
-		if !l.cfg.Enabled {
+		if l.disabled {
 			return
 		}
 

--- a/audit_test.go
+++ b/audit_test.go
@@ -41,14 +41,14 @@ func TestMain(m *testing.M) {
 // Helper: create a logger with a mock output
 // ---------------------------------------------------------------------------
 
-func newTestLogger(t *testing.T, cfg audit.Config, out *testhelper.MockOutput, opts ...audit.Option) *audit.Logger {
+func newTestLogger(t *testing.T, out *testhelper.MockOutput, opts ...audit.Option) *audit.Logger {
 	t.Helper()
 	allOpts := []audit.Option{
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	}
 	allOpts = append(allOpts, opts...)
-	logger, err := audit.NewLogger(cfg, allOpts...)
+	logger, err := audit.NewLogger(allOpts...)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, logger.Close())
@@ -63,7 +63,7 @@ func newTestLogger(t *testing.T, cfg audit.Config, out *testhelper.MockOutput, o
 func TestLogger_Audit_ValidCall(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
@@ -83,7 +83,7 @@ func TestLogger_Audit_ValidCall(t *testing.T) {
 func TestLogger_Audit_MissingRequiredField(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome": "success",
@@ -98,7 +98,7 @@ func TestLogger_Audit_MissingRequiredField(t *testing.T) {
 func TestLogger_Audit_MissingSingleRequiredField(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
@@ -112,7 +112,7 @@ func TestLogger_Audit_MissingSingleRequiredField(t *testing.T) {
 func TestLogger_Audit_UnknownEventType(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.AuditEvent(audit.NewEvent("schema_registr", audit.Fields{}))
 	require.Error(t, err)
@@ -123,11 +123,7 @@ func TestLogger_Audit_UnknownEventType(t *testing.T) {
 func TestLogger_Audit_UnknownFieldStrict(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{
-		Version:        1,
-		Enabled:        true,
-		ValidationMode: audit.ValidationStrict,
-	}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":     "success",
@@ -143,11 +139,7 @@ func TestLogger_Audit_UnknownFieldStrict(t *testing.T) {
 func TestLogger_Audit_UnknownFieldWarn(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{
-		Version:        1,
-		Enabled:        true,
-		ValidationMode: audit.ValidationWarn,
-	}, out)
+	logger := newTestLogger(t, out, audit.WithValidationMode(audit.ValidationWarn))
 
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":     "success",
@@ -163,11 +155,7 @@ func TestLogger_Audit_UnknownFieldWarn(t *testing.T) {
 func TestLogger_Audit_UnknownFieldPermissive(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{
-		Version:        1,
-		Enabled:        true,
-		ValidationMode: audit.ValidationPermissive,
-	}, out)
+	logger := newTestLogger(t, out, audit.WithValidationMode(audit.ValidationPermissive))
 
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":     "success",
@@ -194,7 +182,6 @@ func TestLogger_Audit_ReservedStandardField_AcceptedInStrictMode(t *testing.T) {
 	}
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "strict"},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -221,7 +208,6 @@ func TestLogger_Audit_ReservedStandardField_StillRejectsUnknown(t *testing.T) {
 	}
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "strict"},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -243,7 +229,6 @@ func TestLogger_Audit_ReservedStandardField_StillRejectsUnknown(t *testing.T) {
 func TestWithAppName_Empty_ReturnsError(t *testing.T) {
 	t.Parallel()
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName(""),
 	)
@@ -255,7 +240,6 @@ func TestWithAppName_ExceedsMaxLength(t *testing.T) {
 	t.Parallel()
 	// 256 bytes — one byte over the 255-byte maximum.
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName(strings.Repeat("a", 256)),
 	)
@@ -268,7 +252,6 @@ func TestWithAppName_AtMaxLength(t *testing.T) {
 	// 255 bytes — exactly at the limit, must be accepted.
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithAppName(strings.Repeat("a", 255)),
@@ -280,7 +263,6 @@ func TestWithAppName_AtMaxLength(t *testing.T) {
 func TestWithHost_Empty_ReturnsError(t *testing.T) {
 	t.Parallel()
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithHost(""),
 	)
@@ -292,7 +274,6 @@ func TestWithHost_ExceedsMaxLength(t *testing.T) {
 	t.Parallel()
 	// 256 bytes — one byte over the 255-byte maximum.
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithHost(strings.Repeat("h", 256)),
 	)
@@ -305,7 +286,6 @@ func TestWithHost_AtMaxLength(t *testing.T) {
 	// 255 bytes — exactly at the limit, must be accepted.
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithHost(strings.Repeat("h", 255)),
@@ -317,7 +297,6 @@ func TestWithHost_AtMaxLength(t *testing.T) {
 func TestWithTimezone_Empty_ReturnsError(t *testing.T) {
 	t.Parallel()
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithTimezone(""),
 	)
@@ -329,7 +308,6 @@ func TestWithTimezone_ExceedsMaxLength(t *testing.T) {
 	t.Parallel()
 	// 65 bytes — one byte over the 64-byte maximum.
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithTimezone(strings.Repeat("Z", 65)),
 	)
@@ -342,7 +320,6 @@ func TestWithTimezone_AtMaxLength(t *testing.T) {
 	// 64 bytes — exactly at the limit, must be accepted.
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithTimezone(strings.Repeat("Z", 64)),
@@ -355,7 +332,6 @@ func TestWithStandardFieldDefaults_InvalidKey(t *testing.T) {
 	t.Parallel()
 	// "bogus" is not a reserved standard field and must be rejected.
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithStandardFieldDefaults(map[string]string{"bogus": "value"}),
 	)
@@ -368,7 +344,6 @@ func TestLogger_FrameworkFields_InOutput(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithAppName("testapp"),
@@ -396,7 +371,6 @@ func TestLogger_Timezone_AutoDetected(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	// No WithTimezone — timezone should auto-detect from system.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -424,7 +398,6 @@ func TestWithStandardFieldDefaults_Applied(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
@@ -446,7 +419,6 @@ func TestWithStandardFieldDefaults_PerEventOverride(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
@@ -469,7 +441,6 @@ func TestWithStandardFieldDefaults_EmptyStringOverride(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
@@ -491,7 +462,6 @@ func TestWithStandardFieldDefaults_EmptyStringOverride(t *testing.T) {
 func TestWithStandardFieldDefaults_SetOnce(t *testing.T) {
 	t.Parallel()
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "a"}),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "b"}),
@@ -512,7 +482,6 @@ func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {
 	}
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "strict"},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
@@ -528,7 +497,7 @@ func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {
 func TestLogger_Audit_NilFields(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	// schema_register requires outcome, actor_id, subject — nil map
 	// means all are missing.
@@ -540,7 +509,7 @@ func TestLogger_Audit_NilFields(t *testing.T) {
 func TestLogger_Audit_DisabledCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	// Disable the "read" category at runtime.
 	require.NoError(t, logger.DisableCategory("read"))
@@ -560,7 +529,7 @@ func TestLogger_Audit_DisabledCategory(t *testing.T) {
 func TestLogger_Audit_OptionalFields(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	// Include an optional field.
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
@@ -582,7 +551,7 @@ func TestLogger_Audit_OptionalFields(t *testing.T) {
 func TestLogger_Audit_TimestampAutoPopulated(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	before := time.Now()
 	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
@@ -603,7 +572,7 @@ func TestLogger_Audit_TimestampAutoPopulated(t *testing.T) {
 func TestLogger_Audit_EventTypeAutoPopulated(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
@@ -619,7 +588,7 @@ func TestLogger_Audit_EventTypeAutoPopulated(t *testing.T) {
 func TestLogger_Audit_ConsumerTimestampOverwritten(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true, ValidationMode: audit.ValidationPermissive}, out)
+	logger := newTestLogger(t, out, audit.WithValidationMode(audit.ValidationPermissive))
 
 	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":   "failure",
@@ -641,7 +610,7 @@ func TestLogger_Audit_ConsumerTimestampOverwritten(t *testing.T) {
 func TestLogger_Audit_OmitEmptyTrue(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true, OmitEmpty: true}, out)
+	logger := newTestLogger(t, out, audit.WithOmitEmpty())
 
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
@@ -660,7 +629,7 @@ func TestLogger_Audit_OmitEmptyTrue(t *testing.T) {
 func TestLogger_Audit_OmitEmptyFalse(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true, OmitEmpty: false}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
@@ -683,7 +652,7 @@ func TestLogger_Audit_OmitEmptyFalse(t *testing.T) {
 func TestLogger_Handle_Valid(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	h, err := logger.Handle("schema_register")
 	require.NoError(t, err)
@@ -694,7 +663,7 @@ func TestLogger_Handle_Valid(t *testing.T) {
 func TestLogger_Handle_Error(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	h, err := logger.Handle("nonexistent")
 	require.Error(t, err)
@@ -705,7 +674,7 @@ func TestLogger_Handle_Error(t *testing.T) {
 func TestLogger_MustHandle_Valid(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	assert.NotPanics(t, func() {
 		h := logger.MustHandle("schema_register")
@@ -716,7 +685,7 @@ func TestLogger_MustHandle_Valid(t *testing.T) {
 func TestLogger_MustHandle_Panics(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	assert.Panics(t, func() {
 		logger.MustHandle("nonexistent")
@@ -726,7 +695,7 @@ func TestLogger_MustHandle_Panics(t *testing.T) {
 func TestLogger_Handle_Audit(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	h := logger.MustHandle("auth_failure")
 	err := h.Audit(audit.Fields{
@@ -747,7 +716,7 @@ func TestLogger_Handle_Audit(t *testing.T) {
 func TestLogger_Audit_EventDelivered(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
@@ -767,7 +736,8 @@ func TestLogger_Audit_BufferFull(t *testing.T) {
 	t.Cleanup(func() { close(out.blockCh) })
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 1, DrainTimeout: 50 * time.Millisecond},
+		audit.WithBufferSize(1),
+		audit.WithDrainTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -818,7 +788,6 @@ func TestLogger_Close_DrainsEvents(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -842,7 +811,6 @@ func TestLogger_Close_Idempotent(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -856,7 +824,6 @@ func TestLogger_Audit_AfterClose(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -879,7 +846,8 @@ func TestLogger_Close_DrainTimeout(t *testing.T) {
 	t.Cleanup(func() { close(out.blockCh) })
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 10, DrainTimeout: 10 * time.Millisecond},
+		audit.WithBufferSize(10),
+		audit.WithDrainTimeout(10*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -904,7 +872,6 @@ func TestLogger_Close_OutputError(t *testing.T) {
 
 	out := &errorOutput{name: "bad", closeErr: errors.New("close failed")}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -934,7 +901,6 @@ func TestLogger_Close_MultipleOutputErrors(t *testing.T) {
 	outC := &errorOutput{name: "gamma"} // succeeds
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(outA, outB, outC),
 	)
@@ -958,7 +924,6 @@ func TestLogger_Close_AllOutputsCloseCalledOnError(t *testing.T) {
 	outB := testhelper.NewMockOutput("second")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(outA, outB),
 	)
@@ -975,7 +940,7 @@ func TestLogger_Close_AllOutputsCloseCalledOnError(t *testing.T) {
 func TestLogger_EnableCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	// Disable "read", then re-enable it.
 	require.NoError(t, logger.DisableCategory("read"))
@@ -989,7 +954,7 @@ func TestLogger_EnableCategory(t *testing.T) {
 func TestLogger_DisableCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	// Disable "write" at runtime.
 	require.NoError(t, logger.DisableCategory("write"))
@@ -1011,7 +976,7 @@ func TestLogger_DisableCategory(t *testing.T) {
 func TestLogger_EnableEvent_OverridesCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	// Disable "read" category, then enable one specific event from it.
 	require.NoError(t, logger.DisableCategory("read"))
@@ -1036,7 +1001,7 @@ func TestLogger_EnableEvent_OverridesCategory(t *testing.T) {
 func TestLogger_DisableEvent_OverridesCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	// "write" category is enabled. Disable one specific event.
 	require.NoError(t, logger.DisableEvent("schema_register"))
@@ -1062,7 +1027,7 @@ func TestLogger_DisableEvent_OverridesCategory(t *testing.T) {
 func TestLogger_Filter_InvalidCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.EnableCategory("nonexistent")
 	assert.Error(t, err)
@@ -1088,7 +1053,6 @@ func TestLogger_MultiCategory_DeliveredPerCategory(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -1118,7 +1082,6 @@ func TestLogger_MultiCategory_DisableOneCategory(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -1151,7 +1114,6 @@ func TestLogger_MultiCategory_DisableAllCategories(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -1189,7 +1151,6 @@ func TestLogger_Uncategorised_DeliveredToUnroutedOutput(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -1218,7 +1179,6 @@ func TestLogger_MultiCategory_EnableEventOverride(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -1254,7 +1214,6 @@ func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, &audit.EventRoute{
 			IncludeCategories: []string{"security"},
@@ -1287,7 +1246,6 @@ func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, &audit.EventRoute{
 			ExcludeCategories: []string{"security"},
@@ -1307,7 +1265,7 @@ func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 func TestLogger_Filter_InvalidEvent(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	err := logger.EnableEvent("nonexistent")
 	assert.Error(t, err)
@@ -1328,7 +1286,7 @@ func TestLogger_Filter_InvalidEvent(t *testing.T) {
 func TestLogger_ConcurrentAudit(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
@@ -1350,7 +1308,7 @@ func TestLogger_ConcurrentAudit(t *testing.T) {
 func TestLogger_ConcurrentFilterMutation(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out)
+	logger := newTestLogger(t, out)
 
 	var wg sync.WaitGroup
 	// Concurrent filter mutations + audit calls.
@@ -1376,7 +1334,6 @@ func TestLogger_ConcurrentClose(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -1407,7 +1364,7 @@ func TestLogger_Audit_MetricsRecordSuccess(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test-out")
 	metrics := testhelper.NewMockMetrics()
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out,
+	logger := newTestLogger(t, out,
 		audit.WithMetrics(metrics))
 
 	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
@@ -1428,7 +1385,6 @@ func TestLogger_Audit_MetricsRecordOutputError(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := &errorWriteOutput{name: "bad-write"}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -1463,7 +1419,6 @@ func (e *errorWriteOutput) Name() string         { return e.name }
 func TestLogger_Audit_NoOutputs(t *testing.T) {
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -1483,7 +1438,7 @@ func TestLogger_Audit_NoOutputs(t *testing.T) {
 
 func TestNewLogger_BufferSizeExceedsMax(t *testing.T) {
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: audit.MaxBufferSize + 1},
+		audit.WithBufferSize(audit.MaxBufferSize+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.Error(t, err)
@@ -1492,7 +1447,7 @@ func TestNewLogger_BufferSizeExceedsMax(t *testing.T) {
 
 func TestNewLogger_DrainTimeoutExceedsMax(t *testing.T) {
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, DrainTimeout: audit.MaxDrainTimeout + 1},
+		audit.WithDrainTimeout(audit.MaxDrainTimeout+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.Error(t, err)
@@ -1506,7 +1461,7 @@ func TestNewLogger_DrainTimeoutExceedsMax(t *testing.T) {
 func TestLogger_Audit_OmitEmptyZeroInt(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true, OmitEmpty: true, ValidationMode: audit.ValidationPermissive}, out)
+	logger := newTestLogger(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
 
 	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
@@ -1535,11 +1490,7 @@ func TestLogger_Audit_OmitEmptyZeroInt(t *testing.T) {
 func TestLogger_Audit_SerializationFailure(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{
-		Version:        1,
-		Enabled:        true,
-		ValidationMode: audit.ValidationPermissive,
-	}, out)
+	logger := newTestLogger(t, out, audit.WithValidationMode(audit.ValidationPermissive))
 
 	// A channel cannot be marshalled to JSON. The event passes validation
 	// (permissive mode) and is enqueued, but serialisation fails in the
@@ -1581,7 +1532,6 @@ func TestLogger_Audit_NilFieldsNoRequiredFields(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -1602,7 +1552,6 @@ func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -1636,7 +1585,6 @@ func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
 func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, nil, nil),
 	)
@@ -1690,7 +1638,6 @@ func TestLogger_Handle_AuditAfterClose(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -1719,7 +1666,6 @@ func TestLogger_Audit_MultipleOutputs(t *testing.T) {
 	out1 := testhelper.NewMockOutput("out1")
 	out2 := testhelper.NewMockOutput("out2")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out1, out2),
 	)
@@ -1745,12 +1691,7 @@ func TestLogger_Audit_MultipleOutputs(t *testing.T) {
 func TestLogger_Audit_OmitEmptyNonZeroIncluded(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{
-		Version:        1,
-		Enabled:        true,
-		OmitEmpty:      true,
-		ValidationMode: audit.ValidationPermissive,
-	}, out)
+	logger := newTestLogger(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
 
 	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
@@ -1773,12 +1714,7 @@ func TestLogger_Audit_OmitEmptyNonZeroIncluded(t *testing.T) {
 func TestLogger_Audit_FuncFieldOmitEmpty(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{
-		Version:        1,
-		Enabled:        true,
-		OmitEmpty:      true,
-		ValidationMode: audit.ValidationPermissive,
-	}, out)
+	logger := newTestLogger(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
 
 	// A func value should not cause a panic in isZeroValue.
 	// With OmitEmpty, isZeroValue returns false for a non-nil func,
@@ -1812,7 +1748,8 @@ func TestLogger_Close_ShutdownEventDroppedOnFullBuffer(t *testing.T) {
 	t.Cleanup(func() { close(out.blockCh) })
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 1, DrainTimeout: 50 * time.Millisecond},
+		audit.WithBufferSize(1),
+		audit.WithDrainTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -1848,7 +1785,6 @@ func TestLogger_Audit_AllCategoriesEnabledByDefault(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -1869,7 +1805,7 @@ func TestLogger_Audit_AllCategoriesEnabledByDefault(t *testing.T) {
 func TestAudit_UnknownEventType_RecordsValidationError(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out,
+	logger := newTestLogger(t, out,
 		audit.WithMetrics(metrics))
 
 	_ = logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
@@ -1882,7 +1818,7 @@ func TestAudit_UnknownEventType_RecordsValidationError(t *testing.T) {
 func TestAudit_MissingRequiredField_RecordsValidationError(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out,
+	logger := newTestLogger(t, out,
 		audit.WithMetrics(metrics))
 
 	_ = logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{"outcome": "ok"}))
@@ -1896,7 +1832,6 @@ func TestAudit_UnknownFieldStrict_RecordsValidationError(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: audit.ValidationStrict},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -1918,7 +1853,7 @@ func TestAudit_UnknownFieldStrict_RecordsValidationError(t *testing.T) {
 func TestAudit_FilteredEvent_RecordsFiltered(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out,
+	logger := newTestLogger(t, out,
 		audit.WithMetrics(metrics))
 
 	// Disable "read" category at runtime, then emit an event.
@@ -1933,7 +1868,7 @@ func TestAudit_FilteredEvent_RecordsFiltered(t *testing.T) {
 func TestAudit_FilteredEventOverride_RecordsFiltered(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{Version: 1, Enabled: true}, out,
+	logger := newTestLogger(t, out,
 		audit.WithMetrics(metrics))
 
 	// Disable a specific event in an enabled category.
@@ -1959,7 +1894,6 @@ func TestProcessEntry_SerializationError_RecordsMetric(t *testing.T) {
 		},
 	}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithFormatter(badFormatter),
@@ -1988,7 +1922,8 @@ func TestEmitShutdown_BufferFull_RecordsBufferDrop(t *testing.T) {
 	t.Cleanup(func() { close(out.blockCh) })
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 1, DrainTimeout: 50 * time.Millisecond},
+		audit.WithBufferSize(1),
+		audit.WithDrainTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -2020,7 +1955,6 @@ func TestAudit_NilMetrics_NoPanic(t *testing.T) {
 	}
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithFormatter(badFormatter),
@@ -2079,7 +2013,6 @@ func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
 	out := newDeliveryReporterOutput("self-reporting")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 		audit.WithMetrics(metrics),
@@ -2110,7 +2043,6 @@ func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
 	out.writeErrToReturn = errors.New("delivery failed")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 		audit.WithMetrics(metrics),
@@ -2143,7 +2075,6 @@ func TestWriteToOutput_NonDeliveryReporter_SuccessRecordsCoreMetrics(t *testing.
 	out := testhelper.NewMockOutput("plain")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -2168,12 +2099,7 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 	// Exercises the int32, float32, uint, uint64 branches in isZeroValue
 	// via the OmitEmpty path through the JSON formatter.
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, audit.Config{
-		Version:        1,
-		Enabled:        true,
-		OmitEmpty:      true,
-		ValidationMode: audit.ValidationPermissive,
-	}, out)
+	logger := newTestLogger(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
 
 	tests := []struct {
 		name    string
@@ -2268,12 +2194,8 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 			// Use a fresh output per subtest to avoid event ordering issues.
 			subOut := testhelper.NewMockOutput("sub-" + tt.name)
 			subLogger, err := audit.NewLogger(
-				audit.Config{
-					Version:        1,
-					Enabled:        true,
-					OmitEmpty:      true,
-					ValidationMode: audit.ValidationPermissive,
-				},
+				audit.WithOmitEmpty(),
+				audit.WithValidationMode(audit.ValidationPermissive),
 				audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 				audit.WithOutputs(subOut),
 			)
@@ -2319,7 +2241,6 @@ func TestWithOutputs_DuplicateDestination_ReturnsError(t *testing.T) {
 	o1 := &destKeyOutput{name: "out1", key: "/var/log/audit.log"}
 	o2 := &destKeyOutput{name: "out2", key: "/var/log/audit.log"}
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(o1, o2),
 	)
@@ -2332,7 +2253,6 @@ func TestWithNamedOutput_DuplicateDestination_ReturnsError(t *testing.T) {
 	o1 := &destKeyOutput{name: "out1", key: "localhost:514"}
 	o2 := &destKeyOutput{name: "out2", key: "localhost:514"}
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(o1, nil, nil),
 		audit.WithNamedOutput(o2, nil, nil),
@@ -2347,7 +2267,6 @@ func TestWithOutputs_EmptyDestinationKey_NoCollision(t *testing.T) {
 	o1 := &destKeyOutput{name: "out1", key: ""}
 	o2 := &destKeyOutput{name: "out2", key: ""}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(o1, o2),
 	)
@@ -2360,7 +2279,6 @@ func TestWithOutputs_MixedTypes_NoFalsePositive(t *testing.T) {
 	o1 := &destKeyOutput{name: "keyed", key: "/var/log/audit.log"}
 	o2 := testhelper.NewMockOutput("unkeyed")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(o1, o2),
 	)
@@ -2442,7 +2360,6 @@ func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
 
 	out := testhelper.NewMockOutput("field-test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -2498,7 +2415,7 @@ func TestLogger_Audit_FieldCompleteness_OmittedOptionalFieldsAbsent(t *testing.T
 
 	out := testhelper.NewMockOutput("field-test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, OmitEmpty: true},
+		audit.WithOmitEmpty(),
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -2543,7 +2460,6 @@ func BenchmarkAudit(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -2569,7 +2485,6 @@ func BenchmarkAuditDisabledCategory(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -2590,7 +2505,7 @@ func BenchmarkAuditDisabledCategory(b *testing.B) {
 func BenchmarkAuditDisabledLogger(b *testing.B) {
 	silenceSlog(b)
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: false},
+		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	if err != nil {
@@ -2630,7 +2545,6 @@ func BenchmarkAudit_RealisticFields(b *testing.B) {
 	}
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(taxonomy),
 		audit.WithOutputs(out),
 	)
@@ -2663,7 +2577,6 @@ func BenchmarkAudit_Parallel(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -2697,7 +2610,7 @@ func BenchmarkAudit_PoolAmortised(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -2737,7 +2650,7 @@ func BenchmarkAudit_FanOut_SharedFormatter(b *testing.B) {
 	out2 := testhelper.NewMockOutput("out2")
 	out3 := testhelper.NewMockOutput("out3")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out1, out2, out3),
 	)
@@ -2769,7 +2682,7 @@ func BenchmarkAudit_FanOut_MixedFormatters(b *testing.B) {
 	out3 := testhelper.NewMockOutput("json2")
 	cefFmt := &audit.CEFFormatter{Vendor: "V", Product: "P", Version: "1"}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out1, nil, nil),    // default JSON
 		audit.WithNamedOutput(out2, nil, cefFmt), // CEF
@@ -2803,7 +2716,7 @@ func BenchmarkAudit_FanOut_FilteredOutputs(b *testing.B) {
 	out2 := testhelper.NewMockOutput("write-only")
 	out3 := testhelper.NewMockOutput("security-only")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out1, nil, nil), // receives all events
 		audit.WithNamedOutput(out2, &audit.EventRoute{
@@ -2842,7 +2755,7 @@ func BenchmarkAudit_FanOut_5Outputs(b *testing.B) {
 		outputs[i] = testhelper.NewMockOutput("out" + string(rune('0'+i)))
 	}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(outputs...),
 	)
@@ -2900,7 +2813,6 @@ func TestLogger_DisableEvent_UncategorisedEvent(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -2929,7 +2841,7 @@ func BenchmarkAudit_EndToEnd(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -2957,7 +2869,7 @@ func BenchmarkAudit_WithHMAC(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, nil, nil),
 		audit.WithOutputHMAC("bench", &audit.HMACConfig{
@@ -2991,7 +2903,7 @@ func BenchmarkStandardFieldDefaults_Applied(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, nil, nil),
 		audit.WithStandardFieldDefaults(map[string]string{
@@ -3023,7 +2935,7 @@ func BenchmarkDeliverToOutputs_WithMetadataWriter(b *testing.B) {
 	silenceSlog(b)
 	mock := &mockMetadataOutput{name: "bench-mw"}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(mock, nil, nil),
 	)
@@ -3047,7 +2959,7 @@ func BenchmarkDeliverToOutputs_MixedOutputs(b *testing.B) {
 	mwOut := &mockMetadataOutput{name: "bench-mw"}
 	plainOut := testhelper.NewMockOutput("bench-plain")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 100_000},
+		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(mwOut, nil, nil),
 		audit.WithNamedOutput(plainOut, nil, nil),
@@ -3071,7 +2983,6 @@ func BenchmarkFilterCheck(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -3095,7 +3006,6 @@ func BenchmarkFilterCheck_Parallel(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -3122,7 +3032,6 @@ func BenchmarkFilterCheck_ReadWriteContention(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -3175,7 +3084,6 @@ func TestAuditEvent_WithNewEvent(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -3195,7 +3103,6 @@ func TestAuditEvent_WithNewEvent(t *testing.T) {
 func TestAuditEvent_UnknownEventType(t *testing.T) {
 	t.Parallel()
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -3209,7 +3116,6 @@ func TestAuditEvent_UnknownEventType(t *testing.T) {
 func TestAuditEvent_NilEvent(t *testing.T) {
 	t.Parallel()
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -3342,16 +3248,15 @@ func TestEventCategory_SingleCategory_JSON(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	tax := audit.Taxonomy{
-		Version:           1,
-		EmitEventCategory: true,
-		Categories:        map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
+		Version: 1,
+
+		Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
 		Events: map[string]*audit.EventDef{
 			"auth_failure": {Required: []string{"outcome"}},
 		},
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -3371,8 +3276,8 @@ func TestEventCategory_MultiCategory_SeparateDeliveries(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	tax := audit.Taxonomy{
-		Version:           1,
-		EmitEventCategory: true,
+		Version: 1,
+
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"admin_update"}},
 			"write":    {Events: []string{"admin_update"}},
@@ -3383,7 +3288,6 @@ func TestEventCategory_MultiCategory_SeparateDeliveries(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -3408,9 +3312,9 @@ func TestEventCategory_Uncategorised_NoField(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	tax := audit.Taxonomy{
-		Version:           1,
-		EmitEventCategory: true,
-		Categories:        map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
+		Version: 1,
+
+		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events: map[string]*audit.EventDef{
 			"ev1":         {Required: []string{"outcome"}},
 			"uncat_event": {Required: []string{"outcome"}},
@@ -3418,7 +3322,6 @@ func TestEventCategory_Uncategorised_NoField(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -3439,16 +3342,15 @@ func TestEventCategory_EmitFalse_NoField(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	tax := audit.Taxonomy{
-		Version:           1,
-		EmitEventCategory: false,
-		Categories:        map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
+		Version:               1,
+		SuppressEventCategory: true,
+		Categories:            map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
 		Events: map[string]*audit.EventDef{
 			"auth_failure": {Required: []string{"outcome"}},
 		},
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -3469,16 +3371,16 @@ func TestEventCategory_UserSupplied_Skipped(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	tax := audit.Taxonomy{
-		Version:           1,
-		EmitEventCategory: true,
-		Categories:        map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
+		Version: 1,
+
+		Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
 		Events: map[string]*audit.EventDef{
 			"auth_failure": {Required: []string{"outcome"}},
 		},
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -3541,16 +3443,15 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	tax := audit.Taxonomy{
-		Version:           1,
-		EmitEventCategory: true,
-		Categories:        map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
+		Version: 1,
+
+		Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
 		Events: map[string]*audit.EventDef{
 			"auth_failure": {Required: []string{"outcome"}},
 		},
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, nil, nil),
 		audit.WithOutputHMAC("test", &audit.HMACConfig{
@@ -3582,7 +3483,6 @@ func TestHMAC_Disabled_NoFields(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -3608,7 +3508,6 @@ func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, nil, nil),
 		audit.WithOutputHMAC("test", &audit.HMACConfig{
@@ -3698,7 +3597,6 @@ events:
 	strippedOut := testhelper.NewMockOutput("stripped")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		// "full" output: no label exclusions — gets all fields including email.
 		audit.WithNamedOutput(fullOut, nil, nil),
@@ -3761,16 +3659,15 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 	salt := []byte("e2e-verification-salt-value!!")
 
 	tax := audit.Taxonomy{
-		Version:           1,
-		EmitEventCategory: true,
-		Categories:        map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
+		Version: 1,
+
+		Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
 		Events: map[string]*audit.EventDef{
 			"auth_failure": {Required: []string{"outcome", "actor_id"}},
 		},
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(hmacOut, nil, nil),
 		audit.WithOutputHMAC("with-hmac", &audit.HMACConfig{
@@ -3848,7 +3745,6 @@ events:
 	baseOut := testhelper.NewMockOutput("base-stripped")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		// Both outputs exclude PII — same payload, one with HMAC.
 		audit.WithNamedOutput(hmacOut, nil, nil, "pii"),
@@ -4014,7 +3910,6 @@ func TestMetadataWriter_ImplementingOutput_ReceivesMetadata(t *testing.T) {
 	out := newMockMetadataOutput("meta-out")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -4042,7 +3937,6 @@ func TestMetadataWriter_NonImplementingOutput_ReceivesPlainWrite(t *testing.T) {
 	out := testhelper.NewMockOutput("plain-out")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -4083,7 +3977,6 @@ func TestMetadataWriter_EventMetadata_FieldsCorrect(t *testing.T) {
 	before := time.Now()
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -4136,7 +4029,6 @@ func TestMetadataWriter_MultiCategory_CategoryVaries(t *testing.T) {
 	out := newMockMetadataOutput("multi-cat")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -4185,7 +4077,6 @@ func TestMetadataWriter_UncategorisedEvent_EmptyCategory(t *testing.T) {
 	out := newMockMetadataOutput("uncat")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -4216,7 +4107,6 @@ func TestMetadataWriter_MetricsPreserved(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -4251,7 +4141,6 @@ func TestMetadataWriter_WriteError_RecordsMetrics(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -4286,7 +4175,6 @@ func TestMetadataWriter_DeliveryReporter_SkipsMetrics(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 		audit.WithMetrics(metrics),
@@ -4330,7 +4218,6 @@ func TestMetadataWriter_WithHMAC_ReceivesHMACData(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, nil, nil),
 		audit.WithOutputHMAC("mw-hmac", &audit.HMACConfig{
@@ -4392,7 +4279,6 @@ events:
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		// Exclude PII — email must not appear in the data received by WriteWithMetadata.
 		audit.WithNamedOutput(out, nil, nil, "pii"),
@@ -4425,7 +4311,7 @@ events:
 }
 
 // TestMetadataWriter_WithEventCategory_DataAndMetaConsistent verifies that
-// when EmitEventCategory is true, the event_category field in the serialised
+// when SuppressEventCategory is false (zero value), the event_category field in the serialised
 // data matches meta.Category. The library appends event_category to the
 // payload before calling WriteWithMetadata, so both must agree.
 func TestMetadataWriter_WithEventCategory_DataAndMetaConsistent(t *testing.T) {
@@ -4434,8 +4320,8 @@ func TestMetadataWriter_WithEventCategory_DataAndMetaConsistent(t *testing.T) {
 	out := newMockMetadataOutput("mw-cat")
 
 	tax := audit.Taxonomy{
-		Version:           1,
-		EmitEventCategory: true,
+		Version: 1,
+
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"auth_failure"}},
 		},
@@ -4445,7 +4331,6 @@ func TestMetadataWriter_WithEventCategory_DataAndMetaConsistent(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -4469,7 +4354,7 @@ func TestMetadataWriter_WithEventCategory_DataAndMetaConsistent(t *testing.T) {
 
 	eventCatInData, ok := record["event_category"]
 	require.True(t, ok,
-		"event_category must appear in serialised data when EmitEventCategory=true")
+		"event_category must appear in serialised data when SuppressEventCategory=false")
 	assert.Equal(t, meta.Category, eventCatInData,
 		"event_category in data must equal meta.Category")
 }
@@ -4489,7 +4374,6 @@ func TestMetadataWriter_MixedOutputs_IsolationOnError(t *testing.T) {
 	successOut := testhelper.NewMockOutput("standard-out")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(failingMW, nil, nil),
 		audit.WithNamedOutput(successOut, nil, nil),
@@ -4525,7 +4409,6 @@ func TestMetadataWriter_CachedAssertion_Correct(t *testing.T) {
 	plainOut := testhelper.NewMockOutput("plain-cached")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(mwOut, nil, nil),
 		audit.WithNamedOutput(plainOut, nil, nil),
@@ -4565,7 +4448,6 @@ func TestTimezoneAlwaysPopulated(t *testing.T) {
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
@@ -4594,7 +4476,6 @@ func TestTimezoneAutoDetect(t *testing.T) {
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
@@ -4625,7 +4506,6 @@ func TestTimezoneOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
@@ -4689,7 +4569,6 @@ events:
 	metrics := testhelper.NewMockMetrics()
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		// Excluding "pii" triggers formatWithExclusion (FormatOptions non-nil).
 		audit.WithNamedOutput(out, nil, &exclusionErrorFormatter{}, "pii"),

--- a/audittest/audittest.go
+++ b/audittest/audittest.go
@@ -24,23 +24,25 @@ import (
 type Option func(*config)
 
 type config struct {
-	validationMode audit.ValidationMode
-	cfg            audit.Config
+	extraOpts []audit.Option
 }
 
-// WithConfig overrides the entire default [audit.Config]. Only
-// Version is normalised: if the caller passes Version=0, it is
-// set to 1. All other fields — including Enabled and BufferSize —
-// take the caller's values directly. The test defaults
-// (Enabled=true, BufferSize=1000) are NOT preserved.
+// WithConfig applies a [audit.Config] struct to the test logger.
+// Non-zero fields override the test defaults (BufferSize=100).
 func WithConfig(cfg audit.Config) Option {
-	return func(c *config) { c.cfg = cfg }
+	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithConfig(cfg)) }
 }
 
 // WithValidationMode sets the taxonomy validation mode.
 // Default is [audit.ValidationStrict].
 func WithValidationMode(mode audit.ValidationMode) Option {
-	return func(c *config) { c.validationMode = mode }
+	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithValidationMode(mode)) }
+}
+
+// WithDisabled creates a disabled (no-op) test logger. Events are
+// accepted without error but not delivered.
+func WithDisabled() Option {
+	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithDisabled()) }
 }
 
 // NewLogger creates a test audit logger with an in-memory [Recorder]
@@ -98,33 +100,23 @@ func QuickTaxonomy(eventTypes ...string) audit.Taxonomy {
 func newTestLogger(tb testing.TB, tax audit.Taxonomy, opts ...Option) (*audit.Logger, *Recorder, *MetricsRecorder) {
 	tb.Helper()
 
-	c := &config{
-		cfg: audit.Config{
-			Version:    1,
-			Enabled:    true,
-			BufferSize: 100,
-		},
-	}
+	c := &config{}
 	for _, o := range opts {
 		o(c)
-	}
-	if c.cfg.Version == 0 {
-		c.cfg.Version = 1
-	}
-	if c.validationMode != "" {
-		c.cfg.ValidationMode = c.validationMode
 	}
 
 	rec := NewRecorder()
 	met := NewMetricsRecorder()
 
 	auditOpts := []audit.Option{
+		audit.WithBufferSize(100), // small buffer — recorder has no I/O cost
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(rec),
 		audit.WithMetrics(met),
 	}
+	auditOpts = append(auditOpts, c.extraOpts...)
 
-	logger, err := audit.NewLogger(c.cfg, auditOpts...)
+	logger, err := audit.NewLogger(auditOpts...)
 	if err != nil {
 		tb.Fatalf("audittest: create logger: %v", err)
 	}

--- a/audittest/audittest_test.go
+++ b/audittest/audittest_test.go
@@ -99,13 +99,10 @@ func TestNewLogger_ValidationError(t *testing.T) {
 	assert.Equal(t, 1, metrics.ValidationErrors("user_create"))
 }
 
-func TestNewLogger_WithConfig(t *testing.T) {
+func TestNewLogger_WithDisabled(t *testing.T) {
 	t.Parallel()
 	logger, events, _ := audittest.NewLogger(t, testTaxonomyYAML,
-		audittest.WithConfig(audit.Config{
-			Version: 1,
-			Enabled: false, // disabled logger
-		}),
+		audittest.WithDisabled(),
 	)
 
 	// Disabled logger accepts events without error but does not deliver.

--- a/config.go
+++ b/config.go
@@ -53,7 +53,11 @@ const (
 	MaxDrainTimeout = 60 * time.Second
 )
 
-// Config holds configuration for the audit [Logger].
+// Config holds tuning parameters for the audit [Logger]. The zero
+// value is a valid configuration: buffer=10,000, drain=5s,
+// validation=strict, omit_empty=false. Pass individual fields via
+// [WithBufferSize], [WithDrainTimeout], [WithValidationMode], or
+// [WithOmitEmpty], or pass the whole struct via [WithConfig].
 type Config struct {
 	// ValidationMode controls how unknown fields are handled.
 	// One of [ValidationStrict], [ValidationWarn], or
@@ -67,22 +71,15 @@ type Config struct {
 	// system will cause events to be lost at shutdown.
 	DrainTimeout time.Duration
 
-	// Version is the config schema version. MUST be > 0; the zero
-	// value causes [NewLogger] to return an error wrapping
-	// [ErrConfigInvalid]. Set to 1 for all current consumers; this
-	// field enables forward-compatible migrations when the config
-	// schema changes in future library versions.
-	Version int
+	// version is the config schema version. Defaults to 1 via
+	// [Config.applyDefaults]. Unexported because consumers should
+	// never need to set it — there is only one version.
+	version int
 
 	// BufferSize is the async channel capacity. Zero means
 	// [DefaultBufferSize] (10,000). Values above [MaxBufferSize]
 	// (1,000,000) cause [NewLogger] to return an error.
 	BufferSize int
-
-	// Enabled controls whether audit logging is active. When false
-	// (the zero value), [NewLogger] returns a no-op logger that
-	// discards all events.
-	Enabled bool
 
 	// OmitEmpty controls whether empty/nil/zero-value fields are
 	// included in serialised output. When true, only non-zero fields
@@ -94,6 +91,9 @@ type Config struct {
 
 // applyDefaults fills zero-valued fields with their documented defaults.
 func (c *Config) applyDefaults() {
+	if c.version == 0 {
+		c.version = 1
+	}
 	if c.BufferSize <= 0 {
 		c.BufferSize = DefaultBufferSize
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -24,40 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewLogger_ConfigVersionZero(t *testing.T) {
-	_, err := audit.NewLogger(
-		audit.Config{Version: 0, Enabled: true},
-		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
-	assert.Contains(t, err.Error(), "version is required")
-}
-
-func TestNewLogger_ConfigVersionTooHigh(t *testing.T) {
-	_, err := audit.NewLogger(
-		audit.Config{Version: 999, Enabled: true},
-		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
-	assert.Contains(t, err.Error(), "not supported")
-}
-
-func TestNewLogger_ConfigVersionNegative(t *testing.T) {
-	// Negative version is treated as below minimum supported.
-	_, err := audit.NewLogger(
-		audit.Config{Version: -1, Enabled: true},
-		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
-	assert.Contains(t, err.Error(), "no longer supported")
-}
-
 func TestNewLogger_InvalidValidationMode(t *testing.T) {
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "bogus"},
+		audit.WithValidationMode("bogus"),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.Error(t, err)
@@ -68,7 +37,7 @@ func TestNewLogger_InvalidValidationMode(t *testing.T) {
 func TestNewLogger_BufferSizeDefault(t *testing.T) {
 	// BufferSize 0 should not cause an error; it defaults to 10,000.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 0},
+		audit.WithBufferSize(0),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -78,7 +47,6 @@ func TestNewLogger_BufferSizeDefault(t *testing.T) {
 func TestNewLogger_DrainTimeoutDefault(t *testing.T) {
 	// DrainTimeout 0 should not cause an error; it defaults to 5s.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, DrainTimeout: 0},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -87,7 +55,7 @@ func TestNewLogger_DrainTimeoutDefault(t *testing.T) {
 
 func TestNewLogger_CustomDrainTimeout(t *testing.T) {
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, DrainTimeout: 10 * time.Second},
+		audit.WithDrainTimeout(10*time.Second),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -97,7 +65,7 @@ func TestNewLogger_CustomDrainTimeout(t *testing.T) {
 func TestNewLogger_DisabledNoOp(t *testing.T) {
 	out := testhelper.NewMockOutput("disabled-check")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: false},
+		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -119,7 +87,7 @@ func TestNewLogger_DisabledNoOp(t *testing.T) {
 func TestNewLogger_NegativeBufferSize_DefaultsCorrectly(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: -1},
+		audit.WithBufferSize(-1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -138,7 +106,7 @@ func TestNewLogger_NegativeBufferSize_DefaultsCorrectly(t *testing.T) {
 func TestNewLogger_NegativeDrainTimeout_DefaultsCorrectly(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, DrainTimeout: -1},
+		audit.WithDrainTimeout(-1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)

--- a/doc.go
+++ b/doc.go
@@ -59,7 +59,6 @@
 //	}
 //
 //	logger, err := audit.NewLogger(
-//	    audit.Config{Version: 1, Enabled: true},
 //	    audit.WithTaxonomy(taxonomy),
 //	    audit.WithOutputs(stdout),
 //	)
@@ -91,7 +90,7 @@
 //   - [Event] — interface for typed audit events; pass to [Logger.AuditEvent]
 //   - [NewEvent] — creates an event for dynamic use without code generation
 //   - [EventType] — pre-validated handle for zero-allocation audit calls; see [Logger.MustHandle]
-//   - [Fields] — type alias for map[string]any
+//   - [Fields] — defined type over map[string]any with [Fields.Has], [Fields.String], [Fields.Int] accessors
 //
 // # Outputs
 //

--- a/drain.go
+++ b/drain.go
@@ -167,7 +167,7 @@ func (l *Logger) deliverToOutput(oe *outputEntry, entry *auditEntry, category st
 	}
 
 	// Append event_category if enabled and the event has a category.
-	if category != "" && l.taxonomy.EmitEventCategory {
+	if category != "" && !l.taxonomy.SuppressEventCategory {
 		data = appendEventCategory(data, oe.effectiveFormatter(l.formatter), category)
 	}
 

--- a/example_middleware_test.go
+++ b/example_middleware_test.go
@@ -37,7 +37,6 @@ func ExampleMiddleware() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(taxonomy),
 	)
 	if err != nil {
@@ -96,7 +95,6 @@ func ExampleMiddleware_skip() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(taxonomy),
 	)
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -31,7 +31,6 @@ func ExampleNewLogger() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
@@ -76,7 +75,6 @@ func ExampleLogger_AuditEvent() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
@@ -109,7 +107,6 @@ func ExampleLogger_AuditEvent() {
 
 func ExampleLogger_MustHandle() {
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
@@ -141,7 +138,6 @@ func ExampleLogger_MustHandle() {
 
 func ExampleLogger_EnableCategory() {
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
@@ -175,7 +171,6 @@ func ExampleLogger_EnableCategory() {
 
 func ExampleLogger_Close() {
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
@@ -213,7 +208,6 @@ func ExampleWithFormatter() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
@@ -278,7 +272,6 @@ func ExampleLogger_SetOutputRoute() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{

--- a/examples/01-basic/main.go
+++ b/examples/01-basic/main.go
@@ -54,7 +54,6 @@ func main() {
 
 	// 3. Create the logger with the taxonomy and output.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(stdout),
 	)

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -52,7 +52,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/03-standard-fields/main.go
+++ b/examples/03-standard-fields/main.go
@@ -60,7 +60,7 @@ func main() {
 		opts = append(opts, audit.WithStandardFieldDefaults(result.StandardFields))
 	}
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/04-stdout-output/main.go
+++ b/examples/04-stdout-output/main.go
@@ -53,7 +53,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/05-file-output/main.go
+++ b/examples/05-file-output/main.go
@@ -51,7 +51,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/06-syslog-output/main.go
+++ b/examples/06-syslog-output/main.go
@@ -65,7 +65,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/07-webhook-output/main.go
+++ b/examples/07-webhook-output/main.go
@@ -67,7 +67,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/08-loki-output/main.go
+++ b/examples/08-loki-output/main.go
@@ -64,7 +64,7 @@ func main() {
 	// Create the logger with the Loki output.
 	opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/09-multi-output/main.go
+++ b/examples/09-multi-output/main.go
@@ -51,7 +51,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/10-tls-policy/main.go
+++ b/examples/10-tls-policy/main.go
@@ -59,7 +59,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/11-event-routing/main.go
+++ b/examples/11-event-routing/main.go
@@ -51,7 +51,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/12-sensitivity-labels/main.go
+++ b/examples/12-sensitivity-labels/main.go
@@ -63,7 +63,7 @@ func createLogger() *audit.Logger {
 	}
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/13-hmac-integrity/main.go
+++ b/examples/13-hmac-integrity/main.go
@@ -54,7 +54,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/14-formatters/main.go
+++ b/examples/14-formatters/main.go
@@ -51,7 +51,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/15-middleware/main.go
+++ b/examples/15-middleware/main.go
@@ -79,7 +79,6 @@ func main() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(stdout),
 	)

--- a/examples/16-crud-api/audit_setup.go
+++ b/examples/16-crud-api/audit_setup.go
@@ -61,5 +61,5 @@ func setupAuditLogger(tax audit.Taxonomy, m *auditMetrics) (*audit.Logger, error
 	}
 	opts = append(opts, result.Options...)
 
-	return audit.NewLogger(result.Config, opts...)
+	return audit.NewLogger(opts...)
 }

--- a/examples/17-testing/main.go
+++ b/examples/17-testing/main.go
@@ -81,7 +81,7 @@ func main() {
 
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/18-buffering/main.go
+++ b/examples/18-buffering/main.go
@@ -68,7 +68,7 @@ func main() {
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
 
-	logger, err := audit.NewLogger(result.Config, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -31,7 +31,7 @@ func TestFanout_DeliverToAll(t *testing.T) {
 	out2 := testhelper.NewMockOutput("out2")
 	out3 := testhelper.NewMockOutput("out3")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1, out2, out3),
 	)
@@ -51,7 +51,7 @@ func TestFanout_OutputFailureIsolation(t *testing.T) {
 	failing.SetWriteErr(assert.AnError)
 	healthy := testhelper.NewMockOutput("healthy")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(failing, healthy),
 	)
@@ -131,7 +131,7 @@ func TestFanout_RouteFiltering(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			out := testhelper.NewMockOutput("routed")
 			logger, err := audit.NewLogger(
-				audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+				audit.WithValidationMode(audit.ValidationPermissive),
 				audit.WithTaxonomy(testhelper.TestTaxonomy()),
 				audit.WithNamedOutput(out, &tt.route, nil),
 			)
@@ -151,7 +151,6 @@ func TestFanout_DuplicateOutputName_Error(t *testing.T) {
 	out1 := testhelper.NewMockOutput("same-name")
 	out2 := testhelper.NewMockOutput("same-name")
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1, out2),
 	)
@@ -163,7 +162,6 @@ func TestFanout_WithOutputs_AfterWithNamedOutput_Error(t *testing.T) {
 	out1 := testhelper.NewMockOutput("named")
 	out2 := testhelper.NewMockOutput("plain")
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out1, &audit.EventRoute{}, nil),
 		audit.WithOutputs(out2), // should error
@@ -176,7 +174,6 @@ func TestFanout_WithNamedOutput_AfterWithOutputs_Error(t *testing.T) {
 	out1 := testhelper.NewMockOutput("plain")
 	out2 := testhelper.NewMockOutput("named")
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1),
 		audit.WithNamedOutput(out2, &audit.EventRoute{}, nil), // should error
@@ -188,7 +185,6 @@ func TestFanout_WithNamedOutput_AfterWithOutputs_Error(t *testing.T) {
 func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
@@ -201,7 +197,6 @@ func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{
 			IncludeCategories: []string{"write"},
@@ -215,7 +210,7 @@ func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 func TestFanout_SetOutputRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("routed")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 	)
@@ -242,7 +237,7 @@ func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 	outA := testhelper.NewMockOutput("a")
 	outB := testhelper.NewMockOutput("b")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(outA, &audit.EventRoute{}, nil),
 		audit.WithNamedOutput(outB, &audit.EventRoute{}, nil),
@@ -264,7 +259,6 @@ func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 
 func TestFanout_SetOutputRoute_UnknownOutput(t *testing.T) {
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -278,7 +272,6 @@ func TestFanout_SetOutputRoute_UnknownOutput(t *testing.T) {
 func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 	)
@@ -295,7 +288,7 @@ func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 func TestFanout_ClearOutputRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("routed")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{
 			IncludeCategories: []string{"security"},
@@ -314,7 +307,6 @@ func TestFanout_ClearOutputRoute(t *testing.T) {
 
 func TestFanout_ClearOutputRoute_UnknownOutput(t *testing.T) {
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -329,7 +321,6 @@ func TestFanout_OutputRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	route := audit.EventRoute{IncludeCategories: []string{"security"}}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &route, nil),
 	)
@@ -349,7 +340,6 @@ func TestFanout_OutputRoute(t *testing.T) {
 
 func TestFanout_OutputRoute_UnknownOutput(t *testing.T) {
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -363,7 +353,6 @@ func TestFanout_OutputRoute_UnknownOutput(t *testing.T) {
 func TestFanout_OutputRoute_ReflectsSetAndClear(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 	)
@@ -387,7 +376,7 @@ func TestFanout_OutputRoute_ReflectsSetAndClear(t *testing.T) {
 func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 	out := testhelper.NewMockOutput("concurrent")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 	)
@@ -425,7 +414,7 @@ func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 func TestFanout_GlobalFilterTakesPrecedence(t *testing.T) {
 	out := testhelper.NewMockOutput("all")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
@@ -463,7 +452,7 @@ func TestFanout_PerOutputFormatter(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(jsonOut, &audit.EventRoute{}, nil),
 		audit.WithNamedOutput(cefOut, &audit.EventRoute{}, cefFmt),
@@ -486,7 +475,7 @@ func TestFanout_PerOutputFormatter(t *testing.T) {
 func TestFanout_PanicInFormatter_DrainLoopSurvives(t *testing.T) {
 	out := testhelper.NewMockOutput("survivor")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, &panicFormatter{}),
 	)
@@ -514,7 +503,6 @@ func TestFanout_PanicInOutputWrite_OtherOutputsStillReceive(t *testing.T) {
 	survivor := testhelper.NewMockOutput("survivor")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(panicOut, survivor),
 	)
@@ -546,7 +534,7 @@ func TestFanout_SharedFormatter_DeliversSameBytes(t *testing.T) {
 	out2 := testhelper.NewMockOutput("b")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1, out2), // same default formatter
 	)
@@ -568,7 +556,7 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithMetrics(metrics),
 		audit.WithNamedOutput(out, &audit.EventRoute{
@@ -589,7 +577,7 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 func TestFanout_ExcludeEventType_EndToEnd(t *testing.T) {
 	out := testhelper.NewMockOutput("no-config-get")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, &audit.EventRoute{
 			ExcludeEventTypes: []string{"config_get"},
@@ -617,7 +605,7 @@ func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 	badOut := testhelper.NewMockOutput("bad")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(goodOut, &audit.EventRoute{}, nil),
 		audit.WithNamedOutput(badOut, &audit.EventRoute{}, &errorFormatter{}),
@@ -640,7 +628,7 @@ func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 func TestFanout_ConcurrentEventOverrideAndAudit(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 	)

--- a/format_test.go
+++ b/format_test.go
@@ -810,7 +810,6 @@ func TestLogger_WithFormatter_Custom(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithFormatter(custom),
@@ -838,7 +837,6 @@ func (s *stubFormatter) Format(ts time.Time, eventType string, fields audit.Fiel
 func TestLogger_DefaultJSONFormatter(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -867,7 +865,6 @@ func TestLogger_CEFViaWithFormatter(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithFormatter(cef),
@@ -888,7 +885,6 @@ func TestLogger_CEFViaWithFormatter(t *testing.T) {
 
 func TestLogger_WithFormatter_Nil(t *testing.T) {
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithFormatter(nil),
 	)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -76,7 +76,6 @@ func newMiddlewareTestLogger(t *testing.T) (*audit.Logger, *testhelper.MockOutpu
 	t.Helper()
 	out := testhelper.NewMockOutput("mw-test")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(middlewareTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -608,7 +607,7 @@ func BenchmarkMiddleware(b *testing.B) {
 	taxonomy := middlewareTaxonomy()
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, BufferSize: 1_000_000},
+		audit.WithBufferSize(1_000_000),
 		audit.WithTaxonomy(taxonomy),
 		audit.WithOutputs(out),
 	)

--- a/migrate.go
+++ b/migrate.go
@@ -16,15 +16,9 @@ package audit
 
 import "fmt"
 
-const (
-	// currentConfigVersion is the latest config schema version
-	// supported by this library.
-	currentConfigVersion = 1
-
-	// minSupportedConfigVersion is the oldest config schema version
-	// the library can migrate from.
-	minSupportedConfigVersion = 1
-)
+// currentConfigVersion is the latest config schema version
+// supported by this library.
+const currentConfigVersion = 1
 
 // migrateConfig applies backwards-compatible migrations to older config
 // versions. Called after [validateConfig] (which calls [Config.applyDefaults]),

--- a/migrate.go
+++ b/migrate.go
@@ -27,18 +27,13 @@ const (
 )
 
 // migrateConfig applies backwards-compatible migrations to older config
-// versions. For v0.1.0 only version 1 exists, so this is scaffolding.
+// versions. Called after [validateConfig] (which calls [Config.applyDefaults]),
+// so version is always >= 1. The range check is scaffolding for when
+// version 2 is introduced. For v0.x only version 1 exists.
 func migrateConfig(c *Config) error {
-	if c.Version == 0 {
-		return fmt.Errorf("%w: config version is required: set version to 1", ErrConfigInvalid)
-	}
-	if c.Version > currentConfigVersion {
+	if c.version > currentConfigVersion {
 		return fmt.Errorf("%w: config version %d is not supported by this library version (max: %d), upgrade the library",
-			ErrConfigInvalid, c.Version, currentConfigVersion)
-	}
-	if c.Version < minSupportedConfigVersion {
-		return fmt.Errorf("%w: config version %d is no longer supported, minimum supported is %d",
-			ErrConfigInvalid, c.Version, minSupportedConfigVersion)
+			ErrConfigInvalid, c.version, currentConfigVersion)
 	}
 	// Version 1 → current: no migration needed.
 	return nil

--- a/multicat_severity_test.go
+++ b/multicat_severity_test.go
@@ -70,7 +70,6 @@ events:
 
 	out := testhelper.NewMockOutput("pipeline")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -131,7 +130,6 @@ events:
 
 	out := testhelper.NewMockOutput("consistent")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -178,7 +176,6 @@ events:
 
 	out := testhelper.NewMockOutput("three-cats")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -219,7 +216,6 @@ events:
 
 	out := testhelper.NewMockOutput("concurrent-filter")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -502,7 +498,6 @@ events:
 
 			out := testhelper.NewMockOutput("sev-pipeline")
 			logger, err := audit.NewLogger(
-				audit.Config{Version: 1, Enabled: true},
 				audit.WithTaxonomy(tax),
 				audit.WithOutputs(out),
 			)
@@ -572,7 +567,6 @@ events:
 	// Drive the full pipeline and check the JSON output.
 	out := testhelper.NewMockOutput("mixed-fmt")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)

--- a/options.go
+++ b/options.go
@@ -14,7 +14,10 @@
 
 package audit
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // Option configures a [Logger] during construction via [NewLogger].
 type Option func(*Logger) error
@@ -252,6 +255,88 @@ func WithOutputHMAC(name string, cfg *HMACConfig) Option {
 			return err
 		}
 		return l.setOutputHMAC(name, cfg)
+	}
+}
+
+// WithBufferSize sets the async channel capacity for the logger.
+// Zero or negative values are ignored (the default of
+// [DefaultBufferSize] applies). Values above [MaxBufferSize] cause
+// [NewLogger] to return an error wrapping [ErrConfigInvalid].
+func WithBufferSize(n int) Option {
+	return func(l *Logger) error {
+		l.cfg.BufferSize = n
+		return nil
+	}
+}
+
+// WithDrainTimeout sets the maximum time [Logger.Close] waits for
+// pending events to flush. Zero or negative values are ignored (the
+// default of [DefaultDrainTimeout] applies). Values above
+// [MaxDrainTimeout] cause [NewLogger] to return an error wrapping
+// [ErrConfigInvalid].
+func WithDrainTimeout(d time.Duration) Option {
+	return func(l *Logger) error {
+		l.cfg.DrainTimeout = d
+		return nil
+	}
+}
+
+// WithValidationMode sets how [Logger.AuditEvent] handles unknown
+// fields. Must be one of [ValidationStrict], [ValidationWarn], or
+// [ValidationPermissive]. An invalid mode causes [NewLogger] to
+// return an error wrapping [ErrConfigInvalid].
+func WithValidationMode(m ValidationMode) Option {
+	return func(l *Logger) error {
+		l.cfg.ValidationMode = m
+		return nil
+	}
+}
+
+// WithOmitEmpty enables omission of empty, nil, and zero-value fields
+// from serialised output. When enabled, only non-zero fields are
+// serialised. Consumers operating under compliance regimes that
+// require all registered fields SHOULD NOT use this option.
+func WithOmitEmpty() Option {
+	return func(l *Logger) error {
+		l.cfg.OmitEmpty = true
+		return nil
+	}
+}
+
+// WithDisabled creates a no-op logger that discards all events without
+// validation or delivery. [Logger.AuditEvent] returns nil immediately.
+// This is the explicit opt-out for audit logging — the default is
+// enabled, because silent audit disablement is worse than noisy audit
+// failure.
+func WithDisabled() Option {
+	return func(l *Logger) error {
+		l.disabled = true
+		return nil
+	}
+}
+
+// WithConfig applies configuration from a [Config] struct. Non-zero
+// fields override the corresponding defaults. When combined with
+// individual With* options, the last option applied wins.
+//
+// Boolean fields at their zero value (false) are indistinguishable
+// from unset — use [WithOmitEmpty] or [WithDisabled] for explicit
+// opt-in to boolean behaviours.
+func WithConfig(cfg Config) Option {
+	return func(l *Logger) error {
+		if cfg.BufferSize > 0 {
+			l.cfg.BufferSize = cfg.BufferSize
+		}
+		if cfg.DrainTimeout > 0 {
+			l.cfg.DrainTimeout = cfg.DrainTimeout
+		}
+		if cfg.ValidationMode != "" {
+			l.cfg.ValidationMode = cfg.ValidationMode
+		}
+		if cfg.OmitEmpty {
+			l.cfg.OmitEmpty = true
+		}
+		return nil
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// ---------------------------------------------------------------------------
+// NewLogger default config (#388 AC-1)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_NoConfigOptions_UsesDefaults(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	out := testhelper.NewMockOutput("defaults")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	// Emit an event to verify the logger works with defaults.
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "bob",
+	}))
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+	assert.Equal(t, 1, out.EventCount(), "default logger should deliver events")
+}
+
+// ---------------------------------------------------------------------------
+// NewLogger without taxonomy (#388 AC-2)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_WithoutTaxonomy_ReturnsError(t *testing.T) {
+	_, err := audit.NewLogger()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "taxonomy is required")
+}
+
+// ---------------------------------------------------------------------------
+// WithDisabled (#388 AC-3)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_WithDisabled_CreatesNoOpLogger(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	out := testhelper.NewMockOutput("disabled")
+	logger, err := audit.NewLogger(
+		audit.WithDisabled(),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+
+	// Disabled logger returns nil without delivering.
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "bob",
+	}))
+	assert.NoError(t, err)
+	require.NoError(t, logger.Close())
+	assert.Equal(t, 0, out.EventCount(), "disabled logger must not deliver events")
+}
+
+// ---------------------------------------------------------------------------
+// WithBufferSize (#388 AC-4)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_WithBufferSize_SetsCustomSize(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	logger, err := audit.NewLogger(
+		audit.WithBufferSize(50000),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}
+
+func TestNewLogger_WithBufferSize_RejectsOverMax(t *testing.T) {
+	_, err := audit.NewLogger(
+		audit.WithBufferSize(audit.MaxBufferSize+1),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+// ---------------------------------------------------------------------------
+// WithDrainTimeout (#388 AC-5)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_WithDrainTimeout_SetsCustomTimeout(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	logger, err := audit.NewLogger(
+		audit.WithDrainTimeout(30*time.Second),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}
+
+func TestNewLogger_WithDrainTimeout_RejectsOverMax(t *testing.T) {
+	_, err := audit.NewLogger(
+		audit.WithDrainTimeout(audit.MaxDrainTimeout+1),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+// ---------------------------------------------------------------------------
+// WithValidationMode (#388 AC-6)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_WithValidationMode_SetsMode(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	out := testhelper.NewMockOutput("permissive")
+	logger, err := audit.NewLogger(
+		audit.WithValidationMode(audit.ValidationPermissive),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	// Unknown fields accepted in permissive mode.
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "bob",
+		"bogus":    "value",
+	}))
+	assert.NoError(t, err, "permissive mode should accept unknown fields")
+	require.NoError(t, logger.Close())
+}
+
+// ---------------------------------------------------------------------------
+// WithOmitEmpty (#388 AC-7)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_WithOmitEmpty_OmitsZeroFields(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	out := testhelper.NewMockOutput("omit-empty")
+	logger, err := audit.NewLogger(
+		audit.WithOmitEmpty(),
+		audit.WithValidationMode(audit.ValidationPermissive),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "bob",
+		"empty":    "",
+	}))
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+	require.Equal(t, 1, out.EventCount())
+
+	ev := out.GetEvent(0)
+	_, hasEmpty := ev["empty"]
+	assert.False(t, hasEmpty, "empty string field should be omitted with WithOmitEmpty")
+}
+
+// ---------------------------------------------------------------------------
+// WithConfig (#388 AC-8, AC-9)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_WithConfig_AppliesStructFields(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	logger, err := audit.NewLogger(
+		audit.WithConfig(audit.Config{BufferSize: 50000}),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}
+
+func TestNewLogger_WithConfig_IndividualOptionOverrides(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	// WithConfig sets BufferSize=100, then WithBufferSize(200) overrides.
+	// Last option wins.
+	logger, err := audit.NewLogger(
+		audit.WithConfig(audit.Config{BufferSize: 100}),
+		audit.WithBufferSize(200),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}
+
+// ---------------------------------------------------------------------------
+// Config.version unexported (#388 AC-10)
+// ---------------------------------------------------------------------------
+
+func TestConfig_VersionUnexported(t *testing.T) {
+	// This test verifies that Config{} compiles without Version.
+	// If Version were exported, this would be a different test.
+	cfg := audit.Config{BufferSize: 100}
+	assert.Equal(t, 100, cfg.BufferSize)
+}
+
+// ---------------------------------------------------------------------------
+// Fields defined type (#388 AC-12, AC-13, AC-14)
+// ---------------------------------------------------------------------------
+
+func TestFields_DefinedType_Conversion(t *testing.T) {
+	// Explicit conversion from map[string]any compiles.
+	m := map[string]any{"k": "v"}
+	f := audit.Fields(m)
+	assert.Equal(t, "v", f["k"])
+}
+
+func TestFields_DefinedType_Has(t *testing.T) {
+	f := audit.Fields{"k": "v"}
+	assert.True(t, f.Has("k"))
+	assert.False(t, f.Has("missing"))
+}
+
+func TestFields_DefinedType_String(t *testing.T) {
+	f := audit.Fields{"name": "alice", "count": 42}
+	assert.Equal(t, "alice", f.String("name"))
+	assert.Equal(t, "", f.String("count"), "non-string should return empty")
+	assert.Equal(t, "", f.String("missing"), "missing key should return empty")
+}
+
+func TestFields_DefinedType_Int(t *testing.T) {
+	f := audit.Fields{"count": 42, "rate": 3.14, "name": "alice"}
+	assert.Equal(t, 42, f.Int("count"))
+	assert.Equal(t, 3, f.Int("rate"), "float64 should truncate to int")
+	assert.Equal(t, 0, f.Int("name"), "non-numeric should return 0")
+	assert.Equal(t, 0, f.Int("missing"), "missing key should return 0")
+}
+
+// ---------------------------------------------------------------------------
+// SuppressEventCategory zero value (#388 AC-15)
+// ---------------------------------------------------------------------------
+
+func TestSuppressEventCategory_ZeroValue_EmitsCategory(t *testing.T) {
+	var tax audit.Taxonomy
+	assert.False(t, tax.SuppressEventCategory, "zero value should be false (emit category)")
+}
+
+func TestSuppressEventCategory_True_SuppressesCategory(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	out := testhelper.NewMockOutput("suppress-cat")
+	tax := audit.Taxonomy{
+		Version:               1,
+		SuppressEventCategory: true,
+		Categories:            map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
+		Events:                map[string]*audit.EventDef{"auth_failure": {Required: []string{"outcome", "actor_id"}}},
+	}
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(tax),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "bob",
+	}))
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+	require.Equal(t, 1, out.EventCount())
+
+	ev := out.GetEvent(0)
+	_, hasCategory := ev["event_category"]
+	assert.False(t, hasCategory, "event_category should be suppressed when SuppressEventCategory=true")
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent construction (#388 AC-16 subset)
+// ---------------------------------------------------------------------------
+
+func TestNewLogger_ConcurrentConstruction_NoRace(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Each goroutine gets its own taxonomy to avoid data race
+			// on internal precomputation (precomputeTaxonomy mutates
+			// EventDef slices/maps).
+			tax := testhelper.ValidTaxonomy()
+			logger, err := audit.NewLogger(
+				audit.WithTaxonomy(tax),
+			)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			_ = logger.Close()
+		}()
+	}
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: NewLogger construction (#388)
+// ---------------------------------------------------------------------------
+
+func BenchmarkNewLogger_Construction(b *testing.B) {
+	tax := testhelper.ValidTaxonomy()
+	out := testhelper.NewMockOutput("bench")
+
+	for b.Loop() {
+		logger, err := audit.NewLogger(
+			audit.WithTaxonomy(tax),
+			audit.WithOutputs(out),
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = logger.Close()
+	}
+}

--- a/outputconfig/doc.go
+++ b/outputconfig/doc.go
@@ -101,10 +101,7 @@
 //
 //	opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
 //	opts = append(opts, result.Options...)
-//	if result.StandardFields != nil {
-//	    opts = append(opts, audit.WithStandardFieldDefaults(result.StandardFields))
-//	}
-//	logger, err := audit.NewLogger(result.Config, opts...)
+//	logger, err := audit.NewLogger(opts...)
 //
 // [Load] fails hard on any configuration error — partial configurations
 // are never returned. This ensures that a misconfigured output does not

--- a/outputconfig/logger_config.go
+++ b/outputconfig/logger_config.go
@@ -21,86 +21,90 @@ import (
 	audit "github.com/axonops/go-audit"
 )
 
-func parseLoggerConfig(raw any) (audit.Config, error) { //nolint:gocyclo,gocognit,cyclop // YAML field dispatch
+// loggerConfigResult holds both the Config and the disabled flag parsed
+// from the YAML logger: section. Disabled is tracked separately because
+// Config no longer has an Enabled field.
+type loggerConfigResult struct {
+	config   audit.Config
+	disabled bool
+}
+
+func parseLoggerConfig(raw any) (loggerConfigResult, error) { //nolint:gocyclo,gocognit,cyclop // YAML field dispatch
 	m, ok := raw.(map[string]any)
 	if !ok {
-		return audit.Config{}, fmt.Errorf("expected mapping, got %T", raw)
+		return loggerConfigResult{}, fmt.Errorf("expected mapping, got %T", raw)
 	}
-	cfg := audit.Config{
-		Version: 1,
-		Enabled: true,
-	}
+	var result loggerConfigResult
 	for key, val := range m {
 		switch key {
 		case "enabled":
 			v, err := toBool(val)
 			if err != nil {
-				return cfg, fmt.Errorf("enabled: %w", err)
+				return result, fmt.Errorf("enabled: %w", err)
 			}
-			cfg.Enabled = v
+			if !v {
+				result.disabled = true
+			}
 		case "buffer_size":
 			v, err := toInt(val)
 			if err != nil {
-				return cfg, fmt.Errorf("buffer_size: %w", err)
+				return result, fmt.Errorf("buffer_size: %w", err)
 			}
 			if v < 0 {
-				return cfg, fmt.Errorf("buffer_size: must be non-negative, got %d", v)
+				return result, fmt.Errorf("buffer_size: must be non-negative, got %d", v)
 			}
 			if v > audit.MaxBufferSize {
-				return cfg, fmt.Errorf("buffer_size: %d exceeds maximum %d", v, audit.MaxBufferSize)
+				return result, fmt.Errorf("buffer_size: %d exceeds maximum %d", v, audit.MaxBufferSize)
 			}
-			cfg.BufferSize = v
+			result.config.BufferSize = v
 		case "drain_timeout":
 			s, err := toString(val)
 			if err != nil {
-				return cfg, fmt.Errorf("drain_timeout: %w", err)
+				return result, fmt.Errorf("drain_timeout: %w", err)
 			}
 			if s != "" {
 				d, err := time.ParseDuration(s)
 				if err != nil {
-					return cfg, fmt.Errorf("drain_timeout: invalid duration %q: %w", s, err)
+					return result, fmt.Errorf("drain_timeout: invalid duration %q: %w", s, err)
 				}
 				if d < 0 {
-					return cfg, fmt.Errorf("drain_timeout: must be non-negative, got %s", s)
+					return result, fmt.Errorf("drain_timeout: must be non-negative, got %s", s)
 				}
 				if d > audit.MaxDrainTimeout {
-					return cfg, fmt.Errorf("drain_timeout: %s exceeds maximum %s", d, audit.MaxDrainTimeout)
+					return result, fmt.Errorf("drain_timeout: %s exceeds maximum %s", d, audit.MaxDrainTimeout)
 				}
-				cfg.DrainTimeout = d
+				result.config.DrainTimeout = d
 			}
 		case "validation_mode":
 			s, err := toString(val)
 			if err != nil {
-				return cfg, fmt.Errorf("validation_mode: %w", err)
+				return result, fmt.Errorf("validation_mode: %w", err)
 			}
 			if s != "" {
 				switch audit.ValidationMode(s) {
 				case audit.ValidationStrict, audit.ValidationWarn, audit.ValidationPermissive:
-					cfg.ValidationMode = audit.ValidationMode(s)
+					result.config.ValidationMode = audit.ValidationMode(s)
 				default:
-					return cfg, fmt.Errorf("validation_mode: unknown mode %q (valid: strict, warn, permissive)", s)
+					return result, fmt.Errorf("validation_mode: unknown mode %q (valid: strict, warn, permissive)", s)
 				}
 			}
 		case "omit_empty":
 			v, err := toBool(val)
 			if err != nil {
-				return cfg, fmt.Errorf("omit_empty: %w", err)
+				return result, fmt.Errorf("omit_empty: %w", err)
 			}
-			cfg.OmitEmpty = v
+			result.config.OmitEmpty = v
 		default:
-			return cfg, fmt.Errorf("unknown field %q", key)
+			return result, fmt.Errorf("unknown field %q", key)
 		}
 	}
-	return cfg, nil
+	return result, nil
 }
 
-// defaultLoggerConfig returns an audit.Config with sensible defaults
+// defaultLoggerConfigResult returns a default logger config result
 // for when the logger: section is omitted from YAML.
-func defaultLoggerConfig() audit.Config {
-	return audit.Config{
-		Version: 1,
-		Enabled: true,
-	}
+func defaultLoggerConfigResult() loggerConfigResult {
+	return loggerConfigResult{}
 }
 
 func parseStandardFields(raw any) (map[string]string, error) {

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -40,17 +40,17 @@ const MaxOutputCount = 100
 // produced by [Load], ready to be passed to [audit.NewLogger].
 type LoadResult struct { //nolint:govet // fieldalignment: readability preferred
 	// Config is the logger configuration parsed from the optional
-	// top-level `logger:` section. If the section is omitted, Config
-	// contains Version: 1 and Enabled: true; other fields are zero-valued
-	// and will be filled with sensible defaults by [audit.NewLogger]
-	// (BufferSize: 10,000, DrainTimeout: 5s, ValidationMode: strict).
-	// Pass this directly to [audit.NewLogger] as the first argument.
+	// top-level `logger:` section. Exposed for inspection; pass
+	// Options to [audit.NewLogger] instead — Options includes
+	// config-equivalent options ([audit.WithBufferSize], etc.).
 	Config audit.Config
 
-	// Options contains framework field options ([audit.WithAppName],
-	// [audit.WithHost], optionally [audit.WithTimezone]) and one
-	// [audit.WithNamedOutput] per configured output. Pass these
-	// directly to [audit.NewLogger].
+	// Options contains all options needed to create the logger:
+	// framework fields ([audit.WithAppName], [audit.WithHost]),
+	// config-equivalent options ([audit.WithBufferSize], etc.),
+	// and one [audit.WithNamedOutput] per configured output.
+	// Pass directly to [audit.NewLogger] along with
+	// [audit.WithTaxonomy].
 	Options []audit.Option
 
 	// Outputs is the ordered list of constructed outputs for
@@ -257,7 +257,7 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, coreMetric
 
 	// Phase 8: Build Options slice.
 	result := &LoadResult{
-		Config:         top.config,
+		Config:         top.loggerResult.config,
 		Outputs:        outputs,
 		AppName:        top.appName,
 		Host:           top.host,
@@ -265,10 +265,33 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, coreMetric
 		StandardFields: top.standardFields,
 	}
 
+	// Config-equivalent options so callers can use NewLogger(result.Options...).
+	cfg := top.loggerResult.config
+	if cfg.BufferSize > 0 {
+		result.Options = append(result.Options, audit.WithBufferSize(cfg.BufferSize))
+	}
+	if cfg.DrainTimeout > 0 {
+		result.Options = append(result.Options, audit.WithDrainTimeout(cfg.DrainTimeout))
+	}
+	if cfg.ValidationMode != "" {
+		result.Options = append(result.Options, audit.WithValidationMode(cfg.ValidationMode))
+	}
+	if cfg.OmitEmpty {
+		result.Options = append(result.Options, audit.WithOmitEmpty())
+	}
+	if top.loggerResult.disabled {
+		result.Options = append(result.Options, audit.WithDisabled())
+	}
+
 	// Framework field options.
 	result.Options = append(result.Options, audit.WithAppName(top.appName), audit.WithHost(top.host))
 	if top.timezone != "" {
 		result.Options = append(result.Options, audit.WithTimezone(top.timezone))
+	}
+
+	// Standard field defaults.
+	if len(top.standardFields) > 0 {
+		result.Options = append(result.Options, audit.WithStandardFieldDefaults(top.standardFields))
 	}
 
 	for i := range outputs {
@@ -291,7 +314,7 @@ type topLevel struct {
 	appName        string
 	host           string
 	timezone       string
-	config         audit.Config
+	loggerResult   loggerConfigResult
 }
 
 // parseTopLevel extracts and validates top-level YAML fields.
@@ -428,13 +451,13 @@ func parseTopLevel(ctx context.Context, doc, orderedOutputs yaml.MapSlice, order
 		if vnErr := validateNoUnresolvedRefs(resolved, "logger"); vnErr != nil {
 			return nil, fmt.Errorf("%w: logger: %w", ErrOutputConfigInvalid, vnErr)
 		}
-		cfg, cfgErr := parseLoggerConfig(resolved)
+		lr, cfgErr := parseLoggerConfig(resolved)
 		if cfgErr != nil {
 			return nil, fmt.Errorf("%w: logger: %w", ErrOutputConfigInvalid, cfgErr)
 		}
-		result.config = cfg
+		result.loggerResult = lr
 	} else {
-		result.config = defaultLoggerConfig()
+		result.loggerResult = defaultLoggerConfigResult()
 	}
 
 	// Expand env vars and validate global TLS policy eagerly so that

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -639,7 +639,7 @@ outputs:
 	// Verify options can be applied to NewLogger without error.
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	require.NoError(t, err)
 	require.NoError(t, logger.Close())
 }
@@ -796,7 +796,7 @@ outputs:
 
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	require.NoError(t, err)
 
 	// Emit a write event and a read event.
@@ -1182,8 +1182,6 @@ outputs:
 	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, result.Config.Version)
-	assert.True(t, result.Config.Enabled)
 	assert.Equal(t, 0, result.Config.BufferSize, "zero means applyDefaults will set 10000")
 	assert.Equal(t, time.Duration(0), result.Config.DrainTimeout, "zero means applyDefaults will set 5s")
 	assert.Equal(t, audit.ValidationMode(""), result.Config.ValidationMode, "empty means applyDefaults will set strict")
@@ -1210,8 +1208,6 @@ outputs:
 	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, result.Config.Version)
-	assert.True(t, result.Config.Enabled)
 	assert.Equal(t, 50000, result.Config.BufferSize)
 	assert.Equal(t, 30*time.Second, result.Config.DrainTimeout)
 	assert.Equal(t, audit.ValidationMode("warn"), result.Config.ValidationMode)
@@ -1235,7 +1231,6 @@ outputs:
 	require.NoError(t, err)
 
 	assert.Equal(t, 25000, result.Config.BufferSize)
-	assert.True(t, result.Config.Enabled, "default enabled")
 	assert.Equal(t, time.Duration(0), result.Config.DrainTimeout, "default drain timeout")
 }
 
@@ -1252,10 +1247,8 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
 	require.NoError(t, err)
-
-	assert.False(t, result.Config.Enabled)
 }
 
 func TestLoad_LoggerConfig_EnvVars(t *testing.T) {
@@ -1300,7 +1293,6 @@ outputs:
 	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
 	require.NoError(t, err)
 
-	assert.False(t, result.Config.Enabled)
 	assert.True(t, result.Config.OmitEmpty)
 }
 

--- a/outputconfig/tests/bdd/steps/steps.go
+++ b/outputconfig/tests/bdd/steps/steps.go
@@ -195,7 +195,7 @@ func registerWhenSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 		}
 		opts := []audit.Option{audit.WithTaxonomy(tc.Taxonomy)}
 		opts = append(opts, tc.Options...)
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -209,7 +209,7 @@ func registerWhenSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 		}
 		opts := []audit.Option{audit.WithTaxonomy(tc.Taxonomy)}
 		opts = append(opts, tc.Options...)
-		logger, logErr := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, logErr := audit.NewLogger(opts...)
 		if logErr != nil {
 			tc.LastErr = logErr
 			return nil //nolint:nilerr // scenario asserts on tc.LastErr

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -504,7 +504,6 @@ func TestFieldStripping_SingleLabel(t *testing.T) {
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil, "pii"),
 	)
@@ -553,7 +552,6 @@ func TestFieldStripping_MultiLabel_AnyOverlap(t *testing.T) {
 
 	// Exclude financial only — card_number is stripped.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil, "financial"),
 	)
@@ -587,7 +585,6 @@ func TestFieldStripping_DifferentOutputs(t *testing.T) {
 	outNoPII := testhelper.NewMockOutput("no-pii")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(outAll, nil, nil),          // no exclusions
 		audit.WithNamedOutput(outNoPII, nil, nil, "pii"), // exclude PII
@@ -627,7 +624,6 @@ func TestFieldStripping_NoExclusion_AllFields(t *testing.T) {
 
 	// No exclude_labels → all fields delivered.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil),
 	)
@@ -674,7 +670,6 @@ events:
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil, "pii"),
 	)
@@ -721,7 +716,6 @@ events:
 	require.NoError(t, err)
 
 	_, err = audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil, "pii"),
 	)
@@ -752,7 +746,6 @@ events:
 	require.NoError(t, err)
 
 	_, err = audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil, "nonexistent"),
 	)
@@ -792,7 +785,6 @@ events:
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil, "pii"),
 	)
@@ -833,7 +825,6 @@ func TestFormatWithExclusion_ExclusionPath(t *testing.T) {
 
 	// Output with exclusions — formatOpts should be pre-allocated.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil, "pii"),
 	)
@@ -871,7 +862,6 @@ func TestFormatWithExclusion_NoExclusionNoOverhead(t *testing.T) {
 
 	// Output WITHOUT exclusions — formatOpts should be nil.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, nil, nil),
 	)
@@ -901,7 +891,6 @@ func TestFormatWithExclusion_MultipleOutputsDifferentExclusions(t *testing.T) {
 	outNoFinancial := testhelper.NewMockOutput("no-financial")
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(outAll, nil, nil),
 		audit.WithNamedOutput(outNoPII, nil, nil, "pii"),
@@ -951,7 +940,6 @@ func TestFieldStripping_Concurrent(t *testing.T) {
 
 	out := testhelper.NewMockOutput("concurrent")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, nil, nil, "pii"),
 	)
@@ -1124,7 +1112,6 @@ func BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion(b *testing.B) {
 	outAll := testhelper.NewMockOutput("all")
 	outFiltered := testhelper.NewMockOutput("filtered")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(outAll, nil, nil),
 		audit.WithNamedOutput(outFiltered, nil, nil, "pii"),
@@ -1155,7 +1142,6 @@ func benchAuditWithExclusions(b *testing.B, taxonomyYAML string, excludeLabels [
 	}
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, nil, nil, excludeLabels...),
 	)

--- a/severity_routing_test.go
+++ b/severity_routing_test.go
@@ -368,7 +368,6 @@ func TestSetRoute_CopiesMinSeverityPointer(t *testing.T) {
 
 	out := testhelper.NewMockOutput("copy-min")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 	)
@@ -401,7 +400,6 @@ func TestSetRoute_CopiesMaxSeverityPointer(t *testing.T) {
 
 	out := testhelper.NewMockOutput("copy-max")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 	)
@@ -433,7 +431,6 @@ func TestGetRoute_ReturnsIndependentSeverityPointers(t *testing.T) {
 
 	out := testhelper.NewMockOutput("get-copy")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, &audit.EventRoute{MinSeverity: intPtr(4)}, nil),
 	)
@@ -465,7 +462,6 @@ func TestSetRoute_NilSeverityPointersPreserved(t *testing.T) {
 
 	out := testhelper.NewMockOutput("nil-sev")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 	)
@@ -682,7 +678,6 @@ func TestAudit_SeverityRouteFiltersInDrainLoop(t *testing.T) {
 
 	out := testhelper.NewMockOutput("sev-filter")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, &audit.EventRoute{MinSeverity: intPtr(7)}, nil),
 	)
@@ -738,7 +733,6 @@ events:
 
 	out := testhelper.NewMockOutput("force-enabled")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tax),
 		// Output route: MinSeverity 5 — only events with severity >= 5 delivered.
 		audit.WithNamedOutput(out, &audit.EventRoute{MinSeverity: intPtr(5)}, nil),
@@ -882,7 +876,7 @@ func TestConcurrentSetRouteWithSeverity(t *testing.T) {
 	tax := testhelper.TestTaxonomy()
 	out := testhelper.NewMockOutput("concurrent_sev")
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
 	)

--- a/taxonomy.go
+++ b/taxonomy.go
@@ -19,9 +19,43 @@ import (
 	"slices"
 )
 
-// Fields is a typed alias for audit event field maps. Consumers pass
-// field values as Fields to [Logger.AuditEvent].
-type Fields = map[string]any
+// Fields is the map type for audit event fields. Consumers pass
+// field values as Fields to [Logger.AuditEvent] and generated event
+// builders.
+//
+// Fields is a defined type (not an alias) so it can carry convenience
+// methods. Callers constructing fields from a plain map must convert
+// explicitly: audit.Fields(m).
+//
+// Comparable pattern: [net/url.Values], [net/http.Header].
+type Fields map[string]any
+
+// Has reports whether the field map contains a value for key.
+func (f Fields) Has(key string) bool {
+	_, ok := f[key]
+	return ok
+}
+
+// String returns the value for key as a string. If the key is missing
+// or the value is not a string, it returns the empty string.
+func (f Fields) String(key string) string {
+	v, _ := f[key].(string)
+	return v
+}
+
+// Int returns the value for key as an int. If the key is missing or
+// the value is not an int, it returns 0. Float64 values (common from
+// JSON unmarshalling) are truncated toward zero (e.g. 99.9 → 99).
+func (f Fields) Int(key string) int {
+	switch v := f[key].(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
+}
 
 // SensitivityConfig holds all sensitivity label definitions for a
 // taxonomy. It is optional; a nil SensitivityConfig means no
@@ -161,13 +195,11 @@ type Taxonomy struct {
 	// disabled with zero overhead.
 	Sensitivity *SensitivityConfig
 
-	// EmitEventCategory controls whether the delivery-specific category
-	// name is appended as an `event_category` field in serialised output.
-	// When set via [ParseTaxonomyYAML], defaults to true when absent
-	// from YAML. The Go zero value is false — programmatic consumers
-	// must set this explicitly. When false, the append is skipped
-	// entirely with zero overhead.
-	EmitEventCategory bool
+	// SuppressEventCategory controls whether the `event_category` field
+	// is omitted from serialised output. The zero value (false) means
+	// the category IS emitted — matching the YAML default when
+	// `emit_event_category` is absent. Set to true to suppress.
+	SuppressEventCategory bool
 
 	// Version is the taxonomy schema version. MUST be > 0. Currently
 	// only version 1 is supported; higher values cause [WithTaxonomy]

--- a/taxonomy_test.go
+++ b/taxonomy_test.go
@@ -26,7 +26,6 @@ import (
 
 func TestNewLogger_ValidTaxonomy(t *testing.T) {
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
@@ -74,7 +73,6 @@ func TestNewLogger_TaxonomyValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := audit.NewLogger(
-				audit.Config{Version: 1, Enabled: true},
 				audit.WithTaxonomy(tt.taxonomy),
 			)
 			require.Error(t, err)
@@ -85,14 +83,13 @@ func TestNewLogger_TaxonomyValidation(t *testing.T) {
 }
 
 func TestNewLogger_TaxonomyRequired(t *testing.T) {
-	_, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true})
+	_, err := audit.NewLogger()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "taxonomy is required")
 }
 
 func TestNewLogger_TaxonomyValidation_SentinelError(t *testing.T) {
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{Version: 0}),
 	)
 	require.Error(t, err)
@@ -341,7 +338,6 @@ func TestMigrateTaxonomy(t *testing.T) {
 
 func TestNewLogger_TaxonomyVersionNegative(t *testing.T) {
 	_, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(audit.Taxonomy{
 			Version:    -1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},

--- a/taxonomy_yaml.go
+++ b/taxonomy_yaml.go
@@ -291,17 +291,19 @@ func convertYAMLTaxonomy(yt yamlTaxonomy) Taxonomy {
 		slices.Sort(def.Categories)
 	}
 
-	// Default emit_event_category to true when absent.
-	emitEventCategory := true
+	// Default emit_event_category to true when absent from YAML.
+	// The Go struct uses SuppressEventCategory (inverted): zero value
+	// (false) means "emit category", matching the YAML default.
+	suppressEventCategory := false
 	if yt.Categories.emitEventCategory != nil {
-		emitEventCategory = *yt.Categories.emitEventCategory
+		suppressEventCategory = !*yt.Categories.emitEventCategory
 	}
 
 	tax := Taxonomy{
-		Version:           yt.Version,
-		Categories:        categories,
-		Events:            events,
-		EmitEventCategory: emitEventCategory,
+		Version:               yt.Version,
+		Categories:            categories,
+		Events:                events,
+		SuppressEventCategory: suppressEventCategory,
 	}
 
 	if yt.Sensitivity != nil {

--- a/taxonomy_yaml_test.go
+++ b/taxonomy_yaml_test.go
@@ -654,7 +654,6 @@ events:
 	// be treated as a field name. An event with only outcome + actor_id
 	// should pass strict validation (no unknown fields).
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "strict"},
 		audit.WithTaxonomy(tax),
 	)
 	require.NoError(t, err)
@@ -671,7 +670,7 @@ events:
 // emit_event_category (#227)
 // ---------------------------------------------------------------------------
 
-func TestEmitEventCategory_DefaultTrue(t *testing.T) {
+func TestSuppressEventCategory_DefaultFalse(t *testing.T) {
 	t.Parallel()
 	yml := `
 version: 1
@@ -685,10 +684,10 @@ events:
 `
 	tax, err := audit.ParseTaxonomyYAML([]byte(yml))
 	require.NoError(t, err)
-	assert.True(t, tax.EmitEventCategory, "default should be true when absent")
+	assert.False(t, tax.SuppressEventCategory, "default should be false (emit category) when absent")
 }
 
-func TestEmitEventCategory_ExplicitTrue(t *testing.T) {
+func TestSuppressEventCategory_ExplicitEmit(t *testing.T) {
 	t.Parallel()
 	yml := `
 version: 1
@@ -703,10 +702,10 @@ events:
 `
 	tax, err := audit.ParseTaxonomyYAML([]byte(yml))
 	require.NoError(t, err)
-	assert.True(t, tax.EmitEventCategory)
+	assert.False(t, tax.SuppressEventCategory, "emit_event_category: true → SuppressEventCategory: false")
 }
 
-func TestEmitEventCategory_ExplicitFalse(t *testing.T) {
+func TestSuppressEventCategory_ExplicitSuppress(t *testing.T) {
 	t.Parallel()
 	yml := `
 version: 1
@@ -721,7 +720,7 @@ events:
 `
 	tax, err := audit.ParseTaxonomyYAML([]byte(yml))
 	require.NoError(t, err)
-	assert.False(t, tax.EmitEventCategory)
+	assert.True(t, tax.SuppressEventCategory, "emit_event_category: false → SuppressEventCategory: true")
 }
 
 func BenchmarkParseTaxonomyYAML(b *testing.B) {

--- a/tests/bdd/features/config_versioning.feature
+++ b/tests/bdd/features/config_versioning.feature
@@ -1,46 +1,22 @@
 @core @config
-Feature: Config Versioning
+Feature: Logger Configuration
   As a library consumer, I want the library to validate my configuration
-  version so that mismatched versions fail fast with a clear error instead
+  so that invalid settings fail fast with a clear error instead
   of producing undefined behaviour.
 
-  Scenario: Config version 0 is rejected with exact error
+  Scenario: Default config succeeds
     Given a standard test taxonomy
-    When I try to create a logger with config version 0
-    Then the logger construction should fail with an error matching:
-      """
-      audit: config validation failed: config version is required: set version to 1
-      """
-
-  Scenario: Config version 1 succeeds
-    Given a standard test taxonomy
-    When I create a logger with config version 1
+    When I create a logger
     Then the logger should be created successfully
-
-  Scenario: Unknown future config version is rejected with exact error
-    Given a standard test taxonomy
-    When I try to create a logger with config version 999
-    Then the logger construction should fail with an error matching:
-      """
-      audit: config validation failed: config version 999 is not supported by this library version (max: 1), upgrade the library
-      """
-
-  Scenario: Negative config version is rejected with exact error
-    Given a standard test taxonomy
-    When I try to create a logger with config version -1
-    Then the logger construction should fail with an error matching:
-      """
-      audit: config validation failed: config version -1 is no longer supported, minimum supported is 1
-      """
 
   Scenario: BufferSize defaults to 10000 when zero
     Given a standard test taxonomy
-    When I create a logger with config version 1 and buffer size 0
+    When I create a logger with buffer size 0
     Then the logger should be created successfully
 
   Scenario: BufferSize exceeding maximum is rejected with exact error
     Given a standard test taxonomy
-    When I try to create a logger with config version 1 and buffer size 2000000
+    When I try to create a logger with buffer size 2000000
     Then the logger construction should fail with an error matching:
       """
       audit: config validation failed: buffer_size 2000000 exceeds maximum 1000000
@@ -48,12 +24,12 @@ Feature: Config Versioning
 
   Scenario: DrainTimeout defaults when zero
     Given a standard test taxonomy
-    When I create a logger with config version 1 and drain timeout 0
+    When I create a logger with drain timeout 0
     Then the logger should be created successfully
 
   Scenario: DrainTimeout exceeding maximum is rejected with exact error
     Given a standard test taxonomy
-    When I try to create a logger with config version 1 and drain timeout 120s
+    When I try to create a logger with drain timeout 120s
     Then the logger construction should fail with an error matching:
       """
       audit: config validation failed: drain_timeout 2m0s exceeds maximum 1m0s
@@ -61,7 +37,7 @@ Feature: Config Versioning
 
   Scenario: Disabled config returns no-op logger
     Given a standard test taxonomy
-    When I create a disabled logger with config version 1
+    When I create a disabled logger
     Then the logger should handle audit calls without error
 
   Scenario: ValidationMode defaults to strict when empty

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -92,33 +92,22 @@ func registerAuditGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	})
 
 	ctx.Step(`^a logger with stdout output$`, func() error {
-		return createStdoutLogger(tc, audit.Config{
-			Version: 1,
-			Enabled: true,
-		})
+		return createStdoutLogger(tc)
 	})
 
 	ctx.Step(`^a logger with stdout output and validation mode "([^"]*)"$`, func(mode string) error {
-		return createStdoutLogger(tc, audit.Config{
-			Version:        1,
-			Enabled:        true,
-			ValidationMode: audit.ValidationMode(mode),
-		})
+		return createStdoutLogger(tc, audit.WithValidationMode(audit.ValidationMode(mode)))
 	})
 
 	ctx.Step(`^a logger with stdout output and OmitEmpty "([^"]*)"$`, func(val string) error {
-		cfg := audit.Config{Version: 1, Enabled: true}
 		if val == "true" {
-			cfg.OmitEmpty = true
+			return createStdoutLogger(tc, audit.WithOmitEmpty())
 		}
-		return createStdoutLogger(tc, cfg)
+		return createStdoutLogger(tc)
 	})
 
 	ctx.Step(`^a disabled logger$`, func() error {
-		return createStdoutLogger(tc, audit.Config{
-			Version: 1,
-			Enabled: false,
-		})
+		return createStdoutLogger(tc, audit.WithDisabled())
 	})
 
 	ctx.Step(`^framework fields app_name "([^"]*)" host "([^"]*)" timezone "([^"]*)"$`, func(appName, host, tz string) error {
@@ -256,11 +245,7 @@ func registerAuditWhenHandleSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 	})
 
 	ctx.Step(`^a logger with stdout output and buffer size (\d+)$`, func(bufSize int) error {
-		return createStdoutLogger(tc, audit.Config{
-			Version:    1,
-			Enabled:    true,
-			BufferSize: bufSize,
-		})
+		return createStdoutLogger(tc, audit.WithBufferSize(bufSize))
 	})
 
 	ctx.Step(`^I audit via handle with fields:$`, func(table *godog.Table) error {
@@ -580,7 +565,7 @@ func assertSentinelError(tc *AuditTestContext, sentinel string) error {
 // --- Internal helpers ---
 
 // createStdoutLogger creates a logger with an in-memory stdout output.
-func createStdoutLogger(tc *AuditTestContext, cfg audit.Config) error {
+func createStdoutLogger(tc *AuditTestContext, extraOpts ...audit.Option) error {
 	buf := &bytes.Buffer{}
 	tc.StdoutBuf = buf
 
@@ -597,8 +582,9 @@ func createStdoutLogger(tc *AuditTestContext, cfg audit.Config) error {
 		opts = append(opts, audit.WithMetrics(tc.MockMetrics))
 	}
 	opts = append(opts, tc.Options...)
+	opts = append(opts, extraOpts...)
 
-	logger, err := audit.NewLogger(cfg, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		// Store the error for scenarios that expect construction failure.
 		tc.LastErr = err
@@ -607,6 +593,12 @@ func createStdoutLogger(tc *AuditTestContext, cfg audit.Config) error {
 	tc.Logger = logger
 	tc.AddCleanup(func() { _ = logger.Close() })
 	return nil
+}
+
+// createStdoutLoggerWithOpts is an alias for createStdoutLogger for
+// callers that pass additional options.
+func createStdoutLoggerWithOpts(tc *AuditTestContext, opts ...audit.Option) error {
+	return createStdoutLogger(tc, opts...)
 }
 
 // getStdoutEvents closes the logger (to flush the drain) and parses

--- a/tests/bdd/steps/config_steps.go
+++ b/tests/bdd/steps/config_steps.go
@@ -32,32 +32,32 @@ func registerConfigSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 }
 
 func registerConfigWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^I try to create a logger with config version (\-?\d+)$`, func(version int) error {
-		return tryCreateLogger(tc, audit.Config{Version: version, Enabled: true})
+	ctx.Step(`^I try to create a logger$`, func() error {
+		return tryCreateLogger(tc)
 	})
 
-	ctx.Step(`^I create a logger with config version (\d+)$`, func(version int) error {
-		return tryCreateLogger(tc, audit.Config{Version: version, Enabled: true})
+	ctx.Step(`^I create a logger$`, func() error {
+		return tryCreateLogger(tc)
 	})
 
-	ctx.Step(`^I create a logger with config version (\d+) and buffer size (\d+)$`, func(version, bufSize int) error {
-		return tryCreateLogger(tc, audit.Config{Version: version, Enabled: true, BufferSize: bufSize})
+	ctx.Step(`^I create a logger with buffer size (\d+)$`, func(bufSize int) error {
+		return tryCreateLogger(tc, audit.WithBufferSize(bufSize))
 	})
 
-	ctx.Step(`^I try to create a logger with config version (\d+) and buffer size (\d+)$`, func(version, bufSize int) error {
-		return tryCreateLogger(tc, audit.Config{Version: version, Enabled: true, BufferSize: bufSize})
+	ctx.Step(`^I try to create a logger with buffer size (\d+)$`, func(bufSize int) error {
+		return tryCreateLogger(tc, audit.WithBufferSize(bufSize))
 	})
 
-	ctx.Step(`^I create a logger with config version (\d+) and drain timeout (\d+)$`, func(version int, timeout int) error {
-		return tryCreateLogger(tc, audit.Config{Version: version, Enabled: true, DrainTimeout: time.Duration(timeout)})
+	ctx.Step(`^I create a logger with drain timeout (\d+)$`, func(timeout int) error {
+		return tryCreateLogger(tc, audit.WithDrainTimeout(time.Duration(timeout)))
 	})
 
-	ctx.Step(`^I try to create a logger with config version (\d+) and drain timeout (\d+)s$`, func(version int, secs int) error {
-		return tryCreateLogger(tc, audit.Config{Version: version, Enabled: true, DrainTimeout: time.Duration(secs) * time.Second})
+	ctx.Step(`^I try to create a logger with drain timeout (\d+)s$`, func(secs int) error {
+		return tryCreateLogger(tc, audit.WithDrainTimeout(time.Duration(secs)*time.Second))
 	})
 
-	ctx.Step(`^I create a disabled logger with config version (\d+)$`, func(version int) error {
-		return tryCreateLogger(tc, audit.Config{Version: version, Enabled: false})
+	ctx.Step(`^I create a disabled logger$`, func() error {
+		return tryCreateLogger(tc, audit.WithDisabled())
 	})
 
 }
@@ -103,10 +103,10 @@ func registerConfigThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	})
 }
 
-// tryCreateLogger creates a logger with the given config and stores it
+// tryCreateLogger creates a logger with the given options and stores it
 // in the test context. If creation fails, the error is stored in tc.LastErr
 // without failing the step (the scenario may assert on the error).
-func tryCreateLogger(tc *AuditTestContext, cfg audit.Config) error {
+func tryCreateLogger(tc *AuditTestContext, extraOpts ...audit.Option) error {
 	buf := &bytes.Buffer{}
 	tc.StdoutBuf = buf
 
@@ -119,8 +119,9 @@ func tryCreateLogger(tc *AuditTestContext, cfg audit.Config) error {
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(stdoutOut),
 	}
+	opts = append(opts, extraOpts...)
 
-	logger, err := audit.NewLogger(cfg, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -41,7 +41,6 @@ type AuditTestContext struct { //nolint:govet // fieldalignment: readability pre
 	EventHandle *audit.EventType
 	LastErr     error
 	Taxonomy    audit.Taxonomy
-	Config      audit.Config
 	Options     []audit.Option
 
 	// Output capture.
@@ -111,7 +110,6 @@ func (tc *AuditTestContext) Reset() {
 	tc.EventHandle = nil
 	tc.LastErr = nil
 	tc.Taxonomy = audit.Taxonomy{}
-	tc.Config = audit.Config{}
 	tc.Options = nil
 	tc.StdoutBuf = nil
 	tc.FilePaths = make(map[string]string)

--- a/tests/bdd/steps/fanout_steps.go
+++ b/tests/bdd/steps/fanout_steps.go
@@ -206,7 +206,7 @@ func createSharedFormatterLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(fB, nil, nil),
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -344,7 +344,6 @@ func tryDuplicateOutputNames(tc *AuditTestContext) error {
 		return fmt.Errorf("create file a: %w", err)
 	}
 	_, err = audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(f1, f1), // same output = duplicate name
 	)
@@ -367,7 +366,6 @@ func tryDuplicateFilePath(tc *AuditTestContext) error {
 		return fmt.Errorf("create file 2: %w", err)
 	}
 	_, err = audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(f1, f2),
 	)
@@ -385,7 +383,6 @@ func tryMixedRoute(tc *AuditTestContext) error {
 		return fmt.Errorf("create file: %w", err)
 	}
 	_, err = audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(f, &audit.EventRoute{
 			IncludeCategories: []string{"write"},
@@ -406,7 +403,6 @@ func tryUnknownCategoryRoute(tc *AuditTestContext) error {
 		return fmt.Errorf("create file: %w", err)
 	}
 	_, err = audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(f, &audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
@@ -449,7 +445,6 @@ func tryDuplicateSyslogAddress(tc *AuditTestContext) error {
 		return fmt.Errorf("create syslog 2: %w", err)
 	}
 	_, err = audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(s1, s2),
 	)
@@ -467,7 +462,6 @@ func tryUnknownEventTypeRoute(tc *AuditTestContext) error {
 		return fmt.Errorf("create file: %w", err)
 	}
 	_, err = audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(f, &audit.EventRoute{
 			IncludeEventTypes: []string{"nonexistent_event"},
@@ -535,7 +529,7 @@ func createFanoutLogger(tc *AuditTestContext, useFile, useSyslog, useWebhook boo
 		opts = append(opts, audit.WithNamedOutput(w, nil, webhookFmt))
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
@@ -571,7 +565,7 @@ func createErrorOutputLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(&errorOutput{}, nil, nil),
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -606,7 +600,7 @@ func createPanicOutputLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(&panicOutput{}, nil, nil),
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -655,7 +649,7 @@ func createPanicFormatterLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(&devNullOutput{}, nil, &panicFormatter{}), // panicking formatter
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -689,7 +683,7 @@ func createDualFileRoutedLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(writeOut, &audit.EventRoute{IncludeCategories: []string{"write"}}, nil),
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -733,7 +727,7 @@ func createTripleRoutedLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(webhookOut, &audit.EventRoute{IncludeCategories: []string{"write"}}, nil),   // write only
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -769,7 +763,7 @@ func createRoutedLogger(tc *AuditTestContext, webhookRoute *audit.EventRoute) er
 		audit.WithNamedOutput(w, webhookRoute, nil),
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr

--- a/tests/bdd/steps/file_steps.go
+++ b/tests/bdd/steps/file_steps.go
@@ -37,24 +37,24 @@ func registerFileSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 func registerFileGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^a logger with file output at a temporary path$`, func() error {
-		return createFileLogger(tc, audit.Config{Version: 1, Enabled: true}, file.Config{})
+		return createFileLogger(tc, file.Config{})
 	})
 	ctx.Step(`^a logger with file output with permissions "([^"]*)"$`, func(perms string) error {
-		return createFileLogger(tc, audit.Config{Version: 1, Enabled: true}, file.Config{Permissions: perms})
+		return createFileLogger(tc, file.Config{Permissions: perms})
 	})
 	ctx.Step(`^a logger with file output configured for (\d+) MB max size$`, func(mb int) error {
-		return createFileLogger(tc, audit.Config{Version: 1, Enabled: true}, file.Config{MaxSizeMB: mb})
+		return createFileLogger(tc, file.Config{MaxSizeMB: mb})
 	})
 	ctx.Step(`^a logger with file output configured for (\d+) MB max size with compression$`, func(mb int) error {
 		compress := true
-		return createFileLogger(tc, audit.Config{Version: 1, Enabled: true}, file.Config{MaxSizeMB: mb, Compress: &compress})
+		return createFileLogger(tc, file.Config{MaxSizeMB: mb, Compress: &compress})
 	})
 	ctx.Step(`^a logger with file output configured for (\d+) MB max size without compression$`, func(mb int) error {
 		compress := false
-		return createFileLogger(tc, audit.Config{Version: 1, Enabled: true}, file.Config{MaxSizeMB: mb, Compress: &compress})
+		return createFileLogger(tc, file.Config{MaxSizeMB: mb, Compress: &compress})
 	})
 	ctx.Step(`^a logger with file output configured for (\d+) MB max size and max backups (\d+)$`, func(mb, backups int) error {
-		return createFileLogger(tc, audit.Config{Version: 1, Enabled: true}, file.Config{MaxSizeMB: mb, MaxBackups: backups})
+		return createFileLogger(tc, file.Config{MaxSizeMB: mb, MaxBackups: backups})
 	})
 	ctx.Step(`^at most (\d+) files should exist in the output directory$`, func(maxFiles int) error {
 		if tc.Logger != nil {
@@ -79,18 +79,14 @@ func registerFileGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 	ctx.Step(`^a logger with file output configured for (\d+) MB max size with file metrics$`, func(mb int) error {
 		tc.FileMetrics = &MockFileMetrics{}
-		return createFileLoggerWithMetrics(tc, audit.Config{Version: 1, Enabled: true}, file.Config{MaxSizeMB: mb}, tc.FileMetrics)
+		return createFileLoggerWithMetrics(tc, file.Config{MaxSizeMB: mb}, tc.FileMetrics)
 	})
 	ctx.Step(`^mock file metrics are configured$`, func() error {
 		tc.FileMetrics = &MockFileMetrics{}
 		return nil
 	})
 	ctx.Step(`^a logger with file output at a temporary path and short drain timeout$`, func() error {
-		return createFileLogger(tc, audit.Config{
-			Version:      1,
-			Enabled:      true,
-			DrainTimeout: 100 * time.Millisecond,
-		}, file.Config{})
+		return createFileLoggerWithExtraOpts(tc, file.Config{}, audit.WithDrainTimeout(100*time.Millisecond))
 	})
 	ctx.Step(`^closing the logger should complete within (\d+) seconds$`, func(maxSecs int) error {
 		if tc.Logger == nil {
@@ -221,7 +217,7 @@ func registerFileThenValidationSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 
 func createNoOutputLogger(tc *AuditTestContext) error {
 	opts := []audit.Option{audit.WithTaxonomy(tc.Taxonomy)}
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
@@ -463,11 +459,19 @@ func assertFileRotationCount(tc *AuditTestContext, minCount int) error {
 
 // --- Logger construction helpers ---
 
-func createFileLogger(tc *AuditTestContext, cfg audit.Config, fileCfg file.Config) error {
-	return createFileLoggerWithMetrics(tc, cfg, fileCfg, nil)
+func createFileLogger(tc *AuditTestContext, fileCfg file.Config) error {
+	return createFileLoggerImpl(tc, fileCfg, nil)
 }
 
-func createFileLoggerWithMetrics(tc *AuditTestContext, cfg audit.Config, fileCfg file.Config, fileMetrics file.Metrics) error {
+func createFileLoggerWithMetrics(tc *AuditTestContext, fileCfg file.Config, fileMetrics file.Metrics) error {
+	return createFileLoggerImpl(tc, fileCfg, fileMetrics)
+}
+
+func createFileLoggerWithExtraOpts(tc *AuditTestContext, fileCfg file.Config, extraOpts ...audit.Option) error {
+	return createFileLoggerImpl(tc, fileCfg, nil, extraOpts...)
+}
+
+func createFileLoggerImpl(tc *AuditTestContext, fileCfg file.Config, fileMetrics file.Metrics, extraOpts ...audit.Option) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -491,8 +495,9 @@ func createFileLoggerWithMetrics(tc *AuditTestContext, cfg audit.Config, fileCfg
 		opts = append(opts, audit.WithMetrics(tc.MockMetrics))
 	}
 	opts = append(opts, tc.Options...)
+	opts = append(opts, extraOpts...)
 
-	logger, err := audit.NewLogger(cfg, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr

--- a/tests/bdd/steps/formatter_steps.go
+++ b/tests/bdd/steps/formatter_steps.go
@@ -45,7 +45,7 @@ func registerFormatterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 
 func registerFormatterGivenJSONSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^a logger with file output using JSON formatter$`, func() error {
-		return createFileLogger(tc, audit.Config{Version: 1, Enabled: true}, file.Config{})
+		return createFileLogger(tc, file.Config{})
 	})
 
 	ctx.Step(`^a logger with file output using JSON formatter with unix millis timestamps$`, func() error {
@@ -67,7 +67,7 @@ func registerFormatterGivenJSONSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 			audit.WithOutputs(fileOut),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -77,8 +77,10 @@ func registerFormatterGivenJSONSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 	})
 
 	ctx.Step(`^a logger with file output using JSON formatter and OmitEmpty (true|false)$`, func(val string) error {
-		cfg := audit.Config{Version: 1, Enabled: true, OmitEmpty: val == "true"}
-		return createFileLogger(tc, cfg, file.Config{})
+		if val == "true" {
+			tc.Options = append(tc.Options, audit.WithOmitEmpty())
+		}
+		return createFileLogger(tc, file.Config{})
 	})
 
 }
@@ -109,7 +111,7 @@ func registerFormatterGivenCEFSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 		}
 		opts = append(opts, tc.Options...)
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -149,7 +151,7 @@ func registerFormatterGivenMultiSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithNamedOutput(cefOut, nil, cefFmt), // CEF
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -188,7 +190,7 @@ func registerFormatterGivenCustomSeveritySteps(ctx *godog.ScenarioContext, tc *A
 			audit.WithNamedOutput(fileOut, nil, cefFmt),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -224,7 +226,7 @@ func registerFormatterGivenInvalidKeySteps(ctx *godog.ScenarioContext, tc *Audit
 			audit.WithNamedOutput(fileOut, nil, cefFmt),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -258,7 +260,7 @@ func registerFormatterGivenSeveritySteps(ctx *godog.ScenarioContext, tc *AuditTe
 			audit.WithNamedOutput(fileOut, nil, cefFmt),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -296,7 +298,7 @@ func registerFormatterGivenExtraSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithNamedOutput(fileOut, nil, cefFmt),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}

--- a/tests/bdd/steps/hmac_steps.go
+++ b/tests/bdd/steps/hmac_steps.go
@@ -40,7 +40,6 @@ func registerHMACGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 			tc.CaptureOutput = out
 
 			logger, err := audit.NewLogger(
-				audit.Config{Version: 1, Enabled: true},
 				audit.WithTaxonomy(tc.Taxonomy),
 				audit.WithNamedOutput(out, nil, nil),
 				audit.WithOutputHMAC("stdout", &audit.HMACConfig{
@@ -64,7 +63,6 @@ func registerHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 			out := newCaptureOutput("stdout")
 
 			_, err := audit.NewLogger(
-				audit.Config{Version: 1, Enabled: true},
 				audit.WithTaxonomy(tc.Taxonomy),
 				audit.WithNamedOutput(out, nil, nil),
 				audit.WithOutputHMAC("stdout", &audit.HMACConfig{
@@ -352,7 +350,6 @@ func createDualHMACLogger(tc *AuditTestContext, strippedName, label, fullSalt, s
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(fullOut, nil, nil),
 		audit.WithOutputHMAC("full", fullHMACCfg),

--- a/tests/bdd/steps/loki_fanout_steps.go
+++ b/tests/bdd/steps/loki_fanout_steps.go
@@ -241,7 +241,7 @@ func createFileAndLokiLogger(tc *AuditTestContext, hmacCfg *audit.HMACConfig, lo
 		)
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		_ = fileOut.Close()
 		_ = lokiOut.Close()
@@ -278,7 +278,6 @@ func createFileAndLokiLoggerWithExclusion(tc *AuditTestContext, excludeLabel str
 	tc.LokiOutputName = lokiOut.Name()
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
@@ -331,7 +330,6 @@ func createFileAndLokiLoggerUnreachable(tc *AuditTestContext) error {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),

--- a/tests/bdd/steps/loki_hmac_steps.go
+++ b/tests/bdd/steps/loki_hmac_steps.go
@@ -280,7 +280,7 @@ func createLokiLoggerWithHMAC(tc *AuditTestContext, salt, version, hash string, 
 
 	opts = append(opts, audit.WithOutputHMAC(tc.LokiOutputName, hmacCfg))
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		_ = out.Close()
 		return fmt.Errorf("create logger: %w", err)
@@ -305,7 +305,6 @@ func createLokiLoggerWithHMACAndCapture(tc *AuditTestContext, lokiSalt, lokiVers
 	tc.CaptureOutput = capture
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),

--- a/tests/bdd/steps/loki_receiver_steps.go
+++ b/tests/bdd/steps/loki_receiver_steps.go
@@ -374,7 +374,6 @@ func createLokiLoggerFromConfig(tc *AuditTestContext, cfg *loki.Config) error {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),

--- a/tests/bdd/steps/loki_steps.go
+++ b/tests/bdd/steps/loki_steps.go
@@ -463,7 +463,6 @@ func createLokiLogger(tc *AuditTestContext, cfg *loki.Config) error {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),

--- a/tests/bdd/steps/metadata_writer_steps.go
+++ b/tests/bdd/steps/metadata_writer_steps.go
@@ -89,7 +89,7 @@ func registerMetadataWriterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 		}
 		opts = append(opts, tc.Options...)
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}

--- a/tests/bdd/steps/metrics_steps.go
+++ b/tests/bdd/steps/metrics_steps.go
@@ -49,22 +49,22 @@ func registerMetricsGivenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 
 	ctx.Step(`^a logger with stdout output and metrics$`, func() error {
 		tc.Options = append(tc.Options, audit.WithMetrics(tc.MockMetrics))
-		return createStdoutLogger(tc, audit.Config{Version: 1, Enabled: true})
+		return createStdoutLogger(tc)
 	})
 
 	ctx.Step(`^a logger with stdout output and metrics in strict mode$`, func() error {
 		tc.Options = append(tc.Options, audit.WithMetrics(tc.MockMetrics))
-		return createStdoutLogger(tc, audit.Config{Version: 1, Enabled: true, ValidationMode: audit.ValidationStrict})
+		return createStdoutLogger(tc)
 	})
 
 	ctx.Step(`^a logger with stdout output and metrics in warn mode$`, func() error {
 		tc.Options = append(tc.Options, audit.WithMetrics(tc.MockMetrics))
-		return createStdoutLogger(tc, audit.Config{Version: 1, Enabled: true, ValidationMode: audit.ValidationWarn})
+		return createStdoutLoggerWithOpts(tc, audit.WithValidationMode(audit.ValidationWarn))
 	})
 
 	ctx.Step(`^a logger with stdout output and metrics and buffer size (\d+)$`, func(bufSize int) error {
 		tc.Options = append(tc.Options, audit.WithMetrics(tc.MockMetrics))
-		return createStdoutLogger(tc, audit.Config{Version: 1, Enabled: true, BufferSize: bufSize})
+		return createStdoutLoggerWithOpts(tc, audit.WithBufferSize(bufSize))
 	})
 
 }
@@ -98,7 +98,7 @@ func registerMetricsGivenAdvancedSteps(ctx *godog.ScenarioContext, tc *AuditTest
 			audit.WithNamedOutput(fileOut, nil, nil),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -130,7 +130,7 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithOutputs(w),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -155,7 +155,7 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithOutputs(stdoutOut),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -180,7 +180,7 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithOutputs(stdoutOut),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -196,7 +196,7 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithNamedOutput(&errorOutput{}, nil, nil),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -236,7 +236,7 @@ func registerMetricsGivenFilterSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 			audit.WithNamedOutput(whOut, &audit.EventRoute{ExcludeCategories: []string{excludeCat}}, nil),
 		}
 
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}

--- a/tests/bdd/steps/multicat_steps.go
+++ b/tests/bdd/steps/multicat_steps.go
@@ -133,7 +133,6 @@ func createMultiCatLogger(tc *AuditTestContext, route *audit.EventRoute, formatt
 		return fmt.Errorf("create stdout: %w", err)
 	}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(stdout, route, formatter),
 	)

--- a/tests/bdd/steps/sensitivity_steps.go
+++ b/tests/bdd/steps/sensitivity_steps.go
@@ -71,7 +71,6 @@ func createSensitivityLogger(tc *AuditTestContext, excludeLabels []string) error
 		return fmt.Errorf("create stdout output: %w", err)
 	}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(stdout, nil, nil, excludeLabels...),
 	)

--- a/tests/bdd/steps/severity_routing_steps.go
+++ b/tests/bdd/steps/severity_routing_steps.go
@@ -130,7 +130,6 @@ func registerSeverityLoggerSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 			return fmt.Errorf("create stdout: %w", err)
 		}
 		logger, err := audit.NewLogger(
-			audit.Config{Version: 1, Enabled: true},
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithNamedOutput(audit.WrapOutput(stdout, name), nil, nil),
 		)
@@ -158,7 +157,6 @@ func createSeverityRoutedLogger(tc *AuditTestContext, minSev, maxSev *int, inclu
 		ExcludeCategories: excludeCats,
 	}
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(stdout, route, nil),
 	)
@@ -204,7 +202,6 @@ func trySeverityLoggerCreation(tc *AuditTestContext, minSev, maxSev *int) error 
 		MaxSeverity: maxSev,
 	}
 	logger, lErr := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(stdout, route, nil),
 	)

--- a/tests/bdd/steps/syslog_severity_steps.go
+++ b/tests/bdd/steps/syslog_severity_steps.go
@@ -348,7 +348,7 @@ func createSyslogLoggerWithFormatter(tc *AuditTestContext, cfg *syslog.Config, f
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -382,7 +382,7 @@ func createSyslogLoggerWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt, 
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -409,7 +409,7 @@ func createSyslogLoggerWithExcludeLabels(tc *AuditTestContext, cfg *syslog.Confi
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -451,7 +451,7 @@ func createSyslogLoggerWithRoute(tc *AuditTestContext, cfg *syslog.Config, route
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}

--- a/tests/bdd/steps/syslog_steps.go
+++ b/tests/bdd/steps/syslog_steps.go
@@ -354,7 +354,7 @@ func createSyslogLogger(tc *AuditTestContext, cfg *syslog.Config) error {
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -384,7 +384,7 @@ func createSyslogLoggerWithMetrics(tc *AuditTestContext, cfg *syslog.Config) err
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}

--- a/tests/bdd/steps/webhook_steps.go
+++ b/tests/bdd/steps/webhook_steps.go
@@ -263,7 +263,7 @@ func registerWebhookGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(out),
 		}
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -328,7 +328,7 @@ func registerWebhookGivenSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(out),
 		}
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -481,7 +481,7 @@ func registerWebhookWhenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditT
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(out),
 		}
-		logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+		logger, err := audit.NewLogger(opts...)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)
 		}
@@ -624,7 +624,7 @@ func createWebhookLoggerWithWebhookMetrics(tc *AuditTestContext, batchSize int) 
 		audit.WithOutputs(out),
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -653,7 +653,7 @@ func createWebhookLoggerFromConfig(tc *AuditTestContext, cfg *webhook.Config) er
 		audit.WithOutputs(out),
 	}
 
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}
@@ -904,7 +904,7 @@ func createWebhookLoggerSSRF(tc *AuditTestContext, url string, allowPrivate bool
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(out),
 	}
-	logger, err := audit.NewLogger(audit.Config{Version: 1, Enabled: true}, opts...)
+	logger, err := audit.NewLogger(opts...)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
 	}

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -178,7 +178,6 @@ func TestFanOut_AllOutputs(t *testing.T) {
 
 	// Create logger with all three outputs.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut, nil, nil),
 		audit.WithNamedOutput(syslogOut, nil, nil),
@@ -238,7 +237,6 @@ func TestFanOut_EventRouting(t *testing.T) {
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut, nil, nil), // all events
 		audit.WithNamedOutput(webhookOut, &audit.EventRoute{
@@ -326,7 +324,6 @@ func TestFanOut_PartialFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut, nil, nil),
 		audit.WithNamedOutput(syslogOut, nil, nil),
@@ -380,7 +377,6 @@ func TestFanOut_MixedFormatters(t *testing.T) {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true},
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut, nil, nil),       // JSON (default)
 		audit.WithNamedOutput(webhookOut, nil, cefFmt), // CEF

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1292,7 +1292,7 @@ func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
 
 	// Create a logger with the webhook output and metrics.
 	logger, err := audit.NewLogger(
-		audit.Config{Version: 1, Enabled: true, ValidationMode: "permissive"},
+		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(webhookOut, &audit.EventRoute{}, nil),
 		audit.WithMetrics(metrics),


### PR DESCRIPTION
## Summary

- Replace `NewLogger(Config, ...Option)` with `NewLogger(...Option)` — zero-value Config is now valid
- Make `Config.Version` unexported (defaults to 1), remove `Config.Enabled` in favour of `WithDisabled()`
- Add 6 new options: `WithBufferSize`, `WithDrainTimeout`, `WithValidationMode`, `WithOmitEmpty`, `WithDisabled`, `WithConfig`
- Change `Fields` from type alias to defined type with `Has()`, `String()`, `Int()` methods
- Rename `EmitEventCategory` to `SuppressEventCategory` (inverted: zero value = emit, matching YAML default)
- `outputconfig.LoadResult.Options` now includes config-equivalent options so `NewLogger(result.Options...)` works standalone

Parent issue: #387 (Phase 1)
Closes #388

## Test plan

- [x] `make check` passes (fmt, vet, lint, test, tidy, verify, security)
- [x] All existing tests pass with `-race` (1.6s core, 1.0s audittest, 1.2s outputconfig)
- [x] 18 new acceptance criteria tests in `options_test.go`
- [x] `BenchmarkNewLogger_Construction` added
- [x] BDD `config_versioning.feature` rewritten for new API
- [x] Agent reviews: security (0 findings), code-reviewer (1 fixed), api-ergonomics (approved), go-quality (pass)