### PR TITLE
refactor: per-output OutputOption for WithNamedOutput (#391)

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -1231,9 +1231,9 @@ func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, &audit.EventRoute{
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
-		}, nil),
+		})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = logger.Close() })
@@ -1263,9 +1263,9 @@ func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, &audit.EventRoute{
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			ExcludeCategories: []string{"security"},
-		}, nil),
+		})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = logger.Close() })
@@ -1602,7 +1602,7 @@ func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, nil, nil),
+		audit.WithNamedOutput(out),
 	)
 	require.NoError(t, err)
 
@@ -2030,7 +2030,7 @@ func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
@@ -2060,7 +2060,7 @@ func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
@@ -2270,8 +2270,8 @@ func TestWithNamedOutput_DuplicateDestination_ReturnsError(t *testing.T) {
 	o2 := &destKeyOutput{name: "out2", key: "localhost:514"}
 	_, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(o1, nil, nil),
-		audit.WithNamedOutput(o2, nil, nil),
+		audit.WithNamedOutput(o1),
+		audit.WithNamedOutput(o2),
 	)
 	require.ErrorIs(t, err, audit.ErrDuplicateDestination)
 	assert.Contains(t, err.Error(), "out1")
@@ -2700,9 +2700,9 @@ func BenchmarkAudit_FanOut_MixedFormatters(b *testing.B) {
 	logger, err := audit.NewLogger(
 		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out1, nil, nil),    // default JSON
-		audit.WithNamedOutput(out2, nil, cefFmt), // CEF
-		audit.WithNamedOutput(out3, nil, nil),    // default JSON (shared)
+		audit.WithNamedOutput(out1),                                // default JSON
+		audit.WithNamedOutput(out2, audit.OutputFormatter(cefFmt)), // CEF
+		audit.WithNamedOutput(out3),                                // default JSON (shared)
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -2734,13 +2734,13 @@ func BenchmarkAudit_FanOut_FilteredOutputs(b *testing.B) {
 	logger, err := audit.NewLogger(
 		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out1, nil, nil), // receives all events
-		audit.WithNamedOutput(out2, &audit.EventRoute{
+		audit.WithNamedOutput(out1), // receives all events
+		audit.WithNamedOutput(out2, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
-		}, nil), // receives only write events
-		audit.WithNamedOutput(out3, &audit.EventRoute{
+		})), // receives only write events
+		audit.WithNamedOutput(out3, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
-		}, nil), // receives only security events — filters schema_register
+		})), // receives only security events — filters schema_register
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -2887,13 +2887,12 @@ func BenchmarkAudit_WithHMAC(b *testing.B) {
 	logger, err := audit.NewLogger(
 		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, nil, nil),
-		audit.WithOutputHMAC("bench", &audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   []byte("benchmark-salt-value-32-bytes!!!"),
 			Algorithm:   "HMAC-SHA-256",
-		}),
+		})),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -2921,7 +2920,7 @@ func BenchmarkStandardFieldDefaults_Applied(b *testing.B) {
 	logger, err := audit.NewLogger(
 		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, nil, nil),
+		audit.WithNamedOutput(out),
 		audit.WithStandardFieldDefaults(map[string]string{
 			"source_ip":  "10.0.0.1",
 			"actor_id":   "system",
@@ -2953,7 +2952,7 @@ func BenchmarkDeliverToOutputs_WithMetadataWriter(b *testing.B) {
 	logger, err := audit.NewLogger(
 		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(mock, nil, nil),
+		audit.WithNamedOutput(mock),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -2977,8 +2976,8 @@ func BenchmarkDeliverToOutputs_MixedOutputs(b *testing.B) {
 	logger, err := audit.NewLogger(
 		audit.WithBufferSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(mwOut, nil, nil),
-		audit.WithNamedOutput(plainOut, nil, nil),
+		audit.WithNamedOutput(mwOut),
+		audit.WithNamedOutput(plainOut),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -3469,13 +3468,12 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, nil, nil),
-		audit.WithOutputHMAC("test", &audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   []byte("test-salt-sixteen-bytes!"),
 			Algorithm:   "HMAC-SHA-256",
-		}),
+		})),
 	)
 	require.NoError(t, err)
 
@@ -3525,13 +3523,12 @@ func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, nil, nil),
-		audit.WithOutputHMAC("test", &audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "2026-Q1",
 			SaltValue:   []byte("version-test-salt-16b!"),
 			Algorithm:   "HMAC-SHA-256",
-		}),
+		})),
 	)
 	require.NoError(t, err)
 
@@ -3615,11 +3612,9 @@ events:
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
 		// "full" output: no label exclusions — gets all fields including email.
-		audit.WithNamedOutput(fullOut, nil, nil),
-		audit.WithOutputHMAC("full", fullHMACCfg),
+		audit.WithNamedOutput(fullOut, audit.OutputHMAC(fullHMACCfg)),
 		// "stripped" output: excludes PII — email is removed before HMAC.
-		audit.WithNamedOutput(strippedOut, nil, nil, "pii"),
-		audit.WithOutputHMAC("stripped", strippedHMACCfg),
+		audit.WithNamedOutput(strippedOut, audit.OutputExcludeLabels("pii"), audit.OutputHMAC(strippedHMACCfg)),
 	)
 	require.NoError(t, err)
 
@@ -3685,14 +3680,13 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(hmacOut, nil, nil),
-		audit.WithOutputHMAC("with-hmac", &audit.HMACConfig{
+		audit.WithNamedOutput(hmacOut, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   salt,
 			Algorithm:   "HMAC-SHA-256",
-		}),
-		audit.WithNamedOutput(baseOut, nil, nil),
+		})),
+		audit.WithNamedOutput(baseOut),
 	)
 	require.NoError(t, err)
 
@@ -3763,14 +3757,13 @@ events:
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
 		// Both outputs exclude PII — same payload, one with HMAC.
-		audit.WithNamedOutput(hmacOut, nil, nil, "pii"),
-		audit.WithOutputHMAC("hmac-stripped", &audit.HMACConfig{
+		audit.WithNamedOutput(hmacOut, audit.OutputExcludeLabels("pii"), audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   salt,
 			Algorithm:   "HMAC-SHA-256",
-		}),
-		audit.WithNamedOutput(baseOut, nil, nil, "pii"),
+		})),
+		audit.WithNamedOutput(baseOut, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -4192,7 +4185,7 @@ func TestMetadataWriter_DeliveryReporter_SkipsMetrics(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
@@ -4235,13 +4228,12 @@ func TestMetadataWriter_WithHMAC_ReceivesHMACData(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, nil, nil),
-		audit.WithOutputHMAC("mw-hmac", &audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   []byte("hmac-test-salt-value!"),
 			Algorithm:   "HMAC-SHA-256",
-		}),
+		})),
 	)
 	require.NoError(t, err)
 
@@ -4297,7 +4289,7 @@ events:
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
 		// Exclude PII — email must not appear in the data received by WriteWithMetadata.
-		audit.WithNamedOutput(out, nil, nil, "pii"),
+		audit.WithNamedOutput(out, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -4391,8 +4383,8 @@ func TestMetadataWriter_MixedOutputs_IsolationOnError(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(failingMW, nil, nil),
-		audit.WithNamedOutput(successOut, nil, nil),
+		audit.WithNamedOutput(failingMW),
+		audit.WithNamedOutput(successOut),
 	)
 	require.NoError(t, err)
 
@@ -4426,8 +4418,8 @@ func TestMetadataWriter_CachedAssertion_Correct(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(mwOut, nil, nil),
-		audit.WithNamedOutput(plainOut, nil, nil),
+		audit.WithNamedOutput(mwOut),
+		audit.WithNamedOutput(plainOut),
 	)
 	require.NoError(t, err)
 
@@ -4587,7 +4579,7 @@ events:
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
 		// Excluding "pii" triggers formatWithExclusion (FormatOptions non-nil).
-		audit.WithNamedOutput(out, nil, &exclusionErrorFormatter{}, "pii"),
+		audit.WithNamedOutput(out, audit.OutputFormatter(&exclusionErrorFormatter{}), audit.OutputExcludeLabels("pii")),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)

--- a/doc.go
+++ b/doc.go
@@ -173,7 +173,7 @@
 //   - [ComputeHMAC] — computes HMAC over a payload, returns lowercase hex
 //   - [VerifyHMAC] — verifies an HMAC value matches a payload
 //   - [ValidateHMACConfig] — validates HMAC configuration at startup
-//   - [WithOutputHMAC] — configures HMAC on a named output
+//   - [OutputOption] — per-output configuration for [WithNamedOutput]: [OutputRoute], [OutputFormatter], [OutputExcludeLabels], [OutputHMAC]
 //   - [MigrateTaxonomy] — applies version migration to a [Taxonomy]
 //
 // # How Taxonomy Validation Works

--- a/errors.go
+++ b/errors.go
@@ -103,9 +103,8 @@ var (
 //	var ve *audit.ValidationError
 //	if errors.As(err, &ve) { log.Println(ve.Error()) }
 type ValidationError struct {
-	wrapped  [2]error // pre-allocated to avoid per-Unwrap heap allocation
-	sentinel error
-	msg      string
+	wrapped [2]error // pre-allocated to avoid per-Unwrap heap allocation
+	msg     string
 }
 
 // Error returns the human-readable error message. The text is
@@ -123,8 +122,7 @@ func (e *ValidationError) Unwrap() []error {
 // specific sentinel and formatted message.
 func newValidationError(sentinel error, format string, args ...any) *ValidationError {
 	ve := &ValidationError{
-		sentinel: sentinel,
-		msg:      fmt.Sprintf(format, args...),
+		msg: fmt.Sprintf(format, args...),
 	}
 	ve.wrapped[0] = ErrValidation
 	ve.wrapped[1] = sentinel

--- a/example_test.go
+++ b/example_test.go
@@ -283,7 +283,7 @@ func ExampleLogger_SetOutputRoute() {
 				"auth_failure": {Required: []string{"outcome"}},
 			},
 		}),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -133,7 +133,7 @@ func TestFanout_RouteFiltering(t *testing.T) {
 			logger, err := audit.NewLogger(
 				audit.WithValidationMode(audit.ValidationPermissive),
 				audit.WithTaxonomy(testhelper.TestTaxonomy()),
-				audit.WithNamedOutput(out, &tt.route, nil),
+				audit.WithNamedOutput(out, audit.OutputRoute(&tt.route)),
 			)
 			require.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestFanout_WithOutputs_AfterWithNamedOutput_Error(t *testing.T) {
 	out2 := testhelper.NewMockOutput("plain")
 	_, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out1, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out1, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithOutputs(out2), // should error
 	)
 	require.Error(t, err)
@@ -176,7 +176,7 @@ func TestFanout_WithNamedOutput_AfterWithOutputs_Error(t *testing.T) {
 	_, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1),
-		audit.WithNamedOutput(out2, &audit.EventRoute{}, nil), // should error
+		audit.WithNamedOutput(out2, audit.OutputRoute(&audit.EventRoute{})), // should error
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be used with WithOutputs")
@@ -186,9 +186,9 @@ func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	_, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
-		}, nil),
+		})),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown taxonomy entries")
@@ -198,10 +198,10 @@ func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	_, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
 			ExcludeCategories: []string{"read"},
-		}, nil),
+		})),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "either include or exclude")
@@ -212,7 +212,7 @@ func TestFanout_SetOutputRoute(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 
@@ -239,8 +239,8 @@ func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(outA, &audit.EventRoute{}, nil),
-		audit.WithNamedOutput(outB, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(outA, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(outB, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 
@@ -273,7 +273,7 @@ func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = logger.Close() })
@@ -290,9 +290,9 @@ func TestFanout_ClearOutputRoute(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
-		}, nil),
+		})),
 	)
 	require.NoError(t, err)
 
@@ -322,7 +322,7 @@ func TestFanout_OutputRoute(t *testing.T) {
 	route := audit.EventRoute{IncludeCategories: []string{"security"}}
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &route, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&route)),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = logger.Close() })
@@ -354,7 +354,7 @@ func TestFanout_OutputRoute_ReflectsSetAndClear(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = logger.Close() })
@@ -378,7 +378,7 @@ func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 
@@ -426,9 +426,9 @@ func TestFanout_GlobalFilterTakesPrecedence(t *testing.T) {
 				"auth_failure": {Required: []string{"outcome"}},
 			},
 		}),
-		audit.WithNamedOutput(out, &audit.EventRoute{
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
-		}, nil),
+		})),
 	)
 	require.NoError(t, err)
 
@@ -454,8 +454,8 @@ func TestFanout_PerOutputFormatter(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(jsonOut, &audit.EventRoute{}, nil),
-		audit.WithNamedOutput(cefOut, &audit.EventRoute{}, cefFmt),
+		audit.WithNamedOutput(jsonOut, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(cefOut, audit.OutputRoute(&audit.EventRoute{}), audit.OutputFormatter(cefFmt)),
 	)
 	require.NoError(t, err)
 
@@ -477,7 +477,7 @@ func TestFanout_PanicInFormatter_DrainLoopSurvives(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, &panicFormatter{}),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{}), audit.OutputFormatter(&panicFormatter{})),
 	)
 	require.NoError(t, err)
 
@@ -559,9 +559,9 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithMetrics(metrics),
-		audit.WithNamedOutput(out, &audit.EventRoute{
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
-		}, nil),
+		})),
 	)
 	require.NoError(t, err)
 
@@ -579,9 +579,9 @@ func TestFanout_ExcludeEventType_EndToEnd(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, &audit.EventRoute{
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			ExcludeEventTypes: []string{"config_get"},
-		}, nil),
+		})),
 	)
 	require.NoError(t, err)
 
@@ -607,8 +607,8 @@ func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(goodOut, &audit.EventRoute{}, nil),
-		audit.WithNamedOutput(badOut, &audit.EventRoute{}, &errorFormatter{}),
+		audit.WithNamedOutput(goodOut, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(badOut, audit.OutputRoute(&audit.EventRoute{}), audit.OutputFormatter(&errorFormatter{})),
 	)
 	require.NoError(t, err)
 

--- a/options.go
+++ b/options.go
@@ -123,7 +123,12 @@ func WithStandardFieldDefaults(defaults map[string]string) Option {
 				return fmt.Errorf("audit: standard field default key %q is not a reserved standard field", k)
 			}
 		}
-		l.standardFieldDefaults = defaults
+		// Copy to prevent caller mutation after construction.
+		cp := make(map[string]string, len(defaults))
+		for k, v := range defaults {
+			cp[k] = v
+		}
+		l.standardFieldDefaults = cp
 		return nil
 	}
 }
@@ -178,18 +183,63 @@ func WithOutputs(outputs ...Output) Option {
 	}
 }
 
-// WithNamedOutput adds a single named output with an optional
-// [EventRoute] and per-output [Formatter]. The route restricts which
-// events are delivered to this output. If formatter is nil, the
-// logger's default formatter is used.
-//
-// excludeLabels specifies sensitivity labels whose fields should be
-// stripped from events before delivery to this output. When non-empty,
-// the taxonomy MUST define a [SensitivityConfig] and every label in
-// excludeLabels MUST be defined within it; [NewLogger] returns an
-// error if either condition is violated. An empty slice means no
-// field stripping — the output receives all fields. Framework fields
-// (timestamp, event_type, severity, duration_ms) are never stripped.
+// OutputOption configures a single output registered via
+// [WithNamedOutput]. Use [OutputRoute], [OutputFormatter],
+// [OutputExcludeLabels], and [OutputHMAC] to customise per-output
+// behaviour.
+type OutputOption func(*outputEntryBuilder)
+
+// outputEntryBuilder accumulates per-output configuration before
+// the output entry is registered on the logger.
+type outputEntryBuilder struct {
+	formatter     Formatter
+	route         *EventRoute
+	hmacConfig    *HMACConfig
+	excludeLabels []string
+}
+
+// OutputRoute sets the per-output event route. The route restricts
+// which events are delivered to this output. Nil means all
+// globally-enabled events are delivered.
+func OutputRoute(r *EventRoute) OutputOption {
+	return func(b *outputEntryBuilder) {
+		b.route = r
+	}
+}
+
+// OutputFormatter overrides the logger's default formatter for this
+// output. Nil means the logger's default formatter is used.
+func OutputFormatter(f Formatter) OutputOption {
+	return func(b *outputEntryBuilder) {
+		b.formatter = f
+	}
+}
+
+// OutputExcludeLabels specifies sensitivity labels whose fields should
+// be stripped from events before delivery to this output. When
+// non-empty, the taxonomy MUST define a [SensitivityConfig] and every
+// label MUST be defined within it; [NewLogger] returns an error if
+// either condition is violated. An empty call means no field stripping.
+// Framework fields are never stripped.
+func OutputExcludeLabels(labels ...string) OutputOption {
+	return func(b *outputEntryBuilder) {
+		b.excludeLabels = labels
+	}
+}
+
+// OutputHMAC configures per-output HMAC integrity. The config is
+// validated eagerly during [NewLogger] option application — invalid
+// configs (short salt, unknown algorithm) cause [NewLogger] to return
+// an error. Nil means no HMAC for this output.
+func OutputHMAC(cfg *HMACConfig) OutputOption {
+	return func(b *outputEntryBuilder) {
+		b.hmacConfig = cfg
+	}
+}
+
+// WithNamedOutput adds a single named output with optional per-output
+// configuration. Use [OutputRoute], [OutputFormatter],
+// [OutputExcludeLabels], and [OutputHMAC] to customise behaviour.
 //
 // WithNamedOutput MUST NOT be combined with [WithOutputs]; if
 // [WithOutputs] was already applied, WithNamedOutput returns an error.
@@ -198,18 +248,27 @@ func WithOutputs(outputs ...Output) Option {
 // cause [NewLogger] to return an error. Duplicate destinations are
 // also detected via [DestinationKeyer]. Routes are validated against
 // the taxonomy after all options have been applied.
-func WithNamedOutput(output Output, route *EventRoute, formatter Formatter, excludeLabels ...string) Option {
+func WithNamedOutput(output Output, opts ...OutputOption) Option {
 	return func(l *Logger) error {
 		if l.usedWithOutputs {
 			return fmt.Errorf("audit: WithNamedOutput cannot be used with WithOutputs")
 		}
-		return l.addNamedOutput(output, route, formatter, excludeLabels)
+		var b outputEntryBuilder
+		for _, opt := range opts {
+			opt(&b)
+		}
+		if b.hmacConfig != nil {
+			if err := ValidateHMACConfig(b.hmacConfig); err != nil {
+				return err
+			}
+		}
+		return l.addNamedOutput(output, &b)
 	}
 }
 
 // addNamedOutput registers a named output with dedup checking and
-// optional route/formatter/exclude-label configuration.
-func (l *Logger) addNamedOutput(output Output, route *EventRoute, formatter Formatter, excludeLabels []string) error {
+// optional route/formatter/exclude-label/HMAC configuration.
+func (l *Logger) addNamedOutput(output Output, b *outputEntryBuilder) error {
 	name := output.Name()
 	if l.outputsByName == nil {
 		l.outputsByName = make(map[string]*outputEntry)
@@ -225,41 +284,20 @@ func (l *Logger) addNamedOutput(output Output, route *EventRoute, formatter Form
 	}
 	oe := &outputEntry{
 		output:    output,
-		formatter: formatter,
+		formatter: b.formatter,
 	}
-	if route != nil {
-		oe.setRoute(route)
+	if b.route != nil {
+		oe.setRoute(b.route)
 	}
-	if len(excludeLabels) > 0 {
-		oe.excludedLabels = buildLabelSet(excludeLabels)
+	if len(b.excludeLabels) > 0 {
+		oe.excludedLabels = buildLabelSet(b.excludeLabels)
+	}
+	if b.hmacConfig != nil {
+		oe.hmacConfig = b.hmacConfig
 	}
 	l.entries = append(l.entries, oe)
 	l.outputsByName[name] = oe
 	return nil
-}
-
-// setOutputHMAC configures HMAC on a named output. Called by the
-// outputconfig loader after all outputs have been registered.
-func (l *Logger) setOutputHMAC(name string, cfg *HMACConfig) error {
-	oe, ok := l.outputsByName[name]
-	if !ok {
-		return fmt.Errorf("audit: unknown output %q for hmac configuration", name)
-	}
-	oe.hmacConfig = cfg
-	return nil
-}
-
-// WithOutputHMAC configures HMAC on a named output. Used by the
-// outputconfig loader to apply HMAC settings after output registration.
-// The config is validated — invalid configs (short salt, unknown
-// algorithm) cause [NewLogger] to return an error.
-func WithOutputHMAC(name string, cfg *HMACConfig) Option {
-	return func(l *Logger) error {
-		if err := ValidateHMACConfig(cfg); err != nil {
-			return err
-		}
-		return l.setOutputHMAC(name, cfg)
-	}
 }
 
 // WithBufferSize sets the async channel capacity for the logger.

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -295,12 +295,20 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 	}
 
 	for i := range outputs {
-		result.Options = append(result.Options,
-			audit.WithNamedOutput(outputs[i].Output, outputs[i].Route, outputs[i].Formatter, outputs[i].ExcludeLabels...))
-		if outputs[i].HMACConfig != nil && outputs[i].HMACConfig.Enabled {
-			result.Options = append(result.Options,
-				audit.WithOutputHMAC(outputs[i].Name, outputs[i].HMACConfig))
+		var outOpts []audit.OutputOption
+		if outputs[i].Route != nil {
+			outOpts = append(outOpts, audit.OutputRoute(outputs[i].Route))
 		}
+		if outputs[i].Formatter != nil {
+			outOpts = append(outOpts, audit.OutputFormatter(outputs[i].Formatter))
+		}
+		if len(outputs[i].ExcludeLabels) > 0 {
+			outOpts = append(outOpts, audit.OutputExcludeLabels(outputs[i].ExcludeLabels...))
+		}
+		if outputs[i].HMACConfig != nil && outputs[i].HMACConfig.Enabled {
+			outOpts = append(outOpts, audit.OutputHMAC(outputs[i].HMACConfig))
+		}
+		result.Options = append(result.Options, audit.WithNamedOutput(outputs[i].Output, outOpts...))
 	}
 
 	return result, nil

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -505,7 +505,7 @@ func TestFieldStripping_SingleLabel(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil, "pii"),
+		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -553,7 +553,7 @@ func TestFieldStripping_MultiLabel_AnyOverlap(t *testing.T) {
 	// Exclude financial only — card_number is stripped.
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil, "financial"),
+		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("financial")),
 	)
 	require.NoError(t, err)
 
@@ -586,8 +586,8 @@ func TestFieldStripping_DifferentOutputs(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(outAll, nil, nil),          // no exclusions
-		audit.WithNamedOutput(outNoPII, nil, nil, "pii"), // exclude PII
+		audit.WithNamedOutput(outAll), // no exclusions
+		audit.WithNamedOutput(outNoPII, audit.OutputExcludeLabels("pii")), // exclude PII
 	)
 	require.NoError(t, err)
 
@@ -625,7 +625,7 @@ func TestFieldStripping_NoExclusion_AllFields(t *testing.T) {
 	// No exclude_labels → all fields delivered.
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil),
+		audit.WithNamedOutput(stdout),
 	)
 	require.NoError(t, err)
 
@@ -671,7 +671,7 @@ events:
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil, "pii"),
+		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -717,7 +717,7 @@ events:
 
 	_, err = audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil, "pii"),
+		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no sensitivity config")
@@ -747,7 +747,7 @@ events:
 
 	_, err = audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil, "nonexistent"),
+		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("nonexistent")),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "undefined sensitivity label")
@@ -786,7 +786,7 @@ events:
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil, "pii"),
+		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -826,7 +826,7 @@ func TestFormatWithExclusion_ExclusionPath(t *testing.T) {
 	// Output with exclusions — formatOpts should be pre-allocated.
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil, "pii"),
+		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -863,7 +863,7 @@ func TestFormatWithExclusion_NoExclusionNoOverhead(t *testing.T) {
 	// Output WITHOUT exclusions — formatOpts should be nil.
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, nil, nil),
+		audit.WithNamedOutput(stdout),
 	)
 	require.NoError(t, err)
 
@@ -892,9 +892,9 @@ func TestFormatWithExclusion_MultipleOutputsDifferentExclusions(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(outAll, nil, nil),
-		audit.WithNamedOutput(outNoPII, nil, nil, "pii"),
-		audit.WithNamedOutput(outNoFinancial, nil, nil, "financial"),
+		audit.WithNamedOutput(outAll),
+		audit.WithNamedOutput(outNoPII, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(outNoFinancial, audit.OutputExcludeLabels("financial")),
 	)
 	require.NoError(t, err)
 
@@ -941,7 +941,7 @@ func TestFieldStripping_Concurrent(t *testing.T) {
 	out := testhelper.NewMockOutput("concurrent")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, nil, nil, "pii"),
+		audit.WithNamedOutput(out, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -1113,8 +1113,8 @@ func BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion(b *testing.B) {
 	outFiltered := testhelper.NewMockOutput("filtered")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(outAll, nil, nil),
-		audit.WithNamedOutput(outFiltered, nil, nil, "pii"),
+		audit.WithNamedOutput(outAll),
+		audit.WithNamedOutput(outFiltered, audit.OutputExcludeLabels("pii")),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -1143,7 +1143,7 @@ func benchAuditWithExclusions(b *testing.B, taxonomyYAML string, excludeLabels [
 	out := testhelper.NewMockOutput("bench")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, nil, nil, excludeLabels...),
+		audit.WithNamedOutput(out, audit.OutputExcludeLabels(excludeLabels...)),
 	)
 	if err != nil {
 		b.Fatal(err)

--- a/severity_routing_test.go
+++ b/severity_routing_test.go
@@ -369,7 +369,7 @@ func TestSetRoute_CopiesMinSeverityPointer(t *testing.T) {
 	out := testhelper.NewMockOutput("copy-min")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, logger.Close()) })
@@ -401,7 +401,7 @@ func TestSetRoute_CopiesMaxSeverityPointer(t *testing.T) {
 	out := testhelper.NewMockOutput("copy-max")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, logger.Close()) })
@@ -432,7 +432,7 @@ func TestGetRoute_ReturnsIndependentSeverityPointers(t *testing.T) {
 	out := testhelper.NewMockOutput("get-copy")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, &audit.EventRoute{MinSeverity: intPtr(4)}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(4)})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, logger.Close()) })
@@ -463,7 +463,7 @@ func TestSetRoute_NilSeverityPointersPreserved(t *testing.T) {
 	out := testhelper.NewMockOutput("nil-sev")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, logger.Close()) })
@@ -679,7 +679,7 @@ func TestAudit_SeverityRouteFiltersInDrainLoop(t *testing.T) {
 	out := testhelper.NewMockOutput("sev-filter")
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, &audit.EventRoute{MinSeverity: intPtr(7)}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(7)})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, logger.Close()) })
@@ -735,7 +735,7 @@ events:
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tax),
 		// Output route: MinSeverity 5 — only events with severity >= 5 delivered.
-		audit.WithNamedOutput(out, &audit.EventRoute{MinSeverity: intPtr(5)}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(5)})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, logger.Close()) })
@@ -878,7 +878,7 @@ func TestConcurrentSetRouteWithSeverity(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 

--- a/tests/bdd/steps/fanout_steps.go
+++ b/tests/bdd/steps/fanout_steps.go
@@ -562,7 +562,7 @@ func createErrorOutputLogger(tc *AuditTestContext) error {
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(fileOut),
-		audit.WithNamedOutput(&errorOutput{}, nil, nil),
+		audit.WithNamedOutput(&errorOutput{}),
 	}
 
 	logger, err := audit.NewLogger(opts...)
@@ -597,7 +597,7 @@ func createPanicOutputLogger(tc *AuditTestContext) error {
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(fileOut),
-		audit.WithNamedOutput(&panicOutput{}, nil, nil),
+		audit.WithNamedOutput(&panicOutput{}),
 	}
 
 	logger, err := audit.NewLogger(opts...)

--- a/tests/bdd/steps/fanout_steps.go
+++ b/tests/bdd/steps/fanout_steps.go
@@ -202,8 +202,8 @@ func createSharedFormatterLogger(tc *AuditTestContext) error {
 	// Both outputs share the default JSON formatter (nil = logger default).
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(fA, nil, nil),
-		audit.WithNamedOutput(fB, nil, nil),
+		audit.WithNamedOutput(fA),
+		audit.WithNamedOutput(fB),
 	}
 
 	logger, err := audit.NewLogger(opts...)
@@ -384,10 +384,10 @@ func tryMixedRoute(tc *AuditTestContext) error {
 	}
 	_, err = audit.NewLogger(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(f, &audit.EventRoute{
+		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
 			ExcludeCategories: []string{"read"},
-		}, nil),
+		})),
 	)
 	tc.LastErr = err
 	return nil
@@ -404,9 +404,9 @@ func tryUnknownCategoryRoute(tc *AuditTestContext) error {
 	}
 	_, err = audit.NewLogger(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(f, &audit.EventRoute{
+		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
-		}, nil),
+		})),
 	)
 	tc.LastErr = err
 	return nil
@@ -463,9 +463,9 @@ func tryUnknownEventTypeRoute(tc *AuditTestContext) error {
 	}
 	_, err = audit.NewLogger(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(f, &audit.EventRoute{
+		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
 			IncludeEventTypes: []string{"nonexistent_event"},
-		}, nil),
+		})),
 	)
 	tc.LastErr = err
 	return nil
@@ -499,7 +499,7 @@ func createFanoutLogger(tc *AuditTestContext, useFile, useSyslog, useWebhook boo
 		if err != nil {
 			return fmt.Errorf("create file output: %w", err)
 		}
-		opts = append(opts, audit.WithNamedOutput(f, nil, nil))
+		opts = append(opts, audit.WithNamedOutput(f))
 	}
 
 	if useSyslog {
@@ -510,7 +510,7 @@ func createFanoutLogger(tc *AuditTestContext, useFile, useSyslog, useWebhook boo
 		if err != nil {
 			return fmt.Errorf("create syslog output: %w", err)
 		}
-		opts = append(opts, audit.WithNamedOutput(s, nil, nil))
+		opts = append(opts, audit.WithNamedOutput(s))
 	}
 
 	if useWebhook {
@@ -526,7 +526,7 @@ func createFanoutLogger(tc *AuditTestContext, useFile, useSyslog, useWebhook boo
 		if err != nil {
 			return fmt.Errorf("create webhook output: %w", err)
 		}
-		opts = append(opts, audit.WithNamedOutput(w, nil, webhookFmt))
+		opts = append(opts, audit.WithNamedOutput(w, audit.OutputFormatter(webhookFmt)))
 	}
 
 	logger, err := audit.NewLogger(opts...)
@@ -561,7 +561,7 @@ func createErrorOutputLogger(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(fileOut, nil, nil),
+		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(&errorOutput{}, nil, nil),
 	}
 
@@ -596,7 +596,7 @@ func createPanicOutputLogger(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(fileOut, nil, nil),
+		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(&panicOutput{}, nil, nil),
 	}
 
@@ -645,8 +645,8 @@ func createPanicFormatterLogger(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(fileOut, nil, nil),                        // normal file
-		audit.WithNamedOutput(&devNullOutput{}, nil, &panicFormatter{}), // panicking formatter
+		audit.WithNamedOutput(fileOut), // normal file
+		audit.WithNamedOutput(&devNullOutput{}, audit.OutputFormatter(&panicFormatter{})), // panicking formatter
 	}
 
 	logger, err := audit.NewLogger(opts...)
@@ -679,8 +679,8 @@ func createDualFileRoutedLogger(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(secOut, &audit.EventRoute{IncludeCategories: []string{"security"}}, nil),
-		audit.WithNamedOutput(writeOut, &audit.EventRoute{IncludeCategories: []string{"write"}}, nil),
+		audit.WithNamedOutput(secOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"security"}})),
+		audit.WithNamedOutput(writeOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),
 	}
 
 	logger, err := audit.NewLogger(opts...)
@@ -722,9 +722,9 @@ func createTripleRoutedLogger(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(fileOut, nil, nil), // all events
-		audit.WithNamedOutput(syslogOut, &audit.EventRoute{IncludeCategories: []string{"security"}}, nil), // security only
-		audit.WithNamedOutput(webhookOut, &audit.EventRoute{IncludeCategories: []string{"write"}}, nil),   // write only
+		audit.WithNamedOutput(fileOut), // all events
+		audit.WithNamedOutput(syslogOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"security"}})), // security only
+		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),   // write only
 	}
 
 	logger, err := audit.NewLogger(opts...)
@@ -759,8 +759,8 @@ func createRoutedLogger(tc *AuditTestContext, webhookRoute *audit.EventRoute) er
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(f, nil, nil),
-		audit.WithNamedOutput(w, webhookRoute, nil),
+		audit.WithNamedOutput(f),
+		audit.WithNamedOutput(w, audit.OutputRoute(webhookRoute)),
 	}
 
 	logger, err := audit.NewLogger(opts...)

--- a/tests/bdd/steps/formatter_steps.go
+++ b/tests/bdd/steps/formatter_steps.go
@@ -107,7 +107,7 @@ func registerFormatterGivenCEFSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, nil, cefFmt),
+			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 		opts = append(opts, tc.Options...)
 
@@ -147,8 +147,8 @@ func registerFormatterGivenMultiSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(jsonOut, nil, nil),   // default JSON
-			audit.WithNamedOutput(cefOut, nil, cefFmt), // CEF
+			audit.WithNamedOutput(jsonOut),                               // default JSON
+			audit.WithNamedOutput(cefOut, audit.OutputFormatter(cefFmt)), // CEF
 		}
 
 		logger, err := audit.NewLogger(opts...)
@@ -187,7 +187,7 @@ func registerFormatterGivenCustomSeveritySteps(ctx *godog.ScenarioContext, tc *A
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, nil, cefFmt),
+			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 
 		logger, err := audit.NewLogger(opts...)
@@ -223,7 +223,7 @@ func registerFormatterGivenInvalidKeySteps(ctx *godog.ScenarioContext, tc *Audit
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, nil, cefFmt),
+			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 
 		logger, err := audit.NewLogger(opts...)
@@ -257,7 +257,7 @@ func registerFormatterGivenSeveritySteps(ctx *godog.ScenarioContext, tc *AuditTe
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, nil, cefFmt),
+			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 
 		logger, err := audit.NewLogger(opts...)
@@ -295,7 +295,7 @@ func registerFormatterGivenExtraSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, nil, cefFmt),
+			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 
 		logger, err := audit.NewLogger(opts...)

--- a/tests/bdd/steps/hmac_steps.go
+++ b/tests/bdd/steps/hmac_steps.go
@@ -41,13 +41,12 @@ func registerHMACGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 			logger, err := audit.NewLogger(
 				audit.WithTaxonomy(tc.Taxonomy),
-				audit.WithNamedOutput(out, nil, nil),
-				audit.WithOutputHMAC("stdout", &audit.HMACConfig{
+				audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 					Enabled:     true,
 					SaltVersion: version,
 					SaltValue:   []byte(salt),
 					Algorithm:   hash,
-				}),
+				})),
 			)
 			if err != nil {
 				return fmt.Errorf("create logger with HMAC: %w", err)
@@ -64,13 +63,12 @@ func registerHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 			_, err := audit.NewLogger(
 				audit.WithTaxonomy(tc.Taxonomy),
-				audit.WithNamedOutput(out, nil, nil),
-				audit.WithOutputHMAC("stdout", &audit.HMACConfig{
+				audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 					Enabled:     true,
 					SaltVersion: version,
 					SaltValue:   []byte(salt),
 					Algorithm:   hash,
-				}),
+				})),
 			)
 			tc.LastErr = err
 			return nil
@@ -351,10 +349,8 @@ func createDualHMACLogger(tc *AuditTestContext, strippedName, label, fullSalt, s
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(fullOut, nil, nil),
-		audit.WithOutputHMAC("full", fullHMACCfg),
-		audit.WithNamedOutput(strippedOut, nil, nil, label),
-		audit.WithOutputHMAC(strippedName, strippedHMACCfg),
+		audit.WithNamedOutput(fullOut, audit.OutputHMAC(fullHMACCfg)),
+		audit.WithNamedOutput(strippedOut, audit.OutputExcludeLabels(label), audit.OutputHMAC(strippedHMACCfg)),
 	)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)

--- a/tests/bdd/steps/loki_fanout_steps.go
+++ b/tests/bdd/steps/loki_fanout_steps.go
@@ -230,16 +230,18 @@ func createFileAndLokiLogger(tc *AuditTestContext, hmacCfg *audit.HMACConfig, lo
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
-		audit.WithNamedOutput(fileOut, nil, nil),
-		audit.WithNamedOutput(lokiOut, lokiRoute, nil),
 	}
 
+	var fileOpts, lokiOpts []audit.OutputOption
+	lokiOpts = append(lokiOpts, audit.OutputRoute(lokiRoute))
 	if hmacCfg != nil {
-		opts = append(opts,
-			audit.WithOutputHMAC(fileOut.Name(), hmacCfg),
-			audit.WithOutputHMAC(tc.LokiOutputName, hmacCfg),
-		)
+		fileOpts = append(fileOpts, audit.OutputHMAC(hmacCfg))
+		lokiOpts = append(lokiOpts, audit.OutputHMAC(hmacCfg))
 	}
+	opts = append(opts,
+		audit.WithNamedOutput(fileOut, fileOpts...),
+		audit.WithNamedOutput(lokiOut, lokiOpts...),
+	)
 
 	logger, err := audit.NewLogger(opts...)
 	if err != nil {
@@ -281,8 +283,8 @@ func createFileAndLokiLoggerWithExclusion(tc *AuditTestContext, excludeLabel str
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
-		audit.WithNamedOutput(fileOut, nil, nil),               // no exclusions
-		audit.WithNamedOutput(lokiOut, nil, nil, excludeLabel), // strip PII
+		audit.WithNamedOutput(fileOut),                                          // no exclusions
+		audit.WithNamedOutput(lokiOut, audit.OutputExcludeLabels(excludeLabel)), // strip PII
 	)
 	if err != nil {
 		_ = fileOut.Close()
@@ -333,8 +335,8 @@ func createFileAndLokiLoggerUnreachable(tc *AuditTestContext) error {
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
-		audit.WithNamedOutput(fileOut, nil, nil),
-		audit.WithNamedOutput(lokiOut, nil, nil),
+		audit.WithNamedOutput(fileOut),
+		audit.WithNamedOutput(lokiOut),
 	)
 	if err != nil {
 		_ = fileOut.Close()

--- a/tests/bdd/steps/loki_hmac_steps.go
+++ b/tests/bdd/steps/loki_hmac_steps.go
@@ -260,25 +260,20 @@ func createLokiLoggerWithHMAC(tc *AuditTestContext, salt, version, hash string, 
 		audit.WithHost("bdd-host"),
 	}
 
+	lokiOpts := []audit.OutputOption{audit.OutputHMAC(hmacCfg)}
 	if excludeLabels != nil {
-		opts = append(opts, audit.WithNamedOutput(out, nil, nil, excludeLabels...))
+		lokiOpts = append(lokiOpts, audit.OutputExcludeLabels(excludeLabels...))
 		// Also add a capture output with no exclusions for comparison.
 		capture := newCaptureOutput("capture-full")
 		tc.CaptureOutput = capture
-		opts = append(opts,
-			audit.WithNamedOutput(capture, nil, nil),
-			audit.WithOutputHMAC(capture.Name(), &audit.HMACConfig{
-				Enabled:     true,
-				SaltVersion: "v-capture",
-				SaltValue:   []byte("capture-comparison16"),
-				Algorithm:   "HMAC-SHA-256",
-			}),
-		)
-	} else {
-		opts = append(opts, audit.WithNamedOutput(out, nil, nil))
+		opts = append(opts, audit.WithNamedOutput(capture, audit.OutputHMAC(&audit.HMACConfig{
+			Enabled:     true,
+			SaltVersion: "v-capture",
+			SaltValue:   []byte("capture-comparison16"),
+			Algorithm:   "HMAC-SHA-256",
+		})))
 	}
-
-	opts = append(opts, audit.WithOutputHMAC(tc.LokiOutputName, hmacCfg))
+	opts = append(opts, audit.WithNamedOutput(out, lokiOpts...))
 
 	logger, err := audit.NewLogger(opts...)
 	if err != nil {
@@ -308,20 +303,18 @@ func createLokiLoggerWithHMACAndCapture(tc *AuditTestContext, lokiSalt, lokiVers
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
-		audit.WithNamedOutput(out, nil, nil),
-		audit.WithOutputHMAC(tc.LokiOutputName, &audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: lokiVersion,
 			SaltValue:   []byte(lokiSalt),
 			Algorithm:   "HMAC-SHA-256",
-		}),
-		audit.WithNamedOutput(capture, nil, nil),
-		audit.WithOutputHMAC(capture.Name(), &audit.HMACConfig{
+		})),
+		audit.WithNamedOutput(capture, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v-capture",
 			SaltValue:   []byte("capture-salt-beta16!"),
 			Algorithm:   "HMAC-SHA-256",
-		}),
+		})),
 	)
 	if err != nil {
 		_ = out.Close()

--- a/tests/bdd/steps/metadata_writer_steps.go
+++ b/tests/bdd/steps/metadata_writer_steps.go
@@ -85,7 +85,7 @@ func registerMetadataWriterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(mock, nil, nil),
+			audit.WithNamedOutput(mock),
 		}
 		opts = append(opts, tc.Options...)
 

--- a/tests/bdd/steps/metrics_steps.go
+++ b/tests/bdd/steps/metrics_steps.go
@@ -94,8 +94,8 @@ func registerMetricsGivenAdvancedSteps(ctx *godog.ScenarioContext, tc *AuditTest
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithMetrics(tc.MockMetrics),
-			audit.WithNamedOutput(stdoutOut, nil, nil),
-			audit.WithNamedOutput(fileOut, nil, nil),
+			audit.WithNamedOutput(stdoutOut),
+			audit.WithNamedOutput(fileOut),
 		}
 
 		logger, err := audit.NewLogger(opts...)
@@ -232,8 +232,8 @@ func registerMetricsGivenFilterSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithMetrics(tc.MockMetrics),
-			audit.WithNamedOutput(fileOut, nil, nil),
-			audit.WithNamedOutput(whOut, &audit.EventRoute{ExcludeCategories: []string{excludeCat}}, nil),
+			audit.WithNamedOutput(fileOut),
+			audit.WithNamedOutput(whOut, audit.OutputRoute(&audit.EventRoute{ExcludeCategories: []string{excludeCat}})),
 		}
 
 		logger, err := audit.NewLogger(opts...)

--- a/tests/bdd/steps/metrics_steps.go
+++ b/tests/bdd/steps/metrics_steps.go
@@ -193,7 +193,7 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithMetrics(tc.MockMetrics),
-			audit.WithNamedOutput(&errorOutput{}, nil, nil),
+			audit.WithNamedOutput(&errorOutput{}),
 		}
 
 		logger, err := audit.NewLogger(opts...)

--- a/tests/bdd/steps/multicat_steps.go
+++ b/tests/bdd/steps/multicat_steps.go
@@ -134,7 +134,7 @@ func createMultiCatLogger(tc *AuditTestContext, route *audit.EventRoute, formatt
 	}
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(stdout, route, formatter),
+		audit.WithNamedOutput(stdout, audit.OutputRoute(route), audit.OutputFormatter(formatter)),
 	)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)

--- a/tests/bdd/steps/sensitivity_steps.go
+++ b/tests/bdd/steps/sensitivity_steps.go
@@ -72,7 +72,7 @@ func createSensitivityLogger(tc *AuditTestContext, excludeLabels []string) error
 	}
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(stdout, nil, nil, excludeLabels...),
+		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels(excludeLabels...)),
 	)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)

--- a/tests/bdd/steps/severity_routing_steps.go
+++ b/tests/bdd/steps/severity_routing_steps.go
@@ -131,7 +131,7 @@ func registerSeverityLoggerSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 		}
 		logger, err := audit.NewLogger(
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(audit.WrapOutput(stdout, name), nil, nil),
+			audit.WithNamedOutput(audit.WrapOutput(stdout, name)),
 		)
 		if err != nil {
 			return fmt.Errorf("create logger: %w", err)

--- a/tests/bdd/steps/severity_routing_steps.go
+++ b/tests/bdd/steps/severity_routing_steps.go
@@ -158,7 +158,7 @@ func createSeverityRoutedLogger(tc *AuditTestContext, minSev, maxSev *int, inclu
 	}
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(stdout, route, nil),
+		audit.WithNamedOutput(stdout, audit.OutputRoute(route)),
 	)
 	if err != nil {
 		return fmt.Errorf("create logger: %w", err)
@@ -203,7 +203,7 @@ func trySeverityLoggerCreation(tc *AuditTestContext, minSev, maxSev *int) error 
 	}
 	logger, lErr := audit.NewLogger(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(stdout, route, nil),
+		audit.WithNamedOutput(stdout, audit.OutputRoute(route)),
 	)
 	tc.LastErr = lErr
 	if logger != nil {

--- a/tests/bdd/steps/syslog_severity_steps.go
+++ b/tests/bdd/steps/syslog_severity_steps.go
@@ -344,7 +344,7 @@ func createSyslogLoggerWithFormatter(tc *AuditTestContext, cfg *syslog.Config, f
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(out, nil, formatter),
+		audit.WithNamedOutput(out, audit.OutputFormatter(formatter)),
 	}
 	opts = append(opts, tc.Options...)
 
@@ -369,16 +369,14 @@ func createSyslogLoggerWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt, 
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
 	}
 
-	outputName := out.Name()
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(out, nil, nil),
-		audit.WithOutputHMAC(outputName, &audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: version,
 			SaltValue:   []byte(salt),
 			Algorithm:   hash,
-		}),
+		})),
 	}
 	opts = append(opts, tc.Options...)
 
@@ -405,7 +403,7 @@ func createSyslogLoggerWithExcludeLabels(tc *AuditTestContext, cfg *syslog.Confi
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(out, nil, nil, excludeLabels...),
+		audit.WithNamedOutput(out, audit.OutputExcludeLabels(excludeLabels...)),
 	}
 	opts = append(opts, tc.Options...)
 
@@ -447,7 +445,7 @@ func createSyslogLoggerWithRoute(tc *AuditTestContext, cfg *syslog.Config, route
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(out, route, nil),
+		audit.WithNamedOutput(out, audit.OutputRoute(route)),
 	}
 	opts = append(opts, tc.Options...)
 

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -239,9 +239,9 @@ func TestFanOut_EventRouting(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut), // all events
-		audit.WithNamedOutput(webhookOut, &audit.EventRoute{
+		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
-		}, nil), // security only
+		})), // security only
 	)
 	require.NoError(t, err)
 

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -179,9 +179,9 @@ func TestFanOut_AllOutputs(t *testing.T) {
 	// Create logger with all three outputs.
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testTaxonomy()),
-		audit.WithNamedOutput(fileOut, nil, nil),
-		audit.WithNamedOutput(syslogOut, nil, nil),
-		audit.WithNamedOutput(webhookOut, nil, nil),
+		audit.WithNamedOutput(fileOut),
+		audit.WithNamedOutput(syslogOut),
+		audit.WithNamedOutput(webhookOut),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = logger.Close() })
@@ -238,7 +238,7 @@ func TestFanOut_EventRouting(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testTaxonomy()),
-		audit.WithNamedOutput(fileOut, nil, nil), // all events
+		audit.WithNamedOutput(fileOut), // all events
 		audit.WithNamedOutput(webhookOut, &audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		}, nil), // security only
@@ -325,9 +325,9 @@ func TestFanOut_PartialFailure(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testTaxonomy()),
-		audit.WithNamedOutput(fileOut, nil, nil),
-		audit.WithNamedOutput(syslogOut, nil, nil),
-		audit.WithNamedOutput(webhookOut, nil, nil),
+		audit.WithNamedOutput(fileOut),
+		audit.WithNamedOutput(syslogOut),
+		audit.WithNamedOutput(webhookOut),
 	)
 	require.NoError(t, err)
 
@@ -378,8 +378,8 @@ func TestFanOut_MixedFormatters(t *testing.T) {
 
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(testTaxonomy()),
-		audit.WithNamedOutput(fileOut, nil, nil),       // JSON (default)
-		audit.WithNamedOutput(webhookOut, nil, cefFmt), // CEF
+		audit.WithNamedOutput(fileOut),                                   // JSON (default)
+		audit.WithNamedOutput(webhookOut, audit.OutputFormatter(cefFmt)), // CEF
 	)
 	require.NoError(t, err)
 

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1294,7 +1294,7 @@ func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
 	logger, err := audit.NewLogger(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testTaxonomy()),
-		audit.WithNamedOutput(webhookOut, &audit.EventRoute{}, nil),
+		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Replace `WithNamedOutput(output, route, formatter, labels...)` with `WithNamedOutput(output, ...OutputOption)`
- Add `OutputRoute`, `OutputFormatter`, `OutputExcludeLabels`, `OutputHMAC` per-output option functions
- Remove `WithOutputHMAC` top-level Option — HMAC co-located with output via `OutputHMAC`
- Copy map in `WithStandardFieldDefaults` to prevent caller mutation
- Remove dead `ValidationError.sentinel` field

Parent issue: #387 (Phase 2)
Closes #391

## Test plan

- [x] `make check` passes
- [x] All ~131 call sites migrated from positional to option pattern
- [x] Pre-coding: api-ergonomics-reviewer approved design (OutputRoute naming, export OutputOption, remove WithOutputHMAC)
- [x] Post-coding: code-reviewer (0 blocking, 1 important fixed), api-ergonomics (approved), go-quality (lint clean)