### PR TITLE
feat: add WithLogger option for library diagnostics (#397)

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -101,7 +101,8 @@ type Logger struct {
 	// read-only after construction. Applied in auditInternal before
 	// validation so that defaults satisfy required: true constraints.
 	standardFieldDefaults map[string]string
-	drops                 dropLimiter // rate-limits buffer-full slog.Warn
+	logger                *slog.Logger // library diagnostics logger
+	drops                 dropLimiter  // rate-limits buffer-full warnings
 }
 
 // NewLogger creates a new audit [Logger] from the given options.
@@ -137,18 +138,15 @@ func NewLogger(opts ...Option) (*Logger, error) {
 	// Release construction-only state.
 	l.destKeys = nil
 
+	if l.logger == nil {
+		l.logger = slog.Default()
+	}
+
 	if l.taxonomy == nil {
 		return nil, fmt.Errorf("audit: taxonomy is required: use WithTaxonomy")
 	}
 
-	if l.taxonomy.dev {
-		slog.Warn("audit: using DevTaxonomy — not suitable for production; all event types accepted without schema enforcement")
-		// DevTaxonomy produces empty EventDefs with no declared fields.
-		// Force permissive validation so user fields are not rejected.
-		if l.cfg.ValidationMode == ValidationStrict {
-			l.cfg.ValidationMode = ValidationPermissive
-		}
-	}
+	l.applyDevTaxonomyOverrides()
 
 	if err := l.validateOutputRoutes(); err != nil {
 		return nil, err
@@ -168,7 +166,7 @@ func NewLogger(opts ...Option) (*Logger, error) {
 	l.drainDone = make(chan struct{})
 	go l.drainLoop(ctx)
 
-	slog.Info("audit: logger created",
+	l.logger.Info("audit: logger created",
 		"buffer_size", l.cfg.BufferSize,
 		"drain_timeout", l.cfg.DrainTimeout,
 		"validation_mode", string(l.cfg.ValidationMode),
@@ -176,6 +174,18 @@ func NewLogger(opts ...Option) (*Logger, error) {
 	)
 
 	return l, nil
+}
+
+// applyDevTaxonomyOverrides warns about DevTaxonomy and forces permissive
+// validation mode when a dev taxonomy is used.
+func (l *Logger) applyDevTaxonomyOverrides() {
+	if l.taxonomy == nil || !l.taxonomy.dev {
+		return
+	}
+	l.logger.Warn("audit: using DevTaxonomy — not suitable for production; all event types accepted without schema enforcement")
+	if l.cfg.ValidationMode == ValidationStrict {
+		l.cfg.ValidationMode = ValidationPermissive
+	}
 }
 
 // applyConstructionDefaults sets formatter, PID, timezone, and propagates
@@ -263,7 +273,7 @@ func (l *Logger) enqueue(entry *auditEntry) error {
 		return nil
 	default:
 		l.drops.record(dropWarnInterval, func(dropped int64) {
-			slog.Warn("audit: buffer full, events dropped",
+			l.logger.Warn("audit: buffer full, events dropped",
 				"dropped", dropped,
 				"buffer_size", cap(l.ch))
 		})
@@ -297,7 +307,7 @@ func (l *Logger) Close() error {
 		}
 
 		shutdownStart := time.Now()
-		slog.Info("audit: shutdown started")
+		l.logger.Info("audit: shutdown started")
 
 		l.cancel()
 		l.waitForDrain()
@@ -305,7 +315,7 @@ func (l *Logger) Close() error {
 		var closeErrs []error
 		for _, oe := range l.entries {
 			if err := oe.output.Close(); err != nil {
-				slog.Error("audit: output close failed",
+				l.logger.Error("audit: output close failed",
 					"output", oe.output.Name(),
 					"error", err)
 				closeErrs = append(closeErrs, fmt.Errorf("audit: output %q: %w", oe.output.Name(), err))
@@ -313,7 +323,7 @@ func (l *Logger) Close() error {
 		}
 		l.closeErr = errors.Join(closeErrs...)
 
-		slog.Info("audit: shutdown complete",
+		l.logger.Info("audit: shutdown complete",
 			"duration", time.Since(shutdownStart))
 	})
 	return l.closeErr
@@ -326,7 +336,7 @@ func (l *Logger) waitForDrain() {
 	select {
 	case <-l.drainDone:
 	case <-time.After(l.cfg.DrainTimeout):
-		slog.Warn("audit: drain timed out, some events may be lost",
+		l.logger.Warn("audit: drain timed out, some events may be lost",
 			"drain_timeout", l.cfg.DrainTimeout,
 			"buffer_remaining", len(l.ch))
 	}
@@ -377,7 +387,7 @@ func (l *Logger) EnableCategory(category string) error {
 		return fmt.Errorf("audit: unknown category %q", category)
 	}
 	l.filter.enabledCategories.Store(category, true)
-	slog.Info("audit: category enabled", "category", category)
+	l.logger.Info("audit: category enabled", "category", category)
 	return nil
 }
 
@@ -390,7 +400,7 @@ func (l *Logger) DisableCategory(category string) error {
 		return fmt.Errorf("audit: unknown category %q", category)
 	}
 	l.filter.enabledCategories.Store(category, false)
-	slog.Info("audit: category disabled", "category", category)
+	l.logger.Info("audit: category disabled", "category", category)
 	return nil
 }
 
@@ -404,7 +414,7 @@ func (l *Logger) EnableEvent(eventType string) error {
 	}
 	l.filter.eventOverrides.Store(eventType, true)
 	l.filter.hasEventOverrides.Store(true)
-	slog.Info("audit: event enabled", "event_type", eventType)
+	l.logger.Info("audit: event enabled", "event_type", eventType)
 	return nil
 }
 
@@ -418,7 +428,7 @@ func (l *Logger) DisableEvent(eventType string) error {
 	}
 	l.filter.eventOverrides.Store(eventType, false)
 	l.filter.hasEventOverrides.Store(true)
-	slog.Info("audit: event disabled", "event_type", eventType)
+	l.logger.Info("audit: event disabled", "event_type", eventType)
 	return nil
 }
 
@@ -437,7 +447,7 @@ func (l *Logger) SetOutputRoute(outputName string, route *EventRoute) error {
 		return err
 	}
 	oe.setRoute(route)
-	slog.Info("audit: output route set", "output", outputName)
+	l.logger.Info("audit: output route set", "output", outputName)
 	return nil
 }
 
@@ -451,7 +461,7 @@ func (l *Logger) ClearOutputRoute(outputName string) error {
 		return fmt.Errorf("audit: unknown output %q", outputName)
 	}
 	oe.setRoute(&EventRoute{})
-	slog.Info("audit: output route cleared", "output", outputName)
+	l.logger.Info("audit: output route cleared", "output", outputName)
 	return nil
 }
 

--- a/audittest/recorder.go
+++ b/audittest/recorder.go
@@ -41,7 +41,9 @@ type RecordedEvent struct { //nolint:govet // readability over alignment
 	Severity int
 	// Timestamp is the event timestamp set by the drain goroutine.
 	Timestamp time.Time
-	// Fields contains all non-framework fields.
+	// Fields contains all non-framework fields. Note: numeric values
+	// are stored as float64 due to JSON round-tripping. Use
+	// [RecordedEvent.IntField] for int assertions.
 	Fields map[string]any
 	// RawJSON is the original serialised bytes for format-level assertions.
 	RawJSON []byte
@@ -55,6 +57,35 @@ type RecordedEvent struct { //nolint:govet // readability over alignment
 // Field returns the value of the named field, or nil if not present.
 func (e RecordedEvent) Field(key string) any { //nolint:gocritic // value receiver required for fmt.GoStringer on non-addressable values
 	return e.Fields[key]
+}
+
+// StringField returns the value of the named field as a string.
+// Returns the empty string if the key is missing or the value is not
+// a string.
+func (e RecordedEvent) StringField(key string) string { //nolint:gocritic // value receiver for consistency
+	v, _ := e.Fields[key].(string)
+	return v
+}
+
+// IntField returns the value of the named field as an int. JSON
+// round-tripping stores all numbers as float64, so this method
+// handles the float64→int coercion transparently.
+func (e RecordedEvent) IntField(key string) int { //nolint:gocritic // value receiver for consistency
+	switch v := e.Fields[key].(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
+}
+
+// FloatField returns the value of the named field as a float64.
+// Returns 0 if the key is missing or the value is not numeric.
+func (e RecordedEvent) FloatField(key string) float64 { //nolint:gocritic // value receiver for consistency
+	v, _ := e.Fields[key].(float64)
+	return v
 }
 
 // HasField reports whether the event has a field with the given key

--- a/audittest/recorder_test.go
+++ b/audittest/recorder_test.go
@@ -181,10 +181,10 @@ func TestRecordedEvent_IntField_CoercesFloat64(t *testing.T) {
 	t.Parallel()
 	evt := audittest.RecordedEvent{
 		Fields: map[string]any{
-			"count":   float64(42), // JSON round-trip stores as float64
-			"exact":   5,           // int if set directly
-			"name":    "alice",
-			"rate":    3.14,
+			"count": float64(42), // JSON round-trip stores as float64
+			"exact": 5,           // int if set directly
+			"name":  "alice",
+			"rate":  3.14,
 		},
 	}
 	assert.Equal(t, 42, evt.IntField("count"), "float64 coerced to int")

--- a/audittest/recorder_test.go
+++ b/audittest/recorder_test.go
@@ -159,3 +159,50 @@ func TestRecorder_FullPipeline(t *testing.T) {
 
 	assert.Equal(t, 1, metrics.EventDeliveries("recorder", "success"))
 }
+
+// ---------------------------------------------------------------------------
+// RecordedEvent field accessors (#397)
+// ---------------------------------------------------------------------------
+
+func TestRecordedEvent_StringField(t *testing.T) {
+	t.Parallel()
+	evt := audittest.RecordedEvent{
+		Fields: map[string]any{
+			"name":  "alice",
+			"count": float64(42),
+		},
+	}
+	assert.Equal(t, "alice", evt.StringField("name"))
+	assert.Equal(t, "", evt.StringField("count"), "non-string returns empty")
+	assert.Equal(t, "", evt.StringField("missing"), "missing returns empty")
+}
+
+func TestRecordedEvent_IntField_CoercesFloat64(t *testing.T) {
+	t.Parallel()
+	evt := audittest.RecordedEvent{
+		Fields: map[string]any{
+			"count":   float64(42), // JSON round-trip stores as float64
+			"exact":   5,           // int if set directly
+			"name":    "alice",
+			"rate":    3.14,
+		},
+	}
+	assert.Equal(t, 42, evt.IntField("count"), "float64 coerced to int")
+	assert.Equal(t, 5, evt.IntField("exact"), "int stays int")
+	assert.Equal(t, 0, evt.IntField("name"), "non-numeric returns 0")
+	assert.Equal(t, 3, evt.IntField("rate"), "float64 truncates")
+	assert.Equal(t, 0, evt.IntField("missing"), "missing returns 0")
+}
+
+func TestRecordedEvent_FloatField(t *testing.T) {
+	t.Parallel()
+	evt := audittest.RecordedEvent{
+		Fields: map[string]any{
+			"rate": float64(3.14),
+			"name": "alice",
+		},
+	}
+	assert.InDelta(t, 3.14, evt.FloatField("rate"), 0.001)
+	assert.Equal(t, float64(0), evt.FloatField("name"), "non-float returns 0")
+	assert.Equal(t, float64(0), evt.FloatField("missing"), "missing returns 0")
+}

--- a/drain.go
+++ b/drain.go
@@ -16,15 +16,14 @@ package audit
 
 import (
 	"context"
-	"log/slog"
 	"runtime"
 	"time"
 )
 
 func (l *Logger) drainLoop(ctx context.Context) {
 	defer close(l.drainDone)
-	defer slog.Debug("audit: drain loop exiting")
-	slog.Debug("audit: drain loop started")
+	defer l.logger.Debug("audit: drain loop exiting")
+	l.logger.Debug("audit: drain loop started")
 	for {
 		select {
 		case entry := <-l.ch:
@@ -66,7 +65,7 @@ func (l *Logger) processEntry(entry *auditEntry) {
 	}()
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("audit: panic in processEntry",
+			l.logger.Error("audit: panic in processEntry",
 				"event_type", entry.eventType,
 				"panic", r)
 			if l.metrics != nil {
@@ -135,7 +134,7 @@ func (l *Logger) deliverToOutput(oe *outputEntry, entry *auditEntry, category st
 		if r := recover(); r != nil {
 			buf := make([]byte, 4096)
 			n := runtime.Stack(buf, false)
-			slog.Error("audit: panic in output write",
+			l.logger.Error("audit: panic in output write",
 				"output", oe.output.Name(),
 				"event_type", entry.eventType,
 				"panic", r,
@@ -244,7 +243,7 @@ func (l *Logger) formatWithExclusion(oe *outputEntry, entry *auditEntry, ts time
 	f := oe.effectiveFormatter(l.formatter)
 	data, err := f.Format(ts, entry.eventType, entry.fields, def, oe.formatOpts)
 	if err != nil {
-		slog.Error("audit: format error (filtered)", "event", entry.eventType, "output", oe.output.Name(), "error", err)
+		l.logger.Error("audit: format error (filtered)", "event", entry.eventType, "output", oe.output.Name(), "error", err)
 		if l.metrics != nil {
 			l.metrics.RecordSerializationError(entry.eventType)
 		}
@@ -307,7 +306,7 @@ func (l *Logger) formatCached(oe *outputEntry, entry *auditEntry, ts time.Time, 
 	}
 	data, err := f.Format(ts, entry.eventType, entry.fields, def, nil)
 	if err != nil {
-		slog.Error("audit: serialisation failed",
+		l.logger.Error("audit: serialisation failed",
 			"event_type", entry.eventType,
 			"error", err)
 		if l.metrics != nil {
@@ -326,7 +325,7 @@ func (l *Logger) formatCached(oe *outputEntry, entry *auditEntry, ts time.Time, 
 // dispatch — all parameters are concrete values.
 func (l *Logger) recordWrite(outputName, eventType string, selfReports bool, writeErr error) {
 	if writeErr != nil {
-		slog.Error("audit: output write failed",
+		l.logger.Error("audit: output write failed",
 			"output", outputName,
 			"event_type", eventType,
 			"error", writeErr)

--- a/middleware.go
+++ b/middleware.go
@@ -17,7 +17,6 @@ package audit
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"time"
 )
@@ -235,7 +234,7 @@ func emitAuditEvent(logger *Logger, builder EventBuilder, hints *Hints, transpor
 		defer func() {
 			if v := recover(); v != nil {
 				panicStr := truncateString(fmt.Sprintf("%v", v), 512)
-				slog.Error("audit: EventBuilder panicked",
+				logger.logger.Error("audit: EventBuilder panicked",
 					"panic", panicStr,
 					"request_id", transport.RequestID)
 				skip = true
@@ -249,7 +248,7 @@ func emitAuditEvent(logger *Logger, builder EventBuilder, hints *Hints, transpor
 	}
 
 	if err := logger.AuditEvent(NewEvent(eventType, fields)); err != nil {
-		slog.Warn("audit: middleware event failed",
+		logger.logger.Warn("audit: middleware event failed",
 			"event_type", eventType,
 			"request_id", transport.RequestID,
 			"error", err)

--- a/options.go
+++ b/options.go
@@ -16,6 +16,7 @@ package audit
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 )
 
@@ -107,6 +108,17 @@ func WithTimezone(tz string) Option {
 			return fmt.Errorf("audit: timezone exceeds maximum length of 64 bytes")
 		}
 		l.timezone = tz
+		return nil
+	}
+}
+
+// WithLogger sets the [log/slog.Logger] used for library diagnostics
+// (lifecycle messages, buffer drops, format errors). When not set or
+// when l is nil, [slog.Default] is used. Pass
+// slog.New(slog.DiscardHandler) to silence all library output.
+func WithLogger(l *slog.Logger) Option {
+	return func(lg *Logger) error {
+		lg.logger = l
 		return nil
 	}
 }

--- a/validate_fields.go
+++ b/validate_fields.go
@@ -15,7 +15,6 @@
 package audit
 
 import (
-	"log/slog"
 	"slices"
 	"strings"
 )
@@ -67,7 +66,7 @@ func (l *Logger) checkUnknownFields(eventType string, def *EventDef, fields Fiel
 		return newValidationError(ErrUnknownField, "audit: event %q has unknown fields: [%s]",
 			eventType, strings.Join(unknown, ", "))
 	case ValidationWarn:
-		slog.Warn("audit: event has unknown fields",
+		l.logger.Warn("audit: event has unknown fields",
 			"event_type", eventType,
 			"unknown_fields", unknown)
 	case ValidationPermissive:

--- a/with_logger_test.go
+++ b/with_logger_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithLogger_CustomLogger_ReceivesMessages(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	customLogger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithLogger(customLogger),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+
+	// The "logger created" and "shutdown" messages should appear in buf.
+	assert.Contains(t, buf.String(), "logger created")
+	assert.Contains(t, buf.String(), "shutdown")
+}
+
+func TestWithLogger_NilLogger_UsesDefault(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	// nil logger should not panic — falls back to slog.Default().
+	logger, err := audit.NewLogger(
+		audit.WithLogger(nil),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}
+
+func TestWithLogger_DiscardLogger_SilencesOutput(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	discardLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.Level(100), // above all levels — silences everything
+	}))
+
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithLogger(discardLogger),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+
+	assert.Empty(t, buf.String(), "discard logger should produce no output")
+}


### PR DESCRIPTION
## Summary

- Add `WithLogger(*slog.Logger)` Option for configurable library diagnostics
- Replace 21 package-level slog calls in core with `l.logger.X` (per-logger)
- Default: `slog.Default()`. nil = use default. `slog.New(slog.DiscardHandler)` = silence.
- Add `RecordedEvent.StringField`, `IntField`, `FloatField` for JSON float64 coercion
- Extract `applyDevTaxonomyOverrides` to keep NewLogger below complexity threshold

**Note:** Sub-module slog calls (loki, syslog, webhook, file) are intentionally deferred — they need per-output logger injection which is a separate design.

Parent issue: #387 (Phase 5)
Closes #397

## Test plan

- [x] `make check` passes
- [x] 3 new WithLogger tests: custom, nil, discard
- [x] 3 new RecordedEvent accessor tests: string, int+float64 coercion, float
- [x] Post-coding: code-reviewer (1 blocking fixed — tests added), commit-message (pass)