### PR TITLE
feat: add NoOpMetrics base struct for embedding (#401)

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -57,3 +57,38 @@ type Metrics interface {
 	// main async buffer was full.
 	RecordBufferDrop()
 }
+
+// NoOpMetrics is a [Metrics] implementation where every method is a
+// no-op. Embed it in your own struct to override only the methods you
+// care about:
+//
+//	type MyMetrics struct {
+//	    audit.NoOpMetrics
+//	    drops atomic.Int64
+//	}
+//	func (m *MyMetrics) RecordBufferDrop() { m.drops.Add(1) }
+type NoOpMetrics struct{}
+
+// Compile-time interface check.
+var _ Metrics = NoOpMetrics{}
+
+// RecordEvent is a no-op.
+func (NoOpMetrics) RecordEvent(string, string) {}
+
+// RecordOutputError is a no-op.
+func (NoOpMetrics) RecordOutputError(string) {}
+
+// RecordOutputFiltered is a no-op.
+func (NoOpMetrics) RecordOutputFiltered(string) {}
+
+// RecordValidationError is a no-op.
+func (NoOpMetrics) RecordValidationError(string) {}
+
+// RecordFiltered is a no-op.
+func (NoOpMetrics) RecordFiltered(string) {}
+
+// RecordSerializationError is a no-op.
+func (NoOpMetrics) RecordSerializationError(string) {}
+
+// RecordBufferDrop is a no-op.
+func (NoOpMetrics) RecordBufferDrop() {}

--- a/noop_metrics_test.go
+++ b/noop_metrics_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoOpMetrics_SatisfiesInterface(t *testing.T) {
+	t.Parallel()
+	// Compile-time check (also verified by var _ in metrics.go).
+	var m audit.Metrics = audit.NoOpMetrics{}
+	_ = m
+}
+
+func TestNoOpMetrics_Embedding_OverrideSingleMethod(t *testing.T) {
+	t.Parallel()
+
+	type myMetrics struct {
+		audit.NoOpMetrics
+		drops atomic.Int64
+	}
+	m := &myMetrics{}
+
+	// Verify it satisfies the interface.
+	var _ audit.Metrics = m
+
+	// Use it in a real logger.
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+		audit.WithMetrics(m),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+
+	// The embedded NoOpMetrics handles all other methods silently.
+	assert.Equal(t, int64(0), m.drops.Load())
+}
+
+func TestNoOpMetrics_WithMetrics_Accepted(t *testing.T) {
+	t.Parallel()
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithMetrics(audit.NoOpMetrics{}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Close())
+}


### PR DESCRIPTION
## Summary

- Export `NoOpMetrics` struct satisfying `Metrics` interface with all no-op methods
- Value receivers enable both `NoOpMetrics{}` and `&NoOpMetrics{}` usage
- Consumers embed and override selectively — eliminates 6 boilerplate no-ops
- Compile-time interface check via `var _ Metrics = NoOpMetrics{}`

Parent issue: #387 (Independent)
Closes #401

## Test plan

- [x] `make check` passes
- [x] 3 tests: interface satisfaction, embedding override, WithMetrics acceptance
- [x] Pre-coding: api-ergonomics approved (NoOpMetrics name, struct not func, value receivers)
- [x] Post-coding: code-reviewer (0 blocking, approved), commit-message (pass)