### PR TITLE
refactor: rename EventType to EventHandle (#402)

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -475,21 +475,21 @@ func (l *Logger) OutputRoute(outputName string) (EventRoute, error) {
 	return oe.getRoute(), nil
 }
 
-// Handle returns an [EventType] handle for the named event type. The
+// Handle returns an [EventHandle] for the named event type. The
 // handle enables zero-allocation audit calls. Returns
 // [ErrHandleNotFound] if the event type is not registered.
-func (l *Logger) Handle(eventType string) (*EventType, error) {
+func (l *Logger) Handle(eventType string) (*EventHandle, error) {
 	if _, ok := l.taxonomy.Events[eventType]; !ok {
 		return nil, fmt.Errorf("audit: unknown event type %q: %w", eventType, ErrHandleNotFound)
 	}
-	return &EventType{name: eventType, logger: l}, nil
+	return &EventHandle{name: eventType, logger: l}, nil
 }
 
-// MustHandle returns an [EventType] handle for the named event type.
+// MustHandle returns an [EventHandle] for the named event type.
 // It panics with an error wrapping [ErrHandleNotFound] if the event
 // type is not registered. Use [Logger.Handle] to receive the error
 // instead of panicking.
-func (l *Logger) MustHandle(eventType string) *EventType {
+func (l *Logger) MustHandle(eventType string) *EventHandle {
 	h, err := l.Handle(eventType)
 	if err != nil {
 		panic(err)

--- a/audit_test.go
+++ b/audit_test.go
@@ -673,7 +673,7 @@ func TestLogger_Handle_Valid(t *testing.T) {
 	h, err := logger.Handle("schema_register")
 	require.NoError(t, err)
 	require.NotNil(t, h)
-	assert.Equal(t, "schema_register", h.Name())
+	assert.Equal(t, "schema_register", h.EventType())
 }
 
 func TestLogger_Handle_Error(t *testing.T) {
@@ -694,7 +694,7 @@ func TestLogger_MustHandle_Valid(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		h := logger.MustHandle("schema_register")
-		assert.Equal(t, "schema_register", h.Name())
+		assert.Equal(t, "schema_register", h.EventType())
 	})
 }
 

--- a/doc.go
+++ b/doc.go
@@ -90,7 +90,7 @@
 //   - [Event] — interface for typed audit events; pass to [Logger.AuditEvent]
 //   - [NewEvent] — creates an event for dynamic use without code generation
 //   - [NewEventKV] — creates an event from alternating key-value pairs (slog-style)
-//   - [EventType] — pre-validated handle for zero-allocation audit calls; see [Logger.MustHandle]
+//   - [EventHandle] — pre-validated handle for zero-allocation audit calls; see [Logger.MustHandle]
 //   - [Fields] — defined type over map[string]any with [Fields.Has], [Fields.String], [Fields.Int] accessors
 //
 // # Outputs

--- a/event.go
+++ b/event.go
@@ -93,23 +93,25 @@ func NewEventKV(eventType string, keysAndValues ...any) Event {
 	return NewEvent(eventType, fields)
 }
 
-// EventType is a handle for a registered audit event type. It carries
-// the event type name and a reference to the owning [Logger], enabling
-// audit calls without repeated string lookup. Obtain a handle via
-// [Logger.Handle] or [Logger.MustHandle].
-type EventType struct {
+// EventHandle is a pre-validated reference to a registered event type.
+// It carries the event type name and a reference to the owning [Logger],
+// enabling audit calls without repeated string lookup. Use generated
+// builders for static event types; use [Logger.Handle] or
+// [Logger.MustHandle] for dynamically-determined event types (e.g.
+// event type names from configuration or a database).
+type EventHandle struct {
 	logger *Logger
 	name   string
 }
 
 // Audit emits an audit event using this handle's bound event type.
 // Fields are wrapped in [NewEvent] internally.
-func (e *EventType) Audit(fields Fields) error {
+func (e *EventHandle) Audit(fields Fields) error {
 	return e.logger.AuditEvent(NewEvent(e.name, fields))
 }
 
-// Name returns the event type name this handle represents.
-func (e *EventType) Name() string {
+// EventType returns the event type name this handle represents.
+func (e *EventHandle) EventType() string {
 	return e.name
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -132,8 +132,8 @@ func ExampleLogger_MustHandle() {
 		return
 	}
 
-	fmt.Println("handle name:", docCreate.Name())
-	// Output: handle name: doc_create
+	fmt.Println("handle event type:", docCreate.EventType())
+	// Output: handle event type: doc_create
 }
 
 func ExampleLogger_EnableCategory() {

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -341,8 +341,8 @@ func registerAuditThenHandleSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 		if tc.EventHandle == nil {
 			return fmt.Errorf("handle is nil")
 		}
-		if tc.EventHandle.Name() != name {
-			return fmt.Errorf("handle name: want %q, got %q", name, tc.EventHandle.Name())
+		if tc.EventHandle.EventType() != name {
+			return fmt.Errorf("handle name: want %q, got %q", name, tc.EventHandle.EventType())
 		}
 		return nil
 	})

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -38,7 +38,7 @@ import (
 type AuditTestContext struct { //nolint:govet // fieldalignment: readability preferred over packing
 	// Logger state.
 	Logger      *audit.Logger
-	EventHandle *audit.EventType
+	EventHandle *audit.EventHandle
 	LastErr     error
 	Taxonomy    *audit.Taxonomy
 	Options     []audit.Option


### PR DESCRIPTION
## Summary

- Rename `EventType` struct to `EventHandle` — avoids confusion with string event type concept
- Rename `Name()` method to `EventType()` — clearer at call sites (`handle.EventType()`)
- Improved godoc explaining when to use Handle vs generated builders

Parent issue: #387 (Independent)
Closes #402

## Test plan

- [x] `make check` passes
- [x] All existing tests pass with renamed type
- [x] Pre-coding: api-ergonomics approved (EventHandle + EventType() accessor)
- [x] Post-coding: code-reviewer (0 blocking, approved), api-ergonomics (approved), commit-message (pass)