### PR TITLE
fix: use GOPROXY=direct in capstone Dockerfile (#443)

### DIFF
--- a/examples/17-capstone/Dockerfile
+++ b/examples/17-capstone/Dockerfile
@@ -1,8 +1,10 @@
-# Build stage — dependencies are published on proxy.golang.org.
+# Build stage — fetch dependencies directly from GitHub to avoid
+# Go module proxy indexing delays on newly released versions.
 FROM golang:1.26-alpine AS builder
+RUN apk add --no-cache git
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+RUN GOPROXY=direct GONOSUMCHECK=github.com/axonops/audit GONOSUMDB=github.com/axonops/audit go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o /app .
 


### PR DESCRIPTION
## Summary

The Go module proxy can take hours to index newly released versions. The capstone Docker build fails with `go mod download` when modules aren't yet indexed.

Use `GOPROXY=direct` to fetch directly from GitHub, with `git` installed in the Alpine builder for the direct fetch mechanism.

## Test plan

- [ ] `docker compose build app` succeeds immediately after a new release

Relates to #443