### PR TITLE
refactor: make coreMetrics a LoadOption, last-wins guard (#390)

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -465,15 +465,25 @@ func TestWithStandardFieldDefaults_EmptyStringOverride(t *testing.T) {
 	assert.Equal(t, "", record["source_ip"], "empty string counts as set -- no default applied")
 }
 
-func TestWithStandardFieldDefaults_SetOnce(t *testing.T) {
+func TestWithStandardFieldDefaults_LastWins(t *testing.T) {
 	t.Parallel()
-	_, err := audit.NewLogger(
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "a"}),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "b"}),
+		audit.WithValidationMode(audit.ValidationPermissive),
+		audit.WithOutputs(out),
 	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "standard field defaults already set")
+	require.NoError(t, err, "multiple WithStandardFieldDefaults calls should not error (last wins)")
+
+	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "ok"}))
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+	require.Equal(t, 1, out.EventCount())
+
+	ev := out.GetEvent(0)
+	assert.Equal(t, "b", ev["source_ip"], "second call should win (last wins)")
 }
 
 func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -72,7 +72,7 @@ Complete example:
 ref+openbao://secret/data/audit/hmac#salt
 ```
 
-`ParseRef` returns `(zero, nil)` when the input does not start with
+`ParseRef` returns `(zero)` when the input does not start with
 `ref+` -- the value is treated as a literal. It returns
 `(zero, ErrMalformedRef)` when the input starts with `ref+` but
 violates any of the rules above.

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	// 2. Load output configuration from YAML.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/03-standard-fields/main.go
+++ b/examples/03-standard-fields/main.go
@@ -47,18 +47,15 @@ func main() {
 
 	// Load output config — app_name, host, timezone, and
 	// standard_fields defaults are set here.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}
 
-	// The standard_fields section provides deployment-wide defaults.
-	// Here, source_ip defaults to "10.0.0.1" for every event.
+	// result.Options includes WithStandardFieldDefaults automatically
+	// when standard_fields: is present in the YAML config.
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	if result.StandardFields != nil {
-		opts = append(opts, audit.WithStandardFieldDefaults(result.StandardFields))
-	}
 
 	logger, err := audit.NewLogger(opts...)
 	if err != nil {

--- a/examples/04-stdout-output/main.go
+++ b/examples/04-stdout-output/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// 2. Load output configuration — stdout needs no blank import.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/05-file-output/main.go
+++ b/examples/05-file-output/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/06-syslog-output/main.go
+++ b/examples/06-syslog-output/main.go
@@ -56,7 +56,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/07-webhook-output/main.go
+++ b/examples/07-webhook-output/main.go
@@ -58,7 +58,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/08-loki-output/main.go
+++ b/examples/08-loki-output/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	// Load output configuration — creates the Loki output from YAML.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, taxonomy, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, taxonomy)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/09-multi-output/main.go
+++ b/examples/09-multi-output/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/10-tls-policy/main.go
+++ b/examples/10-tls-policy/main.go
@@ -50,7 +50,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/11-event-routing/main.go
+++ b/examples/11-event-routing/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/12-sensitivity-labels/main.go
+++ b/examples/12-sensitivity-labels/main.go
@@ -57,7 +57,7 @@ func createLogger() *audit.Logger {
 	if err != nil {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/13-hmac-integrity/main.go
+++ b/examples/13-hmac-integrity/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	// 2. Load output configuration (includes HMAC settings).
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/14-formatters/main.go
+++ b/examples/14-formatters/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/16-crud-api/audit_setup.go
+++ b/examples/16-crud-api/audit_setup.go
@@ -50,7 +50,7 @@ func setupAuditLogger(tax *audit.Taxonomy, m *auditMetrics) (*audit.Logger, erro
 	// for event counting, buffer drops, and validation errors.
 	// Output-specific metrics (file.Metrics, loki.Metrics) will be
 	// auto-detected via type assertion once #386 lands.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, m)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, outputconfig.WithCoreMetrics(m))
 	if err != nil {
 		return nil, fmt.Errorf("load output config: %w", err)
 	}

--- a/examples/17-testing/main.go
+++ b/examples/17-testing/main.go
@@ -74,7 +74,7 @@ func main() {
 		log.Fatalf("parse taxonomy: %v", err)
 	}
 
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/examples/18-buffering/main.go
+++ b/examples/18-buffering/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	// Load output configuration.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, nil)
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
 	if err != nil {
 		log.Fatalf("load outputs: %v", err)
 	}

--- a/options.go
+++ b/options.go
@@ -115,13 +115,9 @@ func WithTimezone(tz string) Option {
 // reserved standard fields. Defaults are applied in [Logger.AuditEvent]
 // before validation — a default satisfies required: true constraints.
 // Per-event values always override defaults (key existence check, not
-// zero value). This option may be called at most once; a second call
-// returns an error.
+// zero value). When called multiple times, the last call wins.
 func WithStandardFieldDefaults(defaults map[string]string) Option {
 	return func(l *Logger) error {
-		if l.standardFieldDefaults != nil {
-			return fmt.Errorf("audit: standard field defaults already set -- cannot be overridden")
-		}
 		for k := range defaults {
 			if !IsReservedStandardField(k) {
 				return fmt.Errorf("audit: standard field default key %q is not a reserved standard field", k)

--- a/outputconfig/options.go
+++ b/outputconfig/options.go
@@ -17,6 +17,7 @@ package outputconfig
 import (
 	"time"
 
+	audit "github.com/axonops/go-audit"
 	"github.com/axonops/go-audit/secrets"
 )
 
@@ -29,6 +30,7 @@ type LoadOption func(*loadOptions)
 
 // loadOptions holds the resolved options for a Load call.
 type loadOptions struct {
+	coreMetrics   audit.Metrics
 	providers     []secrets.Provider
 	secretTimeout time.Duration
 }
@@ -52,6 +54,17 @@ func WithSecretTimeout(d time.Duration) LoadOption {
 		if d > 0 {
 			o.secretTimeout = d
 		}
+	}
+}
+
+// WithCoreMetrics sets the core [audit.Metrics] implementation that is
+// forwarded to output factories during construction. If m is nil,
+// factories receive nil metrics (equivalent to not calling this option).
+// This option replaces the former positional `coreMetrics` parameter
+// on [Load].
+func WithCoreMetrics(m audit.Metrics) LoadOption {
+	return func(o *loadOptions) {
+		o.coreMetrics = m
 	}
 }
 

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -150,7 +150,7 @@ func (o *NamedOutput) String() string {
 // The ctx parameter controls timeout for network I/O during secret
 // resolution. Use [WithSecretTimeout] to configure the resolution
 // timeout.
-func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, coreMetrics audit.Metrics, opts ...LoadOption) (*LoadResult, error) { //nolint:gocognit,gocyclo,cyclop // linear pipeline with 8+ phases
+func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...LoadOption) (*LoadResult, error) { //nolint:gocognit,gocyclo,cyclop // linear pipeline with 8+ phases
 	lo := resolveOptions(opts)
 
 	// Build the secret resolver from registered providers.
@@ -239,7 +239,7 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, coreMetric
 		}
 		seen[name] = struct{}{}
 
-		no, err := buildOutput(secretCtx, name, item.Value, taxonomy, top.tlsPolicyRaw, top.appName, top.host, coreMetrics, secretResolver)
+		no, err := buildOutput(secretCtx, name, item.Value, taxonomy, top.tlsPolicyRaw, top.appName, top.host, lo.coreMetrics, secretResolver)
 		if err != nil {
 			closeAll(outputs)
 			return nil, fmt.Errorf("%w: %w", ErrOutputConfigInvalid, err)

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -72,7 +72,7 @@ func TestLoad_MinimalStdout(t *testing.T) {
 	require.NoError(t, err)
 
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -95,7 +95,7 @@ func TestLoad_FileWithRoute(t *testing.T) {
 	require.NoError(t, err)
 
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -133,7 +133,7 @@ outputs:
       path: ` + filepath.Join(dir, "b.log") + `
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 3)
 
@@ -183,7 +183,7 @@ outputs:
     formatter:
       type: %s
 `, tt.formatter))
-			_, err := outputconfig.Load(context.Background(), data, tax, nil)
+			_, err := outputconfig.Load(context.Background(), data, tax)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "loki does not support custom formatters")
 			assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
@@ -231,7 +231,7 @@ outputs:
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tax := testTaxonomy(t)
-			result, err := outputconfig.Load(context.Background(), []byte(tt.yaml), tax, nil)
+			result, err := outputconfig.Load(context.Background(), []byte(tt.yaml), tax)
 			require.NoError(t, err)
 			assert.Len(t, result.Outputs, 1)
 			require.NotNil(t, result.Outputs[0].Formatter, "explicit JSON should set per-output formatter")
@@ -258,7 +258,7 @@ outputs:
   console:
     type: stdout
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "default_formatter has been removed")
 	assert.Contains(t, err.Error(), "set formatter on each output individually")
@@ -278,7 +278,7 @@ outputs:
   console:
     type: stdout
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "default_formatter has been removed")
 }
@@ -296,7 +296,7 @@ outputs:
   loki_out:
     type: loki
 `)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	assert.Len(t, result.Outputs, 2)
@@ -324,7 +324,7 @@ outputs:
     formatter:
       type: cef
 `)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err, "disabled Loki output with CEF formatter should not cause an error")
 	assert.Len(t, result.Outputs, 1, "only the stdout output should be active")
 	_ = result.Outputs[0].Output.Close()
@@ -342,7 +342,7 @@ outputs:
     type: loki
     formatter: cef
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "loki does not support custom formatters")
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
@@ -366,7 +366,7 @@ outputs:
       version: "1.0"
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.NoError(t, err)
 
 	assert.Len(t, result.Outputs, 1)
@@ -387,7 +387,7 @@ outputs:
     enabled: false
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.NoError(t, err)
 
 	assert.Len(t, result.Outputs, 1)
@@ -407,7 +407,7 @@ outputs:
     enabled: true
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 1)
 	_ = result.Outputs[0].Output.Close()
@@ -417,7 +417,7 @@ outputs:
 
 func TestLoad_EmptyInput(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), nil, tax, nil)
+	_, err := outputconfig.Load(context.Background(), nil, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "empty")
@@ -429,7 +429,7 @@ func TestLoad_OversizedInput(t *testing.T) {
 	for i := range big {
 		big[i] = 'x'
 	}
-	_, err := outputconfig.Load(context.Background(), big, tax, nil)
+	_, err := outputconfig.Load(context.Background(), big, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "exceeds maximum")
@@ -437,7 +437,7 @@ func TestLoad_OversizedInput(t *testing.T) {
 
 func TestLoad_InvalidYAML(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("{{broken"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("{{broken"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
@@ -445,7 +445,7 @@ func TestLoad_InvalidYAML(t *testing.T) {
 func TestLoad_MultiDocument(t *testing.T) {
 	tax := testTaxonomy(t)
 	yaml := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n---\nversion: 1\n")
-	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "multiple YAML documents")
@@ -453,7 +453,7 @@ func TestLoad_MultiDocument(t *testing.T) {
 
 func TestLoad_Version0(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 0\noutputs:\n  c:\n    type: stdout\n"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 0\noutputs:\n  c:\n    type: stdout\n"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unsupported version")
@@ -461,7 +461,7 @@ func TestLoad_Version0(t *testing.T) {
 
 func TestLoad_Version2(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 2\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 2\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unsupported version")
@@ -469,7 +469,7 @@ func TestLoad_Version2(t *testing.T) {
 
 func TestLoad_NoOutputs(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\n"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\n"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "at least one output")
@@ -477,7 +477,7 @@ func TestLoad_NoOutputs(t *testing.T) {
 
 func TestLoad_EmptyOutputs(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs: {}\n"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs: {}\n"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "at least one output")
@@ -486,7 +486,7 @@ func TestLoad_EmptyOutputs(t *testing.T) {
 func TestLoad_MissingType(t *testing.T) {
 	tax := testTaxonomy(t)
 	yaml := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    enabled: true\n")
-	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "missing required field 'type'")
@@ -495,7 +495,7 @@ func TestLoad_MissingType(t *testing.T) {
 func TestLoad_UnknownType(t *testing.T) {
 	tax := testTaxonomy(t)
 	yaml := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: kafka\n")
-	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown output type \"kafka\"")
@@ -506,7 +506,7 @@ func TestLoad_DuplicateOutputName(t *testing.T) {
 	// goccy/go-yaml detects duplicate mapping keys at parse time.
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  dupe:\n    type: stdout\n  dupe:\n    type: stdout\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "dupe")
@@ -515,7 +515,7 @@ func TestLoad_DuplicateOutputName(t *testing.T) {
 func TestLoad_TwoDistinctNames(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  a:\n    type: stdout\n  b:\n    type: stdout\n")
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 2)
 	for _, o := range result.Outputs {
@@ -526,7 +526,7 @@ func TestLoad_TwoDistinctNames(t *testing.T) {
 func TestLoad_UnknownTopLevelKey(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\nmetrics: true\noutputs:\n  c:\n    type: stdout\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown top-level key")
@@ -536,7 +536,7 @@ func TestLoad_UnknownTopLevelKey(t *testing.T) {
 func TestLoad_AllDisabled(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  a:\n    type: stdout\n    enabled: false\n  b:\n    type: stdout\n    enabled: false\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "all outputs are disabled")
@@ -554,7 +554,7 @@ outputs:
     route:
       include_categories: [nonexistent]
 `)
-	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "bad")
@@ -574,7 +574,7 @@ outputs:
       include_categories: [write]
       exclude_categories: [security]
 `)
-	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "bad")
@@ -595,7 +595,7 @@ outputs:
       path: ${TEST_AUDIT_PATH}
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 1)
 	_ = result.Outputs[0].Output.Close()
@@ -613,7 +613,7 @@ outputs:
       path: ${TOTALLY_MISSING_VAR}
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "TOTALLY_MISSING_VAR")
@@ -630,7 +630,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	result, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.NoError(t, err)
 
 	// Options should contain at least one WithNamedOutput.
@@ -657,7 +657,7 @@ outputs:
       address: localhost:514
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), yaml, tax, nil)
+	_, err := outputconfig.Load(context.Background(), yaml, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "does not match type")
@@ -667,21 +667,21 @@ outputs:
 
 func TestLoad_TopLevelSequence_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("- item1\n- item2\n"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("- item1\n- item2\n"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
 
 func TestLoad_OutputsIsSequence_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  - stdout\n"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  - stdout\n"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
 
 func TestLoad_OutputValueIsScalar_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad: scalar_value\n"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad: scalar_value\n"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "bad")
@@ -689,7 +689,7 @@ func TestLoad_OutputValueIsScalar_ReturnsError(t *testing.T) {
 
 func TestLoad_EnabledInvalidValue_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    enabled: not_a_bool\n"), tax, nil)
+	_, err := outputconfig.Load(context.Background(), []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    enabled: not_a_bool\n"), tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
@@ -697,7 +697,7 @@ func TestLoad_EnabledInvalidValue_ReturnsError(t *testing.T) {
 func TestLoad_TwoTypeConfigBlocks_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    file:\n      path: /tmp/a\n    syslog:\n      network: tcp\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unexpected key")
@@ -707,7 +707,7 @@ func TestLoad_TwoTypeConfigBlocks_ReturnsError(t *testing.T) {
 func TestLoad_RouteUnknownField_Rejected(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    route:\n      include_category: [write]\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
@@ -715,7 +715,7 @@ func TestLoad_RouteUnknownField_Rejected(t *testing.T) {
 func TestLoad_PerOutputFormatterInvalid_ReturnsError(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    formatter:\n      type: protobuf\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "protobuf")
@@ -724,7 +724,7 @@ func TestLoad_PerOutputFormatterInvalid_ReturnsError(t *testing.T) {
 func TestLoad_RouteWithEventTypes(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  filtered:\n    type: stdout\n    route:\n      include_event_types: [user_create]\n")
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.NotNil(t, result.Outputs[0].Route)
 	assert.Equal(t, []string{"user_create"}, result.Outputs[0].Route.IncludeEventTypes)
@@ -734,7 +734,7 @@ func TestLoad_RouteWithEventTypes(t *testing.T) {
 func TestLoad_RouteExcludeEventTypes(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  filtered:\n    type: stdout\n    route:\n      exclude_event_types: [auth_failure]\n")
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.NotNil(t, result.Outputs[0].Route)
 	assert.Equal(t, []string{"auth_failure"}, result.Outputs[0].Route.ExcludeEventTypes)
@@ -745,7 +745,7 @@ func TestLoad_EnabledFalseBeforeType(t *testing.T) {
 	// Verify enabled: false works regardless of key ordering in YAML.
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  active:\n    type: stdout\n  skipped:\n    enabled: false\n    type: stdout\n")
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	assert.Len(t, result.Outputs, 1)
 	assert.Equal(t, "active", result.Outputs[0].Name)
@@ -755,7 +755,7 @@ func TestLoad_EnabledFalseBeforeType(t *testing.T) {
 func TestLoad_MissingEnvVarInFormatter(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    formatter:\n      type: json\n      timestamp: ${MISSING_FMT_VAR}\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "MISSING_FMT_VAR")
@@ -765,7 +765,7 @@ func TestLoad_MissingEnvVarInRoute(t *testing.T) {
 	tax := testTaxonomy(t)
 	// Route values are string sequences — env var in a sequence element.
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  bad:\n    type: stdout\n    route:\n      include_categories:\n        - ${MISSING_ROUTE_VAR}\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "MISSING_ROUTE_VAR")
@@ -791,7 +791,7 @@ outputs:
       include_categories: [write]
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), yamlCfg, tax, nil)
+	result, err := outputconfig.Load(context.Background(), yamlCfg, tax)
 	require.NoError(t, err)
 
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
@@ -833,7 +833,7 @@ func TestLoad_ClosesOutputOnRouteError(t *testing.T) {
 	})
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  leak:\n    type: spy\n    route:\n      include_categories: [nonexistent]\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.True(t, spy.closed.Load(), "output must be closed when buildRoute fails")
 }
@@ -845,7 +845,7 @@ func TestLoad_ClosesOutputOnFormatterError(t *testing.T) {
 	})
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  leak:\n    type: spy\n    formatter:\n      type: protobuf\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.True(t, spy.closed.Load(), "output must be closed when buildOutputFormatter fails")
 }
@@ -858,7 +858,7 @@ func TestLoad_ClosesEarlierOutputsWhenLaterFails(t *testing.T) {
 	tax := testTaxonomy(t)
 	// First output (spy) succeeds. Second output (unknown type) fails.
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  good:\n    type: spy\n  bad:\n    type: nonexistent_type\n")
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.True(t, spy.closed.Load(),
 		"first output must be closed when second output construction fails")
@@ -867,7 +867,7 @@ func TestLoad_ClosesEarlierOutputsWhenLaterFails(t *testing.T) {
 func TestLoadResult_String_NoCredentials(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  console:\n    type: stdout\n")
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	s := result.String()
@@ -910,7 +910,7 @@ outputs:
     route:
       min_severity: 7
 `)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].Route)
@@ -931,7 +931,7 @@ outputs:
     route:
       max_severity: 3
 `)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].Route)
@@ -953,7 +953,7 @@ outputs:
       min_severity: 3
       max_severity: 7
 `)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].Route)
@@ -975,7 +975,7 @@ outputs:
     route:
       include_categories: [write]
 `)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].Route)
@@ -996,7 +996,7 @@ outputs:
     route:
       min_severity: 11
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "min_severity 11 out of range 0-10")
 }
@@ -1013,7 +1013,7 @@ outputs:
     route:
       max_severity: -1
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_severity -1 out of range 0-10")
 }
@@ -1031,7 +1031,7 @@ outputs:
       min_severity: 8
       max_severity: 3
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "min_severity 8 exceeds max_severity 3")
 }
@@ -1048,7 +1048,7 @@ outputs:
     route:
       min_severity: 0
 `)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err, "severity 0 is a valid value, not rejected as zero-value")
 	require.NotNil(t, result.Outputs[0].Route.MinSeverity)
 	assert.Equal(t, 0, *result.Outputs[0].Route.MinSeverity,
@@ -1068,7 +1068,7 @@ outputs:
       include_categories: [security]
       min_severity: 7
 `)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.NotNil(t, result.Outputs[0].Route)
 	assert.Equal(t, []string{"security"}, result.Outputs[0].Route.IncludeCategories)
@@ -1118,7 +1118,7 @@ outputs:
       - financial
 `)
 	tax := testTaxonomyWithSensitivity(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	assert.Equal(t, []string{"pii", "financial"}, result.Outputs[0].ExcludeLabels)
@@ -1136,7 +1136,7 @@ outputs:
     exclude_labels: []
 `)
 	tax := testTaxonomyWithSensitivity(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	assert.Empty(t, result.Outputs[0].ExcludeLabels)
@@ -1155,7 +1155,7 @@ outputs:
       - pii
 `)
 	tax := testTaxonomy(t) // no sensitivity config
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	// The Load itself succeeds — validation happens at NewLogger time.
@@ -1179,7 +1179,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.Config.BufferSize, "zero means applyDefaults will set 10000")
@@ -1205,7 +1205,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	assert.Equal(t, 50000, result.Config.BufferSize)
@@ -1227,7 +1227,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	assert.Equal(t, 25000, result.Config.BufferSize)
@@ -1247,7 +1247,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 }
 
@@ -1267,7 +1267,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	assert.Equal(t, 75000, result.Config.BufferSize)
@@ -1290,7 +1290,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	assert.True(t, result.Config.OmitEmpty)
@@ -1308,7 +1308,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "logger")
@@ -1328,7 +1328,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "logger")
@@ -1347,7 +1347,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "non-negative")
@@ -1366,7 +1366,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "exceeds maximum")
@@ -1385,7 +1385,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "non-negative")
@@ -1404,7 +1404,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "exceeds maximum")
@@ -1423,7 +1423,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "duration")
@@ -1442,7 +1442,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown mode")
@@ -1464,7 +1464,7 @@ outputs:
     type: stdout
 `, mode))
 			tax := testTaxonomy(t)
-			result, err := outputconfig.Load(context.Background(), data, tax, nil)
+			result, err := outputconfig.Load(context.Background(), data, tax)
 			require.NoError(t, err)
 			assert.Equal(t, audit.ValidationMode(mode), result.Config.ValidationMode)
 		})
@@ -1490,7 +1490,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 }
@@ -1507,7 +1507,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 }
@@ -1530,7 +1530,7 @@ outputs:
       path: "` + dir + `/audit.log"
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	for _, o := range result.Outputs {
@@ -1568,7 +1568,7 @@ outputs:
       url: "https://example.com"
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 
@@ -1606,7 +1606,7 @@ outputs:
         allow_tls12: true
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 
@@ -1637,7 +1637,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "tls_policy")
@@ -1655,7 +1655,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "tls_policy")
@@ -1682,7 +1682,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	require.NotNil(t, result.Outputs[0].HMACConfig)
@@ -1702,7 +1702,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	assert.Nil(t, result.Outputs[0].HMACConfig)
@@ -1721,7 +1721,7 @@ outputs:
       enabled: false
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	assert.Nil(t, result.Outputs[0].HMACConfig, "disabled HMAC should be nil")
@@ -1744,7 +1744,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least")
 }
@@ -1766,7 +1766,7 @@ outputs:
       hash: MD5
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown")
 }
@@ -1785,7 +1785,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "salt")
 }
@@ -1806,7 +1806,7 @@ outputs:
         value: "valid-salt-sixteen-b!"
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithm")
 }
@@ -1829,7 +1829,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.NotNil(t, result.Outputs[0].HMACConfig)
 	assert.Equal(t, []byte("env-salt-value-sixteen!"), result.Outputs[0].HMACConfig.SaltValue)
@@ -1852,7 +1852,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	// Salt value must NOT appear in the error message.
 	assert.NotContains(t, err.Error(), "short")
@@ -1876,7 +1876,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -1902,7 +1902,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown field")
@@ -1922,7 +1922,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "non-empty")
@@ -1942,7 +1942,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -1964,7 +1964,7 @@ func TestLoad_StandardFields_EnvVarMissing(t *testing.T) {
 
 	data := []byte("version: 1\napp_name: test\nhost: test\nstandard_fields:\n  source_ip: \"${" + missingVar + "}\"\noutputs:\n  console:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), missingVar)
@@ -1982,7 +1982,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 }
@@ -2005,7 +2005,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -2036,7 +2036,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -2060,7 +2060,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -2083,7 +2083,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, o := range result.Outputs {
@@ -2104,7 +2104,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "app_name is required")
@@ -2120,7 +2120,7 @@ outputs:
     type: stdout
 `)
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "host is required")
@@ -2132,7 +2132,7 @@ func TestLoad_AppNameTooLong_Rejected(t *testing.T) {
 	longName := strings.Repeat("a", 256)
 	data := []byte("version: 1\napp_name: " + longName + "\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "app_name exceeds maximum length")
@@ -2144,7 +2144,7 @@ func TestLoad_HostTooLong_Rejected(t *testing.T) {
 	longHost := strings.Repeat("h", 256)
 	data := []byte("version: 1\napp_name: test\nhost: " + longHost + "\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "host exceeds maximum length")
@@ -2156,7 +2156,7 @@ func TestLoad_TimezoneTooLong_Rejected(t *testing.T) {
 	longTZ := strings.Repeat("Z", 65)
 	data := []byte("version: 1\napp_name: test\nhost: test\ntimezone: " + longTZ + "\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "timezone exceeds maximum length")
@@ -2166,7 +2166,7 @@ func TestLoad_TimezoneEmptyString_Rejected(t *testing.T) {
 	t.Parallel()
 	data := []byte("version: 1\napp_name: test\nhost: test\ntimezone: \"\"\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "timezone must be non-empty")
@@ -2178,7 +2178,7 @@ func TestLoad_AppNameAtMaxLength_Accepted(t *testing.T) {
 	maxName := strings.Repeat("a", 255)
 	data := []byte("version: 1\napp_name: " + maxName + "\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err, "255-byte app_name is exactly at the limit and must be accepted")
 	assert.Equal(t, maxName, result.AppName)
 	for _, o := range result.Outputs {
@@ -2192,7 +2192,7 @@ func TestLoad_HostAtMaxLength_Accepted(t *testing.T) {
 	maxHost := strings.Repeat("h", 255)
 	data := []byte("version: 1\napp_name: test\nhost: " + maxHost + "\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err, "255-byte host is exactly at the limit and must be accepted")
 	assert.Equal(t, maxHost, result.Host)
 	for _, o := range result.Outputs {
@@ -2206,7 +2206,7 @@ func TestLoad_TimezoneAtMaxLength_Accepted(t *testing.T) {
 	maxTZ := strings.Repeat("Z", 64)
 	data := []byte("version: 1\napp_name: test\nhost: test\ntimezone: " + maxTZ + "\noutputs:\n  c:\n    type: stdout\n")
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err, "64-byte timezone is exactly at the limit and must be accepted")
 	assert.Equal(t, maxTZ, result.Timezone)
 	for _, o := range result.Outputs {
@@ -2244,7 +2244,7 @@ outputs:
       hostname: per-output-hostname
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	raw, ok := captured.Load().(string)
@@ -2286,7 +2286,7 @@ outputs:
       address: localhost:514
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	raw, ok := captured.Load().(string)
@@ -2329,7 +2329,7 @@ outputs:
       app_name: per-output-app
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	raw, ok := captured.Load().(string)
@@ -2368,7 +2368,7 @@ outputs:
       url: "https://example.com/hook"
 `)
 	tax := testTaxonomy(t)
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
 	raw, _ := captured.Load().(string)
@@ -2422,7 +2422,7 @@ outputs:
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tax := testTaxonomy(t)
-			result, err := outputconfig.Load(context.Background(), []byte(tt.yaml), tax, nil)
+			result, err := outputconfig.Load(context.Background(), []byte(tt.yaml), tax)
 			require.NoError(t, err)
 			assert.GreaterOrEqual(t, len(result.Options), tt.wantOpts,
 				"got %d options, want at least %d", len(result.Options), tt.wantOpts)
@@ -2475,7 +2475,7 @@ func TestLoad_WithSecretTimeout_Accepted(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretTimeout(5*time.Second),
 	)
 	require.NoError(t, err)
@@ -2491,7 +2491,7 @@ func TestLoad_MultipleLoadOptions_Compose(t *testing.T) {
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	// Multiple options applied — last write wins for timeout.
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretTimeout(5*time.Second),
 		outputconfig.WithSecretTimeout(20*time.Second),
 	)

--- a/outputconfig/secrets_test.go
+++ b/outputconfig/secrets_test.go
@@ -147,7 +147,7 @@ func TestLoad_WithSecretProvider_AllHMACFieldsResolved(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -186,7 +186,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestLoad_WithSecretProvider_HMACDisabledSkipsRefs(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -239,7 +239,7 @@ func TestLoad_WithSecretProvider_HMACDisabledLiteral_SkipsRefs(t *testing.T) {
 		"false",
 	)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
@@ -253,7 +253,7 @@ func TestLoad_WithSecretProvider_NoProviderNoRefsUnchanged(t *testing.T) {
 	t.Parallel()
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
-	result, err := outputconfig.Load(context.Background(), data, tax, nil)
+	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.Len(t, result.Outputs, 1)
 	for _, o := range result.Outputs {
@@ -274,7 +274,7 @@ outputs:
     stdout:
       format: ref+openbao://secret/data/config#format
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	// No provider registered → resolver is nil → refs pass through
 	// env+secret expansion unchanged → safety net catches them.
@@ -288,7 +288,7 @@ func TestLoad_WithSecretProvider_DuplicateSchemeErrors(t *testing.T) {
 	mock2 := newMockProvider("mock", nil)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock1),
 		outputconfig.WithSecretProvider(mock2),
 	)
@@ -321,7 +321,7 @@ outputs:
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	_, err := outputconfig.Load(
-		ctx, data, tax, nil,
+		ctx, data, tax,
 		outputconfig.WithSecretProvider(mock),
 		outputconfig.WithSecretTimeout(50*time.Millisecond),
 	)
@@ -344,7 +344,7 @@ func TestLoad_WithSecretProvider_ErrorNeverContainsSecretValue(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -373,7 +373,7 @@ func TestLoad_WithSecretProvider_PathLevelCache_OneCallForMultipleKeys(t *testin
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -412,7 +412,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -445,7 +445,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock), // mock scheme, not vault
 	)
 	require.Error(t, err)
@@ -468,7 +468,7 @@ func TestLoad_WithSecretProvider_EmptyResolvedValueRejected(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -493,7 +493,7 @@ func TestLoad_WithSecretProvider_OversizedValueRejected(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -515,7 +515,7 @@ func TestLoad_WithSecretProvider_HMACEnabledTrue_RequiresAllFields(t *testing.T)
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -544,7 +544,7 @@ outputs:
     type: stdout
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -577,7 +577,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -620,7 +620,7 @@ outputs:
 	// The resolved value contains "ref+mock://..." which the safety
 	// net should flag as an unresolved reference.
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -655,7 +655,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -693,7 +693,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -725,7 +725,7 @@ outputs:
     type: stdout
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -747,7 +747,7 @@ func TestLoad_WithSecretProvider_NilProviderErrors(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(nil),
 	)
 	require.Error(t, err)
@@ -769,7 +769,7 @@ outputs:
   c:
     type: stdout
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, secrets.ErrUnresolvedRef)
 }
@@ -785,7 +785,7 @@ outputs:
   c:
     type: stdout
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, secrets.ErrUnresolvedRef)
 }
@@ -811,7 +811,7 @@ outputs:
         value: my-salt-value-32-bytes!!!!!!!!
       hash: HMAC-SHA-256
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	// Should get a clear error about no provider, not a toBool error
 	// leaking the ref URI.
@@ -843,7 +843,7 @@ outputs:
         - security
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -875,7 +875,7 @@ outputs:
       version: "1.0"
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.NoError(t, err)
@@ -907,7 +907,7 @@ outputs:
       product: MyProduct
       version: "1.0"
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, secrets.ErrUnresolvedRef)
 }
@@ -928,7 +928,7 @@ outputs:
       include_event_types:
         - ref+openbao://secret/data/routing#event_type
 `)
-	_, err := outputconfig.Load(context.Background(), data, tax, nil)
+	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, secrets.ErrUnresolvedRef)
 }
@@ -954,7 +954,7 @@ func TestLoad_WithSecretProvider_PreCallContextCancelled(t *testing.T) {
 		"ref+mock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		ctx, data, tax, nil,
+		ctx, data, tax,
 		outputconfig.WithSecretProvider(mock),
 		outputconfig.WithSecretTimeout(time.Second),
 	)
@@ -986,7 +986,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1012,7 +1012,7 @@ outputs:
       format: "ref+mock://no-key-fragment"
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1082,7 +1082,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.NoError(t, err)
@@ -1117,7 +1117,7 @@ outputs:
     type: stdout
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.NoError(t, err)
@@ -1152,7 +1152,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.Error(t, err)
@@ -1178,7 +1178,7 @@ func TestLoad_NonBatchProvider_EmptyValueRejected(t *testing.T) {
 		"ref+nbmock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.Error(t, err)
@@ -1206,7 +1206,7 @@ func TestLoad_NonBatchProvider_OversizedValueRejected(t *testing.T) {
 		"ref+nbmock://secret/data/hmac#enabled",
 	)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(p),
 	)
 	require.Error(t, err)
@@ -1243,7 +1243,7 @@ outputs:
       hash: ref+provb://secret/data/hmac#algorithm
 `)
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(provA),
 		outputconfig.WithSecretProvider(provB),
 	)
@@ -1295,7 +1295,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1327,7 +1327,7 @@ outputs:
     type: stdout
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1351,7 +1351,7 @@ outputs:
     type: stdout
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)
@@ -1364,7 +1364,7 @@ func TestLoad_WithSecretProvider_SameInstanceTwice_Error(t *testing.T) {
 	mock := newMockProvider("mock", nil)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 		outputconfig.WithSecretProvider(mock), // same instance
 	)
@@ -1378,7 +1378,7 @@ func TestLoad_WithSecretTimeout_ZeroIgnored(t *testing.T) {
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	// Zero timeout should be silently ignored (keeps 10s default).
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretTimeout(0),
 	)
 	require.NoError(t, err)
@@ -1392,7 +1392,7 @@ func TestLoad_WithSecretTimeout_NegativeIgnored(t *testing.T) {
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  c:\n    type: stdout\n")
 	result, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretTimeout(-5*time.Second),
 	)
 	require.NoError(t, err)
@@ -1431,7 +1431,7 @@ outputs:
       hash: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
-		context.Background(), data, tax, nil,
+		context.Background(), data, tax,
 		outputconfig.WithSecretProvider(mock),
 	)
 	require.Error(t, err)

--- a/outputconfig/tests/bdd/steps/secret_steps.go
+++ b/outputconfig/tests/bdd/steps/secret_steps.go
@@ -235,7 +235,6 @@ func (tc *TestContext) stepLoadYAMLWithProviders(doc *godog.DocString) error {
 		context.Background(),
 		[]byte(doc.Content),
 		tc.Taxonomy,
-		nil,
 		opts...,
 	)
 	if loadErr != nil {

--- a/outputconfig/tests/bdd/steps/steps.go
+++ b/outputconfig/tests/bdd/steps/steps.go
@@ -177,7 +177,7 @@ events:
 			return fmt.Errorf("set AUDIT_BDD_DIR: %w", err)
 		}
 
-		result, loadErr := outputconfig.Load(context.Background(), []byte(doc.Content), tc.Taxonomy, nil)
+		result, loadErr := outputconfig.Load(context.Background(), []byte(doc.Content), tc.Taxonomy)
 		if loadErr != nil {
 			tc.LastErr = loadErr
 			return nil //nolint:nilerr // scenario may assert on tc.LastErr


### PR DESCRIPTION
## Summary

- Move `coreMetrics` from positional parameter to `WithCoreMetrics(m) LoadOption` on `outputconfig.Load`
- Relax `WithStandardFieldDefaults` guard from error-on-second-call to last-wins semantics
- Remove redundant manual StandardFields wiring from Example 03
- Example 16 uses `outputconfig.WithCoreMetrics(m)` instead of positional arg

Parent issue: #387 (Phase 2)
Closes #390

## Test plan

- [x] `make check` passes
- [x] `TestWithStandardFieldDefaults_LastWins` verifies override semantics
- [x] All existing outputconfig tests pass (120+ Load calls updated)
- [x] Pre-coding: api-ergonomics-reviewer approved both changes
- [x] Post-coding: code-reviewer (0 blocking), api-ergonomics (approved), go-quality (lint clean)