### PR TITLE
refactor: return *Taxonomy from ParseTaxonomyYAML with deep copy (#389)

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -173,7 +173,7 @@ func TestLogger_Audit_UnknownFieldPermissive(t *testing.T) {
 
 func TestLogger_Audit_ReservedStandardField_AcceptedInStrictMode(t *testing.T) {
 	t.Parallel()
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events: map[string]*audit.EventDef{
@@ -199,7 +199,7 @@ func TestLogger_Audit_ReservedStandardField_AcceptedInStrictMode(t *testing.T) {
 
 func TestLogger_Audit_ReservedStandardField_StillRejectsUnknown(t *testing.T) {
 	t.Parallel()
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events: map[string]*audit.EventDef{
@@ -473,7 +473,7 @@ func TestWithStandardFieldDefaults_SetOnce(t *testing.T) {
 func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {
 	t.Parallel()
 	// Taxonomy with source_ip as required.
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events: map[string]*audit.EventDef{
@@ -1041,7 +1041,7 @@ func TestLogger_MultiCategory_DeliveredPerCategory(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 
 	// Create a taxonomy where auth_failure is in both security and access.
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"auth_failure"}},
@@ -1070,7 +1070,7 @@ func TestLogger_MultiCategory_DeliveredPerCategory(t *testing.T) {
 func TestLogger_MultiCategory_DisableOneCategory(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"auth_failure"}},
@@ -1102,7 +1102,7 @@ func TestLogger_MultiCategory_DisableOneCategory(t *testing.T) {
 func TestLogger_MultiCategory_DisableAllCategories(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"auth_failure"}},
@@ -1139,7 +1139,7 @@ func TestLogger_Uncategorised_DeliveredToUnroutedOutput(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 
 	// data_export is not in any category.
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"write": {Events: []string{"user_create"}},
@@ -1167,7 +1167,7 @@ func TestLogger_Uncategorised_DeliveredToUnroutedOutput(t *testing.T) {
 func TestLogger_MultiCategory_EnableEventOverride(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security":   {Events: []string{"auth_failure"}},
@@ -1202,7 +1202,7 @@ func TestLogger_MultiCategory_EnableEventOverride(t *testing.T) {
 func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security":   {Events: []string{"auth_failure"}},
@@ -1234,7 +1234,7 @@ func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security":   {Events: []string{"auth_failure"}},
@@ -1522,7 +1522,7 @@ func TestLogger_Audit_SerializationFailure(t *testing.T) {
 func TestLogger_Audit_NilFieldsNoRequiredFields(t *testing.T) {
 
 	// Create a taxonomy with an event that has no required fields.
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"misc": {Events: []string{"no_req"}}},
 		Events: map[string]*audit.EventDef{
@@ -1775,7 +1775,7 @@ func TestLogger_Close_ShutdownEventDroppedOnFullBuffer(t *testing.T) {
 
 func TestLogger_Audit_AllCategoriesEnabledByDefault(t *testing.T) {
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events: map[string]*audit.EventDef{
@@ -2346,7 +2346,7 @@ func TestFormatCache_NilData(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"auth_check"}},
@@ -2400,7 +2400,7 @@ func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
 }
 
 func TestLogger_Audit_FieldCompleteness_OmittedOptionalFieldsAbsent(t *testing.T) {
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"auth_check"}},
@@ -2531,7 +2531,7 @@ func BenchmarkAuditDisabledLogger(b *testing.B) {
 
 func BenchmarkAudit_RealisticFields(b *testing.B) {
 	silenceSlog(b)
-	taxonomy := audit.Taxonomy{
+	taxonomy := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"write": {Events: []string{"api_request"}},
@@ -2800,7 +2800,7 @@ func TestDropLimiter_SubsequentDropsSuppressed(t *testing.T) {
 }
 
 func TestLogger_DisableEvent_UncategorisedEvent(t *testing.T) {
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"write": {Events: []string{"user_create"}},
@@ -3247,7 +3247,7 @@ func TestEventCategory_SingleCategory_JSON(t *testing.T) {
 	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 
 		Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
@@ -3275,7 +3275,7 @@ func TestEventCategory_MultiCategory_SeparateDeliveries(t *testing.T) {
 	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 
 		Categories: map[string]*audit.CategoryDef{
@@ -3311,7 +3311,7 @@ func TestEventCategory_Uncategorised_NoField(t *testing.T) {
 	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
@@ -3341,7 +3341,7 @@ func TestEventCategory_EmitFalse_NoField(t *testing.T) {
 	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:               1,
 		SuppressEventCategory: true,
 		Categories:            map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
@@ -3370,7 +3370,7 @@ func TestEventCategory_UserSupplied_Skipped(t *testing.T) {
 	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 
 		Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
@@ -3442,7 +3442,7 @@ func BenchmarkAppendPostFields_Disabled(b *testing.B) {
 func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 
 		Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
@@ -3476,7 +3476,7 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 func TestHMAC_Disabled_NoFields(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"outcome"}}},
@@ -3501,7 +3501,7 @@ func TestHMAC_Disabled_NoFields(t *testing.T) {
 func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"outcome"}}},
@@ -3533,14 +3533,14 @@ func TestHMAC_ReservedFieldNames(t *testing.T) {
 	for _, field := range []string{"_hmac", "_hmac_v"} {
 		t.Run(field, func(t *testing.T) {
 			t.Parallel()
-			tax := audit.Taxonomy{
+			tax := &audit.Taxonomy{
 				Version:    1,
 				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 				Events: map[string]*audit.EventDef{
 					"ev1": {Required: []string{field}},
 				},
 			}
-			err := audit.ValidateTaxonomy(tax)
+			err := audit.ValidateTaxonomy(*tax)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "reserved framework field")
 		})
@@ -3658,7 +3658,7 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 
 	salt := []byte("e2e-verification-salt-value!!")
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 
 		Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
@@ -3963,7 +3963,7 @@ func TestMetadataWriter_EventMetadata_FieldsCorrect(t *testing.T) {
 
 	// Build a taxonomy with an explicit severity so the resolved value is deterministic.
 	sev := 8
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"auth_failure"}, Severity: &sev},
@@ -4015,7 +4015,7 @@ func TestMetadataWriter_EventMetadata_FieldsCorrect(t *testing.T) {
 func TestMetadataWriter_MultiCategory_CategoryVaries(t *testing.T) {
 	t.Parallel()
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"security": {Events: []string{"auth_failure"}},
@@ -4063,7 +4063,7 @@ func TestMetadataWriter_UncategorisedEvent_EmptyCategory(t *testing.T) {
 	t.Parallel()
 
 	// data_export is not placed in any category.
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"write": {Events: []string{"user_create"}},
@@ -4211,7 +4211,7 @@ func TestMetadataWriter_WithHMAC_ReceivesHMACData(t *testing.T) {
 
 	out := newMockMetadataOutput("mw-hmac")
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"outcome"}}},
@@ -4319,7 +4319,7 @@ func TestMetadataWriter_WithEventCategory_DataAndMetaConsistent(t *testing.T) {
 
 	out := newMockMetadataOutput("mw-cat")
 
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 
 		Categories: map[string]*audit.CategoryDef{
@@ -4436,7 +4436,7 @@ func TestMetadataWriter_CachedAssertion_Correct(t *testing.T) {
 
 func TestTimezoneAlwaysPopulated(t *testing.T) {
 	// Create a logger with NO timezone config — it should auto-detect.
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Events:  map[string]*audit.EventDef{"test_event": {}},
 		Categories: map[string]*audit.CategoryDef{
@@ -4464,7 +4464,7 @@ func TestTimezoneAlwaysPopulated(t *testing.T) {
 }
 
 func TestTimezoneAutoDetect(t *testing.T) {
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Events:  map[string]*audit.EventDef{"test_event": {}},
 		Categories: map[string]*audit.CategoryDef{
@@ -4494,7 +4494,7 @@ func TestTimezoneAutoDetect(t *testing.T) {
 }
 
 func TestTimezoneOverride(t *testing.T) {
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Events:  map[string]*audit.EventDef{"test_event": {}},
 		Categories: map[string]*audit.CategoryDef{

--- a/audittest/audittest.go
+++ b/audittest/audittest.go
@@ -78,17 +78,17 @@ func NewLoggerQuick(tb testing.TB, eventTypes ...string) (*audit.Logger, *Record
 	return newTestLogger(tb, QuickTaxonomy(eventTypes...), WithValidationMode(audit.ValidationPermissive))
 }
 
-// QuickTaxonomy builds a minimal [audit.Taxonomy] where every listed
+// QuickTaxonomy builds a minimal [*audit.Taxonomy] where every listed
 // event type accepts any fields. All events are in a single enabled
 // category ("test"). The returned taxonomy does not enforce required
 // fields; pair it with [audit.ValidationPermissive] (as [NewLoggerQuick]
 // does) for fully unconstrained testing.
-func QuickTaxonomy(eventTypes ...string) audit.Taxonomy {
+func QuickTaxonomy(eventTypes ...string) *audit.Taxonomy {
 	events := make(map[string]*audit.EventDef, len(eventTypes))
 	for _, et := range eventTypes {
 		events[et] = &audit.EventDef{}
 	}
-	return audit.Taxonomy{
+	return &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"test": {Events: eventTypes},
@@ -97,7 +97,7 @@ func QuickTaxonomy(eventTypes ...string) audit.Taxonomy {
 	}
 }
 
-func newTestLogger(tb testing.TB, tax audit.Taxonomy, opts ...Option) (*audit.Logger, *Recorder, *MetricsRecorder) {
+func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.Logger, *Recorder, *MetricsRecorder) {
 	tb.Helper()
 
 	c := &config{}

--- a/cmd/audit-gen/generate_test.go
+++ b/cmd/audit-gen/generate_test.go
@@ -36,7 +36,7 @@ type failWriter struct{ err error }
 
 func (f *failWriter) Write([]byte) (int, error) { return 0, f.err }
 
-func loadTestTaxonomy(t *testing.T, path string) audit.Taxonomy {
+func loadTestTaxonomy(t *testing.T, path string) *audit.Taxonomy {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -45,10 +45,10 @@ func loadTestTaxonomy(t *testing.T, path string) audit.Taxonomy {
 	return tax
 }
 
-func generateToString(t *testing.T, tax audit.Taxonomy, opts generateOptions) string {
+func generateToString(t *testing.T, tax *audit.Taxonomy, opts generateOptions) string {
 	t.Helper()
 	var buf bytes.Buffer
-	err := generate(&buf, tax, opts)
+	err := generate(&buf, *tax, opts)
 	require.NoError(t, err)
 	return buf.String()
 }
@@ -460,7 +460,7 @@ func TestGenerate_WriteError(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, "testdata/valid_taxonomy.yaml")
 	w := &failWriter{err: errors.New("disk full")}
-	err := generate(w, tax, defaultOpts())
+	err := generate(w, *tax, defaultOpts())
 	assert.ErrorContains(t, err, "write output")
 }
 
@@ -542,7 +542,7 @@ func TestGenerate_NoCommentWhenEmpty(t *testing.T) {
 
 func TestGenerate_MultiLineDescription(t *testing.T) {
 	t.Parallel()
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"test": {Events: []string{"multi_line"}}},
 		Events: map[string]*audit.EventDef{
@@ -562,7 +562,7 @@ func TestGenerate_MultiLineDescription(t *testing.T) {
 
 func TestGenerate_WhitespaceOnlyDescription(t *testing.T) {
 	t.Parallel()
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"test": {Events: []string{"blank_desc"}}},
 		Events: map[string]*audit.EventDef{
@@ -609,7 +609,7 @@ func TestGenerate_LabelConstants(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "taxonomy_with_labels.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package: "myapp",
 		Header:  "// test",
 		Types:   true,
@@ -640,7 +640,7 @@ func TestGenerate_LabelConstants_Disabled(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "taxonomy_with_labels.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package: "myapp",
 		Header:  "// test",
 		Types:   true,
@@ -655,7 +655,7 @@ func TestGenerate_NoLabels_NoSection(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "valid_taxonomy.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package: "myapp",
 		Header:  "// test",
 		Labels:  true,
@@ -678,7 +678,7 @@ func TestGenerate_Builders(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "taxonomy_with_labels.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package:  "myapp",
 		Header:   "// test",
 		Types:    true,
@@ -720,7 +720,7 @@ func TestGenerate_Builders_StandardSetters(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "valid_taxonomy.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package:  "myapp",
 		Header:   "// test",
 		Types:    true,
@@ -768,7 +768,7 @@ func TestGenerate_Builders_Disabled(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "valid_taxonomy.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package:  "myapp",
 		Header:   "// test",
 		Builders: false,
@@ -781,7 +781,7 @@ func TestGenerate_Builders_NoLabels(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "valid_taxonomy.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package:  "myapp",
 		Header:   "// test",
 		Types:    true,
@@ -840,7 +840,7 @@ events:
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = generate(&buf, tax, generateOptions{
+	err = generate(&buf, *tax, generateOptions{
 		Package:  "myapp",
 		Header:   "// test",
 		Types:    true,
@@ -863,7 +863,7 @@ func TestGenerate_Builders_NoSeverity_NoIntPtr(t *testing.T) {
 	t.Parallel()
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "valid_taxonomy.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package:  "myapp",
 		Header:   "// test",
 		Types:    true,
@@ -880,7 +880,7 @@ func TestGenerate_Builders_RuntimeEquivalent(t *testing.T) {
 	// produce correct Go that a consumer would use.
 	tax := loadTestTaxonomy(t, filepath.Join("testdata", "taxonomy_with_labels.yaml"))
 	var buf bytes.Buffer
-	err := generate(&buf, tax, generateOptions{
+	err := generate(&buf, *tax, generateOptions{
 		Package:    "myapp",
 		Header:     "// test",
 		Types:      true,

--- a/cmd/audit-gen/main.go
+++ b/cmd/audit-gen/main.go
@@ -159,7 +159,7 @@ func execute(cfg cliConfig, stdout, stderr io.Writer) int {
 	}
 
 	var buf bytes.Buffer
-	if err := generate(&buf, tax, opts); err != nil {
+	if err := generate(&buf, *tax, opts); err != nil {
 		_, _ = fmt.Fprintf(stderr, "audit-gen: generate: %v\n", err)
 		return exitWriteError
 	}

--- a/config.go
+++ b/config.go
@@ -108,7 +108,7 @@ func (c *Config) applyDefaults() {
 // validateConfig applies defaults to zero-valued fields, then checks the
 // config for correctness. It mutates c (via [Config.applyDefaults]) before
 // validation. Returns an error wrapping [ErrConfigInvalid] on failure.
-// Version checks are handled by [migrateConfig] which runs before this.
+// Version checks are handled by [migrateConfig] which runs after this.
 func validateConfig(c *Config) error {
 	c.applyDefaults()
 

--- a/doc.go
+++ b/doc.go
@@ -43,7 +43,7 @@
 // Define a taxonomy describing your event types, create a logger with
 // a stdout output, and emit an event:
 //
-//	taxonomy := audit.Taxonomy{
+//	taxonomy := &audit.Taxonomy{
 //	    Version: 1,
 //	    Categories: map[string]*audit.CategoryDef{
 //	        "write": {Events: []string{"user_create"}},

--- a/example_middleware_test.go
+++ b/example_middleware_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func ExampleMiddleware() {
-	taxonomy := audit.Taxonomy{
+	taxonomy := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"access": {Events: []string{"http_request"}},
@@ -81,7 +81,7 @@ func ExampleHintsFromContext() {
 }
 
 func ExampleMiddleware_skip() {
-	taxonomy := audit.Taxonomy{
+	taxonomy := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"access": {Events: []string{"http_request"}},

--- a/example_test.go
+++ b/example_test.go
@@ -31,7 +31,7 @@ func ExampleNewLogger() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
 				"write": {Events: []string{"user_create"}},
@@ -75,7 +75,7 @@ func ExampleLogger_AuditEvent() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
 			Events: map[string]*audit.EventDef{
@@ -107,7 +107,7 @@ func ExampleLogger_AuditEvent() {
 
 func ExampleLogger_MustHandle() {
 	logger, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
 			Events: map[string]*audit.EventDef{
@@ -138,7 +138,7 @@ func ExampleLogger_MustHandle() {
 
 func ExampleLogger_EnableCategory() {
 	logger, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
 				"read":  {Events: []string{"doc_read"}},
@@ -171,7 +171,7 @@ func ExampleLogger_EnableCategory() {
 
 func ExampleLogger_Close() {
 	logger, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
 			Events: map[string]*audit.EventDef{
@@ -208,7 +208,7 @@ func ExampleWithFormatter() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
 			Events: map[string]*audit.EventDef{
@@ -272,7 +272,7 @@ func ExampleLogger_SetOutputRoute() {
 	}
 
 	logger, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
 				"write":    {Events: []string{"user_create"}},

--- a/examples/01-basic/main.go
+++ b/examples/01-basic/main.go
@@ -27,7 +27,7 @@ import (
 func main() {
 	// 1. Define a taxonomy inline. In production you would load this
 	//    from a YAML file — see the code-generation example.
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"write":    {Events: []string{"user_create", "user_delete"}},

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	// 2. Load output configuration from YAML.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/03-standard-fields/main.go
+++ b/examples/03-standard-fields/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	// Load output config — app_name, host, timezone, and
 	// standard_fields defaults are set here.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/04-stdout-output/main.go
+++ b/examples/04-stdout-output/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// 2. Load output configuration — stdout needs no blank import.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/05-file-output/main.go
+++ b/examples/05-file-output/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/06-syslog-output/main.go
+++ b/examples/06-syslog-output/main.go
@@ -56,7 +56,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/07-webhook-output/main.go
+++ b/examples/07-webhook-output/main.go
@@ -58,7 +58,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/08-loki-output/main.go
+++ b/examples/08-loki-output/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	// Load output configuration — creates the Loki output from YAML.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &taxonomy, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, taxonomy, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/09-multi-output/main.go
+++ b/examples/09-multi-output/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/10-tls-policy/main.go
+++ b/examples/10-tls-policy/main.go
@@ -50,7 +50,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/11-event-routing/main.go
+++ b/examples/11-event-routing/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/12-sensitivity-labels/main.go
+++ b/examples/12-sensitivity-labels/main.go
@@ -57,7 +57,7 @@ func createLogger() *audit.Logger {
 	if err != nil {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/13-hmac-integrity/main.go
+++ b/examples/13-hmac-integrity/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	// 2. Load output configuration (includes HMAC settings).
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/14-formatters/main.go
+++ b/examples/14-formatters/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/15-middleware/main.go
+++ b/examples/15-middleware/main.go
@@ -58,7 +58,7 @@ func buildEvent(hints *audit.Hints, transport *audit.TransportMetadata) (eventTy
 }
 
 func main() {
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"access": {Events: []string{"http_request"}},

--- a/examples/16-crud-api/audit_setup.go
+++ b/examples/16-crud-api/audit_setup.go
@@ -35,7 +35,7 @@ import (
 // outputs is a config change, not a code change. Per-output metrics
 // (file rotation, Loki flush) will be auto-detected from the core
 // metrics interface once issue #386 is resolved.
-func setupAuditLogger(tax audit.Taxonomy, m *auditMetrics) (*audit.Logger, error) {
+func setupAuditLogger(tax *audit.Taxonomy, m *auditMetrics) (*audit.Logger, error) {
 	// Load output configuration from the filesystem. In production,
 	// this path comes from a flag or environment variable so each
 	// environment (dev/staging/prod) can use different output configs
@@ -50,7 +50,7 @@ func setupAuditLogger(tax audit.Taxonomy, m *auditMetrics) (*audit.Logger, error
 	// for event counting, buffer drops, and validation errors.
 	// Output-specific metrics (file.Metrics, loki.Metrics) will be
 	// auto-detected via type assertion once #386 lands.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, m)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, m)
 	if err != nil {
 		return nil, fmt.Errorf("load output config: %w", err)
 	}

--- a/examples/17-testing/main.go
+++ b/examples/17-testing/main.go
@@ -74,7 +74,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/18-buffering/main.go
+++ b/examples/18-buffering/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	// Load output configuration.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -415,7 +415,7 @@ func TestFanout_GlobalFilterTakesPrecedence(t *testing.T) {
 	out := testhelper.NewMockOutput("all")
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
 				"write":    {Events: []string{"user_create"}},

--- a/filter_test.go
+++ b/filter_test.go
@@ -120,7 +120,7 @@ func TestValidateEventRoute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := audit.ValidateEventRoute(&tt.route, &tax)
+			err := audit.ValidateEventRoute(&tt.route, tax)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/internal/testhelper/taxonomy.go
+++ b/internal/testhelper/taxonomy.go
@@ -18,8 +18,8 @@ import "github.com/axonops/go-audit"
 
 // ValidTaxonomy returns a taxonomy suitable for general testing with
 // read, write, and security categories.
-func ValidTaxonomy() audit.Taxonomy {
-	return audit.Taxonomy{
+func ValidTaxonomy() *audit.Taxonomy {
+	return &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"read":     {Events: []string{"schema_read", "config_read"}},
@@ -38,8 +38,8 @@ func ValidTaxonomy() audit.Taxonomy {
 
 // TestTaxonomy returns a taxonomy with user_create, user_delete, and
 // other common event types for routing and filter tests.
-func TestTaxonomy() audit.Taxonomy {
-	return audit.Taxonomy{
+func TestTaxonomy() *audit.Taxonomy {
+	return &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"write":    {Events: []string{"user_create", "user_delete"}},

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -33,8 +33,8 @@ import (
 // --- Middleware test helpers ---
 
 // middlewareTaxonomy returns a taxonomy suitable for middleware tests.
-func middlewareTaxonomy() audit.Taxonomy {
-	return audit.Taxonomy{
+func middlewareTaxonomy() *audit.Taxonomy {
+	return &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"access": {Events: []string{"http_request"}},

--- a/options.go
+++ b/options.go
@@ -28,20 +28,28 @@ type Option func(*Logger) error
 // Calling it more than once replaces the taxonomy and resets all
 // runtime category and event overrides established by the previous call.
 //
-// The taxonomy is validated and pre-computed at construction time.
-func WithTaxonomy(t Taxonomy) Option {
+// WithTaxonomy makes a deep copy of t; mutations to t after this call
+// have no effect on the logger. When t was returned by
+// [ParseTaxonomyYAML], redundant re-validation is skipped.
+func WithTaxonomy(t *Taxonomy) Option {
 	return func(l *Logger) error {
-		if err := MigrateTaxonomy(&t); err != nil {
-			return err
+		if t == nil {
+			return fmt.Errorf("%w: taxonomy must not be nil", ErrTaxonomyInvalid)
 		}
-		if err := ValidateTaxonomy(t); err != nil {
-			return err
+		cp := deepCopyTaxonomy(t)
+		if !cp.validated {
+			if err := MigrateTaxonomy(cp); err != nil {
+				return err
+			}
+			if err := ValidateTaxonomy(*cp); err != nil {
+				return err
+			}
+			if err := precomputeTaxonomy(cp); err != nil {
+				return err
+			}
 		}
-		if err := precomputeTaxonomy(&t); err != nil {
-			return err
-		}
-		l.taxonomy = &t
-		l.filter = newFilterState(&t)
+		l.taxonomy = cp
+		l.filter = newFilterState(cp)
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -267,7 +267,7 @@ func TestSuppressEventCategory_ZeroValue_EmitsCategory(t *testing.T) {
 func TestSuppressEventCategory_True_SuppressesCategory(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	out := testhelper.NewMockOutput("suppress-cat")
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:               1,
 		SuppressEventCategory: true,
 		Categories:            map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},

--- a/outputconfig/doc.go
+++ b/outputconfig/doc.go
@@ -83,7 +83,7 @@
 // URIs that are resolved from external secret backends (OpenBao, Vault)
 // at load time. Register providers with [WithSecretProvider]:
 //
-//	result, err := outputconfig.Load(ctx, yamlData, &taxonomy, metrics,
+//	result, err := outputconfig.Load(ctx, yamlData, taxonomy, metrics,
 //	    outputconfig.WithSecretProvider(provider),
 //	    outputconfig.WithSecretTimeout(30*time.Second),
 //	)
@@ -94,7 +94,7 @@
 //
 // # Usage
 //
-//	result, err := outputconfig.Load(ctx, yamlData, &taxonomy, metrics)
+//	result, err := outputconfig.Load(ctx, yamlData, taxonomy, metrics)
 //	if err != nil {
 //	    return fmt.Errorf("audit config: %w", err)
 //	}

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-func testTaxonomy(t *testing.T) audit.Taxonomy {
+func testTaxonomy(t *testing.T) *audit.Taxonomy {
 	t.Helper()
 	tax, err := audit.ParseTaxonomyYAML([]byte(`
 version: 1
@@ -72,7 +72,7 @@ func TestLoad_MinimalStdout(t *testing.T) {
 	require.NoError(t, err)
 
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -95,7 +95,7 @@ func TestLoad_FileWithRoute(t *testing.T) {
 	require.NoError(t, err)
 
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -133,7 +133,7 @@ outputs:
       path: ` + filepath.Join(dir, "b.log") + `
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 3)
 
@@ -183,7 +183,7 @@ outputs:
     formatter:
       type: %s
 `, tt.formatter))
-			_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+			_, err := outputconfig.Load(context.Background(), data, tax, nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "loki does not support custom formatters")
 			assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
@@ -231,7 +231,7 @@ outputs:
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tax := testTaxonomy(t)
-			result, err := outputconfig.Load(context.Background(), []byte(tt.yaml), &tax, nil)
+			result, err := outputconfig.Load(context.Background(), []byte(tt.yaml), tax, nil)
 			require.NoError(t, err)
 			assert.Len(t, result.Outputs, 1)
 			require.NotNil(t, result.Outputs[0].Formatter, "explicit JSON should set per-output formatter")
@@ -258,7 +258,7 @@ outputs:
   console:
     type: stdout
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "default_formatter has been removed")
 	assert.Contains(t, err.Error(), "set formatter on each output individually")
@@ -278,7 +278,7 @@ outputs:
   console:
     type: stdout
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "default_formatter has been removed")
 }
@@ -296,7 +296,7 @@ outputs:
   loki_out:
     type: loki
 `)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	assert.Len(t, result.Outputs, 2)
@@ -324,7 +324,7 @@ outputs:
     formatter:
       type: cef
 `)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err, "disabled Loki output with CEF formatter should not cause an error")
 	assert.Len(t, result.Outputs, 1, "only the stdout output should be active")
 	_ = result.Outputs[0].Output.Close()
@@ -342,7 +342,7 @@ outputs:
     type: loki
     formatter: cef
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "loki does not support custom formatters")
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
@@ -366,7 +366,7 @@ outputs:
       version: "1.0"
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.NoError(t, err)
 
 	assert.Len(t, result.Outputs, 1)
@@ -387,7 +387,7 @@ outputs:
     enabled: false
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.NoError(t, err)
 
 	assert.Len(t, result.Outputs, 1)
@@ -407,7 +407,7 @@ outputs:
     enabled: true
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 1)
 	_ = result.Outputs[0].Output.Close()
@@ -417,7 +417,7 @@ outputs:
 
 func TestLoad_EmptyInput(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), nil, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), nil, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "empty")
@@ -429,7 +429,7 @@ func TestLoad_OversizedInput(t *testing.T) {
 	for i := range big {
 		big[i] = 'x'
 	}
-	_, err := outputconfig.Load(context.Background(), big, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), big, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "exceeds maximum")
@@ -437,7 +437,7 @@ func TestLoad_OversizedInput(t *testing.T) {
 
 func TestLoad_InvalidYAML(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("{{broken"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("{{broken"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
@@ -445,7 +445,7 @@ func TestLoad_InvalidYAML(t *testing.T) {
 func TestLoad_MultiDocument(t *testing.T) {
 	tax := testTaxonomy(t)
 	yaml := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n---\nversion: 1\n")
-	_, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "multiple YAML documents")
@@ -453,7 +453,7 @@ func TestLoad_MultiDocument(t *testing.T) {
 
 func TestLoad_Version0(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 0\noutputs:\n  c:\n    type: stdout\n"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 0\noutputs:\n  c:\n    type: stdout\n"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unsupported version")
@@ -461,7 +461,7 @@ func TestLoad_Version0(t *testing.T) {
 
 func TestLoad_Version2(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 2\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 2\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unsupported version")
@@ -469,7 +469,7 @@ func TestLoad_Version2(t *testing.T) {
 
 func TestLoad_NoOutputs(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\n"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\n"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "at least one output")
@@ -477,7 +477,7 @@ func TestLoad_NoOutputs(t *testing.T) {
 
 func TestLoad_EmptyOutputs(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs: {}\n"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs: {}\n"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "at least one output")
@@ -486,7 +486,7 @@ func TestLoad_EmptyOutputs(t *testing.T) {
 func TestLoad_MissingType(t *testing.T) {
 	tax := testTaxonomy(t)
 	yaml := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    enabled: true\n")
-	_, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "missing required field 'type'")
@@ -495,7 +495,7 @@ func TestLoad_MissingType(t *testing.T) {
 func TestLoad_UnknownType(t *testing.T) {
 	tax := testTaxonomy(t)
 	yaml := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: kafka\n")
-	_, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown output type \"kafka\"")
@@ -506,7 +506,7 @@ func TestLoad_DuplicateOutputName(t *testing.T) {
 	// goccy/go-yaml detects duplicate mapping keys at parse time.
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  dupe:\n    type: stdout\n  dupe:\n    type: stdout\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "dupe")
@@ -515,7 +515,7 @@ func TestLoad_DuplicateOutputName(t *testing.T) {
 func TestLoad_TwoDistinctNames(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  a:\n    type: stdout\n  b:\n    type: stdout\n")
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 2)
 	for _, o := range result.Outputs {
@@ -526,7 +526,7 @@ func TestLoad_TwoDistinctNames(t *testing.T) {
 func TestLoad_UnknownTopLevelKey(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\nmetrics: true\noutputs:\n  c:\n    type: stdout\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown top-level key")
@@ -536,7 +536,7 @@ func TestLoad_UnknownTopLevelKey(t *testing.T) {
 func TestLoad_AllDisabled(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  a:\n    type: stdout\n    enabled: false\n  b:\n    type: stdout\n    enabled: false\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "all outputs are disabled")
@@ -554,7 +554,7 @@ outputs:
     route:
       include_categories: [nonexistent]
 `)
-	_, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "bad")
@@ -574,7 +574,7 @@ outputs:
       include_categories: [write]
       exclude_categories: [security]
 `)
-	_, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "bad")
@@ -595,7 +595,7 @@ outputs:
       path: ${TEST_AUDIT_PATH}
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 1)
 	_ = result.Outputs[0].Output.Close()
@@ -613,7 +613,7 @@ outputs:
       path: ${TOTALLY_MISSING_VAR}
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "TOTALLY_MISSING_VAR")
@@ -630,7 +630,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.NoError(t, err)
 
 	// Options should contain at least one WithNamedOutput.
@@ -657,7 +657,7 @@ outputs:
       address: localhost:514
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), yaml, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "does not match type")
@@ -667,21 +667,21 @@ outputs:
 
 func TestLoad_TopLevelSequence_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("- item1\n- item2\n"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("- item1\n- item2\n"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
 
 func TestLoad_OutputsIsSequence_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  - stdout\n"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  - stdout\n"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
 
 func TestLoad_OutputValueIsScalar_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad: scalar_value\n"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad: scalar_value\n"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "bad")
@@ -689,7 +689,7 @@ func TestLoad_OutputValueIsScalar_ReturnsError(t *testing.T) {
 
 func TestLoad_EnabledInvalidValue_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    enabled: not_a_bool\n"), &tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    enabled: not_a_bool\n"), tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
@@ -697,7 +697,7 @@ func TestLoad_EnabledInvalidValue_ReturnsError(t *testing.T) {
 func TestLoad_TwoTypeConfigBlocks_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    file:\n      path: /tmp/a\n    syslog:\n      network: tcp\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unexpected key")
@@ -707,7 +707,7 @@ func TestLoad_TwoTypeConfigBlocks_ReturnsError(t *testing.T) {
 func TestLoad_RouteUnknownField_Rejected(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    route:\n      include_category: [write]\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
@@ -715,7 +715,7 @@ func TestLoad_RouteUnknownField_Rejected(t *testing.T) {
 func TestLoad_PerOutputFormatterInvalid_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    formatter:\n      type: protobuf\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "protobuf")
@@ -724,7 +724,7 @@ func TestLoad_PerOutputFormatterInvalid_ReturnsError(t *testing.T) {
 func TestLoad_RouteWithEventTypes(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  filtered:\n    type: stdout\n    route:\n      include_event_types: [user_create]\n")
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Outputs[0].Route)
 	assert.Equal(t, []string{"user_create"}, result.Outputs[0].Route.IncludeEventTypes)
@@ -734,7 +734,7 @@ func TestLoad_RouteWithEventTypes(t *testing.T) {
 func TestLoad_RouteExcludeEventTypes(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  filtered:\n    type: stdout\n    route:\n      exclude_event_types: [auth_failure]\n")
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Outputs[0].Route)
 	assert.Equal(t, []string{"auth_failure"}, result.Outputs[0].Route.ExcludeEventTypes)
@@ -745,7 +745,7 @@ func TestLoad_EnabledFalseBeforeType(t *testing.T) {
 	// Verify enabled: false works regardless of key ordering in YAML.
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  active:\n    type: stdout\n  skipped:\n    enabled: false\n    type: stdout\n")
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 1)
 	assert.Equal(t, "active", result.Outputs[0].Name)
@@ -755,7 +755,7 @@ func TestLoad_EnabledFalseBeforeType(t *testing.T) {
 func TestLoad_MissingEnvVarInFormatter(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    formatter:\n      type: json\n      timestamp: ${MISSING_FMT_VAR}\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "MISSING_FMT_VAR")
@@ -765,7 +765,7 @@ func TestLoad_MissingEnvVarInRoute(t *testing.T) {
 	tax := testTaxonomy(t)
 	// Route values are string sequences — env var in a sequence element.
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    route:\n      include_categories:\n        - ${MISSING_ROUTE_VAR}\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "MISSING_ROUTE_VAR")
@@ -791,7 +791,7 @@ outputs:
       include_categories: [write]
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yamlCfg, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), yamlCfg, tax, nil)
 	require.NoError(t, err)
 
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
@@ -833,7 +833,7 @@ func TestLoad_ClosesOutputOnRouteError(t *testing.T) {
 	})
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  leak:\n    type: spy\n    route:\n      include_categories: [nonexistent]\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.True(t, spy.closed.Load(), "output must be closed when buildRoute fails")
 }
@@ -845,7 +845,7 @@ func TestLoad_ClosesOutputOnFormatterError(t *testing.T) {
 	})
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  leak:\n    type: spy\n    formatter:\n      type: protobuf\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.True(t, spy.closed.Load(), "output must be closed when buildOutputFormatter fails")
 }
@@ -858,7 +858,7 @@ func TestLoad_ClosesEarlierOutputsWhenLaterFails(t *testing.T) {
 	tax := testTaxonomy(t)
 	// First output (spy) succeeds. Second output (unknown type) fails.
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  good:\n    type: spy\n  bad:\n    type: nonexistent_type\n")
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.True(t, spy.closed.Load(),
 		"first output must be closed when second output construction fails")
@@ -867,7 +867,7 @@ func TestLoad_ClosesEarlierOutputsWhenLaterFails(t *testing.T) {
 func TestLoadResult_String_NoCredentials(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  console:\n    type: stdout\n")
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	s := result.String()
@@ -910,7 +910,7 @@ outputs:
     route:
       min_severity: 7
 `)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].Route)
@@ -931,7 +931,7 @@ outputs:
     route:
       max_severity: 3
 `)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].Route)
@@ -953,7 +953,7 @@ outputs:
       min_severity: 3
       max_severity: 7
 `)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].Route)
@@ -975,7 +975,7 @@ outputs:
     route:
       include_categories: [write]
 `)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].Route)
@@ -996,7 +996,7 @@ outputs:
     route:
       min_severity: 11
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "min_severity 11 out of range 0-10")
 }
@@ -1013,7 +1013,7 @@ outputs:
     route:
       max_severity: -1
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_severity -1 out of range 0-10")
 }
@@ -1031,7 +1031,7 @@ outputs:
       min_severity: 8
       max_severity: 3
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "min_severity 8 exceeds max_severity 3")
 }
@@ -1048,7 +1048,7 @@ outputs:
     route:
       min_severity: 0
 `)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err, "severity 0 is a valid value, not rejected as zero-value")
 	require.NotNil(t, result.Outputs[0].Route.MinSeverity)
 	assert.Equal(t, 0, *result.Outputs[0].Route.MinSeverity,
@@ -1068,7 +1068,7 @@ outputs:
       include_categories: [security]
       min_severity: 7
 `)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Outputs[0].Route)
 	assert.Equal(t, []string{"security"}, result.Outputs[0].Route.IncludeCategories)
@@ -1080,7 +1080,7 @@ outputs:
 // exclude_labels YAML parsing
 // ---------------------------------------------------------------------------
 
-func testTaxonomyWithSensitivity(t *testing.T) audit.Taxonomy {
+func testTaxonomyWithSensitivity(t *testing.T) *audit.Taxonomy {
 	t.Helper()
 	tax, err := audit.ParseTaxonomyYAML([]byte(`
 version: 1
@@ -1118,7 +1118,7 @@ outputs:
       - financial
 `)
 	tax := testTaxonomyWithSensitivity(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	assert.Equal(t, []string{"pii", "financial"}, result.Outputs[0].ExcludeLabels)
@@ -1136,7 +1136,7 @@ outputs:
     exclude_labels: []
 `)
 	tax := testTaxonomyWithSensitivity(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	assert.Empty(t, result.Outputs[0].ExcludeLabels)
@@ -1155,7 +1155,7 @@ outputs:
       - pii
 `)
 	tax := testTaxonomy(t) // no sensitivity config
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	// The Load itself succeeds — validation happens at NewLogger time.
@@ -1179,7 +1179,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.Config.BufferSize, "zero means applyDefaults will set 10000")
@@ -1205,7 +1205,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 50000, result.Config.BufferSize)
@@ -1227,7 +1227,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 25000, result.Config.BufferSize)
@@ -1247,7 +1247,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 }
 
@@ -1267,7 +1267,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 75000, result.Config.BufferSize)
@@ -1290,7 +1290,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	assert.True(t, result.Config.OmitEmpty)
@@ -1308,7 +1308,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "logger")
@@ -1328,7 +1328,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "logger")
@@ -1347,7 +1347,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "non-negative")
@@ -1366,7 +1366,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "exceeds maximum")
@@ -1385,7 +1385,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "non-negative")
@@ -1404,7 +1404,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "exceeds maximum")
@@ -1423,7 +1423,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "duration")
@@ -1442,7 +1442,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown mode")
@@ -1464,7 +1464,7 @@ outputs:
     type: stdout
 `, mode))
 			tax := testTaxonomy(t)
-			result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+			result, err := outputconfig.Load(context.Background(), data, tax, nil)
 			require.NoError(t, err)
 			assert.Equal(t, audit.ValidationMode(mode), result.Config.ValidationMode)
 		})
@@ -1490,7 +1490,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 }
@@ -1507,7 +1507,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 }
@@ -1530,7 +1530,7 @@ outputs:
       path: "` + dir + `/audit.log"
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	for _, o := range result.Outputs {
@@ -1568,7 +1568,7 @@ outputs:
       url: "https://example.com"
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 
@@ -1606,7 +1606,7 @@ outputs:
         allow_tls12: true
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 
@@ -1637,7 +1637,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "tls_policy")
@@ -1655,7 +1655,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "tls_policy")
@@ -1682,7 +1682,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].HMACConfig)
@@ -1702,7 +1702,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	assert.Nil(t, result.Outputs[0].HMACConfig)
@@ -1721,7 +1721,7 @@ outputs:
       enabled: false
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	assert.Nil(t, result.Outputs[0].HMACConfig, "disabled HMAC should be nil")
@@ -1744,7 +1744,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least")
 }
@@ -1766,7 +1766,7 @@ outputs:
       hash: MD5
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown")
 }
@@ -1785,7 +1785,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "salt")
 }
@@ -1806,7 +1806,7 @@ outputs:
         value: "valid-salt-sixteen-b!"
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithm")
 }
@@ -1829,7 +1829,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Outputs[0].HMACConfig)
 	assert.Equal(t, []byte("env-salt-value-sixteen!"), result.Outputs[0].HMACConfig.SaltValue)
@@ -1852,7 +1852,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	// Salt value must NOT appear in the error message.
 	assert.NotContains(t, err.Error(), "short")
@@ -1876,7 +1876,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -1902,7 +1902,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown field")
@@ -1922,7 +1922,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "non-empty")
@@ -1942,7 +1942,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -1964,7 +1964,7 @@ func TestLoad_StandardFields_EnvVarMissing(t *testing.T) {
 
 	data := []byte("version: 1\napp_name: test\nhost: test\nstandard_fields:\n  source_ip: \"${" + missingVar + "}\"\noutputs:\n  console:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), missingVar)
@@ -1982,7 +1982,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
@@ -2005,7 +2005,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -2036,7 +2036,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -2060,7 +2060,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -2083,7 +2083,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -2104,7 +2104,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "app_name is required")
@@ -2120,7 +2120,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "host is required")
@@ -2132,7 +2132,7 @@ func TestLoad_AppNameTooLong_Rejected(t *testing.T) {
 	longName := strings.Repeat("a", 256)
 	data := []byte("version: 1\napp_name: " + longName + "\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "app_name exceeds maximum length")
@@ -2144,7 +2144,7 @@ func TestLoad_HostTooLong_Rejected(t *testing.T) {
 	longHost := strings.Repeat("h", 256)
 	data := []byte("version: 1\napp_name: test\nhost: " + longHost + "\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "host exceeds maximum length")
@@ -2156,7 +2156,7 @@ func TestLoad_TimezoneTooLong_Rejected(t *testing.T) {
 	longTZ := strings.Repeat("Z", 65)
 	data := []byte("version: 1\napp_name: test\nhost: test\ntimezone: " + longTZ + "\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "timezone exceeds maximum length")
@@ -2166,7 +2166,7 @@ func TestLoad_TimezoneEmptyString_Rejected(t *testing.T) {
 	t.Parallel()
 	data := []byte("version: 1\napp_name: test\nhost: test\ntimezone: \"\"\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "timezone must be non-empty")
@@ -2178,7 +2178,7 @@ func TestLoad_AppNameAtMaxLength_Accepted(t *testing.T) {
 	maxName := strings.Repeat("a", 255)
 	data := []byte("version: 1\napp_name: " + maxName + "\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err, "255-byte app_name is exactly at the limit and must be accepted")
 	assert.Equal(t, maxName, result.AppName)
 	for _, o := range result.Outputs {
@@ -2192,7 +2192,7 @@ func TestLoad_HostAtMaxLength_Accepted(t *testing.T) {
 	maxHost := strings.Repeat("h", 255)
 	data := []byte("version: 1\napp_name: test\nhost: " + maxHost + "\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err, "255-byte host is exactly at the limit and must be accepted")
 	assert.Equal(t, maxHost, result.Host)
 	for _, o := range result.Outputs {
@@ -2206,7 +2206,7 @@ func TestLoad_TimezoneAtMaxLength_Accepted(t *testing.T) {
 	maxTZ := strings.Repeat("Z", 64)
 	data := []byte("version: 1\napp_name: test\nhost: test\ntimezone: " + maxTZ + "\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err, "64-byte timezone is exactly at the limit and must be accepted")
 	assert.Equal(t, maxTZ, result.Timezone)
 	for _, o := range result.Outputs {
@@ -2244,7 +2244,7 @@ outputs:
       hostname: per-output-hostname
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	raw, ok := captured.Load().(string)
@@ -2286,7 +2286,7 @@ outputs:
       address: localhost:514
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	raw, ok := captured.Load().(string)
@@ -2329,7 +2329,7 @@ outputs:
       app_name: per-output-app
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	raw, ok := captured.Load().(string)
@@ -2368,7 +2368,7 @@ outputs:
       url: "https://example.com/hook"
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 
 	raw, _ := captured.Load().(string)
@@ -2422,7 +2422,7 @@ outputs:
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tax := testTaxonomy(t)
-			result, err := outputconfig.Load(context.Background(), []byte(tt.yaml), &tax, nil)
+			result, err := outputconfig.Load(context.Background(), []byte(tt.yaml), tax, nil)
 			require.NoError(t, err)
 			assert.GreaterOrEqual(t, len(result.Options), tt.wantOpts,
 				"got %d options, want at least %d", len(result.Options), tt.wantOpts)
@@ -2475,7 +2475,7 @@ func TestLoad_WithSecretTimeout_Accepted(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretTimeout(5*time.Second),
 	)
 	require.NoError(t, err)
@@ -2491,7 +2491,7 @@ func TestLoad_MultipleLoadOptions_Compose(t *testing.T) {
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	// Multiple options applied — last write wins for timeout.
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretTimeout(5*time.Second),
 		outputconfig.WithSecretTimeout(20*time.Second),
 	)

--- a/outputconfig/secrets_test.go
+++ b/outputconfig/secrets_test.go
@@ -147,7 +147,7 @@ func TestLoad_WithSecretProvider_AllHMACFieldsResolved(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -186,7 +186,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestLoad_WithSecretProvider_HMACDisabledSkipsRefs(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -239,7 +239,7 @@ func TestLoad_WithSecretProvider_HMACDisabledLiteral_SkipsRefs(t *testing.T) {
 		"false",
 	)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
@@ -253,7 +253,7 @@ func TestLoad_WithSecretProvider_NoProviderNoRefsUnchanged(t *testing.T) {
 	t.Parallel()
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
-	result, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	for _, o := range result.Outputs {
@@ -274,7 +274,7 @@ outputs:
     stdout:
       format: ref+openbao://secret/data/config#format
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	// No provider registered → resolver is nil → refs pass through
 	// env+secret expansion unchanged → safety net catches them.
@@ -288,7 +288,7 @@ func TestLoad_WithSecretProvider_DuplicateSchemeErrors(t *testing.T) {
 	mock2 := newMockProvider("mock", nil)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock1),
 		outputconfig.WithSecretProvider(mock2),
 	)
@@ -321,7 +321,7 @@ outputs:
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	_, err := outputconfig.Load(
-		ctx, data, &tax, nil,
+		ctx, data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 		outputconfig.WithSecretTimeout(50*time.Millisecond),
 	)
@@ -344,7 +344,7 @@ func TestLoad_WithSecretProvider_ErrorNeverContainsSecretValue(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -373,7 +373,7 @@ func TestLoad_WithSecretProvider_PathLevelCache_OneCallForMultipleKeys(t *testin
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -412,7 +412,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -445,7 +445,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock), // mock scheme, not vault
 	)
 	require.Error(t, err)
@@ -468,7 +468,7 @@ func TestLoad_WithSecretProvider_EmptyResolvedValueRejected(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -493,7 +493,7 @@ func TestLoad_WithSecretProvider_OversizedValueRejected(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -515,7 +515,7 @@ func TestLoad_WithSecretProvider_HMACEnabledTrue_RequiresAllFields(t *testing.T)
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -544,7 +544,7 @@ outputs:
     type: stdout
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -577,7 +577,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -620,7 +620,7 @@ outputs:
 	// The resolved value contains "ref+mock://..." which the safety
 	// net should flag as an unresolved reference.
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -655,7 +655,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -693,7 +693,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -725,7 +725,7 @@ outputs:
     type: stdout
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -747,7 +747,7 @@ func TestLoad_WithSecretProvider_NilProviderErrors(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(nil),
 	)
 	require.Error(t, err)
@@ -769,7 +769,7 @@ outputs:
   c:
     type: stdout
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, secrets.ErrUnresolvedRef)
 }
@@ -785,7 +785,7 @@ outputs:
   c:
     type: stdout
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, secrets.ErrUnresolvedRef)
 }
@@ -811,7 +811,7 @@ outputs:
         value: my-salt-value-32-bytes!!!!!!!!
       hash: HMAC-SHA-256
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	// Should get a clear error about no provider, not a toBool error
 	// leaking the ref URI.
@@ -843,7 +843,7 @@ outputs:
         - security
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -875,7 +875,7 @@ outputs:
       version: "1.0"
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -907,7 +907,7 @@ outputs:
       product: MyProduct
       version: "1.0"
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, secrets.ErrUnresolvedRef)
 }
@@ -928,7 +928,7 @@ outputs:
       include_event_types:
         - ref+openbao://secret/data/routing#event_type
 `)
-	_, err := outputconfig.Load(context.Background(), data, &tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, secrets.ErrUnresolvedRef)
 }
@@ -954,7 +954,7 @@ func TestLoad_WithSecretProvider_PreCallContextCancelled(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		ctx, data, &tax, nil,
+		ctx, data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 		outputconfig.WithSecretTimeout(time.Second),
 	)
@@ -986,7 +986,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1012,7 +1012,7 @@ outputs:
       format: "ref+mock://no-key-fragment"
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1082,7 +1082,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.NoError(t, err)
@@ -1117,7 +1117,7 @@ outputs:
     type: stdout
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.NoError(t, err)
@@ -1152,7 +1152,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.Error(t, err)
@@ -1178,7 +1178,7 @@ func TestLoad_NonBatchProvider_EmptyValueRejected(t *testing.T) {
 		"ref+nbmock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.Error(t, err)
@@ -1206,7 +1206,7 @@ func TestLoad_NonBatchProvider_OversizedValueRejected(t *testing.T) {
 		"ref+nbmock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.Error(t, err)
@@ -1243,7 +1243,7 @@ outputs:
       hash: ref+provb://secret/data/hmac#algorithm
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(provA),
 		outputconfig.WithSecretProvider(provB),
 	)
@@ -1295,7 +1295,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1327,7 +1327,7 @@ outputs:
     type: stdout
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1351,7 +1351,7 @@ outputs:
     type: stdout
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1364,7 +1364,7 @@ func TestLoad_WithSecretProvider_SameInstanceTwice_Error(t *testing.T) {
 	mock := newMockProvider("mock", nil)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 		outputconfig.WithSecretProvider(mock), // same instance
 	)
@@ -1378,7 +1378,7 @@ func TestLoad_WithSecretTimeout_ZeroIgnored(t *testing.T) {
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	// Zero timeout should be silently ignored (keeps 10s default).
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretTimeout(0),
 	)
 	require.NoError(t, err)
@@ -1392,7 +1392,7 @@ func TestLoad_WithSecretTimeout_NegativeIgnored(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	result, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretTimeout(-5*time.Second),
 	)
 	require.NoError(t, err)
@@ -1431,7 +1431,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, &tax, nil,
+		context.Background(), data, tax, nil,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)

--- a/outputconfig/tests/bdd/steps/secret_steps.go
+++ b/outputconfig/tests/bdd/steps/secret_steps.go
@@ -234,7 +234,7 @@ func (tc *TestContext) stepLoadYAMLWithProviders(doc *godog.DocString) error {
 	result, loadErr := outputconfig.Load(
 		context.Background(),
 		[]byte(doc.Content),
-		&tc.Taxonomy,
+		tc.Taxonomy,
 		nil,
 		opts...,
 	)

--- a/outputconfig/tests/bdd/steps/steps.go
+++ b/outputconfig/tests/bdd/steps/steps.go
@@ -49,7 +49,7 @@ func (l *lokiStub) Name() string       { return "loki-stub" }
 
 // TestContext holds mutable state for a single BDD scenario.
 type TestContext struct { //nolint:govet // fieldalignment: readability preferred
-	Taxonomy      audit.Taxonomy
+	Taxonomy      *audit.Taxonomy
 	Logger        *audit.Logger
 	Options       []audit.Option
 	LoadResult    *outputconfig.LoadResult
@@ -177,7 +177,7 @@ events:
 			return fmt.Errorf("set AUDIT_BDD_DIR: %w", err)
 		}
 
-		result, loadErr := outputconfig.Load(context.Background(), []byte(doc.Content), &tc.Taxonomy, nil)
+		result, loadErr := outputconfig.Load(context.Background(), []byte(doc.Content), tc.Taxonomy, nil)
 		if loadErr != nil {
 			tc.LastErr = loadErr
 			return nil //nolint:nilerr // scenario may assert on tc.LastErr

--- a/severity_routing_test.go
+++ b/severity_routing_test.go
@@ -266,7 +266,7 @@ func TestValidateEventRoute_MinSeverityOutOfRange(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			route := audit.EventRoute{MinSeverity: intPtr(tt.minSev)}
-			err := audit.ValidateEventRoute(&route, &tax)
+			err := audit.ValidateEventRoute(&route, tax)
 			require.Error(t, err,
 				"min_severity %d must be rejected", tt.minSev)
 			assert.Contains(t, err.Error(), tt.wantErr,
@@ -302,7 +302,7 @@ func TestValidateEventRoute_MaxSeverityOutOfRange(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			route := audit.EventRoute{MaxSeverity: intPtr(tt.maxSev)}
-			err := audit.ValidateEventRoute(&route, &tax)
+			err := audit.ValidateEventRoute(&route, tax)
 			require.Error(t, err,
 				"max_severity %d must be rejected", tt.maxSev)
 			assert.Contains(t, err.Error(), tt.wantErr,
@@ -322,7 +322,7 @@ func TestValidateEventRoute_MinGreaterThanMax(t *testing.T) {
 		MinSeverity: intPtr(8),
 		MaxSeverity: intPtr(3),
 	}
-	err := audit.ValidateEventRoute(&route, &tax)
+	err := audit.ValidateEventRoute(&route, tax)
 	require.Error(t, err, "min_severity 8 > max_severity 3 must be rejected")
 	assert.Contains(t, err.Error(), "min_severity 8 exceeds max_severity 3",
 		"error message must name both values")
@@ -338,7 +338,7 @@ func TestValidateEventRoute_ValidSeverityRange(t *testing.T) {
 		MinSeverity: intPtr(3),
 		MaxSeverity: intPtr(7),
 	}
-	err := audit.ValidateEventRoute(&route, &tax)
+	err := audit.ValidateEventRoute(&route, tax)
 	require.NoError(t, err, "valid severity range [3, 7] must be accepted")
 }
 
@@ -350,7 +350,7 @@ func TestValidateEventRoute_SeverityZero_Valid(t *testing.T) {
 	tax := testhelper.TestTaxonomy()
 
 	route := audit.EventRoute{MinSeverity: intPtr(0)}
-	err := audit.ValidateEventRoute(&route, &tax)
+	err := audit.ValidateEventRoute(&route, tax)
 	require.NoError(t, err, "min_severity 0 is a valid CEF severity and must be accepted")
 }
 
@@ -779,7 +779,7 @@ func TestValidateEventRoute_SeverityWithMixedIncludeExclude(t *testing.T) {
 		MinSeverity:       intPtr(3),
 		MaxSeverity:       intPtr(8),
 	}
-	err := audit.ValidateEventRoute(&route, &tax)
+	err := audit.ValidateEventRoute(&route, tax)
 	require.Error(t, err,
 		"mixed include+exclude route with valid severity must still be rejected")
 	assert.Contains(t, err.Error(), "either include or exclude, not both",

--- a/severity_test.go
+++ b/severity_test.go
@@ -358,7 +358,7 @@ func TestValidateTaxonomy_CategorySeverityOutOfRange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			tax := audit.Taxonomy{
+			tax := &audit.Taxonomy{
 				Version: 1,
 				Categories: map[string]*audit.CategoryDef{
 					"ops": {
@@ -370,7 +370,7 @@ func TestValidateTaxonomy_CategorySeverityOutOfRange(t *testing.T) {
 					"deploy": {Required: []string{"outcome"}},
 				},
 			}
-			err := audit.ValidateTaxonomy(tax)
+			err := audit.ValidateTaxonomy(*tax)
 
 			if tt.wantMsg != "" {
 				require.Error(t, err)
@@ -406,7 +406,7 @@ func TestValidateTaxonomy_EventSeverityOutOfRange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			tax := audit.Taxonomy{
+			tax := &audit.Taxonomy{
 				Version: 1,
 				Categories: map[string]*audit.CategoryDef{
 					"ops": {Events: []string{"deploy"}},
@@ -418,7 +418,7 @@ func TestValidateTaxonomy_EventSeverityOutOfRange(t *testing.T) {
 					},
 				},
 			}
-			err := audit.ValidateTaxonomy(tax)
+			err := audit.ValidateTaxonomy(*tax)
 
 			if tt.wantErr {
 				require.Error(t, err,

--- a/taxonomy.go
+++ b/taxonomy.go
@@ -195,16 +195,21 @@ type Taxonomy struct {
 	// disabled with zero overhead.
 	Sensitivity *SensitivityConfig
 
+	// Version is the taxonomy schema version. MUST be > 0. Currently
+	// only version 1 is supported; higher values cause [WithTaxonomy]
+	// to return an error wrapping [ErrTaxonomyInvalid].
+	Version int
+
 	// SuppressEventCategory controls whether the `event_category` field
 	// is omitted from serialised output. The zero value (false) means
 	// the category IS emitted — matching the YAML default when
 	// `emit_event_category` is absent. Set to true to suppress.
 	SuppressEventCategory bool
 
-	// Version is the taxonomy schema version. MUST be > 0. Currently
-	// only version 1 is supported; higher values cause [WithTaxonomy]
-	// to return an error wrapping [ErrTaxonomyInvalid].
-	Version int
+	// validated is set by [ParseTaxonomyYAML] after migration,
+	// validation, and precomputation succeed. [WithTaxonomy] skips
+	// redundant re-validation when this flag is true.
+	validated bool
 }
 
 const (
@@ -223,9 +228,26 @@ const (
 // are not set on EventDef directly) and building the field lookup
 // structures. Must be called after validation succeeds.
 func precomputeTaxonomy(t *Taxonomy) error {
-	// Derive EventDef.Categories from the categories map. This
-	// ensures Categories is populated for both YAML-parsed and
-	// Go-constructed taxonomies.
+	deriveEventCategories(t)
+
+	for _, def := range t.Events {
+		def.resolvedSeverity = resolveEventSeverity(def, t)
+		def.severityResolved = true
+	}
+	for _, def := range t.Events {
+		precomputeEventDef(def)
+	}
+	if err := precomputeSensitivity(t); err != nil {
+		return err
+	}
+	t.validated = true
+	return nil
+}
+
+// deriveEventCategories populates EventDef.Categories from the
+// taxonomy's category map. This ensures Categories is populated for
+// both YAML-parsed and Go-constructed taxonomies.
+func deriveEventCategories(t *Taxonomy) {
 	for catName, catDef := range t.Categories {
 		if catDef == nil {
 			continue
@@ -241,19 +263,6 @@ func precomputeTaxonomy(t *Taxonomy) error {
 	for _, def := range t.Events {
 		slices.Sort(def.Categories)
 	}
-
-	// Resolve severity for each event. Resolution chain:
-	// event Severity (if non-nil) → first category Severity (if non-nil) → 5.
-	for _, def := range t.Events {
-		def.resolvedSeverity = resolveEventSeverity(def, t)
-		def.severityResolved = true
-	}
-
-	for _, def := range t.Events {
-		precomputeEventDef(def)
-	}
-
-	return precomputeSensitivity(t)
 }
 
 // resolveEventSeverity computes the effective severity for an event.
@@ -314,6 +323,108 @@ func sortedCopy(s []string) []string {
 	cp := make([]string, len(s))
 	copy(cp, s)
 	slices.Sort(cp)
+	return cp
+}
+
+// deepCopyTaxonomy returns a deep copy of t. All mutable maps, slices,
+// and pointer fields are copied so that mutations to the original after
+// the copy do not affect the copy. Called by [WithTaxonomy] to prevent
+// post-construction mutation by the consumer.
+func deepCopyTaxonomy(t *Taxonomy) *Taxonomy {
+	cp := &Taxonomy{
+		Version:               t.Version,
+		SuppressEventCategory: t.SuppressEventCategory,
+		validated:             t.validated,
+	}
+	cp.Categories = deepCopyCategories(t.Categories)
+	cp.Events = deepCopyEvents(t.Events)
+	cp.Sensitivity = deepCopySensitivity(t.Sensitivity)
+	return cp
+}
+
+func deepCopyCategories(cats map[string]*CategoryDef) map[string]*CategoryDef {
+	if cats == nil {
+		return nil
+	}
+	cp := make(map[string]*CategoryDef, len(cats))
+	for name, cat := range cats {
+		cp[name] = &CategoryDef{
+			Severity: copyIntPtr(cat.Severity),
+			Events:   copyStrings(cat.Events),
+		}
+	}
+	return cp
+}
+
+func deepCopyEvents(events map[string]*EventDef) map[string]*EventDef {
+	if events == nil {
+		return nil
+	}
+	cp := make(map[string]*EventDef, len(events))
+	for name, ev := range events {
+		cp[name] = deepCopyEventDef(ev)
+	}
+	return cp
+}
+
+func deepCopyEventDef(ev *EventDef) *EventDef {
+	cpEv := &EventDef{
+		Categories:       copyStrings(ev.Categories),
+		Description:      ev.Description,
+		Severity:         copyIntPtr(ev.Severity),
+		Required:         copyStrings(ev.Required),
+		Optional:         copyStrings(ev.Optional),
+		resolvedSeverity: ev.resolvedSeverity,
+		severityResolved: ev.severityResolved,
+		sortedRequired:   copyStrings(ev.sortedRequired),
+		sortedOptional:   copyStrings(ev.sortedOptional),
+		sortedAllKeys:    copyStrings(ev.sortedAllKeys),
+	}
+	if ev.knownFields != nil {
+		cpEv.knownFields = make(map[string]struct{}, len(ev.knownFields))
+		for k := range ev.knownFields {
+			cpEv.knownFields[k] = struct{}{}
+		}
+	}
+	if ev.FieldLabels != nil {
+		cpEv.FieldLabels = make(map[string]map[string]struct{}, len(ev.FieldLabels))
+		for field, labels := range ev.FieldLabels {
+			cpLabels := make(map[string]struct{}, len(labels))
+			for l := range labels {
+				cpLabels[l] = struct{}{}
+			}
+			cpEv.FieldLabels[field] = cpLabels
+		}
+	}
+	if ev.fieldAnnotations != nil {
+		cpEv.fieldAnnotations = make(map[string][]string, len(ev.fieldAnnotations))
+		for field, labels := range ev.fieldAnnotations {
+			cpEv.fieldAnnotations[field] = copyStrings(labels)
+		}
+	}
+	return cpEv
+}
+
+func deepCopySensitivity(sc *SensitivityConfig) *SensitivityConfig {
+	if sc == nil {
+		return nil
+	}
+	cp := &SensitivityConfig{
+		Labels: make(map[string]*SensitivityLabel, len(sc.Labels)),
+	}
+	for name, label := range sc.Labels {
+		cpLabel := &SensitivityLabel{
+			Description: label.Description,
+			Fields:      copyStrings(label.Fields),
+			Patterns:    copyStrings(label.Patterns),
+		}
+		if label.compiled != nil {
+			// regexp.Regexp is safe for concurrent use; shallow copy is intentional.
+			cpLabel.compiled = make([]*regexp.Regexp, len(label.compiled))
+			copy(cpLabel.compiled, label.compiled)
+		}
+		cp.Labels[name] = cpLabel
+	}
 	return cp
 }
 

--- a/taxonomy_pointer_test.go
+++ b/taxonomy_pointer_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"testing"
+
+	"github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ParseTaxonomyYAML returns *Taxonomy (#389 AC-1, AC-2)
+// ---------------------------------------------------------------------------
+
+func TestParseTaxonomyYAML_ValidInput_ReturnsPointer(t *testing.T) {
+	t.Parallel()
+	yaml := []byte(`
+version: 1
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    fields:
+      outcome: {required: true}
+`)
+	tax, err := audit.ParseTaxonomyYAML(yaml)
+	require.NoError(t, err)
+	require.NotNil(t, tax, "ParseTaxonomyYAML should return non-nil pointer on success")
+	assert.Equal(t, 1, tax.Version)
+	assert.Contains(t, tax.Events, "user_create")
+}
+
+func TestParseTaxonomyYAML_InvalidInput_ReturnsNilAndError(t *testing.T) {
+	t.Parallel()
+	tax, err := audit.ParseTaxonomyYAML([]byte("not valid yaml: ["))
+	require.Error(t, err)
+	assert.Nil(t, tax, "ParseTaxonomyYAML should return nil on error")
+}
+
+func TestParseTaxonomyYAML_EmptyInput_ReturnsNilAndError(t *testing.T) {
+	t.Parallel()
+	tax, err := audit.ParseTaxonomyYAML(nil)
+	require.Error(t, err)
+	assert.Nil(t, tax)
+}
+
+// ---------------------------------------------------------------------------
+// WithTaxonomy nil check (#389 AC-3)
+// ---------------------------------------------------------------------------
+
+func TestWithTaxonomy_NilPointer_ReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := audit.NewLogger(
+		audit.WithTaxonomy(nil),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
+	assert.Contains(t, err.Error(), "taxonomy must not be nil")
+}
+
+// ---------------------------------------------------------------------------
+// WithTaxonomy skips re-validation (#389 AC-7)
+// ---------------------------------------------------------------------------
+
+func TestWithTaxonomy_ParsedTaxonomy_SkipsRevalidation(t *testing.T) {
+	t.Parallel()
+
+	// Parse a valid taxonomy — this sets the internal validated flag.
+	yaml := []byte(`
+version: 1
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    fields:
+      outcome: {required: true}
+`)
+	tax, err := audit.ParseTaxonomyYAML(yaml)
+	require.NoError(t, err)
+
+	// Create logger — should succeed without re-validating.
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(tax),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	// Verify the logger works.
+	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome": "success",
+	}))
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+	assert.Equal(t, 1, out.EventCount())
+}
+
+// ---------------------------------------------------------------------------
+// Deep copy prevents post-construction mutation (#389 AC-6)
+// ---------------------------------------------------------------------------
+
+func TestWithTaxonomy_PostConstructionMutation_DoesNotAffectLogger(t *testing.T) {
+	t.Parallel()
+
+	tax := &audit.Taxonomy{
+		Version: 1,
+		Categories: map[string]*audit.CategoryDef{
+			"write": {Events: []string{"user_create"}},
+		},
+		Events: map[string]*audit.EventDef{
+			"user_create": {
+				Required: []string{"outcome"},
+				Optional: []string{"details"},
+			},
+		},
+	}
+
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(tax),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	// Mutate the original taxonomy AFTER logger creation.
+	delete(tax.Events, "user_create")
+	tax.Events["hacked_event"] = &audit.EventDef{Required: []string{"x"}}
+
+	// The logger should still accept user_create (uses the deep copy).
+	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome": "success",
+	}))
+	require.NoError(t, err, "logger should use deep copy, not the mutated original")
+
+	// The logger should NOT accept hacked_event (not in the copy).
+	err = logger.AuditEvent(audit.NewEvent("hacked_event", audit.Fields{
+		"x": "y",
+	}))
+	require.Error(t, err, "hacked_event should not be in the logger's taxonomy")
+	assert.Contains(t, err.Error(), "unknown event type")
+
+	require.NoError(t, logger.Close())
+}
+
+// ---------------------------------------------------------------------------
+// Inline taxonomy with & (#389 AC-9)
+// ---------------------------------------------------------------------------
+
+func TestWithTaxonomy_InlineTaxonomy_TakesAddress(t *testing.T) {
+	t.Parallel()
+
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(&audit.Taxonomy{
+			Version: 1,
+			Categories: map[string]*audit.CategoryDef{
+				"write": {Events: []string{"ev1"}},
+			},
+			Events: map[string]*audit.EventDef{
+				"ev1": {Required: []string{"f1"}},
+			},
+		}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}

--- a/taxonomy_test.go
+++ b/taxonomy_test.go
@@ -34,14 +34,14 @@ func TestNewLogger_ValidTaxonomy(t *testing.T) {
 }
 
 func TestNewLogger_TaxonomyValidation(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // fieldalignment: test struct readability
 		name      string
 		wantError string
-		taxonomy  audit.Taxonomy
+		taxonomy  *audit.Taxonomy
 	}{
 		{
 			name: "version zero",
-			taxonomy: audit.Taxonomy{
+			taxonomy: &audit.Taxonomy{
 				Version:    0,
 				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 				Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"f1"}}},
@@ -50,7 +50,7 @@ func TestNewLogger_TaxonomyValidation(t *testing.T) {
 		},
 		{
 			name: "version too high",
-			taxonomy: audit.Taxonomy{
+			taxonomy: &audit.Taxonomy{
 				Version:    999,
 				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 				Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"f1"}}},
@@ -59,7 +59,7 @@ func TestNewLogger_TaxonomyValidation(t *testing.T) {
 		},
 		{
 			name: "category member not in Events map",
-			taxonomy: audit.Taxonomy{
+			taxonomy: &audit.Taxonomy{
 				Version:    1,
 				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1", "ev_missing"}}},
 				Events: map[string]*audit.EventDef{
@@ -90,7 +90,7 @@ func TestNewLogger_TaxonomyRequired(t *testing.T) {
 
 func TestNewLogger_TaxonomyValidation_SentinelError(t *testing.T) {
 	_, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{Version: 0}),
+		audit.WithTaxonomy(&audit.Taxonomy{Version: 0}),
 	)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, audit.ErrTaxonomyInvalid))
@@ -99,20 +99,20 @@ func TestNewLogger_TaxonomyValidation_SentinelError(t *testing.T) {
 func TestValidateTaxonomy(t *testing.T) {
 	t.Run("valid taxonomy passes", func(t *testing.T) {
 		tax := testhelper.ValidTaxonomy()
-		err := audit.ValidateTaxonomy(tax)
+		err := audit.ValidateTaxonomy(*tax)
 		assert.NoError(t, err)
 	})
 
 	t.Run("invalid taxonomy returns ErrTaxonomyInvalid", func(t *testing.T) {
-		tax := audit.Taxonomy{Version: 0}
-		err := audit.ValidateTaxonomy(tax)
+		tax := &audit.Taxonomy{Version: 0}
+		err := audit.ValidateTaxonomy(*tax)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 	})
 
 	t.Run("empty categories returns error", func(t *testing.T) {
-		tax := audit.Taxonomy{Version: 1, Events: map[string]*audit.EventDef{}}
-		err := audit.ValidateTaxonomy(tax)
+		tax := &audit.Taxonomy{Version: 1, Events: map[string]*audit.EventDef{}}
+		err := audit.ValidateTaxonomy(*tax)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 		assert.Contains(t, err.Error(), "at least one category")
@@ -124,14 +124,14 @@ func TestValidateTaxonomy_AllReservedFields_RejectedAsRequired(t *testing.T) {
 	for _, field := range []string{"timestamp", "event_type", "severity", "event_category", "app_name", "host", "timezone", "pid"} {
 		t.Run(field, func(t *testing.T) {
 			t.Parallel()
-			tax := audit.Taxonomy{
+			tax := &audit.Taxonomy{
 				Version:    1,
 				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 				Events: map[string]*audit.EventDef{
 					"ev1": {Required: []string{field}},
 				},
 			}
-			err := audit.ValidateTaxonomy(tax)
+			err := audit.ValidateTaxonomy(*tax)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 			assert.Contains(t, err.Error(), "reserved framework field")
@@ -145,14 +145,14 @@ func TestValidateTaxonomy_AllReservedFields_RejectedAsOptional(t *testing.T) {
 	for _, field := range []string{"timestamp", "event_type", "severity", "event_category", "app_name", "host", "timezone", "pid"} {
 		t.Run(field, func(t *testing.T) {
 			t.Parallel()
-			tax := audit.Taxonomy{
+			tax := &audit.Taxonomy{
 				Version:    1,
 				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 				Events: map[string]*audit.EventDef{
 					"ev1": {Required: []string{"outcome"}, Optional: []string{field}},
 				},
 			}
-			err := audit.ValidateTaxonomy(tax)
+			err := audit.ValidateTaxonomy(*tax)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 			assert.Contains(t, err.Error(), "reserved framework field")
@@ -165,14 +165,14 @@ func TestValidateTaxonomy_DurationMs_AllowedAsOptional(t *testing.T) {
 	t.Parallel()
 	// duration_ms is a framework field for sensitivity protection but
 	// is NOT reserved — it can be used as an optional user field.
-	tax := audit.Taxonomy{
+	tax := &audit.Taxonomy{
 		Version:    1,
 		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 		Events: map[string]*audit.EventDef{
 			"ev1": {Required: []string{"outcome"}, Optional: []string{"duration_ms"}},
 		},
 	}
-	err := audit.ValidateTaxonomy(tax)
+	err := audit.ValidateTaxonomy(*tax)
 	assert.NoError(t, err)
 }
 
@@ -217,14 +217,14 @@ func TestValidateTaxonomy_ReservedStandardField_BareDeclaration_Rejected(t *test
 	for _, field := range []string{"source_ip", "actor_id", "reason", "method", "outcome"} {
 		t.Run(field, func(t *testing.T) {
 			t.Parallel()
-			tax := audit.Taxonomy{
+			tax := &audit.Taxonomy{
 				Version:    1,
 				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 				Events: map[string]*audit.EventDef{
 					"ev1": {Required: []string{"marker"}, Optional: []string{field}},
 				},
 			}
-			err := audit.ValidateTaxonomy(tax)
+			err := audit.ValidateTaxonomy(*tax)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 			assert.Contains(t, err.Error(), "reserved standard field")
@@ -238,14 +238,14 @@ func TestValidateTaxonomy_ReservedStandardField_Required_Allowed(t *testing.T) {
 	for _, field := range []string{"source_ip", "actor_id", "reason", "method"} {
 		t.Run(field, func(t *testing.T) {
 			t.Parallel()
-			tax := audit.Taxonomy{
+			tax := &audit.Taxonomy{
 				Version:    1,
 				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 				Events: map[string]*audit.EventDef{
 					"ev1": {Required: []string{field}},
 				},
 			}
-			err := audit.ValidateTaxonomy(tax)
+			err := audit.ValidateTaxonomy(*tax)
 			assert.NoError(t, err)
 		})
 	}
@@ -317,20 +317,20 @@ events:
 func TestMigrateTaxonomy(t *testing.T) {
 	t.Run("valid version passes", func(t *testing.T) {
 		tax := testhelper.ValidTaxonomy()
-		err := audit.MigrateTaxonomy(&tax)
+		err := audit.MigrateTaxonomy(tax)
 		assert.NoError(t, err)
 	})
 
 	t.Run("version zero returns error", func(t *testing.T) {
-		tax := audit.Taxonomy{Version: 0}
-		err := audit.MigrateTaxonomy(&tax)
+		tax := &audit.Taxonomy{Version: 0}
+		err := audit.MigrateTaxonomy(tax)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 	})
 
 	t.Run("version too high returns error", func(t *testing.T) {
-		tax := audit.Taxonomy{Version: 999}
-		err := audit.MigrateTaxonomy(&tax)
+		tax := &audit.Taxonomy{Version: 999}
+		err := audit.MigrateTaxonomy(tax)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 	})
@@ -338,7 +338,7 @@ func TestMigrateTaxonomy(t *testing.T) {
 
 func TestNewLogger_TaxonomyVersionNegative(t *testing.T) {
 	_, err := audit.NewLogger(
-		audit.WithTaxonomy(audit.Taxonomy{
+		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    -1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 			Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"f1"}}},

--- a/taxonomy_yaml.go
+++ b/taxonomy_yaml.go
@@ -206,58 +206,57 @@ type yamlFieldDef struct {
 	Required bool     `yaml:"required"`
 }
 
-// ParseTaxonomyYAML parses a YAML document into a [Taxonomy].
+// ParseTaxonomyYAML parses a YAML document into a [*Taxonomy].
 // The input MUST be a single YAML document containing a valid taxonomy
 // definition. Unknown keys are rejected.
 //
 // The returned Taxonomy is fully migrated, validated, and
-// lifecycle-injected. Passing it to [WithTaxonomy] is safe;
-// migration, injection, and validation run again inside WithTaxonomy
-// but produce no additional errors for a well-formed taxonomy.
+// precomputed. Passing it to [WithTaxonomy] skips redundant
+// re-validation.
 //
 // Input errors (empty, oversized, multi-document, invalid syntax) wrap
 // [ErrInvalidInput]. Taxonomy validation errors wrap
-// [ErrTaxonomyInvalid].
+// [ErrTaxonomyInvalid]. On error, nil is returned.
 //
 // ParseTaxonomyYAML accepts []byte only — no file paths, no readers.
 // Use [embed.FS] or [os.ReadFile] in the caller to load from disk.
-func ParseTaxonomyYAML(data []byte) (Taxonomy, error) {
+func ParseTaxonomyYAML(data []byte) (*Taxonomy, error) {
 	if len(data) == 0 {
-		return Taxonomy{}, fmt.Errorf("%w: input is empty", ErrInvalidInput)
+		return nil, fmt.Errorf("%w: input is empty", ErrInvalidInput)
 	}
 	if len(data) > MaxTaxonomyInputSize {
-		return Taxonomy{}, fmt.Errorf("%w: input size %d exceeds maximum %d bytes", ErrInvalidInput, len(data), MaxTaxonomyInputSize)
+		return nil, fmt.Errorf("%w: input size %d exceeds maximum %d bytes", ErrInvalidInput, len(data), MaxTaxonomyInputSize)
 	}
 
 	dec := yaml.NewDecoder(bytes.NewReader(data), yaml.DisallowUnknownField())
 
 	var yt yamlTaxonomy
 	if err := dec.Decode(&yt); err != nil {
-		return Taxonomy{}, fmt.Errorf("%w: %v", ErrInvalidInput, err) //nolint:errorlint // intentionally not wrapping yaml.v3 error to avoid leaking third-party types into the public error chain
+		return nil, fmt.Errorf("%w: %v", ErrInvalidInput, err) //nolint:errorlint // intentionally not wrapping yaml.v3 error to avoid leaking third-party types into the public error chain
 	}
 
 	// Reject multi-document YAML and trailing content.
 	var discard any
 	if err := dec.Decode(&discard); err == nil {
-		return Taxonomy{}, fmt.Errorf("%w: input contains multiple YAML documents", ErrInvalidInput)
+		return nil, fmt.Errorf("%w: input contains multiple YAML documents", ErrInvalidInput)
 	} else if !errors.Is(err, io.EOF) {
-		return Taxonomy{}, fmt.Errorf("%w: trailing content after YAML document: %v", ErrInvalidInput, err) //nolint:errorlint // intentionally not wrapping yaml.v3 error
+		return nil, fmt.Errorf("%w: trailing content after YAML document: %v", ErrInvalidInput, err) //nolint:errorlint // intentionally not wrapping yaml.v3 error
 	}
 
 	tax := convertYAMLTaxonomy(yt)
 
 	if err := MigrateTaxonomy(&tax); err != nil {
-		return Taxonomy{}, err
+		return nil, err
 	}
 
 	if err := ValidateTaxonomy(tax); err != nil {
-		return Taxonomy{}, err
+		return nil, err
 	}
 
 	if err := precomputeTaxonomy(&tax); err != nil {
-		return Taxonomy{}, err
+		return nil, err
 	}
-	return tax, nil
+	return &tax, nil
 }
 
 // convertYAMLTaxonomy transforms the intermediate yamlTaxonomy into a

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -638,7 +638,7 @@ func tableToStringMap(table *godog.Table) map[string]string {
 
 // defaultRequiredFields returns fields satisfying all required fields
 // for the given event type, with sensible defaults.
-func defaultRequiredFields(tax audit.Taxonomy, eventType string) audit.Fields {
+func defaultRequiredFields(tax *audit.Taxonomy, eventType string) audit.Fields {
 	fields := make(audit.Fields)
 	def, ok := tax.Events[eventType]
 	if !ok {

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -40,7 +40,7 @@ type AuditTestContext struct { //nolint:govet // fieldalignment: readability pre
 	Logger      *audit.Logger
 	EventHandle *audit.EventType
 	LastErr     error
-	Taxonomy    audit.Taxonomy
+	Taxonomy    *audit.Taxonomy
 	Options     []audit.Option
 
 	// Output capture.
@@ -109,7 +109,7 @@ func (tc *AuditTestContext) Reset() {
 	tc.Logger = nil
 	tc.EventHandle = nil
 	tc.LastErr = nil
-	tc.Taxonomy = audit.Taxonomy{}
+	tc.Taxonomy = nil
 	tc.Options = nil
 	tc.StdoutBuf = nil
 	tc.FilePaths = make(map[string]string)

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -130,8 +130,8 @@ func waitForWebhookEvents(t *testing.T, n int, timeout time.Duration) bool {
 }
 
 // testTaxonomy returns a taxonomy for fan-out tests.
-func testTaxonomy() audit.Taxonomy {
-	return audit.Taxonomy{
+func testTaxonomy() *audit.Taxonomy {
+	return &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"write":    {Events: []string{"user_create"}},

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -273,8 +273,8 @@ var _ webhook.Metrics = (*mockMetrics)(nil)
 // ---------------------------------------------------------------------------
 
 // testTaxonomy returns a taxonomy with common event types for testing.
-func testTaxonomy() audit.Taxonomy {
-	return audit.Taxonomy{
+func testTaxonomy() *audit.Taxonomy {
+	return &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
 			"write":    {Events: []string{"user_create", "user_delete"}},


### PR DESCRIPTION
## Summary

- Change `ParseTaxonomyYAML` to return `(*Taxonomy, error)` — nil on error
- Change `WithTaxonomy` to accept `*Taxonomy` with nil check, deep copy, and validated flag skip
- Deep copy all mutable maps/slices in `WithTaxonomy` to prevent post-construction mutation
- Add `validated` internal flag — skip redundant re-validation for YAML-parsed taxonomies
- Update all call sites: inline `Taxonomy{}` → `&Taxonomy{}`, drop `&` on outputconfig.Load callers

Parent issue: #387 (Phase 1)
Closes #389

## Test plan

- [x] `make check` passes (with workspace)
- [x] All existing tests pass with `-race`
- [x] 7 new tests in `taxonomy_pointer_test.go`: pointer return, nil rejection, deep copy mutation, validated skip, inline address
- [x] Agent reviews: code-reviewer (approved, 1 important fixed), security-reviewer (approved, 1 medium fixed)