### PR TITLE
feat: add error discrimination sentinels (#400)

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -212,7 +212,7 @@ func (l *Logger) auditInternal(eventType string, fields Fields) error {
 		if l.metrics != nil {
 			l.metrics.RecordValidationError(eventType)
 		}
-		return fmt.Errorf("audit: unknown event type %q", eventType)
+		return newValidationError(ErrUnknownEventType, "audit: unknown event type %q", eventType)
 	}
 
 	// Copy fields and merge defaults in one pass to avoid double

--- a/audit_test.go
+++ b/audit_test.go
@@ -90,6 +90,8 @@ func TestLogger_Audit_MissingRequiredField(t *testing.T) {
 		// missing actor_id and subject
 	}))
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
 	assert.Contains(t, err.Error(), "missing required fields")
 	assert.Contains(t, err.Error(), "actor_id")
 	assert.Contains(t, err.Error(), "subject")
@@ -116,6 +118,8 @@ func TestLogger_Audit_UnknownEventType(t *testing.T) {
 
 	err := logger.AuditEvent(audit.NewEvent("schema_registr", audit.Fields{}))
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	assert.ErrorIs(t, err, audit.ErrUnknownEventType)
 	assert.Contains(t, err.Error(), "unknown event type")
 	assert.Contains(t, err.Error(), "schema_registr")
 }
@@ -132,6 +136,8 @@ func TestLogger_Audit_UnknownFieldStrict(t *testing.T) {
 		"bogus_field": "value",
 	}))
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	assert.ErrorIs(t, err, audit.ErrUnknownField)
 	assert.Contains(t, err.Error(), "unknown fields")
 	assert.Contains(t, err.Error(), "bogus_field")
 }

--- a/doc.go
+++ b/doc.go
@@ -135,6 +135,28 @@
 //
 //   - [Metrics] — optional instrumentation interface; track deliveries, drops, and errors
 //
+// # Error Discrimination
+//
+// Validation errors returned by [Logger.AuditEvent] wrap [ErrValidation]
+// as a parent sentinel. Specific sub-sentinels identify the failure:
+//
+//   - [ErrUnknownEventType] — event type not in taxonomy
+//   - [ErrMissingRequiredField] — required fields absent
+//   - [ErrUnknownField] — unrecognised fields (strict mode only)
+//
+// Use [errors.Is] to match broadly or narrowly:
+//
+//	if errors.Is(err, audit.ErrValidation) { /* any validation failure */ }
+//	if errors.Is(err, audit.ErrUnknownEventType) { /* specific case */ }
+//
+// Use [errors.As] to access the [ValidationError] struct:
+//
+//	var ve *audit.ValidationError
+//	if errors.As(err, &ve) { log.Println(ve.Error()) }
+//
+// [ErrBufferFull] and [ErrClosed] are NOT validation errors and will
+// never match [ErrValidation].
+//
 // # Code Generation Support
 //
 //   - [LabelInfo] — sensitivity label descriptor; embedded in [FieldInfo]

--- a/errors.go
+++ b/errors.go
@@ -14,7 +14,10 @@
 
 package audit
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Sentinel errors returned by the audit package.
 // Use [errors.Is] to test for these in consumer code.
@@ -63,4 +66,67 @@ var (
 	// a multi-document YAML stream, or syntactically invalid. Taxonomy
 	// content validation errors wrap [ErrTaxonomyInvalid] instead.
 	ErrInvalidInput = errors.New("audit: invalid input")
+
+	// ErrValidation is the parent sentinel for all [Logger.AuditEvent]
+	// validation failures (unknown event type, missing required fields,
+	// unknown fields in strict mode). Use [errors.Is] to catch any
+	// validation failure:
+	//
+	//	if errors.Is(err, audit.ErrValidation) { ... }
+	//
+	// [ErrBufferFull] and [ErrClosed] are NOT validation errors.
+	ErrValidation = errors.New("audit: validation error")
+
+	// ErrUnknownEventType is returned by [Logger.AuditEvent] when the
+	// event type is not registered in the taxonomy. Always wrapped
+	// alongside [ErrValidation] via [ValidationError].
+	ErrUnknownEventType = errors.New("audit: unknown event type")
+
+	// ErrMissingRequiredField is returned by [Logger.AuditEvent] when
+	// one or more required fields are absent. Always wrapped alongside
+	// [ErrValidation] via [ValidationError].
+	ErrMissingRequiredField = errors.New("audit: missing required field")
+
+	// ErrUnknownField is returned by [Logger.AuditEvent] in strict
+	// validation mode when one or more fields are not declared in the
+	// taxonomy. Always wrapped alongside [ErrValidation] via
+	// [ValidationError].
+	ErrUnknownField = errors.New("audit: unknown field")
 )
+
+// ValidationError is returned by [Logger.AuditEvent] for event
+// validation failures. It wraps both [ErrValidation] and a specific
+// sentinel ([ErrUnknownEventType], [ErrMissingRequiredField], or
+// [ErrUnknownField]). Use [errors.Is] to match broadly or narrowly,
+// and [errors.As] to access the structured error:
+//
+//	var ve *audit.ValidationError
+//	if errors.As(err, &ve) { log.Println(ve.Error()) }
+type ValidationError struct {
+	wrapped  [2]error // pre-allocated to avoid per-Unwrap heap allocation
+	sentinel error
+	msg      string
+}
+
+// Error returns the human-readable error message. The text is
+// identical to the pre-sentinel format for backwards compatibility.
+func (e *ValidationError) Error() string { return e.msg }
+
+// Unwrap returns the sentinel errors that this validation error wraps.
+// Always includes [ErrValidation]; also includes the specific sentinel
+// when set.
+func (e *ValidationError) Unwrap() []error {
+	return e.wrapped[:]
+}
+
+// newValidationError creates a [ValidationError] with the given
+// specific sentinel and formatted message.
+func newValidationError(sentinel error, format string, args ...any) *ValidationError {
+	ve := &ValidationError{
+		sentinel: sentinel,
+		msg:      fmt.Sprintf(format, args...),
+	}
+	ve.wrapped[0] = ErrValidation
+	ve.wrapped[1] = sentinel
+	return ve
+}

--- a/tests/bdd/features/error_discrimination.feature
+++ b/tests/bdd/features/error_discrimination.feature
@@ -1,0 +1,54 @@
+@core @errors
+Feature: Error Discrimination
+  As a library consumer, I want to distinguish validation errors
+  programmatically using errors.Is so that I can handle different
+  failure modes without parsing error strings.
+
+  Background:
+    Given a standard test taxonomy
+
+  # --- Unknown event type ---
+
+  Scenario: Unknown event type wraps ErrValidation and ErrUnknownEventType
+    Given a logger with stdout output
+    When I audit event "nonexistent_event" with fields:
+      | field   | value   |
+      | outcome | success |
+    Then the audit call should return an error matching:
+      """
+      audit: unknown event type "nonexistent_event"
+      """
+    And the audit call should return an error wrapping "ErrValidation"
+    And the audit call should return an error wrapping "ErrUnknownEventType"
+    And the audit call should return an error NOT wrapping "ErrMissingRequiredField"
+    And the audit call should return an error NOT wrapping "ErrUnknownField"
+
+  # --- Missing required field ---
+
+  Scenario: Missing required field wraps ErrValidation and ErrMissingRequiredField
+    Given a logger with stdout output
+    When I audit event "auth_failure" with fields:
+      | field | value |
+    Then the audit call should return an error wrapping "ErrValidation"
+    And the audit call should return an error wrapping "ErrMissingRequiredField"
+    And the audit call should return an error NOT wrapping "ErrUnknownEventType"
+    And the audit call should return an error NOT wrapping "ErrUnknownField"
+
+  # --- Unknown field (strict mode) ---
+
+  Scenario: Unknown field in strict mode wraps ErrValidation and ErrUnknownField
+    Given a logger with stdout output
+    When I audit event "auth_failure" with required fields and an unknown field "bogus"
+    Then the audit call should return an error wrapping "ErrValidation"
+    And the audit call should return an error wrapping "ErrUnknownField"
+    And the audit call should return an error NOT wrapping "ErrUnknownEventType"
+    And the audit call should return an error NOT wrapping "ErrMissingRequiredField"
+
+  # --- Non-validation errors ---
+
+  Scenario: ErrClosed is not ErrValidation
+    Given a logger with stdout output
+    When I close the logger
+    And I audit event "auth_failure" with required fields
+    Then the audit call should return an error wrapping "ErrClosed"
+    And the audit call should return an error NOT wrapping "ErrValidation"

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -432,6 +432,7 @@ func registerAuditThenOutputSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 	ctx.Step(`^the output should contain field "([^"]*)" as a positive integer$`, func(f string) error { return assertFieldPositiveInt(tc, f) })
 	ctx.Step(`^the output should not contain field "([^"]*)"$`, func(f string) error { return assertFieldAbsent(tc, f) })
 	ctx.Step(`^the audit call should return an error wrapping "([^"]*)"$`, func(s string) error { return assertSentinelError(tc, s) })
+	ctx.Step(`^the audit call should return an error NOT wrapping "([^"]*)"$`, func(s string) error { return assertNotSentinelError(tc, s) })
 }
 
 func assertNoEvents(tc *AuditTestContext) error {
@@ -543,21 +544,40 @@ func assertEventMatching(tc *AuditTestContext, table *godog.Table) error {
 	return fmt.Errorf("no event matching expected fields in %d events", len(events))
 }
 
+// sentinelsByName maps BDD sentinel names to their Go error values.
+var sentinelsByName = map[string]error{
+	"ErrClosed":               audit.ErrClosed,
+	"ErrBufferFull":           audit.ErrBufferFull,
+	"ErrValidation":           audit.ErrValidation,
+	"ErrUnknownEventType":     audit.ErrUnknownEventType,
+	"ErrMissingRequiredField": audit.ErrMissingRequiredField,
+	"ErrUnknownField":         audit.ErrUnknownField,
+}
+
 func assertSentinelError(tc *AuditTestContext, sentinel string) error {
 	if tc.LastErr == nil {
 		return fmt.Errorf("expected error wrapping %q, got nil", sentinel)
 	}
-	switch sentinel {
-	case "ErrClosed":
-		if !errors.Is(tc.LastErr, audit.ErrClosed) {
-			return fmt.Errorf("expected ErrClosed, got: %w", tc.LastErr)
-		}
-	case "ErrBufferFull":
-		if !errors.Is(tc.LastErr, audit.ErrBufferFull) {
-			return fmt.Errorf("expected ErrBufferFull, got: %w", tc.LastErr)
-		}
-	default:
+	target, ok := sentinelsByName[sentinel]
+	if !ok {
 		return fmt.Errorf("unknown sentinel: %s", sentinel)
+	}
+	if !errors.Is(tc.LastErr, target) {
+		return fmt.Errorf("expected %s, got: %w", sentinel, tc.LastErr)
+	}
+	return nil
+}
+
+func assertNotSentinelError(tc *AuditTestContext, sentinel string) error {
+	if tc.LastErr == nil {
+		return nil // no error means it does not wrap anything
+	}
+	target, ok := sentinelsByName[sentinel]
+	if !ok {
+		return fmt.Errorf("unknown sentinel: %s", sentinel)
+	}
+	if errors.Is(tc.LastErr, target) {
+		return fmt.Errorf("expected error NOT wrapping %s, but it does: %w", sentinel, tc.LastErr)
 	}
 	return nil
 }

--- a/validate_fields.go
+++ b/validate_fields.go
@@ -15,7 +15,6 @@
 package audit
 
 import (
-	"fmt"
 	"log/slog"
 	"slices"
 	"strings"
@@ -40,7 +39,7 @@ func checkRequiredFields(eventType string, def *EventDef, fields Fields) error {
 		return nil
 	}
 	slices.Sort(missing)
-	return fmt.Errorf("audit: event %q missing required fields: [%s]",
+	return newValidationError(ErrMissingRequiredField, "audit: event %q missing required fields: [%s]",
 		eventType, strings.Join(missing, ", "))
 }
 
@@ -65,7 +64,7 @@ func (l *Logger) checkUnknownFields(eventType string, def *EventDef, fields Fiel
 
 	switch l.cfg.ValidationMode {
 	case ValidationStrict:
-		return fmt.Errorf("audit: event %q has unknown fields: [%s]",
+		return newValidationError(ErrUnknownField, "audit: event %q has unknown fields: [%s]",
 			eventType, strings.Join(unknown, ", "))
 	case ValidationWarn:
 		slog.Warn("audit: event has unknown fields",

--- a/validation_error_test.go
+++ b/validation_error_test.go
@@ -1,0 +1,307 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// errors.Is — parent sentinel covers all validation failures (#400 AC-1)
+// ---------------------------------------------------------------------------
+
+func TestAuditEvent_AllValidationErrors_WrapErrValidation(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	tests := []struct { //nolint:govet // fieldalignment: test readability
+		name      string
+		eventType string
+		fields    audit.Fields
+	}{
+		{
+			name:      "unknown event type",
+			eventType: "nonexistent",
+			fields:    audit.Fields{},
+		},
+		{
+			name:      "missing required field",
+			eventType: "auth_failure",
+			fields:    audit.Fields{}, // outcome and actor_id required
+		},
+		{
+			name:      "unknown field strict",
+			eventType: "auth_failure",
+			fields:    audit.Fields{"outcome": "ok", "actor_id": "a", "bogus": "val"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := logger.AuditEvent(audit.NewEvent(tt.eventType, tt.fields))
+			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrValidation, "all validation errors must wrap ErrValidation")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// errors.Is — specific sentinels (#400 AC-2, AC-3, AC-4)
+// ---------------------------------------------------------------------------
+
+func TestAuditEvent_UnknownEventType_WrapsErrUnknownEventType(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	err = logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrUnknownEventType)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	// Mutual exclusivity: not the other sentinels.
+	assert.False(t, errors.Is(err, audit.ErrMissingRequiredField))
+	assert.False(t, errors.Is(err, audit.ErrUnknownField))
+}
+
+func TestAuditEvent_MissingRequired_WrapsErrMissingRequiredField(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	// Mutual exclusivity.
+	assert.False(t, errors.Is(err, audit.ErrUnknownEventType))
+	assert.False(t, errors.Is(err, audit.ErrUnknownField))
+}
+
+func TestAuditEvent_UnknownFieldStrict_WrapsErrUnknownField(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "fail",
+		"actor_id": "bob",
+		"bogus":    "val",
+	}))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrUnknownField)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	// Mutual exclusivity.
+	assert.False(t, errors.Is(err, audit.ErrUnknownEventType))
+	assert.False(t, errors.Is(err, audit.ErrMissingRequiredField))
+}
+
+// ---------------------------------------------------------------------------
+// errors.Is — non-validation errors not affected (#400 AC-5, AC-6)
+// ---------------------------------------------------------------------------
+
+func TestErrBufferFull_NotErrValidation(t *testing.T) {
+	t.Parallel()
+	assert.False(t, errors.Is(audit.ErrBufferFull, audit.ErrValidation),
+		"ErrBufferFull must NOT be ErrValidation")
+}
+
+func TestErrClosed_NotErrValidation(t *testing.T) {
+	t.Parallel()
+	assert.False(t, errors.Is(audit.ErrClosed, audit.ErrValidation),
+		"ErrClosed must NOT be ErrValidation")
+}
+
+// ---------------------------------------------------------------------------
+// errors.As — ValidationError struct access
+// ---------------------------------------------------------------------------
+
+func TestValidationError_ErrorsAs(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	err = logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	require.Error(t, err)
+
+	var ve *audit.ValidationError
+	require.True(t, errors.As(err, &ve), "should be extractable via errors.As")
+	assert.Contains(t, ve.Error(), "nonexistent")
+}
+
+// ---------------------------------------------------------------------------
+// Error message text unchanged (#400 AC-7)
+// ---------------------------------------------------------------------------
+
+func TestValidationError_MessageTextUnchanged(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	// Unknown event type — exact text check.
+	err = logger.AuditEvent(audit.NewEvent("bogus", audit.Fields{}))
+	require.Error(t, err)
+	assert.Equal(t, `audit: unknown event type "bogus"`, err.Error())
+
+	// Missing required — text starts with expected prefix.
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `audit: event "auth_failure" missing required fields:`)
+}
+
+// ---------------------------------------------------------------------------
+// Consumer wrapping preserves errors.Is
+// ---------------------------------------------------------------------------
+
+func TestValidationError_ConsumerWrapping_PreservesErrorsIs(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	inner := logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	require.Error(t, inner)
+
+	// Consumer wraps the error with additional context.
+	wrapped := fmt.Errorf("my service: %w", inner)
+	assert.ErrorIs(t, wrapped, audit.ErrValidation)
+	assert.ErrorIs(t, wrapped, audit.ErrUnknownEventType)
+}
+
+// ---------------------------------------------------------------------------
+// Warn/permissive modes do not leak sentinels
+// ---------------------------------------------------------------------------
+
+func TestAuditEvent_WarnMode_NoSentinelLeak(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithValidationMode(audit.ValidationWarn),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "fail",
+		"actor_id": "bob",
+		"bogus":    "val",
+	}))
+	assert.NoError(t, err, "warn mode should not return an error")
+}
+
+func TestAuditEvent_PermissiveMode_NoSentinelLeak(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithValidationMode(audit.ValidationPermissive),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "fail",
+		"actor_id": "bob",
+		"bogus":    "val",
+	}))
+	assert.NoError(t, err, "permissive mode should not return an error")
+}
+
+// ---------------------------------------------------------------------------
+// Reserved standard fields do not trigger ErrUnknownField
+// ---------------------------------------------------------------------------
+
+func TestAuditEvent_ReservedStandardField_NotErrUnknownField(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	// actor_id is a reserved standard field — should not trigger unknown field.
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":   "fail",
+		"actor_id":  "bob",
+		"source_ip": "10.0.0.1", // reserved standard field
+	}))
+	assert.NoError(t, err, "reserved standard fields must not trigger ErrUnknownField")
+}
+
+// ---------------------------------------------------------------------------
+// Empty string event type wraps ErrUnknownEventType
+// ---------------------------------------------------------------------------
+
+func TestAuditEvent_EmptyEventType_WrapsErrUnknownEventType(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	err = logger.AuditEvent(audit.NewEvent("", audit.Fields{}))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrUnknownEventType)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+}


### PR DESCRIPTION
## Summary

- Add `ErrValidation` parent sentinel and specific sentinels: `ErrUnknownEventType`, `ErrMissingRequiredField`, `ErrUnknownField`
- Implement `ValidationError` struct with `Unwrap() []error` for multi-sentinel matching via `errors.Is`
- Error message text is unchanged — sentinels are additive wrapping
- Pre-allocated `[2]error` array in `Unwrap()` to avoid per-call heap allocation

Parent issue: #387 (Phase 1)
Closes #400

## Test plan

- [x] `make check` passes
- [x] 12 new unit tests in `validation_error_test.go`: sentinels, mutual exclusivity, errors.As, message stability, consumer wrapping, warn/permissive modes, reserved fields
- [x] `errors.Is` assertions added to 3 existing tests
- [x] New BDD feature: `error_discrimination.feature` (5 scenarios)
- [x] Agent reviews: code-reviewer (1 blocking fixed), api-ergonomics (approved, Message() removed), go-quality (lint clean)
- [x] Pre-coding consultations: code-reviewer, test-analyst, api-ergonomics