### PR TITLE
fix: flush file output after every write (#450)

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -526,3 +526,50 @@ func TestFileOutput_DestinationKey_EquivalentPaths(t *testing.T) {
 			"paths %q and %q should produce the same key", tests[0].path, tests[i].path)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Write — data visible on disk without Close (#450)
+// ---------------------------------------------------------------------------
+
+func TestFileOutput_Write_DataVisibleWithoutClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+
+	out, err := file.New(file.Config{Path: path}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+
+	event := []byte(`{"event_type":"auth.login","outcome":"success"}` + "\n")
+	require.NoError(t, out.Write(event))
+
+	// Read file WITHOUT closing the output.
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(event), string(data),
+		"event must be visible on disk immediately after Write, without Close (#450)")
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+func BenchmarkFileOutput_Write(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "bench.log")
+
+	out, err := file.New(file.Config{Path: path, MaxSizeMB: 1024}, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = out.Close() }()
+
+	event := []byte(`{"timestamp":"2026-04-14T12:00:00Z","event_type":"user_create","severity":5,"app_name":"bench","host":"localhost","outcome":"success","actor_id":"alice"}` + "\n")
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(event)))
+	for b.Loop() {
+		if err := out.Write(event); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/file/internal/rotate/writer.go
+++ b/file/internal/rotate/writer.go
@@ -187,6 +187,15 @@ func (w *Writer) writeLocked(p []byte) (n int, rotated bool, err error) {
 	if err != nil {
 		return n, rotated, fmt.Errorf("rotate: write: %w", err)
 	}
+
+	// Flush buffered data to the OS page cache after every write so
+	// audit events are visible on disk immediately. This does NOT
+	// call fsync — the OS persists to stable storage on its own
+	// schedule. For a compliance audit log, prompt visibility is
+	// more important than syscall batching. (#450)
+	if fErr := w.bw.Flush(); fErr != nil {
+		return n, rotated, fmt.Errorf("rotate: flush: %w", fErr)
+	}
 	return n, rotated, nil
 }
 

--- a/file/internal/rotate/writer_test.go
+++ b/file/internal/rotate/writer_test.go
@@ -832,6 +832,55 @@ func TestWriter_Sync(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Write — data visible on disk without Sync/Close (#450)
+// ---------------------------------------------------------------------------
+
+func TestWriter_Write_DataVisibleWithoutSync(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+
+	w, err := rotate.New(path, rotate.Config{MaxSize: 1 << 20, Mode: 0o600})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, w.Close()) })
+
+	event := []byte(`{"event_type":"auth.login","outcome":"success"}` + "\n")
+	_, err = w.Write(event)
+	require.NoError(t, err)
+
+	// Data must be visible on disk WITHOUT calling Sync() or Close().
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(event), string(data),
+		"event must be visible on disk immediately after Write (#450)")
+}
+
+func TestWriter_Write_MultipleEventsVisibleWithoutSync(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+
+	w, err := rotate.New(path, rotate.Config{MaxSize: 1 << 20, Mode: 0o600})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, w.Close()) })
+
+	const count = 10
+	for i := range count {
+		event := []byte(fmt.Sprintf(`{"seq":%d}`+"\n", i))
+		_, err = w.Write(event)
+		require.NoError(t, err)
+	}
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	assert.Len(t, lines, count,
+		"all %d events must be visible on disk without Sync or Close (#450)", count)
+}
+
+// ---------------------------------------------------------------------------
 // Edge cases for coverage
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The file output's rotate writer buffers writes in a 32KB `bufio.Writer` that only flushes on `Close()` or size-based rotation. Audit events appear as 0 bytes on disk until the app shuts down — risking data loss on crash.

## Fix

Add `bw.Flush()` after every `bw.Write(p)` in `writeLocked()`. This pushes data to the OS page cache immediately via `write(2)`, NOT `fsync(2)`. The `bufio.Writer` still serves as a write-coalescing buffer within each `Write` call.

## Benchmark

```
BenchmarkFileOutput_Write-32    1750136    687.1 ns/op    224.12 MB/s    0 B/op    0 allocs/op
```

At 100 events/sec, total overhead is 69 microseconds — negligible.

## Test plan

- [x] `TestWriter_Write_DataVisibleWithoutSync` — data visible on disk after Write, no Sync/Close
- [x] `TestWriter_Write_MultipleEventsVisibleWithoutSync` — 10 events all visible
- [x] `TestFileOutput_Write_DataVisibleWithoutClose` — public API integration test
- [x] `BenchmarkFileOutput_Write` — new benchmark for file output throughput
- [x] `make check` clean
- [ ] Capstone `docker compose up` shows data in audit.log without restart

Closes #450