### PR TITLE
refactor: rewrite examples using simplified API (#396)

### DIFF
--- a/examples/01-basic/main.go
+++ b/examples/01-basic/main.go
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Basic demonstrates the minimum viable audit event: create a logger
-// with an inline taxonomy, emit one valid event, and show what happens
-// when a required field is missing.
+// Basic demonstrates the absolute minimum: a file-free logger that
+// requires no YAML, no go:embed, and no output configuration. This is
+// the fastest way to evaluate go-audit in a playground or single-file
+// program. For production use, see examples 02+ which use YAML
+// taxonomy and output configuration.
 package main
 
 import (
@@ -25,63 +27,32 @@ import (
 )
 
 func main() {
-	// 1. Define a taxonomy inline. In production you would load this
-	//    from a YAML file — see the code-generation example.
-	tax := &audit.Taxonomy{
-		Version: 1,
-		Categories: map[string]*audit.CategoryDef{
-			"write":    {Events: []string{"user_create", "user_delete"}},
-			"security": {Events: []string{"auth_failure"}},
-		},
-		Events: map[string]*audit.EventDef{
-			"user_create": {
-				Required: []string{"outcome", "actor_id"},
-			},
-			"user_delete": {
-				Required: []string{"outcome", "actor_id"},
-			},
-			"auth_failure": {
-				Required: []string{"outcome", "actor_id"},
-			},
-		},
-	}
-
-	// 2. Create a stdout output — events are printed as JSON lines.
-	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{})
-	if err != nil {
-		log.Fatalf("create stdout output: %v", err)
-	}
-
-	// 3. Create the logger with the taxonomy and output.
+	// Create a logger with a development taxonomy and stdout output.
+	// DevTaxonomy accepts any event type with any fields — not for production.
 	logger, err := audit.NewLogger(
-		audit.WithTaxonomy(tax),
-		audit.WithOutputs(stdout),
+		audit.WithTaxonomy(audit.DevTaxonomy("user_create", "auth_failure")),
+		audit.WithOutputs(audit.Stdout()),
 	)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}
-	defer func() {
-		if closeErr := logger.Close(); closeErr != nil {
-			log.Printf("close logger: %v", closeErr)
-		}
-	}()
+	defer func() { _ = logger.Close() }()
 
-	// 4. Emit a valid event — this prints a JSON line to stdout.
+	// Emit a valid event using slog-style key-value pairs.
 	fmt.Println("--- Valid event ---")
-	if auditErr := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
-		"outcome":  "success",
-		"actor_id": "alice",
-	})); auditErr != nil {
+	if auditErr := logger.AuditEvent(audit.NewEventKV("user_create",
+		"outcome", "success",
+		"actor_id", "alice",
+	)); auditErr != nil {
 		log.Printf("audit error: %v", auditErr)
 	}
 
-	// 5. Emit an invalid event — actor_id is missing (required by taxonomy).
-	fmt.Println("\n--- Invalid event (missing required field) ---")
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
-		"outcome": "success",
-		// actor_id intentionally omitted
-	}))
-	if err != nil {
-		fmt.Printf("Validation error: %v\n", err)
+	// Emit another event using the Fields map style.
+	fmt.Println("\n--- Auth failure event ---")
+	if auditErr := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "unknown",
+	})); auditErr != nil {
+		log.Printf("audit error: %v", auditErr)
 	}
 }

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Code-generation demonstrates the recommended go-audit workflow:
-// define events in a YAML taxonomy, generate type-safe Go constants
-// with audit-gen, and configure outputs in a separate YAML file.
+// Code Generation demonstrates audit-gen typed builders: compile-time
+// safety for event types, required fields, and sensitivity labels.
+//
+// Run:
+//
+//	go generate ./...
+//	go run .
 package main
 
 import (
 	"context"
 	_ "embed"
-	"fmt"
 	"log"
 
-	audit "github.com/axonops/go-audit"
 	"github.com/axonops/go-audit/outputconfig"
 )
 
@@ -32,53 +34,20 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
-	// 1. Parse the embedded taxonomy.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	// 2. Load output configuration from YAML.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// 3. Create the logger with taxonomy + outputs.
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}
-	defer func() {
-		if closeErr := logger.Close(); closeErr != nil {
-			log.Printf("close logger: %v", closeErr)
-		}
-	}()
+	defer func() { _ = logger.Close() }()
 
 	// All event types, field names, and categories are generated constants.
 	// A typo like "NewUserCrateEvent" would fail at compile time.
-	fmt.Println("--- Using typed event builders ---")
-
-	if err := logger.AuditEvent(NewUserCreateEvent("alice", "success").
-		SetTargetID("user-42")); err != nil {
-		log.Printf("audit error: %v", err)
-	}
-
-	if err := logger.AuditEvent(NewAuthFailureEvent("unknown", "failure").
-		SetReason("invalid credentials").
-		SetSourceIP("192.168.1.100")); err != nil {
-		log.Printf("audit error: %v", err)
-	}
-
-	if err := logger.AuditEvent(NewUserReadEvent("success").
-		SetActorID("bob")); err != nil {
-		log.Printf("audit error: %v", err)
+	if auditErr := logger.AuditEvent(
+		NewUserCreateEvent("alice", "success").
+			SetTargetID("user-42"),
+	); auditErr != nil {
+		log.Printf("audit: %v", auditErr)
 	}
 }

--- a/examples/03-standard-fields/main.go
+++ b/examples/03-standard-fields/main.go
@@ -26,38 +26,18 @@ import (
 	"fmt"
 	"log"
 
-	audit "github.com/axonops/go-audit"
 	"github.com/axonops/go-audit/outputconfig"
 )
 
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
 	// Parse taxonomy — only outcome and actor_id are declared.
 	// All 31 standard fields (source_ip, reason, target_id, etc.)
 	// are available automatically.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	// Load output config — app_name, host, timezone, and
-	// standard_fields defaults are set here.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// result.Options includes WithStandardFieldDefaults automatically
-	// when standard_fields: is present in the YAML config.
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/04-stdout-output/main.go
+++ b/examples/04-stdout-output/main.go
@@ -33,27 +33,10 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
-	// 1. Parse the taxonomy.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	// 2. Load output configuration — stdout needs no blank import.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// 3. Create the logger.
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	// Stdout needs no blank import — it is always registered.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/05-file-output/main.go
+++ b/examples/05-file-output/main.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"os"
 
-	audit "github.com/axonops/go-audit"
 	_ "github.com/axonops/go-audit/file"
 	"github.com/axonops/go-audit/outputconfig"
 )
@@ -34,24 +33,9 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/06-syslog-output/main.go
+++ b/examples/06-syslog-output/main.go
@@ -39,9 +39,6 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
 	// 1. Start a local TCP syslog receiver on port 1514.
 	//    In production, this would be rsyslog, syslog-ng, Splunk, etc.
@@ -51,21 +48,8 @@ func main() {
 	time.Sleep(50 * time.Millisecond)
 
 	// 2. Parse taxonomy and load output config.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// 3. Create the logger.
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/07-webhook-output/main.go
+++ b/examples/07-webhook-output/main.go
@@ -40,9 +40,6 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
 	// 1. Start a local HTTP server that receives NDJSON batches.
 	//    In production, this would be your alerting endpoint, log
@@ -53,21 +50,8 @@ func main() {
 	time.Sleep(50 * time.Millisecond)
 
 	// 2. Parse taxonomy and load output config.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// 3. Create the logger.
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/08-loki-output/main.go
+++ b/examples/08-loki-output/main.go
@@ -45,26 +45,10 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
 	// Parse taxonomy.
-	taxonomy, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	// Load output configuration — creates the Loki output from YAML.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, taxonomy)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// Create the logger with the Loki output.
-	opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
-	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/09-multi-output/main.go
+++ b/examples/09-multi-output/main.go
@@ -34,24 +34,9 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/10-tls-policy/main.go
+++ b/examples/10-tls-policy/main.go
@@ -40,26 +40,10 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
 	// 1. Parse taxonomy and load output config.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// 2. Create the logger.
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/11-event-routing/main.go
+++ b/examples/11-event-routing/main.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"os"
 
-	audit "github.com/axonops/go-audit"
 	_ "github.com/axonops/go-audit/file"
 	"github.com/axonops/go-audit/outputconfig"
 )
@@ -34,24 +33,9 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/12-sensitivity-labels/main.go
+++ b/examples/12-sensitivity-labels/main.go
@@ -35,9 +35,6 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 var logFiles = []string{"full-audit.log", "public-audit.log", "pci-audit.log"}
 
 func main() {
@@ -53,17 +50,8 @@ func main() {
 }
 
 func createLogger() *audit.Logger {
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/13-hmac-integrity/main.go
+++ b/examples/13-hmac-integrity/main.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"os"
 
-	audit "github.com/axonops/go-audit"
 	_ "github.com/axonops/go-audit/file"
 	"github.com/axonops/go-audit/outputconfig"
 )
@@ -34,27 +33,10 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
 	// 1. Parse taxonomy.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	// 2. Load output configuration (includes HMAC settings).
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// 3. Create logger.
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/14-formatters/main.go
+++ b/examples/14-formatters/main.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"os"
 
-	audit "github.com/axonops/go-audit"
 	_ "github.com/axonops/go-audit/file"
 	"github.com/axonops/go-audit/outputconfig"
 )
@@ -34,24 +33,9 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/17-testing/main.go
+++ b/examples/17-testing/main.go
@@ -32,9 +32,6 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 // UserService is a simple service that emits audit events.
 // It takes a *audit.Logger as a dependency — making it testable.
 type UserService struct {
@@ -69,19 +66,8 @@ func (s *UserService) Login(username, password string) error {
 }
 
 func main() {
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/18-buffering/main.go
+++ b/examples/18-buffering/main.go
@@ -48,27 +48,10 @@ import (
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-//go:embed outputs.yaml
-var outputsYAML []byte
-
 func main() {
 	// Parse taxonomy.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		log.Fatalf("parse taxonomy: %v", err)
-	}
-
-	// Load output configuration.
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax)
-	if err != nil {
-		log.Fatalf("load outputs: %v", err)
-	}
-
-	// Create the logger with the tiny buffer from outputs.yaml.
-	opts := []audit.Option{audit.WithTaxonomy(tax)}
-	opts = append(opts, result.Options...)
-
-	logger, err := audit.NewLogger(opts...)
+	// Single-call facade: parse taxonomy, load outputs, create logger.
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Rewrite Example 01 to use `DevTaxonomy()` + `Stdout()` + `NewEventKV()` — file-free path in ~15 lines
- Simplify Examples 02-18 to use `outputconfig.NewLogger()` facade — net deletion of 285 lines
- Remove `go:embed` for `outputs.yaml` in favour of facade filesystem read
- Each example now focuses on its unique feature, not shared boilerplate

Parent issue: #387 (Phase 5)
Closes #396

## Test plan

- [x] `make check` passes
- [x] `make test-examples` — all 18 examples compile
- [x] Post-coding: code-reviewer (0 findings, approved), commit-message (pass)