### PR TITLE
feat: add WithSynchronousDelivery for inline event processing (#403)

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -90,6 +90,14 @@ type Logger struct {
 	// the former Config.Enabled field (inverted: disabled=true means
 	// the logger does nothing).
 	disabled bool
+	// synchronous is set by WithSynchronousDelivery to deliver events
+	// inline within AuditEvent instead of via the async channel. No
+	// drain goroutine is started. Useful for testing and CLIs.
+	synchronous bool
+	// syncMu guards processEntry calls in synchronous delivery mode.
+	// processEntry reuses per-output state (formatOpts, HMAC) that is
+	// only safe under single-goroutine access.
+	syncMu sync.Mutex
 	// Framework fields set via WithAppName, WithHost, WithTimezone.
 	// PID is captured once at construction via os.Getpid().
 	appName  string
@@ -160,17 +168,20 @@ func NewLogger(opts ...Option) (*Logger, error) {
 		return l, nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	l.cancel = cancel
-	l.ch = make(chan *auditEntry, l.cfg.BufferSize)
-	l.drainDone = make(chan struct{})
-	go l.drainLoop(ctx)
+	if !l.synchronous {
+		ctx, cancel := context.WithCancel(context.Background())
+		l.cancel = cancel
+		l.ch = make(chan *auditEntry, l.cfg.BufferSize)
+		l.drainDone = make(chan struct{})
+		go l.drainLoop(ctx)
+	}
 
 	l.logger.Info("audit: logger created",
 		"buffer_size", l.cfg.BufferSize,
 		"drain_timeout", l.cfg.DrainTimeout,
 		"validation_mode", string(l.cfg.ValidationMode),
 		"outputs", len(l.entries),
+		"synchronous", l.synchronous,
 	)
 
 	return l, nil
@@ -227,24 +238,8 @@ func (l *Logger) auditInternal(eventType string, fields Fields) error {
 		return ErrClosed
 	}
 
-	def, ok := l.taxonomy.Events[eventType]
-	if !ok {
-		if l.metrics != nil {
-			l.metrics.RecordValidationError(eventType)
-		}
-		return newValidationError(ErrUnknownEventType, "audit: unknown event type %q", eventType)
-	}
-
-	// Copy fields and merge defaults in one pass to avoid double
-	// allocation. The copy isolates the caller's map from the drain
-	// goroutine; defaults are applied into the copy so that they
-	// satisfy required: true validation without mutating the original.
-	copied := l.copyFieldsWithDefaults(fields)
-
-	if err := l.validateFields(eventType, def, copied); err != nil {
-		if l.metrics != nil {
-			l.metrics.RecordValidationError(eventType)
-		}
+	_, copied, err := l.validateEvent(eventType, fields)
+	if err != nil {
 		return err
 	}
 
@@ -261,7 +256,47 @@ func (l *Logger) auditInternal(eventType string, fields Fields) error {
 	}
 	entry.eventType = eventType
 	entry.fields = copied
+
+	if l.synchronous {
+		l.deliverSync(entry)
+		return nil
+	}
 	return l.enqueue(entry)
+}
+
+// validateEvent checks the event type exists, copies fields with defaults,
+// and validates field constraints. Returns the definition and copied fields.
+func (l *Logger) validateEvent(eventType string, fields Fields) (*EventDef, Fields, error) {
+	def, ok := l.taxonomy.Events[eventType]
+	if !ok {
+		if l.metrics != nil {
+			l.metrics.RecordValidationError(eventType)
+		}
+		return nil, nil, newValidationError(ErrUnknownEventType, "audit: unknown event type %q", eventType)
+	}
+
+	copied := l.copyFieldsWithDefaults(fields)
+
+	if err := l.validateFields(eventType, def, copied); err != nil {
+		if l.metrics != nil {
+			l.metrics.RecordValidationError(eventType)
+		}
+		return nil, nil, err
+	}
+
+	return def, copied, nil
+}
+
+// deliverSync processes an event inline within AuditEvent for
+// synchronous delivery mode. It reuses the same processEntry logic
+// as the drain goroutine, including panic recovery and pool return.
+// A mutex serialises calls because processEntry reuses per-output
+// state (formatOpts, HMAC) that is only safe under single-goroutine
+// access.
+func (l *Logger) deliverSync(entry *auditEntry) {
+	l.syncMu.Lock()
+	defer l.syncMu.Unlock()
+	l.processEntry(entry)
 }
 
 // enqueue attempts a non-blocking send to the async channel. On
@@ -309,8 +344,10 @@ func (l *Logger) Close() error {
 		shutdownStart := time.Now()
 		l.logger.Info("audit: shutdown started")
 
-		l.cancel()
-		l.waitForDrain()
+		if !l.synchronous {
+			l.cancel()
+			l.waitForDrain()
+		}
 
 		var closeErrs []error
 		for _, oe := range l.entries {

--- a/audittest/audittest.go
+++ b/audittest/audittest.go
@@ -45,6 +45,13 @@ func WithDisabled() Option {
 	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithDisabled()) }
 }
 
+// WithSync creates a synchronous test logger where events are
+// available in the [Recorder] immediately after [audit.Logger.AuditEvent]
+// returns. No Close-before-assert ceremony is needed.
+func WithSync() Option {
+	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithSynchronousDelivery()) }
+}
+
 // NewLogger creates a test audit logger with an in-memory [Recorder]
 // and [MetricsRecorder]. The taxonomy is parsed from YAML bytes.
 //
@@ -71,11 +78,11 @@ func NewLogger(tb testing.TB, taxonomyYAML []byte, opts ...Option) (*audit.Logge
 
 // NewLoggerQuick creates a test audit logger with a permissive
 // taxonomy containing the named event types. No required fields, no
-// unknown field validation. Use for tests that only care about which
-// events were emitted, not about field validation.
+// unknown field validation. Defaults to synchronous delivery — events
+// are available in the Recorder immediately without calling Close.
 func NewLoggerQuick(tb testing.TB, eventTypes ...string) (*audit.Logger, *Recorder, *MetricsRecorder) {
 	tb.Helper()
-	return newTestLogger(tb, QuickTaxonomy(eventTypes...), WithValidationMode(audit.ValidationPermissive))
+	return newTestLogger(tb, QuickTaxonomy(eventTypes...), WithValidationMode(audit.ValidationPermissive), WithSync())
 }
 
 // QuickTaxonomy builds a minimal [*audit.Taxonomy] where every listed

--- a/options.go
+++ b/options.go
@@ -112,6 +112,22 @@ func WithTimezone(tz string) Option {
 	}
 }
 
+// WithSynchronousDelivery configures the logger to deliver events
+// inline within [Logger.AuditEvent] instead of via the async channel
+// and drain goroutine. Events are immediately available in outputs
+// after AuditEvent returns.
+//
+// This mode is useful for testing (no Close-before-assert ceremony)
+// and for simple deployments (CLI tools, Lambda functions) where
+// async complexity is unwanted. [Logger.Close] is still safe to call
+// but is not required before reading output.
+func WithSynchronousDelivery() Option {
+	return func(l *Logger) error {
+		l.synchronous = true
+		return nil
+	}
+}
+
 // WithLogger sets the [log/slog.Logger] used for library diagnostics
 // (lifecycle messages, buffer drops, format errors). When not set or
 // when l is nil, [slog.Default] is used. Pass

--- a/sync_delivery_test.go
+++ b/sync_delivery_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"testing"
+
+	"github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/audittest"
+	"github.com/axonops/go-audit/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncLogger_EventAvailableImmediately(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithSynchronousDelivery(),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "bob",
+	}))
+	require.NoError(t, err)
+
+	// No Close() called — events should be available immediately.
+	assert.Equal(t, 1, out.EventCount(), "sync logger should deliver events immediately")
+
+	// Close is still safe.
+	require.NoError(t, logger.Close())
+}
+
+func TestSyncLogger_CloseIsSafe(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithSynchronousDelivery(),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+
+	// Close without any events — should not panic.
+	require.NoError(t, logger.Close())
+
+	// Double close — should not panic.
+	require.NoError(t, logger.Close())
+}
+
+func TestSyncLogger_ValidationStillRuns(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithSynchronousDelivery(),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	// Missing required field should still be rejected.
+	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
+}
+
+func TestNewLoggerQuick_DefaultsToSync(t *testing.T) {
+	t.Parallel()
+	logger, events, _ := audittest.NewLoggerQuick(t, "user_create")
+
+	err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "ok"}))
+	require.NoError(t, err)
+
+	// No Close — events available immediately because Quick defaults to sync.
+	assert.Equal(t, 1, events.Count(), "NewLoggerQuick should use synchronous delivery")
+}


### PR DESCRIPTION
## Summary

- Add `WithSynchronousDelivery()` Option — events processed inline in AuditEvent, no drain goroutine
- Mutex guards sync processEntry calls for concurrent safety (code-reviewer finding)
- `audittest.NewLoggerQuick` defaults to sync — no Close-before-assert ceremony
- Extract `validateEvent` helper to reduce auditInternal complexity

Parent issue: #387 (Independent)
Closes #403

## Test plan

- [x] `make check` passes
- [x] 4 new tests: immediate availability, Close safe, validation runs, Quick defaults to sync
- [x] Pre-coding: api-ergonomics approved (WithSynchronousDelivery naming, Quick sync default)
- [x] Post-coding: code-reviewer (1 blocking fixed — mutex for race safety), api-ergonomics (approved), commit-message (pass)