### PR TITLE
refactor: extend NewLogger facade with LoadOption support (#443)

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -49,7 +49,7 @@
 //	//go:embed taxonomy.yaml
 //	var taxonomyYAML []byte
 //
-//	logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml")
+//	logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml", nil)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -570,7 +570,7 @@ The simplest way to create a logger from YAML is the
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml")
+logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml", nil)
 if err != nil {
     return fmt.Errorf("audit: %w", err)
 }

--- a/examples/02-code-generation/README.md
+++ b/examples/02-code-generation/README.md
@@ -238,7 +238,7 @@ result, err := outputconfig.Load(ctx, outputsYAML, &tax, nil)
 Or use the facade — one call instead of three steps:
 
 ```go
-logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml")
+logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml", nil)
 ```
 
 ### Two Files, Two Purposes

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -36,7 +36,7 @@ var taxonomyYAML []byte
 
 func main() {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/03-file-output/main.go
+++ b/examples/03-file-output/main.go
@@ -35,7 +35,7 @@ var taxonomyYAML []byte
 
 func main() {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/04-testing/main.go
+++ b/examples/04-testing/main.go
@@ -67,7 +67,7 @@ func (s *UserService) Login(username, password string) error {
 
 func main() {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/05-formatters/main.go
+++ b/examples/05-formatters/main.go
@@ -35,7 +35,7 @@ var taxonomyYAML []byte
 
 func main() {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/06-middleware/main.go
+++ b/examples/06-middleware/main.go
@@ -67,7 +67,7 @@ func buildEvent(hints *audit.Hints, transport *audit.TransportMetadata) (eventTy
 
 func main() {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/07-syslog-output/main.go
+++ b/examples/07-syslog-output/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	// 2. Parse taxonomy and load output config.
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/08-webhook-output/main.go
+++ b/examples/08-webhook-output/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	// 2. Parse taxonomy and load output config.
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/09-multi-output/main.go
+++ b/examples/09-multi-output/main.go
@@ -36,7 +36,7 @@ var taxonomyYAML []byte
 
 func main() {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/10-event-routing/main.go
+++ b/examples/10-event-routing/main.go
@@ -35,7 +35,7 @@ var taxonomyYAML []byte
 
 func main() {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/11-sensitivity-labels/main.go
+++ b/examples/11-sensitivity-labels/main.go
@@ -51,7 +51,7 @@ func main() {
 
 func createLogger() *audit.Logger {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/12-hmac-integrity/main.go
+++ b/examples/12-hmac-integrity/main.go
@@ -36,7 +36,7 @@ var taxonomyYAML []byte
 func main() {
 	// 1. Parse taxonomy.
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/13-standard-fields/README.md
+++ b/examples/13-standard-fields/README.md
@@ -127,7 +127,7 @@ The `standard_fields` YAML section is handled automatically by
 `outputconfig.NewLogger` — no manual wiring needed:
 
 ```go
-logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml")
+logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml", nil)
 ```
 
 The facade reads the `standard_fields` map, creates a

--- a/examples/13-standard-fields/main.go
+++ b/examples/13-standard-fields/main.go
@@ -39,7 +39,7 @@ func main() {
 	// All 31 standard fields (source_ip, reason, target_id, etc.)
 	// are available automatically.
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/14-loki-output/main.go
+++ b/examples/14-loki-output/main.go
@@ -49,7 +49,7 @@ var taxonomyYAML []byte
 
 func main() {
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/15-tls-policy/main.go
+++ b/examples/15-tls-policy/main.go
@@ -43,7 +43,7 @@ var taxonomyYAML []byte
 func main() {
 	// 1. Parse taxonomy and load output config.
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/16-buffering/main.go
+++ b/examples/16-buffering/main.go
@@ -51,7 +51,7 @@ var taxonomyYAML []byte
 func main() {
 	// Parse taxonomy.
 	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml")
+	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
 		log.Fatalf("create logger: %v", err)
 	}

--- a/examples/17-capstone/audit_setup.go
+++ b/examples/17-capstone/audit_setup.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/axonops/audit"
 	_ "github.com/axonops/audit/file" // register "file" output type
@@ -25,10 +23,10 @@ import (
 	"github.com/axonops/audit/outputconfig"
 )
 
-// setupAuditLogger loads outputs.yaml from the filesystem and creates
-// the logger. The taxonomy is embedded (compile-time contract), but
-// output configuration is loaded at runtime so it can change per
-// environment without rebuilding the binary.
+// setupAuditLogger creates a logger using the NewLogger facade.
+// The taxonomy is embedded (compile-time contract), and output
+// configuration is loaded from the filesystem at runtime so it can
+// change per environment without rebuilding the binary.
 //
 // Blank imports register each output type's factory via init().
 // The YAML file defines which outputs are active — adding or removing
@@ -38,32 +36,12 @@ import (
 //
 // HMAC salts, versions, algorithms, and enabled flags are resolved
 // from OpenBao at startup via ref+openbao:// URIs in outputs.yaml.
-// No secrets are stored in configuration files or environment variables.
-//
 // The OpenBao provider is configured declaratively in the outputs.yaml
-// secrets: section. Environment variables BAO_ADDR and BAO_TOKEN are
-// resolved by outputconfig.Load via ${} substitution in the YAML.
-// No programmatic provider setup is needed.
-func setupAuditLogger(tax *audit.Taxonomy, m *auditMetrics) (*audit.Logger, error) {
-	// Load output configuration from the filesystem.
+// secrets: section — no programmatic provider setup is needed.
+func setupAuditLogger(m *auditMetrics) (*audit.Logger, error) {
 	configPath := envOr("AUDIT_CONFIG_PATH", "outputs.yaml")
-	outputsYAML, err := os.ReadFile(configPath) //nolint:gosec // config path from trusted source (env var or default)
-	if err != nil {
-		return nil, fmt.Errorf("read output config %s: %w", configPath, err)
-	}
-
-	result, err := outputconfig.Load(context.Background(), outputsYAML, tax,
-		outputconfig.WithCoreMetrics(m),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("load output config: %w", err)
-	}
-
-	opts := []audit.Option{
-		audit.WithTaxonomy(tax),
+	return outputconfig.NewLogger(context.Background(), taxonomyYAML, configPath,
+		[]outputconfig.LoadOption{outputconfig.WithCoreMetrics(m)},
 		audit.WithMetrics(m),
-	}
-	opts = append(opts, result.Options...)
-
-	return audit.NewLogger(opts...)
+	)
 }

--- a/examples/17-capstone/auth.go
+++ b/examples/17-capstone/auth.go
@@ -168,8 +168,11 @@ func (a *authHandlers) login(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		a.log.Warn("login: invalid request body", "ip", clientIP(r), "error", err)
 		a.rl.record(clientIP(r))
-		a.emitAuthEvent(EventAuthFailure, "anonymous", "failure",
-			"invalid request body", r)
+		if auditErr := a.logger.AuditEvent(NewAuthFailureEvent("anonymous", "failure").
+			SetReason("invalid request body").
+			SetSourceIP(clientIP(r))); auditErr != nil {
+			a.log.Error("audit event failed", "event_type", EventAuthFailure, "error", auditErr)
+		}
 		writeLoginError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -182,15 +185,21 @@ func (a *authHandlers) login(w http.ResponseWriter, r *http.Request) {
 	if !exists || subtle.ConstantTimeCompare(got[:], want[:]) != 1 {
 		a.log.Warn("login failed", "username", req.Username, "ip", clientIP(r))
 		a.rl.record(clientIP(r))
-		a.emitAuthEvent(EventAuthFailure, req.Username, "failure",
-			"invalid credentials", r)
+		if auditErr := a.logger.AuditEvent(NewAuthFailureEvent(req.Username, "failure").
+			SetReason("invalid credentials").
+			SetSourceIP(clientIP(r))); auditErr != nil {
+			a.log.Error("audit event failed", "event_type", EventAuthFailure, "error", auditErr)
+		}
 		writeLoginError(w, http.StatusUnauthorized, "invalid credentials")
 		return
 	}
 
 	a.log.Info("login successful", "username", req.Username, "ip", clientIP(r))
 	token := a.sessions.createToken(req.Username)
-	a.emitAuthEvent(EventAuthSuccess, req.Username, "success", "", r)
+	if auditErr := a.logger.AuditEvent(NewAuthSuccessEvent(req.Username, "success").
+		SetSourceIP(clientIP(r))); auditErr != nil {
+		a.log.Error("audit event failed", "event_type", EventAuthSuccess, "error", auditErr)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -206,38 +215,30 @@ func (a *authHandlers) logout(w http.ResponseWriter, r *http.Request) {
 
 	username, err := a.sessions.validate(token)
 	if err != nil {
-		eventType := EventAuthFailure
+		var ev audit.Event
 		if errors.Is(err, errTokenExpired) {
-			eventType = EventTokenExpired
+			ev = NewTokenExpiredEvent(username, "failure").
+				SetReason("invalid session").
+				SetSourceIP(clientIP(r))
+		} else {
+			ev = NewAuthFailureEvent(username, "failure").
+				SetReason("invalid session").
+				SetSourceIP(clientIP(r))
 		}
-		a.emitAuthEvent(eventType, username, "failure", "invalid session", r)
+		if auditErr := a.logger.AuditEvent(ev); auditErr != nil {
+			a.log.Error("audit event failed", "event_type", ev.EventType(), "error", auditErr)
+		}
 		writeLoginError(w, http.StatusUnauthorized, "invalid session")
 		return
 	}
 
 	a.sessions.revoke(token)
-	a.emitAuthEvent(EventAuthLogout, username, "success", "", r)
+	if auditErr := a.logger.AuditEvent(NewAuthLogoutEvent(username, "success").
+		SetSourceIP(clientIP(r))); auditErr != nil {
+		a.log.Error("audit event failed", "event_type", EventAuthLogout, "error", auditErr)
+	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// emitAuthEvent directly emits a security audit event. This is used
-// by login/logout handlers which are outside the audit middleware.
-func (a *authHandlers) emitAuthEvent(eventType, actorID, outcome, reason string, r *http.Request) {
-	fields := audit.Fields{
-		FieldActorID: actorID,
-		FieldOutcome: outcome,
-	}
-	if reason != "" {
-		fields[FieldReason] = reason
-	}
-	if ip := clientIP(r); ip != "" {
-		fields[FieldSourceIP] = ip
-	}
-	if err := a.logger.AuditEvent(audit.NewEvent(eventType, fields)); err != nil {
-		// Log but don't fail — audit should not block auth.
-		a.log.Error("audit event failed", "event_type", eventType, "error", err)
-	}
 }
 
 // --- Auth middleware for CRUD routes ---

--- a/examples/17-capstone/main.go
+++ b/examples/17-capstone/main.go
@@ -49,18 +49,11 @@ func main() {
 		defer func() { _ = appLog.Close() }()
 	}
 
-	// Parse taxonomy.
-	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
-	if err != nil {
-		appLogger.Error("fatal: parse taxonomy", "error", err)
-		return
-	}
-
 	// Set up Prometheus metrics.
 	metrics := newMetrics()
 
 	// Set up audit logger with four outputs.
-	logger, err := setupAuditLogger(tax, metrics)
+	logger, err := setupAuditLogger(metrics)
 	if err != nil {
 		appLogger.Error("fatal: setup audit logger", "error", err)
 		return

--- a/examples/17-capstone/ratelimit.go
+++ b/examples/17-capstone/ratelimit.go
@@ -86,16 +86,14 @@ func rateLimitMiddleware(logger *audit.Logger, rl *rateLimiter, appLog ...*slog.
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ip := clientIP(r)
 			if !rl.allow(ip) {
-				// Emit rate limit event directly.
-				fields := audit.Fields{
-					FieldOutcome: "failure",
-					FieldReason:  "too many failed authentication attempts",
-				}
+				// Emit rate limit event using generated builder.
+				ev := NewRateLimitExceededEvent("failure").
+					SetReason("too many failed authentication attempts")
 				if ip != "" {
-					fields[FieldSourceIP] = ip
+					ev.SetSourceIP(ip)
 				}
-				if err := logger.AuditEvent(audit.NewEvent(EventRateLimitExceeded, fields)); err != nil {
-					lg.Error("audit event failed", "event_type", "rate_limit_exceeded", "error", err)
+				if err := logger.AuditEvent(ev); err != nil {
+					lg.Error("audit event failed", "event_type", EventRateLimitExceeded, "error", err)
 				}
 				lg.Warn("rate limit exceeded", "ip", ip)
 

--- a/outputconfig/facade.go
+++ b/outputconfig/facade.go
@@ -34,6 +34,10 @@ import (
 // from [os.Hostname]. This is useful for local development and
 // quick evaluation.
 //
+// loadOpts are forwarded to [Load] and can include [WithCoreMetrics],
+// [WithSecretProvider], [WithSecretTimeout], etc. Pass nil when no
+// load options are needed.
+//
 // Additional opts are applied after the options produced by [Load],
 // so they take precedence (last wins). Use this to add
 // [audit.WithMetrics], [audit.WithDisabled], or other overrides.
@@ -45,11 +49,7 @@ import (
 //	import _ "github.com/axonops/audit/syslog"  // syslog output
 //	import _ "github.com/axonops/audit/webhook" // webhook output
 //	import _ "github.com/axonops/audit/loki"    // loki output
-//
-// For advanced scenarios requiring secret providers, custom
-// LoadOptions, or fine-grained control, use the manual
-// [Load] + [audit.NewLogger] path instead.
-func NewLogger(ctx context.Context, taxonomyYAML []byte, outputsConfigPath string, opts ...audit.Option) (*audit.Logger, error) {
+func NewLogger(ctx context.Context, taxonomyYAML []byte, outputsConfigPath string, loadOpts []LoadOption, opts ...audit.Option) (*audit.Logger, error) {
 	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
 	if err != nil {
 		return nil, fmt.Errorf("outputconfig: parse taxonomy: %w", err)
@@ -69,7 +69,7 @@ func NewLogger(ctx context.Context, taxonomyYAML []byte, outputsConfigPath strin
 		if readErr != nil {
 			return nil, readErr
 		}
-		result, loadErr := Load(ctx, data, tax)
+		result, loadErr := Load(ctx, data, tax, loadOpts...)
 		if loadErr != nil {
 			return nil, fmt.Errorf("outputconfig: load: %w", loadErr)
 		}

--- a/outputconfig/facade_test.go
+++ b/outputconfig/facade_test.go
@@ -51,7 +51,7 @@ func TestNewLogger_BasicEndToEnd(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path)
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path, nil)
 	require.NoError(t, err)
 	require.NotNil(t, logger)
 
@@ -65,7 +65,7 @@ func TestNewLogger_WithOptions_UserOptionsTakePrecedence(t *testing.T) {
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
 	// User option WithDisabled should take precedence over config.
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path,
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path, nil,
 		audit.WithDisabled(),
 	)
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestNewLogger_WithOptions_UserOptionsTakePrecedence(t *testing.T) {
 func TestNewLogger_EmptyPath_StdoutDevLogger(t *testing.T) {
 	t.Parallel()
 
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, "")
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, "", nil)
 	require.NoError(t, err)
 	require.NotNil(t, logger)
 
@@ -92,7 +92,7 @@ func TestNewLogger_EmptyPath_StdoutDevLogger(t *testing.T) {
 func TestNewLogger_FileNotFound(t *testing.T) {
 	t.Parallel()
 
-	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, "/nonexistent/path/outputs.yaml")
+	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, "/nonexistent/path/outputs.yaml", nil)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, os.ErrNotExist), "should wrap os.ErrNotExist, got: %v", err)
 	assert.Contains(t, err.Error(), "nonexistent")
@@ -102,7 +102,7 @@ func TestNewLogger_InvalidTaxonomy(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	_, err := outputconfig.NewLogger(context.Background(), []byte("not: valid: taxonomy"), path)
+	_, err := outputconfig.NewLogger(context.Background(), []byte("not: valid: taxonomy"), path, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "taxonomy")
 }
@@ -111,7 +111,7 @@ func TestNewLogger_InvalidOutputConfig(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", []byte("not: [valid: config"))
 
-	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path)
+	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "load")
 }
@@ -120,7 +120,7 @@ func TestNewLogger_EmptyTaxonomy(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	_, err := outputconfig.NewLogger(context.Background(), nil, path)
+	_, err := outputconfig.NewLogger(context.Background(), nil, path, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "taxonomy")
 }
@@ -129,7 +129,7 @@ func TestNewLogger_Close_FlushesEvents(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path)
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path, nil)
 	require.NoError(t, err)
 
 	// Send events then close — should not panic or error.
@@ -144,9 +144,21 @@ func TestNewLogger_NotRegularFile(t *testing.T) {
 	dir := t.TempDir()
 
 	// Directories are not regular files.
-	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, dir)
+	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, dir, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a regular file")
+}
+
+func TestNewLogger_WithLoadOptions(t *testing.T) {
+	t.Parallel()
+	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
+
+	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path,
+		[]outputconfig.LoadOption{outputconfig.WithCoreMetrics(nil)},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+	require.NoError(t, logger.Close())
 }
 
 // writeTempFile creates a temporary file with the given content and


### PR DESCRIPTION
## Summary

- Extend `outputconfig.NewLogger` facade to accept `[]LoadOption` parameter (forwarded to `Load`)
- Replace raw `audit.NewEvent()` calls in capstone with generated typed builders
- Simplify capstone init: use facade instead of manual `Load + NewLogger`

## Changes

| Area | What |
|------|------|
| `outputconfig/facade.go` | Add `loadOpts []LoadOption` parameter, forward to `Load` |
| `outputconfig/facade_test.go` | Update all calls, add `TestNewLogger_WithLoadOptions` |
| 15 examples (02–16) | Mechanical `nil` insertion as 4th arg |
| Capstone `audit_setup.go` | Use facade with `WithCoreMetrics` via `LoadOption` |
| Capstone `main.go` | Remove `ParseTaxonomyYAML` (facade handles it) |
| Capstone `auth.go` | Delete `emitAuthEvent`, use `NewAuthFailureEvent` etc. |
| Capstone `ratelimit.go` | Use `NewRateLimitExceededEvent` builder |
| `doc.go`, READMEs, docs | Update signatures |

## Test plan

- [x] `make check` clean
- [x] `make test-examples` — all 17 compile
- [x] Capstone tests pass (`go test ./examples/17-capstone/...`)
- [ ] CI green

Relates to #443