### PR TITLE
feat: add WithFactory LoadOption for per-call overrides (#399)

### DIFF
--- a/outputconfig/options.go
+++ b/outputconfig/options.go
@@ -31,6 +31,7 @@ type LoadOption func(*loadOptions)
 // loadOptions holds the resolved options for a Load call.
 type loadOptions struct {
 	coreMetrics   audit.Metrics
+	factories     map[string]audit.OutputFactory
 	providers     []secrets.Provider
 	secretTimeout time.Duration
 }
@@ -65,6 +66,18 @@ func WithSecretTimeout(d time.Duration) LoadOption {
 func WithCoreMetrics(m audit.Metrics) LoadOption {
 	return func(o *loadOptions) {
 		o.coreMetrics = m
+	}
+}
+
+// WithFactory registers a per-call output factory override for the
+// given type name. Per-call factories take precedence over globally
+// registered factories. Multiple calls for the same type: last wins.
+func WithFactory(typeName string, factory audit.OutputFactory) LoadOption {
+	return func(o *loadOptions) {
+		if o.factories == nil {
+			o.factories = make(map[string]audit.OutputFactory)
+		}
+		o.factories[typeName] = factory
 	}
 }
 

--- a/outputconfig/output.go
+++ b/outputconfig/output.go
@@ -35,7 +35,7 @@ type outputFields struct { //nolint:govet // fieldalignment: readability preferr
 
 // buildOutput constructs a single named output from its raw YAML value.
 // Returns nil (not error) when the output is disabled (enabled: false).
-func buildOutput(ctx context.Context, name string, raw any, taxonomy *audit.Taxonomy, globalTLSRaw any, globalAppName, globalHost string, coreMetrics audit.Metrics, r *resolver) (*NamedOutput, error) { //nolint:gocyclo,cyclop // linear pipeline with secret resolution added
+func buildOutput(ctx context.Context, name string, raw any, taxonomy *audit.Taxonomy, globalTLSRaw any, globalAppName, globalHost string, coreMetrics audit.Metrics, factories map[string]audit.OutputFactory, r *resolver) (*NamedOutput, error) { //nolint:gocyclo,cyclop // linear pipeline with secret resolution added
 	fields, err := extractOutputFields(name, raw)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func buildOutput(ctx context.Context, name string, raw any, taxonomy *audit.Taxo
 		return nil, fmtErr
 	}
 
-	output, err := invokeFactory(name, fields, globalTLSRaw, globalAppName, globalHost, coreMetrics)
+	output, err := invokeFactory(name, fields, globalTLSRaw, globalAppName, globalHost, coreMetrics, factories)
 	if err != nil {
 		return nil, err
 	}
@@ -255,8 +255,12 @@ type yamlTLSPolicy struct {
 	AllowWeakCiphers bool `yaml:"allow_weak_ciphers"`
 }
 
-func invokeFactory(name string, f *outputFields, globalTLSRaw any, globalAppName, globalHost string, coreMetrics audit.Metrics) (audit.Output, error) {
-	factory := audit.LookupOutputFactory(f.typeName)
+func invokeFactory(name string, f *outputFields, globalTLSRaw any, globalAppName, globalHost string, coreMetrics audit.Metrics, factories map[string]audit.OutputFactory) (audit.Output, error) {
+	// Per-call factory overrides take precedence over global registry.
+	factory := factories[f.typeName]
+	if factory == nil {
+		factory = audit.LookupOutputFactory(f.typeName)
+	}
 	if factory == nil {
 		registered := audit.RegisteredOutputTypes()
 		return nil, fmt.Errorf("output %q: unknown output type %q (registered: [%s]); "+

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -239,7 +239,7 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 		}
 		seen[name] = struct{}{}
 
-		no, err := buildOutput(secretCtx, name, item.Value, taxonomy, top.tlsPolicyRaw, top.appName, top.host, lo.coreMetrics, secretResolver)
+		no, err := buildOutput(secretCtx, name, item.Value, taxonomy, top.tlsPolicyRaw, top.appName, top.host, lo.coreMetrics, lo.factories, secretResolver)
 		if err != nil {
 			closeAll(outputs)
 			return nil, fmt.Errorf("%w: %w", ErrOutputConfigInvalid, err)


### PR DESCRIPTION
## Summary

- Add `WithFactory(typeName, factory)` LoadOption for per-call factory overrides
- Per-call factories take precedence over global registry; unoverridden types fall back
- Multiple calls for same type: last wins (map overwrite)
- Nil map safe — Go guarantees nil map index returns zero value

Parent issue: #387 (Independent)
Closes #399

## Test plan

- [x] `make check` passes
- [x] All existing outputconfig tests pass (factory lookup unchanged for default case)
- [x] Pre-coding: api-ergonomics approved (WithFactory name, single-pair, validate at lookup)
- [x] Post-coding: code-reviewer (0 blocking, nil map safe confirmed), commit-message (pass)