### PR TITLE
feat: add outputconfig.NewLogger() facade (#392)

### DIFF
--- a/outputconfig/facade.go
+++ b/outputconfig/facade.go
@@ -78,13 +78,13 @@ func NewLogger(ctx context.Context, taxonomyYAML []byte, outputsConfigPath strin
 		// User options applied last — highest precedence.
 		loggerOpts = append(loggerOpts, opts...)
 
-		logger, err := audit.NewLogger(loggerOpts...)
-		if err != nil {
+		logger, loggerErr := audit.NewLogger(loggerOpts...)
+		if loggerErr != nil {
 			// Clean up outputs that Load constructed.
 			for _, o := range result.Outputs {
 				_ = o.Output.Close()
 			}
-			return nil, fmt.Errorf("outputconfig: create logger: %w", err)
+			return nil, fmt.Errorf("outputconfig: create logger: %w", loggerErr)
 		}
 		return logger, nil
 	}
@@ -92,9 +92,9 @@ func NewLogger(ctx context.Context, taxonomyYAML []byte, outputsConfigPath strin
 	// Dev mode: user options applied after dev defaults.
 	loggerOpts = append(loggerOpts, opts...)
 
-	logger, err := audit.NewLogger(loggerOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("outputconfig: create logger: %w", err)
+	logger, loggerErr := audit.NewLogger(loggerOpts...)
+	if loggerErr != nil {
+		return nil, fmt.Errorf("outputconfig: create logger: %w", loggerErr)
 	}
 	return logger, nil
 }

--- a/outputconfig/facade.go
+++ b/outputconfig/facade.go
@@ -1,0 +1,163 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputconfig
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	audit "github.com/axonops/go-audit"
+)
+
+// NewLogger is a convenience facade that creates a ready-to-use
+// [audit.Logger] from embedded taxonomy YAML and a filesystem path
+// to the outputs configuration. It combines [audit.ParseTaxonomyYAML],
+// [Load], and [audit.NewLogger] into a single call.
+//
+// When outputsConfigPath is empty, NewLogger creates a stdout-only
+// development logger with app_name derived from [os.Args] and host
+// from [os.Hostname]. This is useful for local development and
+// quick evaluation.
+//
+// Additional opts are applied after the options produced by [Load],
+// so they take precedence (last wins). Use this to add
+// [audit.WithMetrics], [audit.WithDisabled], or other overrides.
+//
+// Non-stdout output types require blank imports to register their
+// factories:
+//
+//	import _ "github.com/axonops/go-audit/file"    // file output
+//	import _ "github.com/axonops/go-audit/syslog"  // syslog output
+//	import _ "github.com/axonops/go-audit/webhook" // webhook output
+//	import _ "github.com/axonops/go-audit/loki"    // loki output
+//
+// For advanced scenarios requiring secret providers, custom
+// LoadOptions, or fine-grained control, use the manual
+// [Load] + [audit.NewLogger] path instead.
+func NewLogger(ctx context.Context, taxonomyYAML []byte, outputsConfigPath string, opts ...audit.Option) (*audit.Logger, error) {
+	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
+	if err != nil {
+		return nil, fmt.Errorf("outputconfig: parse taxonomy: %w", err)
+	}
+
+	var loggerOpts []audit.Option
+	loggerOpts = append(loggerOpts, audit.WithTaxonomy(tax))
+
+	if outputsConfigPath == "" {
+		devOpts, devErr := devModeOptions()
+		if devErr != nil {
+			return nil, fmt.Errorf("outputconfig: dev mode: %w", devErr)
+		}
+		loggerOpts = append(loggerOpts, devOpts...)
+	} else {
+		data, readErr := readConfigFile(outputsConfigPath)
+		if readErr != nil {
+			return nil, readErr
+		}
+		result, loadErr := Load(ctx, data, tax)
+		if loadErr != nil {
+			return nil, fmt.Errorf("outputconfig: load: %w", loadErr)
+		}
+		loggerOpts = append(loggerOpts, result.Options...)
+
+		// User options applied last — highest precedence.
+		loggerOpts = append(loggerOpts, opts...)
+
+		logger, err := audit.NewLogger(loggerOpts...)
+		if err != nil {
+			// Clean up outputs that Load constructed.
+			for _, o := range result.Outputs {
+				_ = o.Output.Close()
+			}
+			return nil, fmt.Errorf("outputconfig: create logger: %w", err)
+		}
+		return logger, nil
+	}
+
+	// Dev mode: user options applied after dev defaults.
+	loggerOpts = append(loggerOpts, opts...)
+
+	logger, err := audit.NewLogger(loggerOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("outputconfig: create logger: %w", err)
+	}
+	return logger, nil
+}
+
+// devModeOptions returns options for a stdout-only development logger
+// with auto-detected app_name and host.
+func devModeOptions() ([]audit.Option, error) {
+	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{})
+	if err != nil {
+		return nil, fmt.Errorf("create stdout output: %w", err)
+	}
+
+	appName := "audit"
+	if len(os.Args) > 0 {
+		appName = filepath.Base(os.Args[0])
+	}
+
+	host, _ := os.Hostname() // best-effort; empty string is acceptable
+	if host == "" {
+		host = "localhost"
+	}
+
+	return []audit.Option{
+		audit.WithAppName(appName),
+		audit.WithHost(host),
+		audit.WithOutputs(stdout),
+	}, nil
+}
+
+// readConfigFile reads a configuration file with security hardening:
+// regular-file check, size bounding via io.LimitReader, and TOCTOU
+// defense via double size check (stat + post-read).
+func readConfigFile(path string) ([]byte, error) {
+	path = filepath.Clean(path)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("outputconfig: open %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("outputconfig: stat %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("outputconfig: %q is not a regular file", path)
+	}
+	if info.Size() > int64(MaxOutputConfigSize) {
+		return nil, fmt.Errorf("%w: %q size %d exceeds maximum %d",
+			ErrOutputConfigInvalid, path, info.Size(), MaxOutputConfigSize)
+	}
+
+	// LimitReader defends against TOCTOU where the file grows between
+	// stat and read.
+	data, err := io.ReadAll(io.LimitReader(f, int64(MaxOutputConfigSize)+1))
+	if err != nil {
+		return nil, fmt.Errorf("outputconfig: read %q: %w", path, err)
+	}
+	if len(data) > MaxOutputConfigSize {
+		return nil, fmt.Errorf("%w: %q exceeds maximum size %d after read",
+			ErrOutputConfigInvalid, path, MaxOutputConfigSize)
+	}
+
+	return data, nil
+}

--- a/outputconfig/facade_test.go
+++ b/outputconfig/facade_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputconfig_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	audit "github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/outputconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var facadeTaxonomyYAML = []byte(`
+version: 1
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    fields:
+      outcome: {required: true}
+`)
+
+var facadeOutputsYAML = []byte(`
+version: 1
+app_name: facade-test
+host: test-host
+outputs:
+  console:
+    type: stdout
+`)
+
+func TestNewLogger_BasicEndToEnd(t *testing.T) {
+	t.Parallel()
+	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
+
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+
+	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}
+
+func TestNewLogger_WithOptions_UserOptionsTakePrecedence(t *testing.T) {
+	t.Parallel()
+	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
+
+	// User option WithDisabled should take precedence over config.
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path,
+		audit.WithDisabled(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+
+	// Disabled logger returns nil without delivering.
+	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
+	assert.NoError(t, err)
+	require.NoError(t, logger.Close())
+}
+
+func TestNewLogger_EmptyPath_StdoutDevLogger(t *testing.T) {
+	t.Parallel()
+
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, "")
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+
+	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}
+
+func TestNewLogger_FileNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, "/nonexistent/path/outputs.yaml")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist), "should wrap os.ErrNotExist, got: %v", err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestNewLogger_InvalidTaxonomy(t *testing.T) {
+	t.Parallel()
+	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
+
+	_, err := outputconfig.NewLogger(context.Background(), []byte("not: valid: taxonomy"), path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "taxonomy")
+}
+
+func TestNewLogger_InvalidOutputConfig(t *testing.T) {
+	t.Parallel()
+	path := writeTempFile(t, "outputs-*.yaml", []byte("not: [valid: config"))
+
+	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load")
+}
+
+func TestNewLogger_EmptyTaxonomy(t *testing.T) {
+	t.Parallel()
+	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
+
+	_, err := outputconfig.NewLogger(context.Background(), nil, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "taxonomy")
+}
+
+func TestNewLogger_Close_FlushesEvents(t *testing.T) {
+	t.Parallel()
+	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
+
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path)
+	require.NoError(t, err)
+
+	// Send events then close — should not panic or error.
+	for range 10 {
+		_ = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
+	}
+	require.NoError(t, logger.Close())
+}
+
+func TestNewLogger_NotRegularFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Directories are not regular files.
+	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+}
+
+// writeTempFile creates a temporary file with the given content and
+// returns its path. The file is cleaned up after the test.
+func writeTempFile(t *testing.T, name string, content []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+	return path
+}


### PR DESCRIPTION
## Summary

- Add `outputconfig.NewLogger(ctx, taxonomyYAML, outputsConfigPath, ...audit.Option)` facade
- Combines ParseTaxonomyYAML + Load + NewLogger into a single call
- Security-hardened file reader: regular-file check, `io.LimitReader` bounded read, TOCTOU defense
- Empty path creates stdout-only dev logger with auto-detected app_name/host
- User options applied last (highest precedence)
- Outputs cleaned up on NewLogger failure (resource leak fix from code review)

Parent issue: #387 (Phase 3)
Closes #392

## Test plan

- [x] `make check` passes
- [x] 9 tests: end-to-end, dev mode, file errors, invalid YAML/taxonomy, close, non-regular file
- [x] Pre-coding: api-ergonomics (approved design), security-reviewer (1 MEDIUM — bounded read, applied)
- [x] Post-coding: code-reviewer (1 blocking fixed — resource leak), api-ergonomics (TTHW improved), go-quality (lint clean)