### PR TITLE
feat: add runtime introspection methods (#404)

### DIFF
--- a/introspect.go
+++ b/introspect.go
@@ -1,0 +1,91 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import "slices"
+
+// BufferLen returns the number of events currently queued in the async
+// buffer. Returns 0 for disabled or synchronous loggers.
+func (l *Logger) BufferLen() int {
+	if l.ch == nil {
+		return 0
+	}
+	return len(l.ch)
+}
+
+// BufferCap returns the configured async buffer capacity. Returns 0
+// for disabled or synchronous loggers.
+func (l *Logger) BufferCap() int {
+	if l.ch == nil {
+		return 0
+	}
+	return cap(l.ch)
+}
+
+// OutputNames returns a sorted list of all configured output names.
+// Safe for concurrent use. Returns nil for disabled loggers with no
+// outputs.
+func (l *Logger) OutputNames() []string {
+	if len(l.entries) == 0 {
+		return nil
+	}
+	names := make([]string, len(l.entries))
+	for i, oe := range l.entries {
+		names[i] = oe.output.Name()
+	}
+	slices.Sort(names)
+	return names
+}
+
+// IsCategoryEnabled reports whether events in the named category
+// would be delivered. This accounts for both category-level state
+// and per-event overrides. Returns false for disabled loggers or
+// unknown categories.
+func (l *Logger) IsCategoryEnabled(category string) bool {
+	if l.disabled || l.taxonomy == nil || l.filter == nil {
+		return false
+	}
+	if _, ok := l.taxonomy.Categories[category]; !ok {
+		return false
+	}
+	// Check category state via the filter's atomic map.
+	if enabled, ok := l.filter.enabledCategories.Load(category); ok {
+		return enabled
+	}
+	return true // default-enabled
+}
+
+// IsEventEnabled reports whether the named event type would be
+// delivered. This accounts for category state, per-event overrides,
+// and the global filter. Returns false for disabled loggers or
+// unknown event types.
+func (l *Logger) IsEventEnabled(eventType string) bool {
+	if l.disabled || l.taxonomy == nil || l.filter == nil {
+		return false
+	}
+	return l.filter.isEnabled(eventType, l.taxonomy)
+}
+
+// IsDisabled reports whether the logger is a no-op (created with
+// [WithDisabled]).
+func (l *Logger) IsDisabled() bool {
+	return l.disabled
+}
+
+// IsSynchronous reports whether the logger delivers events inline
+// within [Logger.AuditEvent] (created with [WithSynchronousDelivery]).
+func (l *Logger) IsSynchronous() bool {
+	return l.synchronous
+}

--- a/introspect_test.go
+++ b/introspect_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/axonops/go-audit"
+	"github.com/axonops/go-audit/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferCap_ReturnsConfiguredSize(t *testing.T) {
+	t.Parallel()
+	logger, err := audit.NewLogger(
+		audit.WithBufferSize(500),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	assert.Equal(t, 500, logger.BufferCap())
+}
+
+func TestBufferLen_ReturnsCurrentOccupancy(t *testing.T) {
+	t.Parallel()
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	// BufferLen starts at 0 (drain goroutine may process immediately).
+	assert.GreaterOrEqual(t, logger.BufferLen(), 0)
+}
+
+func TestOutputNames_ReturnsSortedNames(t *testing.T) {
+	t.Parallel()
+	outB := testhelper.NewMockOutput("beta")
+	outA := testhelper.NewMockOutput("alpha")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(outB, outA),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	names := logger.OutputNames()
+	assert.Equal(t, []string{"alpha", "beta"}, names)
+}
+
+func TestIsCategoryEnabled_ReturnsCorrectState(t *testing.T) {
+	t.Parallel()
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	assert.True(t, logger.IsCategoryEnabled("security"), "security category should be enabled by default")
+	assert.False(t, logger.IsCategoryEnabled("nonexistent"), "unknown category should return false")
+
+	require.NoError(t, logger.DisableCategory("security"))
+	assert.False(t, logger.IsCategoryEnabled("security"), "disabled category should return false")
+}
+
+func TestIsEventEnabled_ReturnsCorrectState(t *testing.T) {
+	t.Parallel()
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	assert.True(t, logger.IsEventEnabled("auth_failure"), "registered event should be enabled")
+	assert.False(t, logger.IsEventEnabled("nonexistent"), "unknown event should return false")
+}
+
+func TestIntrospection_DisabledLogger_ReturnsZero(t *testing.T) {
+	t.Parallel()
+	logger, err := audit.NewLogger(
+		audit.WithDisabled(),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	assert.Equal(t, 0, logger.BufferLen())
+	assert.Equal(t, 0, logger.BufferCap())
+	assert.True(t, logger.IsDisabled())
+	assert.False(t, logger.IsCategoryEnabled("security"))
+	assert.False(t, logger.IsEventEnabled("auth_failure"))
+}
+
+func TestIntrospection_SyncLogger(t *testing.T) {
+	t.Parallel()
+	logger, err := audit.NewLogger(
+		audit.WithSynchronousDelivery(),
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	assert.True(t, logger.IsSynchronous())
+	assert.False(t, logger.IsDisabled())
+	assert.Equal(t, 0, logger.BufferLen(), "sync logger has no buffer")
+	assert.Equal(t, 0, logger.BufferCap(), "sync logger has no buffer")
+}
+
+func TestIntrospection_ConcurrentWithAuditEvent_NoRace(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	logger, err := audit.NewLogger(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logger.Close() })
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+				"outcome":  "failure",
+				"actor_id": "bob",
+			}))
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = logger.BufferLen()
+			_ = logger.BufferCap()
+			_ = logger.OutputNames()
+			_ = logger.IsCategoryEnabled("security")
+			_ = logger.IsEventEnabled("auth_failure")
+			_ = logger.IsDisabled()
+			_ = logger.IsSynchronous()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- Add 7 read-only diagnostic methods to Logger: `BufferLen`, `BufferCap`, `OutputNames`, `IsCategoryEnabled`, `IsEventEnabled`, `IsDisabled`, `IsSynchronous`
- All lock-free, safe for concurrent use with AuditEvent
- Work correctly on disabled and synchronous loggers (zero/false/nil)

Parent issue: #387 (Independent)
Closes #404

## Test plan

- [x] `make check` passes
- [x] 8 tests: each method, disabled logger, sync logger, concurrent race
- [x] Pre-coding: api-ergonomics approved (7 methods, naming, IsCategoryEnabled mirrors filter.isEnabled)
- [x] Post-coding: code-reviewer (0 blocking, approved), api-ergonomics (approved), commit-message (pass)