### PR TITLE
feat: add Stdout, NewEventKV, DevTaxonomy convenience API (#395)

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -143,6 +143,11 @@ func NewLogger(opts ...Option) (*Logger, error) {
 
 	if l.taxonomy.dev {
 		slog.Warn("audit: using DevTaxonomy — not suitable for production; all event types accepted without schema enforcement")
+		// DevTaxonomy produces empty EventDefs with no declared fields.
+		// Force permissive validation so user fields are not rejected.
+		if l.cfg.ValidationMode == ValidationStrict {
+			l.cfg.ValidationMode = ValidationPermissive
+		}
 	}
 
 	if err := l.validateOutputRoutes(); err != nil {

--- a/audit.go
+++ b/audit.go
@@ -141,25 +141,17 @@ func NewLogger(opts ...Option) (*Logger, error) {
 		return nil, fmt.Errorf("audit: taxonomy is required: use WithTaxonomy")
 	}
 
+	if l.taxonomy.dev {
+		slog.Warn("audit: using DevTaxonomy — not suitable for production; all event types accepted without schema enforcement")
+	}
+
 	if err := l.validateOutputRoutes(); err != nil {
 		return nil, err
 	}
 
 	l.prepareOutputEntries()
 
-	// Default formatter if WithFormatter was not called.
-	if l.formatter == nil {
-		l.formatter = &JSONFormatter{OmitEmpty: l.cfg.OmitEmpty}
-	}
-
-	// Capture PID and timezone once at construction.
-	l.pid = os.Getpid()
-	if l.timezone == "" {
-		l.timezone = time.Now().Location().String()
-	}
-
-	// Propagate framework fields to all formatters that support them.
-	l.propagateFrameworkFields()
+	l.applyConstructionDefaults()
 
 	if l.disabled {
 		return l, nil
@@ -179,6 +171,19 @@ func NewLogger(opts ...Option) (*Logger, error) {
 	)
 
 	return l, nil
+}
+
+// applyConstructionDefaults sets formatter, PID, timezone, and propagates
+// framework fields. Called once during NewLogger after all options are applied.
+func (l *Logger) applyConstructionDefaults() {
+	if l.formatter == nil {
+		l.formatter = &JSONFormatter{OmitEmpty: l.cfg.OmitEmpty}
+	}
+	l.pid = os.Getpid()
+	if l.timezone == "" {
+		l.timezone = time.Now().Location().String()
+	}
+	l.propagateFrameworkFields()
 }
 
 // AuditEvent validates and enqueues a typed audit event. Use

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -113,9 +113,10 @@ func TestDevTaxonomy_WarnsAtConstruction(t *testing.T) {
 func TestFileFreePath_EndToEnd(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
+	// DevTaxonomy auto-forces permissive validation — no explicit
+	// WithValidationMode needed.
 	logger, err := audit.NewLogger(
 		audit.WithTaxonomy(audit.DevTaxonomy("user_create")),
-		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Stdout()
+// ---------------------------------------------------------------------------
+
+func TestStdout_ReturnsWorkingOutput(t *testing.T) {
+	t.Parallel()
+	out := audit.Stdout()
+	require.NotNil(t, out)
+	assert.Equal(t, "stdout", out.Name())
+}
+
+// ---------------------------------------------------------------------------
+// NewEventKV()
+// ---------------------------------------------------------------------------
+
+func TestNewEventKV_ValidPairs(t *testing.T) {
+	t.Parallel()
+	evt := audit.NewEventKV("user_create", "outcome", "success", "actor_id", "alice")
+	assert.Equal(t, "user_create", evt.EventType())
+	assert.Equal(t, "success", evt.Fields()["outcome"])
+	assert.Equal(t, "alice", evt.Fields()["actor_id"])
+}
+
+func TestNewEventKV_EmptyFields(t *testing.T) {
+	t.Parallel()
+	evt := audit.NewEventKV("user_create")
+	assert.Equal(t, "user_create", evt.EventType())
+	assert.Empty(t, evt.Fields())
+}
+
+func TestNewEventKV_OddArgs_Panics(t *testing.T) {
+	t.Parallel()
+	assert.PanicsWithValue(t,
+		"audit: NewEventKV requires even number of arguments, got 1",
+		func() {
+			args := []any{"orphan"}
+			audit.NewEventKV("user_create", args...) //nolint:staticcheck // intentional odd-args test
+		},
+	)
+}
+
+func TestNewEventKV_NonStringKey_Panics(t *testing.T) {
+	t.Parallel()
+	assert.PanicsWithValue(t,
+		"audit: NewEventKV key at index 0 must be string, got int",
+		func() { audit.NewEventKV("user_create", 123, "value") },
+	)
+}
+
+// ---------------------------------------------------------------------------
+// DevTaxonomy()
+// ---------------------------------------------------------------------------
+
+func TestDevTaxonomy_CreatesPermissiveTaxonomy(t *testing.T) {
+	t.Parallel()
+	tax := audit.DevTaxonomy("user_create", "auth_failure")
+	require.NotNil(t, tax)
+	assert.Equal(t, 1, tax.Version)
+	assert.Contains(t, tax.Events, "user_create")
+	assert.Contains(t, tax.Events, "auth_failure")
+	assert.Contains(t, tax.Categories, "dev")
+}
+
+func TestDevTaxonomy_WarnsAtConstruction(t *testing.T) {
+	// Capture slog output to verify the warning is emitted.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(audit.DevTaxonomy("ev1")),
+		audit.WithOutputs(testhelper.NewMockOutput("test")),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+
+	assert.Contains(t, buf.String(), "DevTaxonomy",
+		"slog.Warn should mention DevTaxonomy for production warning")
+}
+
+// ---------------------------------------------------------------------------
+// File-free evaluation path (end-to-end)
+// ---------------------------------------------------------------------------
+
+func TestFileFreePath_EndToEnd(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(audit.DevTaxonomy("user_create")),
+		audit.WithValidationMode(audit.ValidationPermissive),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	err = logger.AuditEvent(audit.NewEventKV("user_create", "outcome", "success", "actor_id", "alice"))
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+	assert.Equal(t, 1, out.EventCount())
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark
+// ---------------------------------------------------------------------------
+
+func BenchmarkNewEventKV(b *testing.B) {
+	for b.Loop() {
+		_ = audit.NewEventKV("user_create", "outcome", "success", "actor_id", "alice")
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -89,12 +89,14 @@
 //
 //   - [Event] — interface for typed audit events; pass to [Logger.AuditEvent]
 //   - [NewEvent] — creates an event for dynamic use without code generation
+//   - [NewEventKV] — creates an event from alternating key-value pairs (slog-style)
 //   - [EventType] — pre-validated handle for zero-allocation audit calls; see [Logger.MustHandle]
 //   - [Fields] — defined type over map[string]any with [Fields.Has], [Fields.String], [Fields.Int] accessors
 //
 // # Outputs
 //
 //   - [Output] — interface for audit event destinations (file, syslog, webhook, stdout)
+//   - [Stdout] — convenience constructor for [StdoutOutput] writing to [os.Stdout]
 //   - [StdoutOutput] — writes events to stdout or any io.Writer; included in core
 //   - [WithOutputs] — registers unnamed outputs; [WithNamedOutput] for per-output routing
 //   - [DeliveryReporter] — optional interface for outputs that handle their own delivery metrics
@@ -113,6 +115,7 @@
 //   - [Taxonomy] — consumer-defined event schema; registered via [WithTaxonomy]
 //   - [EventDef] — definition of a single event type's required and optional fields
 //   - [CategoryDef] — category grouping with optional default severity
+//   - [DevTaxonomy] — creates a permissive development taxonomy (not for production)
 //   - [ParseTaxonomyYAML] — parses a YAML document into a [Taxonomy]; use with //go:embed
 //   - [ValidateTaxonomy] — validates a [Taxonomy] for internal consistency
 //   - [SensitivityConfig] — sensitivity label definitions for field classification

--- a/event.go
+++ b/event.go
@@ -14,6 +14,8 @@
 
 package audit
 
+import "fmt"
+
 // LabelInfo describes a sensitivity label defined in the taxonomy.
 type LabelInfo struct {
 	Name        string // label name, e.g., "pii"
@@ -67,6 +69,29 @@ func NewEvent(eventType string, fields Fields) Event {
 
 func (e *basicEvent) EventType() string { return e.eventType }
 func (e *basicEvent) Fields() Fields    { return e.fields }
+
+// NewEventKV creates an audit event from alternating key-value pairs,
+// following the [log/slog] convention:
+//
+//	audit.NewEventKV("user_create", "outcome", "success", "actor_id", "alice")
+//
+// NewEventKV panics if keysAndValues has an odd number of elements or
+// if any key is not a string. These are always programming errors, not
+// runtime conditions — the same convention as [slog.Info].
+func NewEventKV(eventType string, keysAndValues ...any) Event {
+	if len(keysAndValues)%2 != 0 {
+		panic(fmt.Sprintf("audit: NewEventKV requires even number of arguments, got %d", len(keysAndValues)))
+	}
+	fields := make(Fields, len(keysAndValues)/2)
+	for i := 0; i < len(keysAndValues); i += 2 {
+		key, ok := keysAndValues[i].(string)
+		if !ok {
+			panic(fmt.Sprintf("audit: NewEventKV key at index %d must be string, got %T", i, keysAndValues[i]))
+		}
+		fields[key] = keysAndValues[i+1]
+	}
+	return NewEvent(eventType, fields)
+}
 
 // EventType is a handle for a registered audit event type. It carries
 // the event type name and a reference to the owning [Logger], enabling

--- a/stdout.go
+++ b/stdout.go
@@ -58,6 +58,18 @@ type StdoutOutput struct {
 	closed bool
 }
 
+// Stdout returns a [StdoutOutput] that writes to [os.Stdout]. This is
+// a convenience shorthand for NewStdoutOutput(StdoutConfig{}).
+func Stdout() *StdoutOutput {
+	out, err := NewStdoutOutput(StdoutConfig{})
+	if err != nil {
+		// StdoutConfig{} cannot fail today; panic guards against future
+		// regressions in NewStdoutOutput validation.
+		panic("audit: Stdout(): " + err.Error())
+	}
+	return out
+}
+
 // NewStdoutOutput creates a new [StdoutOutput] from the given config.
 // If [StdoutConfig.Writer] is nil, [os.Stdout] is used.
 func NewStdoutOutput(cfg StdoutConfig) (*StdoutOutput, error) {

--- a/taxonomy.go
+++ b/taxonomy.go
@@ -210,6 +210,33 @@ type Taxonomy struct {
 	// validation, and precomputation succeed. [WithTaxonomy] skips
 	// redundant re-validation when this flag is true.
 	validated bool
+
+	// dev is set by [DevTaxonomy] to signal that this is a permissive
+	// development taxonomy. [NewLogger] emits a slog.Warn when this
+	// flag is true.
+	dev bool
+}
+
+// DevTaxonomy creates a permissive development taxonomy where every
+// listed event type accepts any fields with no required fields. All
+// events are placed in a single "dev" category.
+//
+// DevTaxonomy is for prototyping and testing only. It accepts any
+// event type with any fields and MUST NOT be used in production.
+// [NewLogger] emits a [log/slog] warning when a DevTaxonomy is used.
+func DevTaxonomy(eventTypes ...string) *Taxonomy {
+	events := make(map[string]*EventDef, len(eventTypes))
+	for _, et := range eventTypes {
+		events[et] = &EventDef{}
+	}
+	return &Taxonomy{
+		Version: 1,
+		Categories: map[string]*CategoryDef{
+			"dev": {Events: eventTypes},
+		},
+		Events: events,
+		dev:    true,
+	}
 }
 
 const (
@@ -335,6 +362,7 @@ func deepCopyTaxonomy(t *Taxonomy) *Taxonomy {
 		Version:               t.Version,
 		SuppressEventCategory: t.SuppressEventCategory,
 		validated:             t.validated,
+		dev:                   t.dev,
 	}
 	cp.Categories = deepCopyCategories(t.Categories)
 	cp.Events = deepCopyEvents(t.Events)


### PR DESCRIPTION
## Summary

- `Stdout()` — shorthand for `NewStdoutOutput(StdoutConfig{})` with panic guard
- `NewEventKV()` — slog-style alternating key-value event construction (panics on bad args)
- `DevTaxonomy()` — permissive dev taxonomy with `slog.Warn` at construction time
- Extract `applyConstructionDefaults` to reduce `NewLogger` cyclomatic complexity
- File-free evaluation path now works in 4 lines

Parent issue: #387 (Phase 3)
Closes #395

## Test plan

- [x] `make check` passes
- [x] 8 tests + benchmark in `convenience_test.go`
- [x] DevTaxonomy warning verified via slog capture
- [x] Pre-coding: api-ergonomics approved (Stdout naming, panic convention, dev bool marker)
- [x] Post-coding: code-reviewer (1 blocking fixed — deepCopy dev flag, 1 important fixed — panic guard)