### PR TITLE
fix: use source artifacts for SBOM generation to prevent upload race

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,7 +61,7 @@ changelog:
 
 sboms:
   - id: cyclonedx
-    artifacts: archive
+    artifacts: source
     documents:
       - >-
         {{ .ProjectName }}_{{ .Version }}_sbom.cdx.json
@@ -71,7 +71,7 @@ sboms:
       - "--output"
       - "cyclonedx-json=${document}"
   - id: spdx
-    artifacts: archive
+    artifacts: source
     documents:
       - >-
         {{ .ProjectName }}_{{ .Version }}_sbom.spdx.json


### PR DESCRIPTION
## Summary

GoReleaser SBOM config used `artifacts: archive` which generates one SBOM per platform archive (6 archives × 2 formats = 12 SBOMs). All SBOMs for the same format shared the same filename template, causing concurrent upload races that fail the release.

Switch to `artifacts: source` — one SBOM per format from the source tarball. No duplicate filenames, no race.

This has caused v0.1.7 and v0.1.8 releases to fail at the GoReleaser step.

## Test plan

- [ ] Next release (v0.1.9+) GoReleaser completes without SBOM upload errors