### PR TITLE
feat: add YAML secrets: section for declarative provider config (#443)

### DIFF
--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -168,8 +168,9 @@ outputs:
 | `host` | Yes | Hostname/environment. Emitted as a framework field. Max 255 bytes. Env vars supported. |
 | `timezone` | No | Timezone name (e.g. `UTC`, `America/New_York`). Max 64 bytes. Auto-detected from system when absent. |
 | `standard_fields` | No | Map of reserved standard field names to deployment-wide default values. Keys must be [reserved standard field names](../examples/13-standard-fields/#the-solution-reserved-standard-fields). |
+| `secrets` | No | Secret provider configuration. Constructs providers from YAML instead of programmatic setup. See [Secrets Configuration](#secrets-configuration). |
 | `logger` | No | Logger configuration. All fields optional; defaults applied if omitted. |
-| `tls_policy` | No | Global TLS policy for all TLS-enabled outputs. Per-output `tls_policy` overrides. |
+| `tls_policy` | No | Global TLS policy for all TLS-enabled outputs. Per-output `tls_policy` overrides. Does NOT apply to secret providers — each provider defaults to TLS 1.3 independently. |
 | `outputs` | Yes | Map of named outputs. At least one must be defined. Maximum: 100. |
 
 ## ⚙️ Logger Configuration
@@ -214,6 +215,65 @@ defaults (`false`).
 
 Outputs that do not use TLS (file, stdout, syslog with `network: tcp`
 or `network: udp`) ignore the global TLS policy.
+
+## 🔐 Secrets Configuration
+
+The optional `secrets:` section configures secret providers
+declaratively in YAML, replacing programmatic provider setup via
+`WithSecretProvider`. Providers are constructed, used for `ref+`
+URI resolution during `Load`, and closed automatically — callers
+do not manage their lifecycle.
+
+```yaml
+secrets:
+  timeout: "15s"
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    allow_insecure_http: true    # dev-only — NEVER in production
+    allow_private_ranges: true   # Docker internal network
+  vault:
+    address: "${VAULT_ADDR}"
+    token: "${VAULT_TOKEN}"
+```
+
+### Reserved keys
+
+| Key | Description |
+|-----|-------------|
+| `timeout` | Secret resolution timeout. Min `1s`, max `120s`. Default: `10s`. `WithSecretTimeout` takes precedence when set programmatically. |
+
+All other keys under `secrets:` are treated as provider scheme names.
+Supported providers: `openbao`, `vault`. Unknown keys are rejected
+with an actionable error.
+
+### Provider fields
+
+Both `openbao` and `vault` accept the same configuration fields:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `address` | Yes | — | Server URL. HTTPS required unless `allow_insecure_http` is set. |
+| `token` | Yes | — | Authentication token. Use `${ENV_VAR}` — never hardcode. |
+| `namespace` | No | `""` | Namespace prefix (sent as `X-Vault-Namespace` header). |
+| `tls_ca` | No | `""` | Path to custom CA certificate PEM file. |
+| `tls_cert` | No | `""` | Path to client certificate for mTLS. Must be paired with `tls_key`. |
+| `tls_key` | No | `""` | Path to client private key for mTLS. Must be paired with `tls_cert`. |
+| `tls_policy` | No | TLS 1.3 only | Per-provider TLS policy. The global `tls_policy` does NOT apply to secret providers. |
+| `allow_insecure_http` | No | `false` | Permit `http://` URLs. **MUST NOT be `true` in production.** Plaintext HTTP exposes the authentication token to network observers. Use only for local development with Docker Compose. |
+| `allow_private_ranges` | No | `false` | Permit connections to RFC 1918 private addresses and loopback. Required for local development where the provider runs on `127.0.0.1` or a Docker network. Cloud metadata endpoints remain blocked. |
+
+> ⚠️ **Security:** Only environment variable substitution (`${VAR}`)
+> is applied in the `secrets:` section — `ref+` secret references are
+> NOT resolved (this would be circular since providers must exist
+> before secrets can be resolved). Tokens MUST come from environment
+> variables.
+
+### Duplicate scheme detection
+
+If the same provider scheme appears in both the YAML `secrets:`
+section and a programmatic `WithSecretProvider` call, `Load` returns
+an error. Choose one or the other for each provider scheme.
 
 ## 📦 Output Block
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -246,13 +246,14 @@ Both `openbao.Config` and `vault.Config` share the same field set:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `Address` | Yes | Server URL. MUST use `https://`. |
+| `Address` | Yes | Server URL. MUST use `https://` unless `AllowInsecureHTTP` is set. |
 | `Token` | Yes | Authentication token. See [Authentication](#authentication). |
 | `Namespace` | No | Namespace prefix. Sent as `X-Vault-Namespace` header. |
 | `TLSCA` | No | Path to CA certificate PEM file for server verification. |
 | `TLSCert` | No | Client certificate path for mTLS. MUST be set together with `TLSKey`. |
 | `TLSKey` | No | Client private key path for mTLS. MUST be set together with `TLSCert`. |
 | `TLSPolicy` | No | `*audit.TLSPolicy`. Nil defaults to TLS 1.3 only. |
+| `AllowInsecureHTTP` | No | Permit `http://` URLs. **MUST NOT be `true` in production.** Plaintext HTTP exposes the authentication token to network observers. Use only for local development with Docker Compose where the provider runs on the internal Docker network. Default: `false`. |
 | `AllowPrivateRanges` | No | Permit connections to RFC 1918 addresses (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), IPv6 ULA (`fc00::/7`), and loopback (`127.0.0.0/8`, `::1`). Cloud metadata endpoints (`169.254.169.254`) remain blocked even when this is `true`. Required for local development. Default: `false`. |
 
 ### WithSecretTimeout
@@ -270,6 +271,43 @@ result, err := outputconfig.Load(ctx, yamlData, taxonomy,
 ```
 
 Default: `10s` (`outputconfig.DefaultSecretTimeout`).
+
+### YAML-Based Provider Configuration
+
+Instead of creating providers programmatically, you can configure them
+declaratively in the `secrets:` section of `outputs.yaml`. Providers
+are constructed, used for resolution, and closed automatically within
+`outputconfig.Load` — no manual lifecycle management is needed.
+
+```yaml
+secrets:
+  timeout: "15s"
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    allow_insecure_http: true    # dev-only — NEVER in production
+    allow_private_ranges: true   # Docker internal network
+```
+
+```go
+// No programmatic provider setup needed — just Load.
+result, err := outputconfig.Load(ctx, yamlData, taxonomy)
+```
+
+This replaces the programmatic pattern shown above. The YAML field
+names use `snake_case` equivalents of the Go struct fields (e.g.
+`allow_insecure_http` for `AllowInsecureHTTP`, `tls_ca` for `TLSCA`).
+
+Only environment variable substitution (`${VAR}`) is applied in the
+`secrets:` section — `ref+` secret references are NOT resolved, since
+that would be circular (providers must exist before secrets can be
+resolved).
+
+**Timeout precedence:** `WithSecretTimeout` (programmatic) >
+`secrets.timeout` (YAML) > `DefaultSecretTimeout` (10s).
+
+See [Secrets Configuration](output-configuration.md#secrets-configuration)
+in the output configuration reference for the full field table.
 
 ## Authentication
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -279,7 +279,29 @@ declaratively in the `secrets:` section of `outputs.yaml`. Providers
 are constructed, used for resolution, and closed automatically within
 `outputconfig.Load` — no manual lifecycle management is needed.
 
+**Before (programmatic):**
+
+```go
+provider, err := openbao.New(&openbao.Config{
+    Address:            os.Getenv("BAO_ADDR"),
+    Token:              os.Getenv("BAO_TOKEN"),
+    AllowPrivateRanges: true,
+    AllowInsecureHTTP:  true,
+})
+if err != nil {
+    return fmt.Errorf("openbao provider: %w", err)
+}
+defer provider.Close()
+
+result, err := outputconfig.Load(ctx, yamlData, taxonomy,
+    outputconfig.WithSecretProvider(provider),
+)
+```
+
+**After (YAML):**
+
 ```yaml
+# outputs.yaml
 secrets:
   timeout: "15s"
   openbao:
@@ -290,24 +312,30 @@ secrets:
 ```
 
 ```go
-// No programmatic provider setup needed — just Load.
+// No programmatic provider setup — Load handles everything.
 result, err := outputconfig.Load(ctx, yamlData, taxonomy)
 ```
 
-This replaces the programmatic pattern shown above. The YAML field
-names use `snake_case` equivalents of the Go struct fields (e.g.
-`allow_insecure_http` for `AllowInsecureHTTP`, `tls_ca` for `TLSCA`).
+The YAML approach eliminates the `secrets/openbao` import, the manual
+`Close()` call, the conditional env var checks, and the `LoadOption`
+assembly. Provider config becomes an ops concern, not a code change.
+
+The YAML field names use `snake_case` equivalents of the Go struct
+fields (e.g. `allow_insecure_http` for `AllowInsecureHTTP`, `tls_ca`
+for `TLSCA`).
 
 Only environment variable substitution (`${VAR}`) is applied in the
 `secrets:` section — `ref+` secret references are NOT resolved, since
 that would be circular (providers must exist before secrets can be
 resolved).
 
-**Timeout precedence:** `WithSecretTimeout` (programmatic) >
-`secrets.timeout` (YAML) > `DefaultSecretTimeout` (10s).
+**Timeout precedence:** If you set both, the programmatic value wins:
+`WithSecretTimeout` (programmatic) > `secrets.timeout` (YAML) >
+`DefaultSecretTimeout` (10s).
 
-See [Secrets Configuration](output-configuration.md#secrets-configuration)
-in the output configuration reference for the full field table.
+For the complete field table, see
+[Secrets Configuration](output-configuration.md#secrets-configuration)
+in the output configuration reference.
 
 ## Authentication
 
@@ -593,16 +621,20 @@ logger before replacing it -- `Close` drains buffered events.
 
 ## Security Model
 
-### HTTPS-Only
+### HTTPS by Default
 
-Both providers MUST connect over HTTPS. `New` rejects any address
+Both providers enforce HTTPS by default. `New` rejects any address
 that does not use the `https` scheme:
 
 ```
-openbao: address must use https (got "http")
+vault: address must use https (got "http"); set AllowInsecureHTTP for local development
 ```
 
-There is no `AllowInsecureHTTP` escape hatch for provider connections.
+The `AllowInsecureHTTP` field (Go) / `allow_insecure_http` (YAML)
+overrides this check for local development only. **MUST NOT be
+`true` in production** — plaintext HTTP exposes the authentication
+token to network observers. Use only when the provider runs on the
+Docker internal network or localhost during development.
 
 ### SSRF Protection
 

--- a/examples/17-capstone/audit_setup.go
+++ b/examples/17-capstone/audit_setup.go
@@ -23,7 +23,6 @@ import (
 	_ "github.com/axonops/audit/file" // register "file" output type
 	_ "github.com/axonops/audit/loki" // register "loki" output type
 	"github.com/axonops/audit/outputconfig"
-	"github.com/axonops/audit/secrets/openbao"
 )
 
 // setupAuditLogger loads outputs.yaml from the filesystem and creates
@@ -40,6 +39,11 @@ import (
 // HMAC salts, versions, algorithms, and enabled flags are resolved
 // from OpenBao at startup via ref+openbao:// URIs in outputs.yaml.
 // No secrets are stored in configuration files or environment variables.
+//
+// The OpenBao provider is configured declaratively in the outputs.yaml
+// secrets: section. Environment variables BAO_ADDR and BAO_TOKEN are
+// resolved by outputconfig.Load via ${} substitution in the YAML.
+// No programmatic provider setup is needed.
 func setupAuditLogger(tax *audit.Taxonomy, m *auditMetrics) (*audit.Logger, error) {
 	// Load output configuration from the filesystem.
 	configPath := envOr("AUDIT_CONFIG_PATH", "outputs.yaml")
@@ -48,31 +52,9 @@ func setupAuditLogger(tax *audit.Taxonomy, m *auditMetrics) (*audit.Logger, erro
 		return nil, fmt.Errorf("read output config %s: %w", configPath, err)
 	}
 
-	// Build LoadOptions: core metrics + OpenBao secret provider.
-	loadOpts := []outputconfig.LoadOption{
+	result, err := outputconfig.Load(context.Background(), outputsYAML, tax,
 		outputconfig.WithCoreMetrics(m),
-	}
-
-	// Connect to OpenBao for ref+openbao:// URI resolution.
-	// HMAC salts, versions, algorithms, and enabled flags are all
-	// stored in OpenBao — no secrets in config files or env vars.
-	baoAddr := os.Getenv("BAO_ADDR")
-	baoToken := os.Getenv("BAO_TOKEN")
-	if baoAddr != "" && baoToken != "" {
-		provider, providerErr := openbao.New(&openbao.Config{
-			Address:            baoAddr,
-			Token:              baoToken,
-			AllowPrivateRanges: true, // Docker internal network
-			AllowInsecureHTTP:  true, // Dev-only — NEVER in production
-		})
-		if providerErr != nil {
-			return nil, fmt.Errorf("openbao provider: %w", providerErr)
-		}
-		defer func() { _ = provider.Close() }()
-		loadOpts = append(loadOpts, outputconfig.WithSecretProvider(provider))
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax, loadOpts...)
+	)
 	if err != nil {
 		return nil, fmt.Errorf("load output config: %w", err)
 	}

--- a/examples/17-capstone/go.mod
+++ b/examples/17-capstone/go.mod
@@ -16,7 +16,7 @@ require (
 
 require (
 	github.com/axonops/audit/secrets v0.1.4 // indirect
-	github.com/axonops/audit/secrets/openbao v0.1.4
+	github.com/axonops/audit/secrets/openbao v0.1.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/examples/17-capstone/outputs.yaml
+++ b/examples/17-capstone/outputs.yaml
@@ -12,6 +12,18 @@ version: 1
 app_name: "inventory-demo"
 host: "${HOSTNAME:-localhost}"
 
+# Secret providers — configured declaratively.
+# Tokens come from environment variables; no secrets in config files.
+# Providers are constructed, used for ref+ URI resolution, and closed
+# within outputconfig.Load().
+secrets:
+  timeout: "15s"
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    allow_insecure_http: true    # Dev-only — NEVER in production
+    allow_private_ranges: true   # Docker internal network
+
 logger:
   buffer_size: ${AUDIT_BUFFER_SIZE:-10000}
   drain_timeout: "${AUDIT_DRAIN_TIMEOUT:-5s}"

--- a/outputconfig/options.go
+++ b/outputconfig/options.go
@@ -30,10 +30,11 @@ type LoadOption func(*loadOptions)
 
 // loadOptions holds the resolved options for a Load call.
 type loadOptions struct {
-	coreMetrics   audit.Metrics
-	factories     map[string]audit.OutputFactory
-	providers     []secrets.Provider
-	secretTimeout time.Duration
+	coreMetrics      audit.Metrics
+	factories        map[string]audit.OutputFactory
+	providers        []secrets.Provider
+	secretTimeout    time.Duration
+	secretTimeoutSet bool // true when WithSecretTimeout was called explicitly
 }
 
 // WithSecretProvider registers a secret provider for resolving ref+
@@ -54,6 +55,7 @@ func WithSecretTimeout(d time.Duration) LoadOption {
 	return func(o *loadOptions) {
 		if d > 0 {
 			o.secretTimeout = d
+			o.secretTimeoutSet = true
 		}
 	}
 }

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -146,26 +146,18 @@ func (o *NamedOutput) String() string {
 // prevents YAML injection via env var values.
 //
 // Secret reference resolution (ref+SCHEME://PATH#KEY) runs after env
-// var expansion when providers are registered via [WithSecretProvider].
-// The ctx parameter controls timeout for network I/O during secret
-// resolution. Use [WithSecretTimeout] to configure the resolution
-// timeout.
+// var expansion when providers are registered via [WithSecretProvider]
+// or configured in the YAML secrets: section. The ctx parameter
+// controls timeout for network I/O during secret resolution. Use
+// [WithSecretTimeout] or the YAML secrets.timeout field to configure
+// the resolution timeout.
+//
+// When providers are configured in the YAML secrets: section, they are
+// constructed, used for resolution, and closed within Load. They do
+// not outlive the call.
 func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...LoadOption) (*LoadResult, error) { //nolint:gocognit,gocyclo,cyclop // linear pipeline with 8+ phases
 	lo := resolveOptions(opts)
 
-	// Build the secret resolver from registered providers.
-	secretResolver, rErr := newResolver(lo.providers)
-	if rErr != nil {
-		return nil, rErr
-	}
-
-	// Derive a context with the secret timeout applied.
-	secretCtx := ctx
-	if secretResolver != nil {
-		var cancel context.CancelFunc
-		secretCtx, cancel = contextWithSecretTimeout(ctx, lo.secretTimeout)
-		defer cancel()
-	}
 	// Phase 1: Size check.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("%w: input is empty", ErrOutputConfigInvalid)
@@ -190,11 +182,53 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 		return nil, fmt.Errorf("%w: trailing content: %w", ErrOutputConfigInvalid, err)
 	}
 
+	// Phase 3b: Extract and parse secrets: section (pre-pass).
+	// The secrets: section is parsed BEFORE the resolver is built because
+	// it creates the providers needed for ref+ resolution. Only env var
+	// substitution is applied — ref+ URIs are not resolved (circular).
+	filteredDoc, yamlProviders, yamlTimeout, sErr := extractAndParseSecrets(doc)
+	if sErr != nil {
+		return nil, sErr
+	}
+	// Ensure YAML-created providers are closed on all exit paths.
+	defer func() {
+		for _, p := range yamlProviders {
+			_ = p.Close()
+		}
+	}()
+
+	// Merge YAML-created providers with programmatic ones.
+	allProviders, mErr := mergeProviders(lo.providers, yamlProviders)
+	if mErr != nil {
+		return nil, mErr
+	}
+
+	// Determine effective secret timeout.
+	// Precedence: WithSecretTimeout > YAML timeout > DefaultSecretTimeout.
+	secretTimeout := lo.secretTimeout
+	if !lo.secretTimeoutSet && yamlTimeout > 0 {
+		secretTimeout = yamlTimeout
+	}
+
+	// Build the secret resolver from combined providers.
+	secretResolver, rErr := newResolver(allProviders)
+	if rErr != nil {
+		return nil, rErr
+	}
+
+	// Derive a context with the secret timeout applied.
+	secretCtx := ctx
+	if secretResolver != nil {
+		var cancel context.CancelFunc
+		secretCtx, cancel = contextWithSecretTimeout(ctx, secretTimeout)
+		defer cancel()
+	}
+
 	// Phase 4-6: Parse top-level fields, validate version, resolve config.
 	// Extract ordered outputs separately (goccy/go-yaml decodes nested
 	// maps as map[string]any which loses key order).
 	orderedOutputs, orderedErr := extractOutputsOrdered(data)
-	top, err := parseTopLevel(secretCtx, doc, orderedOutputs, orderedErr, secretResolver)
+	top, err := parseTopLevel(secretCtx, filteredDoc, orderedOutputs, orderedErr, secretResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/outputconfig/provider_config.go
+++ b/outputconfig/provider_config.go
@@ -1,0 +1,294 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputconfig
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/secrets"
+	"github.com/axonops/audit/secrets/openbao"
+	"github.com/axonops/audit/secrets/vault"
+	"github.com/goccy/go-yaml"
+)
+
+// minSecretTimeout is the minimum secret resolution timeout accepted
+// from YAML configuration.
+const minSecretTimeout = 1 * time.Second
+
+// maxSecretTimeout is the maximum secret resolution timeout accepted
+// from YAML configuration.
+const maxSecretTimeout = 120 * time.Second
+
+// supportedProviders lists the provider scheme names recognised by the
+// secrets: section. Used in error messages to guide configuration.
+var supportedProviders = []string{"openbao", "vault"}
+
+// secretsResult holds the providers and timeout parsed from the YAML
+// secrets: section.
+type secretsResult struct {
+	providers []secrets.Provider
+	timeout   time.Duration // zero means not specified in YAML
+}
+
+// parseSecretsSection parses the secrets: top-level YAML value into
+// provider instances and an optional timeout. Only environment variable
+// substitution is applied — ref+ URIs are NOT resolved (providers must
+// exist before secret references can be resolved; resolving secrets to
+// construct providers would be circular).
+//
+// Tokens are handled as Go strings during parsing and passed to
+// provider constructors which store them as []byte for zeroing in
+// Close(). The original Go strings remain in heap memory until GC
+// collects them (same caveat as programmatic API usage).
+//
+// The caller must Close() all returned providers when done.
+func parseSecretsSection(raw any) (*secretsResult, error) { //nolint:gocognit,gocyclo,cyclop // YAML field dispatch mirrors parseTopLevel pattern
+	// Expand environment variables.
+	expanded, err := expandEnvInValue(raw, "secrets")
+	if err != nil {
+		return nil, fmt.Errorf("secrets: %w", err)
+	}
+
+	m, ok := expanded.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: secrets must be a YAML mapping", ErrOutputConfigInvalid)
+	}
+
+	result := &secretsResult{}
+
+	// closeOnError cleans up already-constructed providers when a
+	// later step fails. Prevents token material from persisting in
+	// memory and HTTP transport leaks.
+	closeOnError := func() {
+		for _, p := range result.providers {
+			_ = p.Close()
+		}
+	}
+
+	// Process timeout first (fail-fast before any provider construction).
+	if val, ok := m["timeout"]; ok {
+		s, sErr := toString(val)
+		if sErr != nil {
+			return nil, fmt.Errorf("%w: secrets.timeout: %w", ErrOutputConfigInvalid, sErr)
+		}
+		d, dErr := time.ParseDuration(s)
+		if dErr != nil {
+			return nil, fmt.Errorf("%w: secrets.timeout: invalid duration %q: %w",
+				ErrOutputConfigInvalid, s, dErr)
+		}
+		if d < minSecretTimeout {
+			return nil, fmt.Errorf("%w: secrets.timeout: %s is below minimum %s",
+				ErrOutputConfigInvalid, d, minSecretTimeout)
+		}
+		if d > maxSecretTimeout {
+			return nil, fmt.Errorf("%w: secrets.timeout: %s exceeds maximum %s",
+				ErrOutputConfigInvalid, d, maxSecretTimeout)
+		}
+		result.timeout = d
+		delete(m, "timeout")
+	}
+
+	// Remaining keys are provider scheme names.
+	for key, val := range m {
+		switch key {
+		case "openbao":
+			p, pErr := parseOpenBaoProvider(val)
+			if pErr != nil {
+				closeOnError()
+				return nil, pErr
+			}
+			result.providers = append(result.providers, p)
+
+		case "vault":
+			p, pErr := parseVaultProvider(val)
+			if pErr != nil {
+				closeOnError()
+				return nil, pErr
+			}
+			result.providers = append(result.providers, p)
+
+		default:
+			closeOnError()
+			return nil, fmt.Errorf("%w: secrets: unknown provider %q (supported: %v)",
+				ErrOutputConfigInvalid, key, supportedProviders)
+		}
+	}
+
+	return result, nil
+}
+
+// yamlProviderConfig is the YAML structure for both openbao and vault
+// provider configuration. Fields match the Go Config structs.
+type yamlProviderConfig struct { //nolint:govet // readability over alignment
+	Address            string         `yaml:"address"`
+	Token              string         `yaml:"token"`
+	Namespace          string         `yaml:"namespace"`
+	TLSCA              string         `yaml:"tls_ca"`
+	TLSCert            string         `yaml:"tls_cert"`
+	TLSKey             string         `yaml:"tls_key"`
+	TLSPolicy          *yamlTLSPolicy `yaml:"tls_policy"`
+	AllowInsecureHTTP  bool           `yaml:"allow_insecure_http"`
+	AllowPrivateRanges bool           `yaml:"allow_private_ranges"`
+}
+
+// String returns a redacted representation to prevent token leakage
+// if the struct is accidentally passed to a logging or formatting call.
+func (yamlProviderConfig) String() string { return "[REDACTED]" }
+
+// GoString prevents token leakage via %#v.
+func (yamlProviderConfig) GoString() string { return "[REDACTED]" }
+
+// parseOpenBaoProvider constructs an [openbao.Provider] from parsed
+// YAML configuration.
+func parseOpenBaoProvider(raw any) (secrets.Provider, error) {
+	cfg, err := unmarshalProviderConfig(raw, "openbao")
+	if err != nil {
+		return nil, err
+	}
+
+	var tlsPolicy *audit.TLSPolicy
+	if cfg.TLSPolicy != nil {
+		tlsPolicy = &audit.TLSPolicy{
+			AllowTLS12:       cfg.TLSPolicy.AllowTLS12,
+			AllowWeakCiphers: cfg.TLSPolicy.AllowWeakCiphers,
+		}
+	}
+
+	p, pErr := openbao.New(&openbao.Config{
+		Address:            cfg.Address,
+		Token:              cfg.Token,
+		Namespace:          cfg.Namespace,
+		TLSCA:              cfg.TLSCA,
+		TLSCert:            cfg.TLSCert,
+		TLSKey:             cfg.TLSKey,
+		TLSPolicy:          tlsPolicy,
+		AllowInsecureHTTP:  cfg.AllowInsecureHTTP,
+		AllowPrivateRanges: cfg.AllowPrivateRanges,
+	})
+	if pErr != nil {
+		return nil, fmt.Errorf("%w: secrets.openbao: %w", ErrOutputConfigInvalid, pErr)
+	}
+	return p, nil
+}
+
+// parseVaultProvider constructs a [vault.Provider] from parsed YAML
+// configuration.
+func parseVaultProvider(raw any) (secrets.Provider, error) {
+	cfg, err := unmarshalProviderConfig(raw, "vault")
+	if err != nil {
+		return nil, err
+	}
+
+	var tlsPolicy *audit.TLSPolicy
+	if cfg.TLSPolicy != nil {
+		tlsPolicy = &audit.TLSPolicy{
+			AllowTLS12:       cfg.TLSPolicy.AllowTLS12,
+			AllowWeakCiphers: cfg.TLSPolicy.AllowWeakCiphers,
+		}
+	}
+
+	p, pErr := vault.New(&vault.Config{
+		Address:            cfg.Address,
+		Token:              cfg.Token,
+		Namespace:          cfg.Namespace,
+		TLSCA:              cfg.TLSCA,
+		TLSCert:            cfg.TLSCert,
+		TLSKey:             cfg.TLSKey,
+		TLSPolicy:          tlsPolicy,
+		AllowInsecureHTTP:  cfg.AllowInsecureHTTP,
+		AllowPrivateRanges: cfg.AllowPrivateRanges,
+	})
+	if pErr != nil {
+		return nil, fmt.Errorf("%w: secrets.vault: %w", ErrOutputConfigInvalid, pErr)
+	}
+	return p, nil
+}
+
+// unmarshalProviderConfig marshals a parsed YAML value back to bytes
+// and unmarshals it into [yamlProviderConfig] with strict field
+// checking. This rejects unknown fields (typos) with an actionable
+// error.
+func unmarshalProviderConfig(raw any, providerName string) (*yamlProviderConfig, error) {
+	b, err := yaml.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: secrets.%s: %w", ErrOutputConfigInvalid, providerName, err)
+	}
+
+	var cfg yamlProviderConfig
+	if uErr := yaml.UnmarshalWithOptions(b, &cfg, yaml.DisallowUnknownField()); uErr != nil {
+		return nil, fmt.Errorf("%w: secrets.%s: %w", ErrOutputConfigInvalid, providerName, uErr)
+	}
+
+	return &cfg, nil
+}
+
+// extractAndParseSecrets extracts the secrets: key from a MapSlice,
+// parses it into providers and timeout, and returns the remaining
+// MapSlice with secrets: removed. If no secrets: key is present,
+// returns the original doc unchanged with nil providers.
+func extractAndParseSecrets(doc yaml.MapSlice) (filtered yaml.MapSlice, providers []secrets.Provider, timeout time.Duration, err error) {
+	var secretsRaw any
+	filtered = make(yaml.MapSlice, 0, len(doc))
+	for _, item := range doc {
+		key, ok := item.Key.(string)
+		if ok && key == "secrets" {
+			secretsRaw = item.Value
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+
+	if secretsRaw == nil {
+		return filtered, nil, 0, nil
+	}
+
+	result, pErr := parseSecretsSection(secretsRaw)
+	if pErr != nil {
+		return nil, nil, 0, pErr
+	}
+
+	return filtered, result.providers, result.timeout, nil
+}
+
+// mergeProviders combines programmatic providers (from WithSecretProvider)
+// with YAML-created providers. Returns an error if a scheme appears in
+// both sources.
+func mergeProviders(programmatic, yamlCreated []secrets.Provider) ([]secrets.Provider, error) {
+	if len(yamlCreated) == 0 {
+		return programmatic, nil
+	}
+	if len(programmatic) == 0 {
+		return yamlCreated, nil
+	}
+
+	// Check for duplicate schemes between programmatic and YAML.
+	progSchemes := make(map[string]struct{}, len(programmatic))
+	for _, p := range programmatic {
+		progSchemes[p.Scheme()] = struct{}{}
+	}
+	for _, p := range yamlCreated {
+		if _, dup := progSchemes[p.Scheme()]; dup {
+			return nil, fmt.Errorf("%w: secret provider scheme %q configured in both YAML and WithSecretProvider",
+				ErrOutputConfigInvalid, p.Scheme())
+		}
+	}
+
+	combined := make([]secrets.Provider, 0, len(programmatic)+len(yamlCreated))
+	combined = append(combined, programmatic...)
+	combined = append(combined, yamlCreated...)
+	return combined, nil
+}

--- a/outputconfig/provider_config_test.go
+++ b/outputconfig/provider_config_test.go
@@ -1,0 +1,592 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputconfig_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit/outputconfig"
+	"github.com/axonops/audit/secrets/openbao"
+)
+
+// ---------------------------------------------------------------------------
+// YAML secrets: section — Load integration tests
+// ---------------------------------------------------------------------------
+
+func TestLoad_SecretsSection_OpenBao(t *testing.T) {
+	// Start a TLS server that serves a KV v2 response.
+	srv := httptest.NewTLSServer(kvHandler(map[string]any{
+		"enabled": "true",
+		"salt":    "this-is-a-test-salt-value-at-least-16-bytes",
+		"version": "v1",
+		"hash":    "HMAC-SHA-256",
+	}, "test-bao-token"))
+	t.Cleanup(srv.Close)
+
+	// Write the server's CA cert to a file for the provider.
+	caPath := writeTestCA(t, srv)
+
+	t.Setenv("BAO_ADDR", srv.URL)
+	t.Setenv("BAO_TOKEN", "test-bao-token")
+	t.Setenv("BAO_CA", caPath)
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  timeout: "5s"
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    tls_ca: "${BAO_CA}"
+    allow_private_ranges: true
+outputs:
+  console:
+    type: stdout
+    hmac:
+      enabled: "ref+openbao://secret/data/hmac#enabled"
+      salt:
+        version: "ref+openbao://secret/data/hmac#version"
+        value: "ref+openbao://secret/data/hmac#salt"
+      hash: "ref+openbao://secret/data/hmac#hash"
+`
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+	require.NotNil(t, result.Outputs[0].HMACConfig)
+	assert.True(t, result.Outputs[0].HMACConfig.Enabled)
+	assert.Equal(t, "this-is-a-test-salt-value-at-least-16-bytes", string(result.Outputs[0].HMACConfig.SaltValue))
+	assert.Equal(t, "v1", result.Outputs[0].HMACConfig.SaltVersion)
+}
+
+func TestLoad_SecretsSection_Vault(t *testing.T) {
+	srv := httptest.NewTLSServer(kvHandler(map[string]any{
+		"enabled": "true",
+		"salt":    "vault-salt-value-at-least-sixteen-bytes-long",
+		"version": "v2",
+		"hash":    "HMAC-SHA-512",
+	}, "test-vault-token"))
+	t.Cleanup(srv.Close)
+
+	caPath := writeTestCA(t, srv)
+
+	t.Setenv("VAULT_ADDR", srv.URL)
+	t.Setenv("VAULT_TOKEN", "test-vault-token")
+	t.Setenv("VAULT_CA", caPath)
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  vault:
+    address: "${VAULT_ADDR}"
+    token: "${VAULT_TOKEN}"
+    tls_ca: "${VAULT_CA}"
+    allow_private_ranges: true
+outputs:
+  console:
+    type: stdout
+    hmac:
+      enabled: "ref+vault://secret/data/hmac#enabled"
+      salt:
+        version: "ref+vault://secret/data/hmac#version"
+        value: "ref+vault://secret/data/hmac#salt"
+      hash: "ref+vault://secret/data/hmac#hash"
+`
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+	require.NotNil(t, result.Outputs[0].HMACConfig)
+	assert.True(t, result.Outputs[0].HMACConfig.Enabled)
+	assert.Equal(t, "vault-salt-value-at-least-sixteen-bytes-long", string(result.Outputs[0].HMACConfig.SaltValue))
+	assert.Equal(t, "v2", result.Outputs[0].HMACConfig.SaltVersion)
+}
+
+func TestLoad_SecretsSection_AllowInsecureHTTP(t *testing.T) {
+	// Start an HTTP (not HTTPS) server.
+	srv := httptest.NewServer(kvHandler(map[string]any{
+		"enabled": "true",
+		"salt":    "insecure-salt-value-at-least-sixteen-bytes",
+		"version": "v1",
+		"hash":    "HMAC-SHA-256",
+	}, "test-token"))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("BAO_ADDR", srv.URL)
+	t.Setenv("BAO_TOKEN", "test-token")
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    allow_insecure_http: true
+    allow_private_ranges: true
+outputs:
+  console:
+    type: stdout
+    hmac:
+      enabled: "ref+openbao://secret/data/hmac#enabled"
+      salt:
+        version: "ref+openbao://secret/data/hmac#version"
+        value: "ref+openbao://secret/data/hmac#salt"
+      hash: "ref+openbao://secret/data/hmac#hash"
+`
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+	require.NotNil(t, result.Outputs[0].HMACConfig)
+	assert.Equal(t, "insecure-salt-value-at-least-sixteen-bytes", string(result.Outputs[0].HMACConfig.SaltValue))
+}
+
+func TestLoad_SecretsSection_UnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  consul:
+    address: "https://consul.example.com"
+outputs:
+  console:
+    type: stdout
+`
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "unknown provider")
+	assert.Contains(t, err.Error(), "consul")
+	assert.Contains(t, err.Error(), "openbao")
+	assert.Contains(t, err.Error(), "vault")
+}
+
+func TestLoad_SecretsSection_UnknownField(t *testing.T) {
+	t.Setenv("BAO_ADDR", "https://openbao.example.com")
+	t.Setenv("BAO_TOKEN", "test-token")
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    typo_field: true
+outputs:
+  console:
+    type: stdout
+`
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "openbao")
+}
+
+func TestLoad_SecretsSection_DuplicateScheme_YAMLAndProgrammatic(t *testing.T) {
+	t.Setenv("BAO_ADDR", "https://openbao.example.com")
+	t.Setenv("BAO_TOKEN", "test-token")
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    allow_private_ranges: true
+outputs:
+  console:
+    type: stdout
+`
+	// Create a programmatic provider with the same scheme.
+	progProvider, err := openbao.New(&openbao.Config{
+		Address:            "https://other-openbao.example.com",
+		Token:              "other-token",
+		AllowPrivateRanges: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = progProvider.Close() }()
+
+	tax := testTaxonomy(t)
+	_, err = outputconfig.Load(context.Background(), []byte(yamlConfig), tax,
+		outputconfig.WithSecretProvider(progProvider),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "openbao")
+	assert.Contains(t, err.Error(), "both YAML and WithSecretProvider")
+}
+
+func TestLoad_SecretsSection_TimeoutBounds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timeout string
+		wantErr string
+	}{
+		{
+			name:    "below minimum",
+			timeout: "500ms",
+			wantErr: "below minimum",
+		},
+		{
+			name:    "above maximum",
+			timeout: "5m",
+			wantErr: "exceeds maximum",
+		},
+		{
+			name:    "invalid duration",
+			timeout: "not-a-duration",
+			wantErr: "invalid duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  timeout: "` + tt.timeout + `"
+outputs:
+  console:
+    type: stdout
+`
+			tax := testTaxonomy(t)
+			_, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestLoad_SecretsSection_ValidTimeout(t *testing.T) {
+	t.Parallel()
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  timeout: "30s"
+outputs:
+  console:
+    type: stdout
+`
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestLoad_SecretsSection_TimeoutPrecedence_WithSecretTimeoutWins(t *testing.T) {
+	// Start a slow server that blocks for 4s.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(4 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	caPath := writeTestCA(t, srv)
+
+	t.Setenv("BAO_ADDR", srv.URL)
+	t.Setenv("BAO_TOKEN", "test-token")
+	t.Setenv("BAO_CA", caPath)
+
+	// YAML timeout is 30s, but WithSecretTimeout is 1s — should timeout.
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  timeout: "30s"
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    tls_ca: "${BAO_CA}"
+    allow_private_ranges: true
+outputs:
+  console:
+    type: stdout
+    hmac:
+      enabled: "ref+openbao://secret/data/hmac#enabled"
+      salt:
+        version: "ref+openbao://secret/data/hmac#version"
+        value: "ref+openbao://secret/data/hmac#salt"
+      hash: "ref+openbao://secret/data/hmac#hash"
+`
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax,
+		outputconfig.WithSecretTimeout(1*time.Second),
+	)
+	require.Error(t, err, "WithSecretTimeout(1s) should override YAML timeout(30s)")
+}
+
+func TestLoad_SecretsSection_NoSecrets_StillWorks(t *testing.T) {
+	t.Parallel()
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+outputs:
+  console:
+    type: stdout
+`
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestLoad_SecretsSection_EmptySecretsSection(t *testing.T) {
+	t.Parallel()
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  timeout: "10s"
+outputs:
+  console:
+    type: stdout
+`
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestLoad_SecretsSection_MissingEnvVar(t *testing.T) {
+	t.Parallel()
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  openbao:
+    address: "${NONEXISTENT_BAO_ADDR}"
+    token: "some-token"
+outputs:
+  console:
+    type: stdout
+`
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NONEXISTENT_BAO_ADDR")
+}
+
+func TestLoad_SecretsSection_ProviderConstructionError(t *testing.T) {
+	// Missing token should cause provider construction to fail.
+	t.Setenv("BAO_ADDR", "https://openbao.example.com")
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  openbao:
+    address: "${BAO_ADDR}"
+    token: ""
+outputs:
+  console:
+    type: stdout
+`
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestLoad_SecretsSection_VaultAllowInsecureHTTP(t *testing.T) {
+	srv := httptest.NewServer(kvHandler(map[string]any{
+		"enabled": "true",
+		"salt":    "vault-http-salt-value-at-least-sixteen-bytes",
+		"version": "v1",
+		"hash":    "HMAC-SHA-256",
+	}, "test-vault-token"))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("VAULT_ADDR", srv.URL)
+	t.Setenv("VAULT_TOKEN", "test-vault-token")
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  vault:
+    address: "${VAULT_ADDR}"
+    token: "${VAULT_TOKEN}"
+    allow_insecure_http: true
+    allow_private_ranges: true
+outputs:
+  console:
+    type: stdout
+    hmac:
+      enabled: "ref+vault://secret/data/hmac#enabled"
+      salt:
+        version: "ref+vault://secret/data/hmac#version"
+        value: "ref+vault://secret/data/hmac#salt"
+      hash: "ref+vault://secret/data/hmac#hash"
+`
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 1)
+	require.NotNil(t, result.Outputs[0].HMACConfig)
+	assert.Equal(t, "vault-http-salt-value-at-least-sixteen-bytes", string(result.Outputs[0].HMACConfig.SaltValue))
+}
+
+func TestLoad_SecretsSection_BothProviders(t *testing.T) {
+	baoSrv := httptest.NewTLSServer(kvHandler(map[string]any{
+		"enabled": "true",
+		"salt":    "bao-salt-value-at-least-sixteen-bytes-long",
+		"version": "v1",
+		"hash":    "HMAC-SHA-256",
+	}, "bao-token"))
+	t.Cleanup(baoSrv.Close)
+
+	vaultSrv := httptest.NewTLSServer(kvHandler(map[string]any{
+		"enabled": "true",
+		"salt":    "vault-salt-value-at-least-sixteen-bytes-long",
+		"version": "v2",
+		"hash":    "HMAC-SHA-512",
+	}, "vault-token"))
+	t.Cleanup(vaultSrv.Close)
+
+	baoCA := writeTestCA(t, baoSrv)
+	vaultCA := writeTestCA(t, vaultSrv)
+
+	t.Setenv("BAO_ADDR", baoSrv.URL)
+	t.Setenv("BAO_TOKEN", "bao-token")
+	t.Setenv("BAO_CA", baoCA)
+	t.Setenv("VAULT_ADDR", vaultSrv.URL)
+	t.Setenv("VAULT_TOKEN", "vault-token")
+	t.Setenv("VAULT_CA", vaultCA)
+
+	yamlConfig := `
+version: 1
+app_name: test
+host: test
+secrets:
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    tls_ca: "${BAO_CA}"
+    allow_private_ranges: true
+  vault:
+    address: "${VAULT_ADDR}"
+    token: "${VAULT_TOKEN}"
+    tls_ca: "${VAULT_CA}"
+    allow_private_ranges: true
+outputs:
+  bao_output:
+    type: stdout
+    hmac:
+      enabled: "ref+openbao://secret/data/hmac#enabled"
+      salt:
+        version: "ref+openbao://secret/data/hmac#version"
+        value: "ref+openbao://secret/data/hmac#salt"
+      hash: "ref+openbao://secret/data/hmac#hash"
+  vault_output:
+    type: stdout
+    hmac:
+      enabled: "ref+vault://secret/data/hmac#enabled"
+      salt:
+        version: "ref+vault://secret/data/hmac#version"
+        value: "ref+vault://secret/data/hmac#salt"
+      hash: "ref+vault://secret/data/hmac#hash"
+`
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
+	require.NoError(t, err)
+	require.Len(t, result.Outputs, 2)
+
+	assert.Equal(t, "bao-salt-value-at-least-sixteen-bytes-long", string(result.Outputs[0].HMACConfig.SaltValue))
+	assert.Equal(t, "vault-salt-value-at-least-sixteen-bytes-long", string(result.Outputs[1].HMACConfig.SaltValue))
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func kvHandler(data map[string]any, expectedToken string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != expectedToken {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		resp := map[string]any{
+			"data": map[string]any{"data": data},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+}
+
+func writeTestCA(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	// Extract the server's certificate.
+	certs := srv.TLS.Certificates
+	require.NotEmpty(t, certs)
+
+	cert, err := x509.ParseCertificate(certs[0].Certificate[0])
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	f, err := os.Create(caPath)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+	return caPath
+}
+
+// testTaxonomy is defined in outputconfig_test.go — shared across test files.

--- a/outputconfig/tests/bdd/features/output_config.feature
+++ b/outputconfig/tests/bdd/features/output_config.feature
@@ -69,7 +69,7 @@ Feature: YAML Output Configuration
       """
     When I try to create a logger from the YAML config
     Then the config load should fail with an error containing "unknown output type"
-    And the config load error should contain "did you import"
+    And the config load error should contain "add import"
 
   Scenario: Missing environment variable returns clear error
     Given a test taxonomy

--- a/secrets/openbao/openbao.go
+++ b/secrets/openbao/openbao.go
@@ -97,8 +97,9 @@ type Provider struct { //nolint:govet // readability over alignment
 }
 
 // New creates an OpenBao provider from the given configuration.
-// Validates the address (HTTPS required), builds the TLS config and
-// HTTP client, but performs no network I/O.
+// Validates the address (HTTPS required unless [Config.AllowInsecureHTTP]
+// is set), builds the TLS config and HTTP client, but performs no
+// network I/O.
 func New(cfg *Config) (*Provider, error) {
 	// Validate address.
 	if cfg.Address == "" {

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -75,6 +75,13 @@ type Config struct { //nolint:govet // readability over alignment
 	// Vault runs on 127.0.0.1. Cloud metadata endpoints remain
 	// blocked. Default: false.
 	AllowPrivateRanges bool
+
+	// AllowInsecureHTTP permits http:// URLs. Default: false.
+	// MUST NOT be set to true in production. Plaintext HTTP exposes
+	// the authentication token to network observers. Use only for
+	// local development with Docker Compose where Vault runs
+	// on the internal Docker network.
+	AllowInsecureHTTP bool
 }
 
 // Provider resolves secret references from a HashiCorp Vault KV v2
@@ -90,9 +97,10 @@ type Provider struct { //nolint:govet // readability over alignment
 }
 
 // New creates a HashiCorp Vault provider from the given configuration.
-// Validates the address (HTTPS required), builds the TLS config and
-// HTTP client, but performs no network I/O.
-func New(cfg *Config) (*Provider, error) {
+// Validates the address (HTTPS required unless [Config.AllowInsecureHTTP]
+// is set), builds the TLS config and HTTP client, but performs no
+// network I/O.
+func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear validation pipeline
 	// Validate address.
 	if cfg.Address == "" {
 		return nil, fmt.Errorf("vault: address is required")
@@ -101,8 +109,8 @@ func New(cfg *Config) (*Provider, error) {
 	if err != nil {
 		return nil, fmt.Errorf("vault: invalid address: %w", err)
 	}
-	if u.Scheme != "https" {
-		return nil, fmt.Errorf("vault: address must use https (got %q)", u.Scheme)
+	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
+		return nil, fmt.Errorf("vault: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
 	}
 	if u.Host == "" {
 		return nil, fmt.Errorf("vault: address has empty host")
@@ -119,10 +127,13 @@ func New(cfg *Config) (*Provider, error) {
 		return nil, fmt.Errorf("vault: token is required")
 	}
 
-	// Build TLS config.
-	tlsCfg, err := buildTLSConfig(cfg)
-	if err != nil {
-		return nil, err
+	// Build TLS config (skip when using plain HTTP for development).
+	var tlsCfg *tls.Config
+	if u.Scheme == "https" {
+		tlsCfg, err = buildTLSConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Build SSRF dial control.
@@ -177,8 +188,8 @@ func NewWithHTTPClient(cfg *Config, client *http.Client) (*Provider, error) {
 	if err != nil {
 		return nil, fmt.Errorf("vault: invalid address: %w", err)
 	}
-	if u.Scheme != "https" {
-		return nil, fmt.Errorf("vault: address must use https (got %q)", u.Scheme)
+	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
+		return nil, fmt.Errorf("vault: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
 	}
 	if u.Host == "" {
 		return nil, fmt.Errorf("vault: address has empty host")

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -84,6 +84,32 @@ func TestNew_RequiresHTTPS(t *testing.T) {
 	_, err := vault.New(&vault.Config{Address: "http://vault.example.com", Token: "t"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "https")
+	assert.Contains(t, err.Error(), "AllowInsecureHTTP")
+}
+
+func TestNew_AllowInsecureHTTP(t *testing.T) {
+	t.Parallel()
+	p, err := vault.New(&vault.Config{
+		Address:            "http://vault.example.com",
+		Token:              "t",
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+	assert.Equal(t, "vault", p.Scheme())
+}
+
+func TestNewWithHTTPClient_AllowInsecureHTTP(t *testing.T) {
+	t.Parallel()
+	p, err := vault.NewWithHTTPClient(&vault.Config{
+		Address:           "http://vault.example.com",
+		Token:             "t",
+		AllowInsecureHTTP: true,
+	}, http.DefaultClient)
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+	assert.Equal(t, "vault", p.Scheme())
 }
 
 func TestNew_RequiresAddress(t *testing.T) {
@@ -671,6 +697,7 @@ func TestNewWithHTTPClient_RequiresHTTPS(t *testing.T) {
 	}, http.DefaultClient)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "https")
+	assert.Contains(t, err.Error(), "AllowInsecureHTTP")
 }
 
 func TestResolve_RedirectBlocked(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `secrets:` top-level section to `outputs.yaml` for declarative secret provider configuration (OpenBao, Vault)
- Add `AllowInsecureHTTP` to `vault.Config` (matching existing openbao field) for dev-mode HTTP URLs
- Two-pass `Load()`: extract `secrets:` pre-pass, construct providers, merge with programmatic ones, then process remaining config
- Simplify capstone `audit_setup.go` — remove programmatic provider setup, use YAML-only configuration
- Document `secrets:` section in `output-configuration.md` and `secrets.md`

## Changes

| File | What |
|------|------|
| `secrets/vault/vault.go` | Add `AllowInsecureHTTP bool` to `Config`, conditional TLS build |
| `outputconfig/provider_config.go` | **NEW**: YAML `secrets:` parsing, provider construction, merge, lifecycle |
| `outputconfig/outputconfig.go` | Two-pass `Load` with pre-pass for `secrets:` extraction |
| `outputconfig/options.go` | `secretTimeoutSet` flag for timeout precedence |
| `outputconfig/provider_config_test.go` | **NEW**: 15 integration tests |
| `examples/17-capstone/outputs.yaml` | Add `secrets:` section with openbao config |
| `examples/17-capstone/audit_setup.go` | Remove programmatic openbao setup |
| `docs/output-configuration.md` | Document `secrets:` section schema |
| `docs/secrets.md` | Document YAML-based provider config, add `AllowInsecureHTTP` to field table |
| `secrets/openbao/openbao.go` | Fix godoc to mention `AllowInsecureHTTP` |
| `outputconfig/tests/bdd/features/output_config.feature` | Fix pre-existing assertion mismatch |

## Design decisions

- **Flat schema**: Provider configs sit directly under `secrets:` (no `providers:` wrapper), consistent with how `outputs:` works
- **Timeout precedence**: `WithSecretTimeout` > YAML `secrets.timeout` > `DefaultSecretTimeout`
- **No ref+ in secrets section**: Only `${ENV_VAR}` substitution — prevents circular dependency
- **Provider lifecycle**: Constructed, used, and closed within `Load()` via `defer`
- **Partial failure cleanup**: `closeOnError` helper zeroes tokens and closes transports on construction failure

## Test plan

- [ ] `make lint` — 0 issues across all modules
- [ ] `make test` — all 12 modules pass
- [ ] 15 new unit tests covering: OpenBao/Vault from YAML, AllowInsecureHTTP, unknown provider, unknown field, duplicate scheme, timeout bounds/precedence, missing env var, construction error, both providers simultaneously
- [ ] CI pipeline passes
- [ ] Capstone `docker compose up` works end-to-end (post-release)

Closes #443