### PR TITLE
refactor: rename Logger to Auditor across API (#457, #456)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,7 @@ The pattern for every I/O output:
    retains the slice reference, it will see corrupted data.
 3. **A background goroutine handles actual I/O** with its own
    `defer func() { recover() }()` per event. A panic in one output
-   does not crash the logger or affect other outputs.
+   does not crash the auditor or affect other outputs.
 4. **Buffer full → drop + metrics.** When the internal channel is full,
    the event is silently dropped. `OutputMetrics.RecordDrop()` fires
    and a rate-limited `slog.Warn` is emitted (at most once per 10
@@ -69,7 +69,7 @@ The pattern for every I/O output:
 ## Module Boundaries
 
 ```
-github.com/axonops/audit              ← core (Logger, Output, taxonomy, formatters)
+github.com/axonops/audit              ← core (Auditor, Output, taxonomy, formatters)
 github.com/axonops/audit/file         ← file output (depends on core)
 github.com/axonops/audit/syslog       ← syslog output (depends on core + srslog)
 github.com/axonops/audit/webhook      ← webhook output (depends on core)
@@ -113,7 +113,7 @@ import (
   For async outputs, actual I/O happens in the output's own goroutine
 - `FormatOptions` is pre-allocated per output entry at construction; `FieldLabels` is
   set per-event in the drain goroutine (single writer, no lock needed)
-- `Logger.Close()` is idempotent via `sync.Once`
+- `Auditor.Close()` is idempotent via `sync.Once`
 
 ## Field Categories
 
@@ -125,7 +125,7 @@ The library distinguishes three categories of event fields:
 | **Reserved standard fields** | `actor_id`, `source_ip`, `reason`, `target_id` (31 total) | Optional — can be required or labeled | Yes — via sensitivity labels |
 | **User-defined fields** | Application-specific fields | Yes — in taxonomy YAML | Yes — via sensitivity labels |
 
-Framework fields are set once at logger construction (`WithAppName`, `WithHost`,
+Framework fields are set once at auditor construction (`WithAppName`, `WithHost`,
 `WithTimezone`; `pid` auto-captured via `os.Getpid()`). They appear in every
 serialised event before user fields.
 
@@ -137,7 +137,7 @@ and map to standard ArcSight CEF extension keys.
 
 | File | Purpose |
 |------|---------|
-| `audit.go` | `Logger`, `NewLogger`, `AuditEvent`, `Close`, drain goroutine |
+| `audit.go` | `Auditor`, `New`, `AuditEvent`, `Close`, drain goroutine |
 | `event.go` | `Event` interface, `NewEvent`, `EventType` handle, `FieldInfo`, `CategoryInfo` |
 | `taxonomy.go` | `Taxonomy`, `EventDef`, `CategoryDef`, validation, sensitivity pre-computation |
 | `taxonomy_yaml.go` | `ParseTaxonomyYAML`, YAML deserialization, `ErrInvalidInput` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Breaking Changes
 
-- `NewLogger` signature changed from `NewLogger(Config, ...Option)` to `NewLogger(...Option)` — Config fields expressed as Options (#388)
+- `New` signature changed from `New(Config, ...Option)` to `New(...Option)` — Config fields expressed as Options (#388)
 - `Config.Version` unexported, `Config.Enabled` removed — use `WithDisabled()` (#388)
 - `Fields` changed from type alias to defined type `type Fields map[string]any` with `Has()`, `String()`, `Int()` methods (#388)
 - `EmitEventCategory` renamed to `SuppressEventCategory` (inverted semantics) (#388)
@@ -25,12 +25,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `ErrValidation`, `ErrUnknownEventType`, `ErrMissingRequiredField`, `ErrUnknownField` sentinels with `ValidationError` struct (#400)
-- `outputconfig.NewLogger()` facade for single-call logger creation (#392)
+- `outputconfig.New()` facade for single-call logger creation (#392)
 - `github.com/axonops/audit/outputs` convenience package — single blank import registers all output factories (#393)
 - `Stdout()` convenience constructor, `NewEventKV()` slog-style event creation, `DevTaxonomy()` permissive development taxonomy (#395)
 - `WithSynchronousDelivery()` for inline event processing — no drain goroutine, no Close-before-assert in tests (#403)
-- `WithLogger(*slog.Logger)` for configurable library diagnostics (#397)
-- `LoggerReceiver` interface — sub-module outputs receive the library's diagnostic logger (#397)
+- `WithDiagnosticLogger(*slog.Logger)` for configurable library diagnostics (#397)
+- `DiagnosticLoggerReceiver` interface — sub-module outputs receive the library's diagnostic logger (#397)
 - `RecordedEvent.StringField()`, `IntField()`, `FloatField()` accessors with JSON float64 coercion (#397)
 - `NoOpMetrics` base struct for composable Metrics implementations (#401)
 - `WithFactory` LoadOption for per-call factory overrides (#399)
@@ -110,7 +110,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `emit_event_category` taxonomy config (under `categories:`) controls category emission; defaults to `true` (#227)
 - `PostField` and `AppendPostFields` extensible post-serialisation append mechanism (#227)
 - Reserved field name validation: `timestamp`, `event_type`, `severity`, `event_category` rejected as user-defined fields (#227)
-- `audittest` package: in-memory `Recorder` and `MetricsRecorder`, `NewLogger`, `NewLoggerQuick`, `QuickTaxonomy`, `WithConfig`, `WithValidationMode` for consumer testing (#184)
+- `audittest` package: in-memory `Recorder` and `MetricsRecorder`, `New`, `NewQuick`, `QuickTaxonomy`, `WithConfig`, `WithValidationMode` for consumer testing (#184)
 - `Event` interface, `LabelInfo`, `FieldInfo`, `CategoryInfo` core types (#205)
 - `NewEvent()` for dynamic event construction without code generation (#205)
 - Per-event typed builders with required-field constructors and optional-field setters (#205)

--- a/README.md
+++ b/README.md
@@ -189,14 +189,14 @@ go run github.com/axonops/audit/cmd/audit-gen \
 
 ```go
 // Required fields are constructor parameters — typos are compile errors
-err := logger.AuditEvent(
+err := auditor.AuditEvent(
     NewUserCreateEvent("alice", "success").
         SetTargetID("user-42"),
 )
 ```
 
 > 📚 For the complete runnable application (taxonomy loading, output
-> configuration, logger creation), see
+> configuration, auditor creation), see
 > [examples/02-code-generation](examples/02-code-generation/).
 
 ### Output
@@ -226,7 +226,7 @@ CEF:0|MyCompany|MyApp|1.0|user_create|A new user account was created|3|rt=... ac
 Requires **Go 1.26+**.
 
 ```bash
-go get github.com/axonops/audit             # core: logger, taxonomy, validation, formatters, stdout output
+go get github.com/axonops/audit             # core: auditor, taxonomy, validation, formatters, stdout output
 go get github.com/axonops/audit/file         # file output with rotation
 go get github.com/axonops/audit/syslog       # RFC 5424 syslog (TCP/UDP/TLS/mTLS)
 go get github.com/axonops/audit/webhook      # batched HTTP webhook with SSRF protection
@@ -243,7 +243,7 @@ go get github.com/axonops/audit/outputconfig # YAML-based output configuration
 
 | Module | Description |
 |--------|-------------|
-| `github.com/axonops/audit` | Core: Logger, taxonomy validation, JSON + CEF formatters, HTTP middleware, stdout output, fan-out, routing, `audittest` |
+| `github.com/axonops/audit` | Core: Auditor, taxonomy validation, JSON + CEF formatters, HTTP middleware, stdout output, fan-out, routing, `audittest` |
 | `github.com/axonops/audit/file` | File output with size-based rotation and gzip compression |
 | `github.com/axonops/audit/syslog` | RFC 5424 syslog output (TCP/UDP/TLS/mTLS) |
 | `github.com/axonops/audit/webhook` | Batched HTTP webhook with retry and SSRF protection |
@@ -267,14 +267,14 @@ The `audittest` package provides an in-memory recorder for testing audit events:
 
 ```go
 func TestUserCreation(t *testing.T) {
-    logger, events, _ := audittest.NewLoggerQuick(t, "user_create")
+    auditor, events, _ := audittest.NewQuick(t, "user_create")
 
     // Exercise the code under test...
-    err := logger.AuditEvent(audit.NewEventKV("user_create",
+    err := auditor.AuditEvent(audit.NewEventKV("user_create",
         "outcome", "success", "actor_id", "alice"))
     require.NoError(t, err)
 
-    // Assert immediately — NewLoggerQuick uses synchronous delivery.
+    // Assert immediately — NewQuick uses synchronous delivery.
     assert.Equal(t, 1, events.Count())
     assert.Equal(t, "alice", events.Events()[0].StringField("actor_id"))
 }

--- a/audit.go
+++ b/audit.go
@@ -24,7 +24,7 @@ package audit
 // recorded.
 //
 // Close() cancels the drain goroutine's context, waits up to
-// DrainTimeout for pending events to flush, then closes all outputs in
+// ShutdownTimeout for pending events to flush, then closes all outputs in
 // sequence. Close is idempotent via sync.Once.
 
 import (
@@ -60,7 +60,7 @@ var fieldsPool = sync.Pool{
 	New: func() any { return make(Fields, 8) },
 }
 
-// Logger is the core audit logger. It validates events against a
+// Auditor is the core type. It validates events against a
 // registered [Taxonomy], filters by category and per-event overrides,
 // and delivers events asynchronously to configured [Output]
 // destinations.
@@ -69,10 +69,10 @@ var fieldsPool = sync.Pool{
 // serialisation failures, output write errors). Consumers can configure
 // the slog default handler to control this output.
 //
-// A Logger is safe for concurrent use by multiple goroutines.
+// An Auditor is safe for concurrent use by multiple goroutines.
 //
 //nolint:govet // field order: logical grouping over alignment optimisation
-type Logger struct {
+type Auditor struct {
 	closeErr  error
 	filter    *filterState
 	metrics   Metrics
@@ -94,10 +94,10 @@ type Logger struct {
 	// usedWithOutputs is set during construction when WithOutputs is
 	// applied; prevents mixing WithOutputs and WithNamedOutput.
 	usedWithOutputs bool
-	// disabled is set by WithDisabled to create a no-op logger that
+	// disabled is set by WithDisabled to create a no-op auditor that
 	// discards all events without validation or delivery. Replaces
 	// the former Config.Enabled field (inverted: disabled=true means
-	// the logger does nothing).
+	// the auditor does nothing).
 	disabled bool
 	// synchronous is set by WithSynchronousDelivery to deliver events
 	// inline within AuditEvent instead of via the async channel. No
@@ -123,115 +123,115 @@ type Logger struct {
 	drainCount            uint64       // events processed by drain loop; for sampling RecordQueueDepth
 }
 
-// NewLogger creates a new audit [Logger] from the given options.
+// New creates a new [Auditor] from the given options.
 // A taxonomy MUST be provided via [WithTaxonomy] unless [WithDisabled]
-// is applied; NewLogger returns an error if none is supplied.
+// is applied; New returns an error if none is supplied.
 //
-// The zero-value [Config] is valid: buffer=10,000, drain=5s,
+// The zero-value [Config] is valid: buffer=10,000, shutdown=5s,
 // validation=strict. Pass tuning options like [WithQueueSize] or
-// [WithDrainTimeout] to override defaults, or [WithConfig] to apply
+// [WithShutdownTimeout] to override defaults, or [WithConfig] to apply
 // a struct.
 //
-// When [WithDisabled] is applied, NewLogger returns a valid no-op
-// logger without requiring a taxonomy. All [Logger.AuditEvent] calls
+// When [WithDisabled] is applied, New returns a valid no-op
+// auditor without requiring a taxonomy. All [Auditor.AuditEvent] calls
 // return nil immediately without validation or delivery. Methods
-// that require a taxonomy ([Logger.EnableCategory], etc.) return
+// that require a taxonomy ([Auditor.EnableCategory], etc.) return
 // [ErrDisabled].
-func NewLogger(opts ...Option) (*Logger, error) {
-	l := &Logger{}
+func New(opts ...Option) (*Auditor, error) {
+	a := &Auditor{}
 
 	for _, opt := range opts {
-		if err := opt(l); err != nil {
+		if err := opt(a); err != nil {
 			return nil, err
 		}
 	}
 
 	// validateConfig calls applyDefaults internally, then validates.
 	// migrateConfig runs after defaults so version is always set.
-	if err := validateConfig(&l.cfg); err != nil {
+	if err := validateConfig(&a.cfg); err != nil {
 		return nil, err
 	}
-	if err := migrateConfig(&l.cfg); err != nil {
+	if err := migrateConfig(&a.cfg); err != nil {
 		return nil, err
 	}
 
 	// Release construction-only state.
-	l.destKeys = nil
+	a.destKeys = nil
 
-	if l.logger == nil {
-		l.logger = slog.Default()
+	if a.logger == nil {
+		a.logger = slog.Default()
 	}
 
-	if l.disabled {
-		l.applyConstructionDefaults()
-		return l, nil
+	if a.disabled {
+		a.applyConstructionDefaults()
+		return a, nil
 	}
 
-	if l.taxonomy == nil {
+	if a.taxonomy == nil {
 		return nil, fmt.Errorf("audit: taxonomy is required: use WithTaxonomy")
 	}
 
-	l.applyDevTaxonomyOverrides()
+	a.applyDevTaxonomyOverrides()
 
-	if err := l.validateOutputRoutes(); err != nil {
+	if err := a.validateOutputRoutes(); err != nil {
 		return nil, err
 	}
 
-	l.prepareOutputEntries()
+	a.prepareOutputEntries()
 
-	l.applyConstructionDefaults()
+	a.applyConstructionDefaults()
 
-	if !l.synchronous {
+	if !a.synchronous {
 		ctx, cancel := context.WithCancel(context.Background())
-		l.cancel = cancel
-		l.ch = make(chan *auditEntry, l.cfg.QueueSize)
-		l.drainDone = make(chan struct{})
-		go l.drainLoop(ctx)
+		a.cancel = cancel
+		a.ch = make(chan *auditEntry, a.cfg.QueueSize)
+		a.drainDone = make(chan struct{})
+		go a.drainLoop(ctx)
 	}
 
-	l.logger.Info("audit: logger created",
-		"queue_size", l.cfg.QueueSize,
-		"drain_timeout", l.cfg.DrainTimeout,
-		"validation_mode", string(l.cfg.ValidationMode),
-		"outputs", len(l.entries),
-		"synchronous", l.synchronous,
+	a.logger.Info("audit: auditor created",
+		"queue_size", a.cfg.QueueSize,
+		"shutdown_timeout", a.cfg.ShutdownTimeout,
+		"validation_mode", string(a.cfg.ValidationMode),
+		"outputs", len(a.entries),
+		"synchronous", a.synchronous,
 	)
 
-	return l, nil
+	return a, nil
 }
 
 // applyDevTaxonomyOverrides warns about DevTaxonomy and forces permissive
 // validation mode when a dev taxonomy is used.
-func (l *Logger) applyDevTaxonomyOverrides() {
-	if l.taxonomy == nil || !l.taxonomy.dev {
+func (a *Auditor) applyDevTaxonomyOverrides() {
+	if a.taxonomy == nil || !a.taxonomy.dev {
 		return
 	}
-	l.logger.Warn("audit: using DevTaxonomy — not suitable for production; all event types accepted without schema enforcement")
-	if l.cfg.ValidationMode == ValidationStrict {
-		l.cfg.ValidationMode = ValidationPermissive
+	a.logger.Warn("audit: using DevTaxonomy — not suitable for production; all event types accepted without schema enforcement")
+	if a.cfg.ValidationMode == ValidationStrict {
+		a.cfg.ValidationMode = ValidationPermissive
 	}
 }
 
 // applyConstructionDefaults sets formatter, PID, timezone, and propagates
-// framework fields. Called once during NewLogger after all options are applied.
-func (l *Logger) applyConstructionDefaults() {
-	if l.formatter == nil {
-		l.formatter = &JSONFormatter{OmitEmpty: l.cfg.OmitEmpty}
+// framework fields. Called once during New after all options are applied.
+func (a *Auditor) applyConstructionDefaults() {
+	if a.formatter == nil {
+		a.formatter = &JSONFormatter{OmitEmpty: a.cfg.OmitEmpty}
 	}
-	l.pid = os.Getpid()
-	if l.timezone == "" {
-		l.timezone = time.Now().Location().String()
+	a.pid = os.Getpid()
+	if a.timezone == "" {
+		a.timezone = time.Now().Location().String()
 	}
-	l.propagateFrameworkFields()
-	l.propagateLogger()
+	a.propagateFrameworkFields()
+	a.propagateLogger()
 }
 
 // propagateLogger forwards the library's slog.Logger to outputs that
-// implement [LoggerReceiver].
-func (l *Logger) propagateLogger() {
-	for _, oe := range l.entries {
-		if recv, ok := oe.output.(LoggerReceiver); ok {
-			recv.SetLogger(l.logger)
+// implement [DiagnosticLoggerReceiver].
+func (a *Auditor) propagateLogger() {
+	for _, oe := range a.entries {
+		if recv, ok := oe.output.(DiagnosticLoggerReceiver); ok {
+			recv.SetDiagnosticLogger(a.logger)
 		}
 	}
 }
@@ -241,39 +241,39 @@ func (l *Logger) propagateLogger() {
 // safety, or [NewEvent] for dynamic event construction.
 //
 // AuditEvent returns [ErrQueueFull] if the async buffer is at
-// capacity (the event is dropped), [ErrClosed] if the logger has
+// capacity (the event is dropped), [ErrClosed] if the auditor has
 // been closed, or a descriptive error for validation failures.
 // If the event's category is globally disabled (and no per-event
 // override enables it), the event is silently discarded without error.
-func (l *Logger) AuditEvent(evt Event) error {
+func (a *Auditor) AuditEvent(evt Event) error {
 	if evt == nil {
 		return fmt.Errorf("audit: event must not be nil")
 	}
-	return l.auditInternal(evt.EventType(), evt.Fields())
+	return a.auditInternal(evt.EventType(), evt.Fields())
 }
 
 // auditInternal is the shared validation-and-enqueue path used by
-// both [Logger.AuditEvent] and internal callers.
-func (l *Logger) auditInternal(eventType string, fields Fields) error {
-	if l.disabled {
+// both [Auditor.AuditEvent] and internal callers.
+func (a *Auditor) auditInternal(eventType string, fields Fields) error {
+	if a.disabled {
 		return nil
 	}
-	if l.closed.Load() {
+	if a.closed.Load() {
 		return ErrClosed
 	}
 
-	if l.metrics != nil {
-		l.metrics.RecordSubmitted()
+	if a.metrics != nil {
+		a.metrics.RecordSubmitted()
 	}
 
-	_, copied, err := l.validateEvent(eventType, fields)
+	_, copied, err := a.validateEvent(eventType, fields)
 	if err != nil {
 		return err
 	}
 
-	if !l.filter.isEnabled(eventType, l.taxonomy) {
-		if l.metrics != nil {
-			l.metrics.RecordFiltered(eventType)
+	if !a.filter.isEnabled(eventType, a.taxonomy) {
+		if a.metrics != nil {
+			a.metrics.RecordFiltered(eventType)
 		}
 		return nil
 	}
@@ -285,29 +285,29 @@ func (l *Logger) auditInternal(eventType string, fields Fields) error {
 	entry.eventType = eventType
 	entry.fields = copied
 
-	if l.synchronous {
-		l.deliverSync(entry)
+	if a.synchronous {
+		a.deliverSync(entry)
 		return nil
 	}
-	return l.enqueue(entry)
+	return a.enqueue(entry)
 }
 
 // validateEvent checks the event type exists, copies fields with defaults,
 // and validates field constraints. Returns the definition and copied fields.
-func (l *Logger) validateEvent(eventType string, fields Fields) (*EventDef, Fields, error) {
-	def, ok := l.taxonomy.Events[eventType]
+func (a *Auditor) validateEvent(eventType string, fields Fields) (*EventDef, Fields, error) {
+	def, ok := a.taxonomy.Events[eventType]
 	if !ok {
-		if l.metrics != nil {
-			l.metrics.RecordValidationError(eventType)
+		if a.metrics != nil {
+			a.metrics.RecordValidationError(eventType)
 		}
 		return nil, nil, newValidationError(ErrUnknownEventType, "audit: unknown event type %q", eventType)
 	}
 
-	copied := l.copyFieldsWithDefaults(fields)
+	copied := a.copyFieldsWithDefaults(fields)
 
-	if err := l.validateFields(eventType, def, copied); err != nil {
-		if l.metrics != nil {
-			l.metrics.RecordValidationError(eventType)
+	if err := a.validateFields(eventType, def, copied); err != nil {
+		if a.metrics != nil {
+			a.metrics.RecordValidationError(eventType)
 		}
 		return nil, nil, err
 	}
@@ -321,27 +321,27 @@ func (l *Logger) validateEvent(eventType string, fields Fields) (*EventDef, Fiel
 // A mutex serialises calls because processEntry reuses per-output
 // state (formatOpts, HMAC) that is only safe under single-goroutine
 // access.
-func (l *Logger) deliverSync(entry *auditEntry) {
-	l.syncMu.Lock()
-	defer l.syncMu.Unlock()
-	l.processEntry(entry)
+func (a *Auditor) deliverSync(entry *auditEntry) {
+	a.syncMu.Lock()
+	defer a.syncMu.Unlock()
+	a.processEntry(entry)
 }
 
 // enqueue attempts a non-blocking send to the async channel. On
 // buffer-full, the entry is returned to the pool to avoid leaking
 // pooled objects.
-func (l *Logger) enqueue(entry *auditEntry) error {
+func (a *Auditor) enqueue(entry *auditEntry) error {
 	select {
-	case l.ch <- entry:
+	case a.ch <- entry:
 		return nil
 	default:
-		l.drops.record(dropWarnInterval, func(dropped int64) {
-			l.logger.Warn("audit: buffer full, events dropped",
+		a.drops.record(dropWarnInterval, func(dropped int64) {
+			a.logger.Warn("audit: buffer full, events dropped",
 				"dropped", dropped,
-				"queue_size", cap(l.ch))
+				"queue_size", cap(a.ch))
 		})
-		if l.metrics != nil {
-			l.metrics.RecordBufferDrop()
+		if a.metrics != nil {
+			a.metrics.RecordBufferDrop()
 		}
 		// Return dropped entry and fields map to pools.
 		returnFieldsToPool(entry.fields)
@@ -352,45 +352,45 @@ func (l *Logger) enqueue(entry *auditEntry) error {
 	}
 }
 
-// Close shuts down the logger gracefully. Close MUST be called when the
-// logger is no longer needed; failing to call Close leaks the drain
+// Close shuts down the auditor gracefully. Close MUST be called when the
+// auditor is no longer needed; failing to call Close leaks the drain
 // goroutine and loses all buffered events.
 //
 // Close signals the drain goroutine to stop, waits up to
-// [Config.DrainTimeout] for pending events to flush, then closes all
+// [Config.ShutdownTimeout] for pending events to flush, then closes all
 // outputs in parallel.
 //
 // Close is idempotent -- subsequent calls return nil (or the same
 // error if an output failed to close on the first call).
-func (l *Logger) Close() error {
-	l.closeOnce.Do(func() {
-		l.closed.Store(true)
+func (a *Auditor) Close() error {
+	a.closeOnce.Do(func() {
+		a.closed.Store(true)
 
-		if l.disabled {
+		if a.disabled {
 			return
 		}
 
 		shutdownStart := time.Now()
-		l.logger.Info("audit: shutdown started")
+		a.logger.Info("audit: shutdown started")
 
-		if !l.synchronous {
-			l.cancel()
-			l.waitForDrain()
+		if !a.synchronous {
+			a.cancel()
+			a.waitForDrain()
 		}
 
-		l.closeErr = l.closeOutputs()
+		a.closeErr = a.closeOutputs()
 
-		l.logger.Info("audit: shutdown complete",
+		a.logger.Info("audit: shutdown complete",
 			"duration", time.Since(shutdownStart))
 	})
-	return l.closeErr
+	return a.closeErr
 }
 
 // closeOutputs closes all outputs in parallel. Each output's Close
 // runs in its own goroutine. An overall timeout prevents a single
 // misbehaving output from blocking shutdown indefinitely.
-func (l *Logger) closeOutputs() error {
-	if len(l.entries) == 0 {
+func (a *Auditor) closeOutputs() error {
+	if len(a.entries) == 0 {
 		return nil
 	}
 
@@ -399,8 +399,8 @@ func (l *Logger) closeOutputs() error {
 		err  error
 	}
 
-	results := make(chan closeResult, len(l.entries))
-	for _, oe := range l.entries {
+	results := make(chan closeResult, len(a.entries))
+	for _, oe := range a.entries {
 		go func(oe *outputEntry) {
 			results <- closeResult{
 				name: oe.output.Name(),
@@ -411,25 +411,25 @@ func (l *Logger) closeOutputs() error {
 
 	// Overall close timeout: drain timeout covers the per-output buffer
 	// drain. If any output hangs beyond this, we log and move on.
-	closeTimeout := l.cfg.DrainTimeout + 5*time.Second
+	closeTimeout := a.cfg.ShutdownTimeout + 5*time.Second
 	deadlineTimer := time.NewTimer(closeTimeout)
 	defer deadlineTimer.Stop()
 
 	var closeErrs []error
 	collected := 0
-	for range len(l.entries) {
+	for range len(a.entries) {
 		select {
 		case r := <-results:
 			collected++
 			if r.err != nil {
-				l.logger.Error("audit: output close failed",
+				a.logger.Error("audit: output close failed",
 					"output", r.name,
 					"error", r.err)
 				closeErrs = append(closeErrs, fmt.Errorf("audit: output %q: %w", r.name, r.err))
 			}
 		case <-deadlineTimer.C:
-			remaining := len(l.entries) - collected
-			l.logger.Error("audit: output close timed out",
+			remaining := len(a.entries) - collected
+			a.logger.Error("audit: output close timed out",
 				"timeout", closeTimeout,
 				"remaining_outputs", remaining)
 			closeErrs = append(closeErrs, fmt.Errorf(
@@ -444,30 +444,30 @@ func (l *Logger) closeOutputs() error {
 // waitForDrain waits for the drain goroutine to finish, with a
 // timeout. No extra goroutine is spawned; we select on the drainDone
 // channel that drainLoop closes when it exits.
-func (l *Logger) waitForDrain() {
-	timer := time.NewTimer(l.cfg.DrainTimeout)
+func (a *Auditor) waitForDrain() {
+	timer := time.NewTimer(a.cfg.ShutdownTimeout)
 	defer timer.Stop()
 
 	select {
-	case <-l.drainDone:
+	case <-a.drainDone:
 	case <-timer.C:
-		l.logger.Warn("audit: drain timed out, some events may be lost",
-			"drain_timeout", l.cfg.DrainTimeout,
-			"buffer_remaining", len(l.ch))
+		a.logger.Warn("audit: drain timed out, some events may be lost",
+			"shutdown_timeout", a.cfg.ShutdownTimeout,
+			"buffer_remaining", len(a.ch))
 	}
 }
 
 // validateOutputRoutes checks all per-output event routes and
 // sensitivity exclusion labels against the taxonomy.
-func (l *Logger) validateOutputRoutes() error {
-	for _, oe := range l.entries {
+func (a *Auditor) validateOutputRoutes() error {
+	for _, oe := range a.entries {
 		route := oe.route.Load()
 		if route != nil {
-			if err := ValidateEventRoute(route, l.taxonomy); err != nil {
+			if err := ValidateEventRoute(route, a.taxonomy); err != nil {
 				return fmt.Errorf("audit: output %q: %w", oe.output.Name(), err)
 			}
 		}
-		if err := l.validateExcludeLabels(oe); err != nil {
+		if err := a.validateExcludeLabels(oe); err != nil {
 			return err
 		}
 	}
@@ -476,16 +476,16 @@ func (l *Logger) validateOutputRoutes() error {
 
 // validateExcludeLabels checks that all exclude_labels on an output
 // reference labels defined in the taxonomy's sensitivity config.
-func (l *Logger) validateExcludeLabels(oe *outputEntry) error {
+func (a *Auditor) validateExcludeLabels(oe *outputEntry) error {
 	if len(oe.excludedLabels) == 0 {
 		return nil
 	}
-	if l.taxonomy == nil || l.taxonomy.Sensitivity == nil {
+	if a.taxonomy == nil || a.taxonomy.Sensitivity == nil {
 		return fmt.Errorf("audit: output %q has exclude_labels but taxonomy has no sensitivity config",
 			oe.output.Name())
 	}
 	for label := range oe.excludedLabels {
-		if _, ok := l.taxonomy.Sensitivity.Labels[label]; !ok {
+		if _, ok := a.taxonomy.Sensitivity.Labels[label]; !ok {
 			return fmt.Errorf("audit: output %q exclude_labels references undefined sensitivity label %q",
 				oe.output.Name(), label)
 		}
@@ -495,67 +495,67 @@ func (l *Logger) validateExcludeLabels(oe *outputEntry) error {
 
 // EnableCategory enables all events in the named category. The
 // category MUST exist in the registered taxonomy. Per-event overrides
-// via [Logger.DisableEvent] take precedence over category state.
-func (l *Logger) EnableCategory(category string) error {
-	if l.disabled {
-		return fmt.Errorf("audit: cannot enable category on disabled logger: %w", ErrDisabled)
+// via [Auditor.DisableEvent] take precedence over category state.
+func (a *Auditor) EnableCategory(category string) error {
+	if a.disabled {
+		return fmt.Errorf("audit: cannot enable category on disabled auditor: %w", ErrDisabled)
 	}
 	// taxonomy is immutable after construction; safe to read without lock.
-	if _, ok := l.taxonomy.Categories[category]; !ok {
+	if _, ok := a.taxonomy.Categories[category]; !ok {
 		return fmt.Errorf("audit: unknown category %q", category)
 	}
-	l.filter.enabledCategories.Store(category, true)
-	l.logger.Info("audit: category enabled", "category", category)
+	a.filter.enabledCategories.Store(category, true)
+	a.logger.Info("audit: category enabled", "category", category)
 	return nil
 }
 
 // DisableCategory disables all events in the named category. The
 // category MUST exist in the registered taxonomy. Per-event overrides
-// via [Logger.EnableEvent] take precedence over category state.
-func (l *Logger) DisableCategory(category string) error {
-	if l.disabled {
-		return fmt.Errorf("audit: cannot disable category on disabled logger: %w", ErrDisabled)
+// via [Auditor.EnableEvent] take precedence over category state.
+func (a *Auditor) DisableCategory(category string) error {
+	if a.disabled {
+		return fmt.Errorf("audit: cannot disable category on disabled auditor: %w", ErrDisabled)
 	}
 	// taxonomy is immutable after construction; safe to read without lock.
-	if _, ok := l.taxonomy.Categories[category]; !ok {
+	if _, ok := a.taxonomy.Categories[category]; !ok {
 		return fmt.Errorf("audit: unknown category %q", category)
 	}
-	l.filter.enabledCategories.Store(category, false)
-	l.logger.Info("audit: category disabled", "category", category)
+	a.filter.enabledCategories.Store(category, false)
+	a.logger.Info("audit: category disabled", "category", category)
 	return nil
 }
 
 // EnableEvent enables a specific event type regardless of its
 // category's state. The event type MUST exist in the registered
 // taxonomy. Per-event overrides take precedence over category state.
-func (l *Logger) EnableEvent(eventType string) error {
-	if l.disabled {
-		return fmt.Errorf("audit: cannot enable event on disabled logger: %w", ErrDisabled)
+func (a *Auditor) EnableEvent(eventType string) error {
+	if a.disabled {
+		return fmt.Errorf("audit: cannot enable event on disabled auditor: %w", ErrDisabled)
 	}
 	// taxonomy is immutable after construction; safe to read without lock.
-	if _, ok := l.taxonomy.Events[eventType]; !ok {
+	if _, ok := a.taxonomy.Events[eventType]; !ok {
 		return fmt.Errorf("audit: unknown event type %q", eventType)
 	}
-	l.filter.eventOverrides.Store(eventType, true)
-	l.filter.hasEventOverrides.Store(true)
-	l.logger.Info("audit: event enabled", "event_type", eventType)
+	a.filter.eventOverrides.Store(eventType, true)
+	a.filter.hasEventOverrides.Store(true)
+	a.logger.Info("audit: event enabled", "event_type", eventType)
 	return nil
 }
 
 // DisableEvent disables a specific event type regardless of its
 // category's state. The event type MUST exist in the registered
 // taxonomy. Per-event overrides take precedence over category state.
-func (l *Logger) DisableEvent(eventType string) error {
-	if l.disabled {
-		return fmt.Errorf("audit: cannot disable event on disabled logger: %w", ErrDisabled)
+func (a *Auditor) DisableEvent(eventType string) error {
+	if a.disabled {
+		return fmt.Errorf("audit: cannot disable event on disabled auditor: %w", ErrDisabled)
 	}
 	// taxonomy is immutable after construction; safe to read without lock.
-	if _, ok := l.taxonomy.Events[eventType]; !ok {
+	if _, ok := a.taxonomy.Events[eventType]; !ok {
 		return fmt.Errorf("audit: unknown event type %q", eventType)
 	}
-	l.filter.eventOverrides.Store(eventType, false)
-	l.filter.hasEventOverrides.Store(true)
-	l.logger.Info("audit: event disabled", "event_type", eventType)
+	a.filter.eventOverrides.Store(eventType, false)
+	a.filter.hasEventOverrides.Store(true)
+	a.logger.Info("audit: event disabled", "event_type", eventType)
 	return nil
 }
 
@@ -565,19 +565,19 @@ func (l *Logger) DisableEvent(eventType string) error {
 // error. An unknown output name returns an error.
 //
 // SetOutputRoute is safe for concurrent use with event delivery.
-func (l *Logger) SetOutputRoute(outputName string, route *EventRoute) error {
-	if l.disabled {
-		return fmt.Errorf("audit: cannot set output route on disabled logger: %w", ErrDisabled)
+func (a *Auditor) SetOutputRoute(outputName string, route *EventRoute) error {
+	if a.disabled {
+		return fmt.Errorf("audit: cannot set output route on disabled auditor: %w", ErrDisabled)
 	}
-	oe, ok := l.outputsByName[outputName]
+	oe, ok := a.outputsByName[outputName]
 	if !ok {
 		return fmt.Errorf("audit: unknown output %q", outputName)
 	}
-	if err := ValidateEventRoute(route, l.taxonomy); err != nil {
+	if err := ValidateEventRoute(route, a.taxonomy); err != nil {
 		return err
 	}
 	oe.setRoute(route)
-	l.logger.Info("audit: output route set", "output", outputName)
+	a.logger.Info("audit: output route set", "output", outputName)
 	return nil
 }
 
@@ -585,20 +585,20 @@ func (l *Logger) SetOutputRoute(outputName string, route *EventRoute) error {
 // output, causing it to receive all globally-enabled events.
 //
 // ClearOutputRoute is safe for concurrent use with event delivery.
-func (l *Logger) ClearOutputRoute(outputName string) error {
-	oe, ok := l.outputsByName[outputName]
+func (a *Auditor) ClearOutputRoute(outputName string) error {
+	oe, ok := a.outputsByName[outputName]
 	if !ok {
 		return fmt.Errorf("audit: unknown output %q", outputName)
 	}
 	oe.setRoute(&EventRoute{})
-	l.logger.Info("audit: output route cleared", "output", outputName)
+	a.logger.Info("audit: output route cleared", "output", outputName)
 	return nil
 }
 
 // OutputRoute returns a copy of the current per-output event route
 // for the named output. An unknown output name returns an error.
-func (l *Logger) OutputRoute(outputName string) (EventRoute, error) {
-	oe, ok := l.outputsByName[outputName]
+func (a *Auditor) OutputRoute(outputName string) (EventRoute, error) {
+	oe, ok := a.outputsByName[outputName]
 	if !ok {
 		return EventRoute{}, fmt.Errorf("audit: unknown output %q", outputName)
 	}
@@ -608,22 +608,22 @@ func (l *Logger) OutputRoute(outputName string) (EventRoute, error) {
 // Handle returns an [EventHandle] for the named event type. The
 // handle enables zero-allocation audit calls. Returns
 // [ErrHandleNotFound] if the event type is not registered.
-func (l *Logger) Handle(eventType string) (*EventHandle, error) {
-	if l.disabled {
-		return &EventHandle{name: eventType, logger: l}, nil
+func (a *Auditor) Handle(eventType string) (*EventHandle, error) {
+	if a.disabled {
+		return &EventHandle{name: eventType, auditor: a}, nil
 	}
-	if _, ok := l.taxonomy.Events[eventType]; !ok {
+	if _, ok := a.taxonomy.Events[eventType]; !ok {
 		return nil, fmt.Errorf("audit: unknown event type %q: %w", eventType, ErrHandleNotFound)
 	}
-	return &EventHandle{name: eventType, logger: l}, nil
+	return &EventHandle{name: eventType, auditor: a}, nil
 }
 
 // MustHandle returns an [EventHandle] for the named event type.
 // It panics with an error wrapping [ErrHandleNotFound] if the event
-// type is not registered. Use [Logger.Handle] to receive the error
+// type is not registered. Use [Auditor.Handle] to receive the error
 // instead of panicking.
-func (l *Logger) MustHandle(eventType string) *EventHandle {
-	h, err := l.Handle(eventType)
+func (a *Auditor) MustHandle(eventType string) *EventHandle {
+	h, err := a.Handle(eventType)
 	if err != nil {
 		panic(err)
 	}
@@ -643,8 +643,8 @@ func returnFieldsToPool(fields Fields) {
 // defaults. Standard field defaults have lower precedence (key existence,
 // not zero value). This avoids the double allocation that would result
 // from separate copy + merge steps.
-func (l *Logger) copyFieldsWithDefaults(fields Fields) Fields {
-	size := len(fields) + len(l.standardFieldDefaults)
+func (a *Auditor) copyFieldsWithDefaults(fields Fields) Fields {
+	size := len(fields) + len(a.standardFieldDefaults)
 	if size == 0 {
 		return nil
 	}
@@ -653,7 +653,7 @@ func (l *Logger) copyFieldsWithDefaults(fields Fields) Fields {
 	for k, v := range fields {
 		cp[k] = v
 	}
-	for k, v := range l.standardFieldDefaults {
+	for k, v := range a.standardFieldDefaults {
 		if _, exists := cp[k]; !exists {
 			cp[k] = v
 		}

--- a/audit_export_test.go
+++ b/audit_export_test.go
@@ -18,13 +18,13 @@ package audit
 import "time"
 
 // IsEnabledForTest checks whether the given event type is enabled in
-// the logger's current filter state. Lock-free, matching the
+// the auditor's current filter state. Lock-free, matching the
 // production Audit() hot path.
-func IsEnabledForTest(l *Logger, eventType string) bool {
-	if l.disabled || l.filter == nil || l.taxonomy == nil {
+func IsEnabledForTest(a *Auditor, eventType string) bool {
+	if a.disabled || a.filter == nil || a.taxonomy == nil {
 		return false
 	}
-	return l.filter.isEnabled(eventType, l.taxonomy)
+	return a.filter.isEnabled(eventType, a.taxonomy)
 }
 
 // FormatCacheSizeForTest exposes the array capacity constant.

--- a/audit_test.go
+++ b/audit_test.go
@@ -39,22 +39,22 @@ func TestMain(m *testing.M) {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: create a logger with a mock output
+// Helper: create an auditor with a mock output
 // ---------------------------------------------------------------------------
 
-func newTestLogger(t *testing.T, out *testhelper.MockOutput, opts ...audit.Option) *audit.Logger {
+func newTestAuditor(t *testing.T, out *testhelper.MockOutput, opts ...audit.Option) *audit.Auditor {
 	t.Helper()
 	allOpts := []audit.Option{
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	}
 	allOpts = append(allOpts, opts...)
-	logger, err := audit.NewLogger(allOpts...)
+	auditor, err := audit.New(allOpts...)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, logger.Close())
+		require.NoError(t, auditor.Close())
 	})
-	return logger
+	return auditor
 }
 
 // ---------------------------------------------------------------------------
@@ -64,9 +64,9 @@ func newTestLogger(t *testing.T, out *testhelper.MockOutput, opts ...audit.Optio
 func TestLogger_Audit_ValidCall(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"subject":  "my-topic",
@@ -84,9 +84,9 @@ func TestLogger_Audit_ValidCall(t *testing.T) {
 func TestLogger_Audit_MissingRequiredField(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome": "success",
 		// missing actor_id and subject
 	}))
@@ -101,9 +101,9 @@ func TestLogger_Audit_MissingRequiredField(t *testing.T) {
 func TestLogger_Audit_MissingSingleRequiredField(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		// missing subject
@@ -115,9 +115,9 @@ func TestLogger_Audit_MissingSingleRequiredField(t *testing.T) {
 func TestLogger_Audit_UnknownEventType(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.AuditEvent(audit.NewEvent("schema_registr", audit.Fields{}))
+	err := auditor.AuditEvent(audit.NewEvent("schema_registr", audit.Fields{}))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrValidation)
 	assert.ErrorIs(t, err, audit.ErrUnknownEventType)
@@ -128,9 +128,9 @@ func TestLogger_Audit_UnknownEventType(t *testing.T) {
 func TestLogger_Audit_UnknownFieldStrict(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":     "success",
 		"actor_id":    "alice",
 		"subject":     "my-topic",
@@ -146,9 +146,9 @@ func TestLogger_Audit_UnknownFieldStrict(t *testing.T) {
 func TestLogger_Audit_UnknownFieldWarn(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithValidationMode(audit.ValidationWarn))
+	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationWarn))
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":     "success",
 		"actor_id":    "alice",
 		"subject":     "my-topic",
@@ -162,9 +162,9 @@ func TestLogger_Audit_UnknownFieldWarn(t *testing.T) {
 func TestLogger_Audit_UnknownFieldPermissive(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithValidationMode(audit.ValidationPermissive))
+	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationPermissive))
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":     "success",
 		"actor_id":    "alice",
 		"subject":     "my-topic",
@@ -188,15 +188,15 @@ func TestLogger_Audit_ReservedStandardField_AcceptedInStrictMode(t *testing.T) {
 		},
 	}
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// source_ip is a reserved standard field — accepted without declaration.
-	err = logger.AuditEvent(audit.NewEvent("ev1", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("ev1", audit.Fields{
 		"marker":    "test",
 		"source_ip": "10.0.0.1",
 		"reason":    "test_reason",
@@ -214,15 +214,15 @@ func TestLogger_Audit_ReservedStandardField_StillRejectsUnknown(t *testing.T) {
 		},
 	}
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// "foobar" is NOT a reserved standard field — rejected in strict mode.
-	err = logger.AuditEvent(audit.NewEvent("ev1", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("ev1", audit.Fields{
 		"marker":    "test",
 		"source_ip": "10.0.0.1",
 		"foobar":    "unknown",
@@ -235,7 +235,7 @@ func TestLogger_Audit_ReservedStandardField_StillRejectsUnknown(t *testing.T) {
 
 func TestWithAppName_Empty_ReturnsError(t *testing.T) {
 	t.Parallel()
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName(""),
 	)
@@ -246,7 +246,7 @@ func TestWithAppName_Empty_ReturnsError(t *testing.T) {
 func TestWithAppName_ExceedsMaxLength(t *testing.T) {
 	t.Parallel()
 	// 256 bytes — one byte over the 255-byte maximum.
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName(strings.Repeat("a", 256)),
 	)
@@ -258,18 +258,18 @@ func TestWithAppName_AtMaxLength(t *testing.T) {
 	t.Parallel()
 	// 255 bytes — exactly at the limit, must be accepted.
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithAppName(strings.Repeat("a", 255)),
 	)
 	require.NoError(t, err, "255-byte app_name is at the limit and must be accepted")
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 }
 
 func TestWithHost_Empty_ReturnsError(t *testing.T) {
 	t.Parallel()
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithHost(""),
 	)
@@ -280,7 +280,7 @@ func TestWithHost_Empty_ReturnsError(t *testing.T) {
 func TestWithHost_ExceedsMaxLength(t *testing.T) {
 	t.Parallel()
 	// 256 bytes — one byte over the 255-byte maximum.
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithHost(strings.Repeat("h", 256)),
 	)
@@ -292,18 +292,18 @@ func TestWithHost_AtMaxLength(t *testing.T) {
 	t.Parallel()
 	// 255 bytes — exactly at the limit, must be accepted.
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithHost(strings.Repeat("h", 255)),
 	)
 	require.NoError(t, err, "255-byte host is at the limit and must be accepted")
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 }
 
 func TestWithTimezone_Empty_ReturnsError(t *testing.T) {
 	t.Parallel()
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithTimezone(""),
 	)
@@ -314,7 +314,7 @@ func TestWithTimezone_Empty_ReturnsError(t *testing.T) {
 func TestWithTimezone_ExceedsMaxLength(t *testing.T) {
 	t.Parallel()
 	// 65 bytes — one byte over the 64-byte maximum.
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithTimezone(strings.Repeat("Z", 65)),
 	)
@@ -326,19 +326,19 @@ func TestWithTimezone_AtMaxLength(t *testing.T) {
 	t.Parallel()
 	// 64 bytes — exactly at the limit, must be accepted.
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithTimezone(strings.Repeat("Z", 64)),
 	)
 	require.NoError(t, err, "64-byte timezone is at the limit and must be accepted")
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 }
 
 func TestWithStandardFieldDefaults_InvalidKey(t *testing.T) {
 	t.Parallel()
 	// "bogus" is not a reserved standard field and must be rejected.
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithStandardFieldDefaults(map[string]string{"bogus": "value"}),
 	)
@@ -350,7 +350,7 @@ func TestWithStandardFieldDefaults_InvalidKey(t *testing.T) {
 func TestLogger_FrameworkFields_InOutput(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithAppName("testapp"),
@@ -358,9 +358,9 @@ func TestLogger_FrameworkFields_InOutput(t *testing.T) {
 		audit.WithTimezone("America/New_York"),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	})))
@@ -377,14 +377,14 @@ func TestLogger_Timezone_AutoDetected(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	// No WithTimezone — timezone should auto-detect from system.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	})))
@@ -404,15 +404,15 @@ func TestLogger_Timezone_AutoDetected(t *testing.T) {
 func TestWithStandardFieldDefaults_Applied(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	})))
@@ -425,15 +425,15 @@ func TestWithStandardFieldDefaults_Applied(t *testing.T) {
 func TestWithStandardFieldDefaults_PerEventOverride(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":   "success",
 		"actor_id":  "alice",
 		"source_ip": "192.168.1.1",
@@ -447,15 +447,15 @@ func TestWithStandardFieldDefaults_PerEventOverride(t *testing.T) {
 func TestWithStandardFieldDefaults_EmptyStringOverride(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":   "success",
 		"actor_id":  "alice",
 		"source_ip": "",
@@ -469,7 +469,7 @@ func TestWithStandardFieldDefaults_EmptyStringOverride(t *testing.T) {
 func TestWithStandardFieldDefaults_LastWins(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "a"}),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "b"}),
@@ -478,9 +478,9 @@ func TestWithStandardFieldDefaults_LastWins(t *testing.T) {
 	)
 	require.NoError(t, err, "multiple WithStandardFieldDefaults calls should not error (last wins)")
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "ok"}))
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "ok"}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	require.Equal(t, 1, out.EventCount())
 
 	ev := out.GetEvent(0)
@@ -498,27 +498,27 @@ func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {
 		},
 	}
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// Event only provides outcome — source_ip should come from defaults.
-	err = logger.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
 	assert.NoError(t, err, "default should satisfy required field")
 }
 
 func TestLogger_Audit_NilFields(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	// schema_register requires outcome, actor_id, subject — nil map
 	// means all are missing.
-	err := logger.AuditEvent(audit.NewEvent("schema_register", nil))
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", nil))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required fields")
 }
@@ -526,17 +526,17 @@ func TestLogger_Audit_NilFields(t *testing.T) {
 func TestLogger_Audit_DisabledCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	// Disable the "read" category at runtime.
-	require.NoError(t, logger.DisableCategory("read"))
+	require.NoError(t, auditor.DisableCategory("read"))
 
-	err := logger.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "success"}))
+	err := auditor.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 
 	// Send an enabled event as sentinel to prove the drain loop processed
 	// past the filtered event.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure", "actor_id": "sentinel"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure", "actor_id": "sentinel"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 	assert.Equal(t, 1, out.EventCount(), "disabled category event should not be delivered")
@@ -546,10 +546,10 @@ func TestLogger_Audit_DisabledCategory(t *testing.T) {
 func TestLogger_Audit_OptionalFields(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	// Include an optional field.
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":     "success",
 		"actor_id":    "alice",
 		"subject":     "my-topic",
@@ -568,10 +568,10 @@ func TestLogger_Audit_OptionalFields(t *testing.T) {
 func TestLogger_Audit_TimestampAutoPopulated(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	before := time.Now()
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
@@ -589,9 +589,9 @@ func TestLogger_Audit_TimestampAutoPopulated(t *testing.T) {
 func TestLogger_Audit_EventTypeAutoPopulated(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
@@ -605,9 +605,9 @@ func TestLogger_Audit_EventTypeAutoPopulated(t *testing.T) {
 func TestLogger_Audit_ConsumerTimestampOverwritten(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithValidationMode(audit.ValidationPermissive))
+	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationPermissive))
 
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":   "failure",
 		"actor_id":  "bob",
 		"timestamp": "consumer-set-value",
@@ -627,9 +627,9 @@ func TestLogger_Audit_ConsumerTimestampOverwritten(t *testing.T) {
 func TestLogger_Audit_OmitEmptyTrue(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithOmitEmpty())
+	auditor := newTestAuditor(t, out, audit.WithOmitEmpty())
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"subject":  "my-topic",
@@ -646,9 +646,9 @@ func TestLogger_Audit_OmitEmptyTrue(t *testing.T) {
 func TestLogger_Audit_OmitEmptyFalse(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"subject":  "my-topic",
@@ -669,9 +669,9 @@ func TestLogger_Audit_OmitEmptyFalse(t *testing.T) {
 func TestLogger_Handle_Valid(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	h, err := logger.Handle("schema_register")
+	h, err := auditor.Handle("schema_register")
 	require.NoError(t, err)
 	require.NotNil(t, h)
 	assert.Equal(t, "schema_register", h.EventType())
@@ -680,9 +680,9 @@ func TestLogger_Handle_Valid(t *testing.T) {
 func TestLogger_Handle_Error(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	h, err := logger.Handle("nonexistent")
+	h, err := auditor.Handle("nonexistent")
 	require.Error(t, err)
 	assert.Nil(t, h)
 	assert.ErrorIs(t, err, audit.ErrHandleNotFound)
@@ -691,10 +691,10 @@ func TestLogger_Handle_Error(t *testing.T) {
 func TestLogger_MustHandle_Valid(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	assert.NotPanics(t, func() {
-		h := logger.MustHandle("schema_register")
+		h := auditor.MustHandle("schema_register")
 		assert.Equal(t, "schema_register", h.EventType())
 	})
 }
@@ -702,19 +702,19 @@ func TestLogger_MustHandle_Valid(t *testing.T) {
 func TestLogger_MustHandle_Panics(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	assert.Panics(t, func() {
-		logger.MustHandle("nonexistent")
+		auditor.MustHandle("nonexistent")
 	})
 }
 
 func TestLogger_Handle_Audit(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	h := logger.MustHandle("auth_failure")
+	h := auditor.MustHandle("auth_failure")
 	err := h.Audit(audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
@@ -733,9 +733,9 @@ func TestLogger_Handle_Audit(t *testing.T) {
 func TestLogger_Audit_EventDelivered(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
@@ -752,21 +752,21 @@ func TestLogger_Audit_BufferFull(t *testing.T) {
 	out := &blockingOutput{name: "blocking", blockCh: make(chan struct{})}
 	t.Cleanup(func() { close(out.blockCh) })
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(1),
-		audit.WithDrainTimeout(50*time.Millisecond),
+		audit.WithShutdownTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// Fill the buffer (1 slot) + drain goroutine may take one.
 	// Send enough to guarantee overflow.
 	var bufferFullSeen bool
 	for i := 0; i < 100; i++ {
-		err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 			"outcome":  "failure",
 			"actor_id": "bob",
 		}))
@@ -804,7 +804,7 @@ func (b *blockingOutput) Name() string { return b.name }
 func TestLogger_Close_DrainsEvents(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -812,7 +812,7 @@ func TestLogger_Close_DrainsEvents(t *testing.T) {
 
 	// Send several events.
 	for i := 0; i < 10; i++ {
-		err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 			"outcome":  "failure",
 			"actor_id": "bob",
 		}))
@@ -820,41 +820,41 @@ func TestLogger_Close_DrainsEvents(t *testing.T) {
 	}
 
 	// Close should drain all.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 10, out.EventCount(), "Close should drain all pending events")
 }
 
 func TestLogger_Close_Idempotent(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
-	require.NoError(t, logger.Close()) // second call: no error.
+	require.NoError(t, auditor.Close())
+	require.NoError(t, auditor.Close()) // second call: no error.
 }
 
 func TestLogger_Audit_AfterClose(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	assert.ErrorIs(t, err, audit.ErrClosed)
 }
 
-func TestLogger_Close_DrainTimeout(t *testing.T) {
+func TestLogger_Close_ShutdownTimeout(t *testing.T) {
 
 	// Use a blocking output that never unblocks combined with a very
 	// short drain timeout. Close should return within a bounded time
@@ -862,39 +862,39 @@ func TestLogger_Close_DrainTimeout(t *testing.T) {
 	out := &blockingOutput{name: "stuck", blockCh: make(chan struct{})}
 	t.Cleanup(func() { close(out.blockCh) })
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(10),
-		audit.WithDrainTimeout(10*time.Millisecond),
+		audit.WithShutdownTimeout(10*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
 	// Enqueue an event so the drain goroutine has work to do.
-	_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 
 	start := time.Now()
-	_ = logger.Close()
+	_ = auditor.Close()
 	elapsed := time.Since(start)
 
 	// Close should complete quickly (within 1s), not hang for the
 	// default 5s drain timeout.
-	assert.Less(t, elapsed, 1*time.Second, "Close should respect short DrainTimeout")
+	assert.Less(t, elapsed, 1*time.Second, "Close should respect short ShutdownTimeout")
 }
 
 func TestLogger_Close_OutputError(t *testing.T) {
 
 	out := &errorOutput{name: "bad", closeErr: errors.New("close failed")}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.Close()
+	err = auditor.Close()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "close failed")
 	assert.Contains(t, err.Error(), "bad", "error should include output name")
@@ -917,13 +917,13 @@ func TestLogger_Close_MultipleOutputErrors(t *testing.T) {
 	outB := &errorOutput{name: "beta", closeErr: errBeta}
 	outC := &errorOutput{name: "gamma"} // succeeds
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(outA, outB, outC),
 	)
 	require.NoError(t, err)
 
-	err = logger.Close()
+	err = auditor.Close()
 	require.Error(t, err)
 
 	// Both failures are reported via errors.Join.
@@ -940,13 +940,13 @@ func TestLogger_Close_AllOutputsCloseCalledOnError(t *testing.T) {
 	outA := &errorOutput{name: "fail-first", closeErr: errors.New("first fail")}
 	outB := testhelper.NewMockOutput("second")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(outA, outB),
 	)
 	require.NoError(t, err)
 
-	_ = logger.Close()
+	_ = auditor.Close()
 	assert.True(t, outB.IsClosed(), "output B's Close() must be called even when A fails")
 }
 
@@ -957,13 +957,13 @@ func TestLogger_Close_AllOutputsCloseCalledOnError(t *testing.T) {
 func TestLogger_EnableCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	// Disable "read", then re-enable it.
-	require.NoError(t, logger.DisableCategory("read"))
-	require.NoError(t, logger.EnableCategory("read"))
+	require.NoError(t, auditor.DisableCategory("read"))
+	require.NoError(t, auditor.EnableCategory("read"))
 
-	err := logger.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "success"}))
+	err := auditor.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 }
@@ -971,12 +971,12 @@ func TestLogger_EnableCategory(t *testing.T) {
 func TestLogger_DisableCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	// Disable "write" at runtime.
-	require.NoError(t, logger.DisableCategory("write"))
+	require.NoError(t, auditor.DisableCategory("write"))
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"subject":  "test",
@@ -984,7 +984,7 @@ func TestLogger_DisableCategory(t *testing.T) {
 	require.NoError(t, err)
 
 	// Send an enabled event as sentinel to prove processing.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure", "actor_id": "sentinel"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure", "actor_id": "sentinel"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 	assert.Equal(t, 1, out.EventCount(), "disabled category should not deliver events")
@@ -993,23 +993,23 @@ func TestLogger_DisableCategory(t *testing.T) {
 func TestLogger_EnableEvent_OverridesCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	// Disable "read" category, then enable one specific event from it.
-	require.NoError(t, logger.DisableCategory("read"))
-	require.NoError(t, logger.EnableEvent("schema_read"))
+	require.NoError(t, auditor.DisableCategory("read"))
+	require.NoError(t, auditor.EnableEvent("schema_read"))
 
-	err := logger.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "success"}))
+	err := auditor.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 
 	// config_read (same category, no override) should still be filtered.
-	err = logger.AuditEvent(audit.NewEvent("config_read", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("config_read", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 
 	// Send an enabled event as sentinel, then verify only 2 events
 	// (schema_read + sentinel), not 3.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure", "actor_id": "sentinel"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure", "actor_id": "sentinel"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(2, 2*time.Second))
 	assert.Equal(t, 2, out.EventCount(), "only overridden event + sentinel should be delivered")
@@ -1018,12 +1018,12 @@ func TestLogger_EnableEvent_OverridesCategory(t *testing.T) {
 func TestLogger_DisableEvent_OverridesCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	// "write" category is enabled. Disable one specific event.
-	require.NoError(t, logger.DisableEvent("schema_register"))
+	require.NoError(t, auditor.DisableEvent("schema_register"))
 
-	err := logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"subject":  "test",
@@ -1031,7 +1031,7 @@ func TestLogger_DisableEvent_OverridesCategory(t *testing.T) {
 	require.NoError(t, err)
 
 	// schema_delete (same category, no override) should still work.
-	err = logger.AuditEvent(audit.NewEvent("schema_delete", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("schema_delete", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"subject":  "test",
@@ -1044,13 +1044,13 @@ func TestLogger_DisableEvent_OverridesCategory(t *testing.T) {
 func TestLogger_Filter_InvalidCategory(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.EnableCategory("nonexistent")
+	err := auditor.EnableCategory("nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown category")
 
-	err = logger.DisableCategory("nonexistent")
+	err = auditor.DisableCategory("nonexistent")
 	assert.Error(t, err)
 }
 
@@ -1069,14 +1069,14 @@ func TestLogger_MultiCategory_DeliveredPerCategory(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 
 	// Event in 2 categories → 2 deliveries to the unrouted output.
@@ -1098,17 +1098,17 @@ func TestLogger_MultiCategory_DisableOneCategory(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// Disable one category.
-	require.NoError(t, logger.DisableCategory("security"))
+	require.NoError(t, auditor.DisableCategory("security"))
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 
 	// Only the access pass should deliver.
@@ -1130,23 +1130,23 @@ func TestLogger_MultiCategory_DisableAllCategories(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	require.NoError(t, logger.DisableCategory("security"))
-	require.NoError(t, logger.DisableCategory("access"))
+	require.NoError(t, auditor.DisableCategory("security"))
+	require.NoError(t, auditor.DisableCategory("access"))
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 
 	// Both categories disabled → event enters channel but no category
 	// pass runs. Send a sentinel to prove processing completed.
-	require.NoError(t, logger.EnableCategory("security"))
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "sentinel"}))
+	require.NoError(t, auditor.EnableCategory("security"))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "sentinel"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 	assert.Equal(t, 1, out.EventCount(), "only sentinel should arrive — first event had all categories disabled")
@@ -1167,14 +1167,14 @@ func TestLogger_Uncategorised_DeliveredToUnroutedOutput(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("data_export", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("data_export", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
@@ -1195,19 +1195,19 @@ func TestLogger_MultiCategory_EnableEventOverride(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// Disable both categories, then force-enable the event.
-	require.NoError(t, logger.DisableCategory("security"))
-	require.NoError(t, logger.DisableCategory("compliance"))
-	require.NoError(t, logger.EnableEvent("auth_failure"))
+	require.NoError(t, auditor.DisableCategory("security"))
+	require.NoError(t, auditor.DisableCategory("compliance"))
+	require.NoError(t, auditor.EnableEvent("auth_failure"))
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 
 	// EnableEvent should override disabled categories — event delivered
@@ -1230,16 +1230,16 @@ func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 
 	// Output includes only security — should get 1 delivery (security pass),
@@ -1262,16 +1262,16 @@ func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			ExcludeCategories: []string{"security"},
 		})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 
 	// Output excludes security — should get 1 delivery (compliance pass only).
@@ -1282,13 +1282,13 @@ func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 func TestLogger_Filter_InvalidEvent(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
-	err := logger.EnableEvent("nonexistent")
+	err := auditor.EnableEvent("nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown event type")
 
-	err = logger.DisableEvent("nonexistent")
+	err = auditor.DisableEvent("nonexistent")
 	assert.Error(t, err)
 }
 
@@ -1303,14 +1303,14 @@ func TestLogger_Filter_InvalidEvent(t *testing.T) {
 func TestLogger_ConcurrentAudit(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+			_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 				"outcome":  "failure",
 				"actor_id": "bob",
 			}))
@@ -1325,7 +1325,7 @@ func TestLogger_ConcurrentAudit(t *testing.T) {
 func TestLogger_ConcurrentFilterMutation(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out)
+	auditor := newTestAuditor(t, out)
 
 	var wg sync.WaitGroup
 	// Concurrent filter mutations + audit calls.
@@ -1333,12 +1333,12 @@ func TestLogger_ConcurrentFilterMutation(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			_ = logger.EnableCategory("read")
-			_ = logger.DisableCategory("read")
+			_ = auditor.EnableCategory("read")
+			_ = auditor.DisableCategory("read")
 		}()
 		go func() {
 			defer wg.Done()
-			_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+			_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 				"outcome":  "failure",
 				"actor_id": "bob",
 			}))
@@ -1350,7 +1350,7 @@ func TestLogger_ConcurrentFilterMutation(t *testing.T) {
 func TestLogger_ConcurrentClose(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -1364,7 +1364,7 @@ func TestLogger_ConcurrentClose(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := logger.Close(); err != nil {
+			if err := auditor.Close(); err != nil {
 				errCount.Add(1)
 			}
 		}()
@@ -1381,10 +1381,10 @@ func TestLogger_Audit_MetricsRecordSuccess(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test-out")
 	metrics := testhelper.NewMockMetrics()
-	logger := newTestLogger(t, out,
+	auditor := newTestAuditor(t, out,
 		audit.WithMetrics(metrics))
 
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
@@ -1401,21 +1401,21 @@ func TestLogger_Audit_MetricsRecordOutputError(t *testing.T) {
 
 	metrics := testhelper.NewMockMetrics()
 	out := &errorWriteOutput{name: "bad-write"}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
 	// Close drains all pending events and completes metric recording.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Greater(t, metrics.GetEventCount("bad-write", "error"), 0)
 	assert.Greater(t, metrics.GetOutputErrorCount("bad-write"), 0)
@@ -1435,26 +1435,26 @@ func (e *errorWriteOutput) Name() string         { return e.name }
 
 func TestLogger_Audit_NoOutputs(t *testing.T) {
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
 
 	// Should not error — events are validated and filtered but go nowhere.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	assert.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 // ---------------------------------------------------------------------------
 // Config bounds tests
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_QueueSizeExceedsMax(t *testing.T) {
-	_, err := audit.NewLogger(
+func TestNew_QueueSizeExceedsMax(t *testing.T) {
+	_, err := audit.New(
 		audit.WithQueueSize(audit.MaxQueueSize+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
@@ -1462,9 +1462,9 @@ func TestNewLogger_QueueSizeExceedsMax(t *testing.T) {
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }
 
-func TestNewLogger_DrainTimeoutExceedsMax(t *testing.T) {
-	_, err := audit.NewLogger(
-		audit.WithDrainTimeout(audit.MaxDrainTimeout+1),
+func TestNew_ShutdownTimeoutExceedsMax(t *testing.T) {
+	_, err := audit.New(
+		audit.WithShutdownTimeout(audit.MaxShutdownTimeout+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.Error(t, err)
@@ -1478,9 +1478,9 @@ func TestNewLogger_DrainTimeoutExceedsMax(t *testing.T) {
 func TestLogger_Audit_OmitEmptyZeroInt(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
+	auditor := newTestAuditor(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
 
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 		"count":    0,     // zero int should be omitted
@@ -1507,13 +1507,13 @@ func TestLogger_Audit_OmitEmptyZeroInt(t *testing.T) {
 func TestLogger_Audit_SerializationFailure(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithValidationMode(audit.ValidationPermissive))
+	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationPermissive))
 
 	// A channel cannot be marshalled to JSON. The event passes validation
 	// (permissive mode) and is enqueued, but serialisation fails in the
 	// drain loop. The output should receive zero events and no panic.
 	ch := make(chan struct{})
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 		"bad":      ch,
@@ -1522,7 +1522,7 @@ func TestLogger_Audit_SerializationFailure(t *testing.T) {
 
 	// Send a valid event as sentinel to confirm drain loop processed
 	// the bad event without crashing.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "sentinel",
 	}))
@@ -1548,15 +1548,15 @@ func TestLogger_Audit_NilFieldsNoRequiredFields(t *testing.T) {
 	}
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// nil fields should work when there are no required fields.
-	err = logger.AuditEvent(audit.NewEvent("no_req", nil))
+	err = auditor.AuditEvent(audit.NewEvent("no_req", nil))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 }
@@ -1568,7 +1568,7 @@ func TestLogger_Audit_NilFieldsNoRequiredFields(t *testing.T) {
 func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -1581,7 +1581,7 @@ func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 10; j++ {
-				_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+				_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 					"outcome":  "failure",
 					"actor_id": "bob",
 				}))
@@ -1593,7 +1593,7 @@ func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = logger.Close()
+		_ = auditor.Close()
 	}()
 
 	wg.Wait()
@@ -1601,7 +1601,7 @@ func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
 
 func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out),
 	)
@@ -1615,7 +1615,7 @@ func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 		go func(n int) {
 			defer wg.Done()
 			for range 10 {
-				_ = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+				_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 					"outcome": "success",
 				}))
 			}
@@ -1628,10 +1628,10 @@ func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 5 {
-				_ = logger.SetOutputRoute("test", &audit.EventRoute{
+				_ = auditor.SetOutputRoute("test", &audit.EventRoute{
 					IncludeCategories: []string{"write"},
 				})
-				_ = logger.SetOutputRoute("test", &audit.EventRoute{})
+				_ = auditor.SetOutputRoute("test", &audit.EventRoute{})
 			}
 		}()
 	}
@@ -1640,7 +1640,7 @@ func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = logger.Close()
+		_ = auditor.Close()
 	}()
 
 	wg.Wait()
@@ -1654,14 +1654,14 @@ func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 func TestLogger_Handle_AuditAfterClose(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	h := logger.MustHandle("auth_failure")
-	require.NoError(t, logger.Close())
+	h := auditor.MustHandle("auth_failure")
+	require.NoError(t, auditor.Close())
 
 	err = h.Audit(audit.Fields{
 		"outcome":  "failure",
@@ -1682,14 +1682,14 @@ func TestLogger_Audit_MultipleOutputs(t *testing.T) {
 
 	out1 := testhelper.NewMockOutput("out1")
 	out2 := testhelper.NewMockOutput("out2")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out1, out2),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
@@ -1708,9 +1708,9 @@ func TestLogger_Audit_MultipleOutputs(t *testing.T) {
 func TestLogger_Audit_OmitEmptyNonZeroIncluded(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
+	auditor := newTestAuditor(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
 
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 		"count":    42,
@@ -1731,14 +1731,14 @@ func TestLogger_Audit_OmitEmptyNonZeroIncluded(t *testing.T) {
 func TestLogger_Audit_FuncFieldOmitEmpty(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
+	auditor := newTestAuditor(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
 
 	// A func value should not cause a panic in isZeroValue.
 	// With OmitEmpty, isZeroValue returns false for a non-nil func,
 	// so the func is included in the map. json.Marshal will fail on
 	// func types, causing the event to be dropped. The drain goroutine
 	// must survive this without panicking.
-	err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 		"callback": func() {},
@@ -1746,7 +1746,7 @@ func TestLogger_Audit_FuncFieldOmitEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	// Send sentinel to prove drain goroutine survived the bad event.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "sentinel",
 	}))
@@ -1764,9 +1764,9 @@ func TestLogger_Close_ShutdownEventDroppedOnFullBuffer(t *testing.T) {
 	out := &blockingOutput{name: "stuck", blockCh: make(chan struct{})}
 	t.Cleanup(func() { close(out.blockCh) })
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(1),
-		audit.WithDrainTimeout(50*time.Millisecond),
+		audit.WithShutdownTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
@@ -1776,14 +1776,14 @@ func TestLogger_Close_ShutdownEventDroppedOnFullBuffer(t *testing.T) {
 
 	// Fill the buffer so emitShutdown's non-blocking send hits default.
 	for i := 0; i < 100; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 			"outcome":  "failure",
 			"actor_id": "bob",
 		}))
 	}
 
 	// Close should not panic or hang even when shutdown event is dropped.
-	_ = logger.Close()
+	_ = auditor.Close()
 }
 
 // ---------------------------------------------------------------------------
@@ -1801,15 +1801,15 @@ func TestLogger_Audit_AllCategoriesEnabledByDefault(t *testing.T) {
 	}
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// ev1 should be delivered — all categories enabled by default.
-	err = logger.AuditEvent(audit.NewEvent("ev1", audit.Fields{"f1": "val"}))
+	err = auditor.AuditEvent(audit.NewEvent("ev1", audit.Fields{"f1": "val"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 	assert.Equal(t, 1, out.EventCount(), "event should be delivered — all categories enabled by default")
@@ -1822,10 +1822,10 @@ func TestLogger_Audit_AllCategoriesEnabledByDefault(t *testing.T) {
 func TestAudit_UnknownEventType_RecordsValidationError(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out,
+	auditor := newTestAuditor(t, out,
 		audit.WithMetrics(metrics))
 
-	_ = logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	_ = auditor.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
 
 	metrics.Mu.Lock()
 	defer metrics.Mu.Unlock()
@@ -1835,10 +1835,10 @@ func TestAudit_UnknownEventType_RecordsValidationError(t *testing.T) {
 func TestAudit_MissingRequiredField_RecordsValidationError(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out,
+	auditor := newTestAuditor(t, out,
 		audit.WithMetrics(metrics))
 
-	_ = logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{"outcome": "ok"}))
+	_ = auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{"outcome": "ok"}))
 
 	metrics.Mu.Lock()
 	defer metrics.Mu.Unlock()
@@ -1848,15 +1848,15 @@ func TestAudit_MissingRequiredField_RecordsValidationError(t *testing.T) {
 func TestAudit_UnknownFieldStrict_RecordsValidationError(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "fail",
 		"actor_id": "bob",
 		"bogus":    "val",
@@ -1870,12 +1870,12 @@ func TestAudit_UnknownFieldStrict_RecordsValidationError(t *testing.T) {
 func TestAudit_FilteredEvent_RecordsFiltered(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out,
+	auditor := newTestAuditor(t, out,
 		audit.WithMetrics(metrics))
 
 	// Disable "read" category at runtime, then emit an event.
-	require.NoError(t, logger.DisableCategory("read"))
-	_ = logger.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "ok"}))
+	require.NoError(t, auditor.DisableCategory("read"))
+	_ = auditor.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "ok"}))
 
 	metrics.Mu.Lock()
 	defer metrics.Mu.Unlock()
@@ -1885,13 +1885,13 @@ func TestAudit_FilteredEvent_RecordsFiltered(t *testing.T) {
 func TestAudit_FilteredEventOverride_RecordsFiltered(t *testing.T) {
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out,
+	auditor := newTestAuditor(t, out,
 		audit.WithMetrics(metrics))
 
 	// Disable a specific event in an enabled category.
-	require.NoError(t, logger.DisableEvent("schema_register"))
+	require.NoError(t, auditor.DisableEvent("schema_register"))
 
-	_ = logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	_ = auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "ok",
 		"actor_id": "alice",
 		"subject":  "test",
@@ -1910,7 +1910,7 @@ func TestProcessEntry_SerializationError_RecordsMetric(t *testing.T) {
 			return nil, errors.New("format failed")
 		},
 	}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithFormatter(badFormatter),
@@ -1918,7 +1918,7 @@ func TestProcessEntry_SerializationError_RecordsMetric(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "fail",
 		"actor_id": "bob",
 	}))
@@ -1926,7 +1926,7 @@ func TestProcessEntry_SerializationError_RecordsMetric(t *testing.T) {
 
 	// Close drains the event through processEntry, triggering the
 	// serialization error metric.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	metrics.Mu.Lock()
 	defer metrics.Mu.Unlock()
@@ -1938,9 +1938,9 @@ func TestEmitShutdown_BufferFull_RecordsBufferDrop(t *testing.T) {
 	out := &blockingOutput{name: "stuck", blockCh: make(chan struct{})}
 	t.Cleanup(func() { close(out.blockCh) })
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(1),
-		audit.WithDrainTimeout(50*time.Millisecond),
+		audit.WithShutdownTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -1949,13 +1949,13 @@ func TestEmitShutdown_BufferFull_RecordsBufferDrop(t *testing.T) {
 
 	// Fill the buffer.
 	for i := 0; i < 100; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 			"outcome":  "fail",
 			"actor_id": "bob",
 		}))
 	}
 
-	_ = logger.Close()
+	_ = auditor.Close()
 
 	metrics.Mu.Lock()
 	defer metrics.Mu.Unlock()
@@ -1971,7 +1971,7 @@ func TestAudit_NilMetrics_NoPanic(t *testing.T) {
 		},
 	}
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithFormatter(badFormatter),
@@ -1980,17 +1980,17 @@ func TestAudit_NilMetrics_NoPanic(t *testing.T) {
 	require.NoError(t, err)
 
 	// Validation error path (unknown event type).
-	_ = logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	_ = auditor.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
 	// Missing required field path.
-	_ = logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{"outcome": "ok"}))
+	_ = auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{"outcome": "ok"}))
 	// Filtered event path.
-	_ = logger.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "ok"}))
+	_ = auditor.AuditEvent(audit.NewEvent("schema_read", audit.Fields{"outcome": "ok"}))
 	// Normal path (will trigger serialization error in drain goroutine).
-	_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "fail", "actor_id": "bob"}))
+	_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "fail", "actor_id": "bob"}))
 
 	// Close drains the bad event through processEntry -> serialize error
 	// with nil metrics. Must not panic.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 // ---------------------------------------------------------------------------
@@ -1998,7 +1998,7 @@ func TestAudit_NilMetrics_NoPanic(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // deliveryReporterOutput is a mock output that implements DeliveryReporter.
-// It reports its own delivery, so the core logger must NOT call RecordEvent
+// It reports its own delivery, so the core auditor must NOT call RecordEvent
 // or RecordOutputError for it.
 type deliveryReporterOutput struct {
 	writeErrToReturn error
@@ -2025,87 +2025,87 @@ var _ audit.Output = (*deliveryReporterOutput)(nil)
 
 func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
 	// When an output satisfies DeliveryReporter and ReportsDelivery()
-	// returns true, the core logger must NOT call RecordEvent on success.
+	// returns true, the core auditor must NOT call RecordEvent on success.
 	metrics := testhelper.NewMockMetrics()
 	out := newDeliveryReporterOutput("self-reporting")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// The self-reporting output received the event.
 	assert.Equal(t, 1, out.EventCount())
 
-	// The core logger must not have called RecordEvent for this output.
+	// The core auditor must not have called RecordEvent for this output.
 	assert.Equal(t, 0, metrics.GetEventCount("self-reporting", "success"),
-		"core logger must not call RecordEvent(success) for DeliveryReporter outputs")
+		"core auditor must not call RecordEvent(success) for DeliveryReporter outputs")
 	assert.Equal(t, 0, metrics.GetEventCount("self-reporting", "error"),
-		"core logger must not call RecordEvent(error) for DeliveryReporter outputs")
+		"core auditor must not call RecordEvent(error) for DeliveryReporter outputs")
 }
 
 func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
-	// When a DeliveryReporter output fails on Write, the core logger must
+	// When a DeliveryReporter output fails on Write, the core auditor must
 	// NOT call RecordEvent or RecordOutputError — the output is responsible.
 	metrics := testhelper.NewMockMetrics()
 	out := newDeliveryReporterOutput("self-reporting-fail")
 	out.writeErrToReturn = errors.New("delivery failed")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
-	// Core logger must not record any metrics for the self-reporting output.
+	// Core auditor must not record any metrics for the self-reporting output.
 	assert.Equal(t, 0, metrics.GetEventCount("self-reporting-fail", "success"),
-		"core logger must not call RecordEvent(success) for DeliveryReporter outputs")
+		"core auditor must not call RecordEvent(success) for DeliveryReporter outputs")
 	assert.Equal(t, 0, metrics.GetEventCount("self-reporting-fail", "error"),
-		"core logger must not call RecordEvent(error) for DeliveryReporter outputs")
+		"core auditor must not call RecordEvent(error) for DeliveryReporter outputs")
 
 	metrics.Mu.Lock()
 	errCount := metrics.OutputErrors["self-reporting-fail"]
 	metrics.Mu.Unlock()
 	assert.Equal(t, 0, errCount,
-		"core logger must not call RecordOutputError for DeliveryReporter outputs")
+		"core auditor must not call RecordOutputError for DeliveryReporter outputs")
 }
 
 func TestWriteToOutput_NonDeliveryReporter_SuccessRecordsCoreMetrics(t *testing.T) {
 	// A plain output (not DeliveryReporter) must have RecordEvent(success)
-	// called by the core logger on a successful write.
+	// called by the core auditor on a successful write.
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("plain")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Greater(t, metrics.GetEventCount("plain", "success"), 0,
-		"core logger must call RecordEvent(success) for plain (non-DeliveryReporter) outputs")
+		"core auditor must call RecordEvent(success) for plain (non-DeliveryReporter) outputs")
 }
 
 // ---------------------------------------------------------------------------
@@ -2116,7 +2116,7 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 	// Exercises the int32, float32, uint, uint64 branches in isZeroValue
 	// via the OmitEmpty path through the JSON formatter.
 	out := testhelper.NewMockOutput("test")
-	logger := newTestLogger(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
+	auditor := newTestAuditor(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
 
 	tests := []struct {
 		name    string
@@ -2210,7 +2210,7 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Use a fresh output per subtest to avoid event ordering issues.
 			subOut := testhelper.NewMockOutput("sub-" + tt.name)
-			subLogger, err := audit.NewLogger(
+			subLogger, err := audit.New(
 				audit.WithOmitEmpty(),
 				audit.WithValidationMode(audit.ValidationPermissive),
 				audit.WithTaxonomy(testhelper.ValidTaxonomy()),
@@ -2232,8 +2232,8 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 		})
 	}
 
-	// Prevent unused warning for the outer logger.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "ok", "actor_id": "x"})))
+	// Prevent unused warning for the outer auditor.
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "ok", "actor_id": "x"})))
 	_ = out
 }
 
@@ -2257,7 +2257,7 @@ func (d *destKeyOutput) DestinationKey() string {
 func TestWithOutputs_DuplicateDestination_ReturnsError(t *testing.T) {
 	o1 := &destKeyOutput{name: "out1", key: "/var/log/audit.log"}
 	o2 := &destKeyOutput{name: "out2", key: "/var/log/audit.log"}
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(o1, o2),
 	)
@@ -2269,7 +2269,7 @@ func TestWithOutputs_DuplicateDestination_ReturnsError(t *testing.T) {
 func TestWithNamedOutput_DuplicateDestination_ReturnsError(t *testing.T) {
 	o1 := &destKeyOutput{name: "out1", key: "localhost:514"}
 	o2 := &destKeyOutput{name: "out2", key: "localhost:514"}
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(o1),
 		audit.WithNamedOutput(o2),
@@ -2283,24 +2283,24 @@ func TestWithOutputs_EmptyDestinationKey_NoCollision(t *testing.T) {
 	// Outputs returning empty DestinationKey opt out of dedup.
 	o1 := &destKeyOutput{name: "out1", key: ""}
 	o2 := &destKeyOutput{name: "out2", key: ""}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(o1, o2),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 }
 
 func TestWithOutputs_MixedTypes_NoFalsePositive(t *testing.T) {
 	// destKeyOutput + MockOutput (no DestinationKeyer) should not collide.
 	o1 := &destKeyOutput{name: "keyed", key: "/var/log/audit.log"}
 	o2 := testhelper.NewMockOutput("unkeyed")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(o1, o2),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 }
 
 // ---------------------------------------------------------------------------
@@ -2376,12 +2376,12 @@ func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
 	}
 
 	out := testhelper.NewMockOutput("field-test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	fields := audit.Fields{
 		"outcome":     "success",
@@ -2394,7 +2394,7 @@ func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
 		"user_agent":  "test-client/1.0",
 		"request_id":  "req-12345",
 	}
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_check", fields)))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_check", fields)))
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 
 	record := out.GetEvent(0)
@@ -2431,16 +2431,16 @@ func TestLogger_Audit_FieldCompleteness_OmittedOptionalFieldsAbsent(t *testing.T
 	}
 
 	out := testhelper.NewMockOutput("field-test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithOmitEmpty(),
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// Send event with only required fields — optional fields omitted.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_check", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_check", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	})))
@@ -2464,7 +2464,7 @@ func TestLogger_Audit_FieldCompleteness_OmittedOptionalFieldsAbsent(t *testing.T
 // ---------------------------------------------------------------------------
 
 // silenceSlog suppresses slog output during benchmarks so that
-// logger creation messages do not pollute benchmark output. The
+// auditor creation messages do not pollute benchmark output. The
 // previous handler is restored via b.Cleanup.
 func silenceSlog(b *testing.B) {
 	b.Helper()
@@ -2476,14 +2476,14 @@ func silenceSlog(b *testing.B) {
 func BenchmarkAudit(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -2494,41 +2494,41 @@ func BenchmarkAudit(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 }
 
 func BenchmarkAuditDisabledCategory(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{"outcome": "success"}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_read", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_read", fields))
 	}
 }
 
-func BenchmarkAuditDisabledLogger(b *testing.B) {
+func BenchmarkAuditDisabledAuditor(b *testing.B) {
 	silenceSlog(b)
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -2538,7 +2538,7 @@ func BenchmarkAuditDisabledLogger(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("auth_failure", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("auth_failure", fields))
 	}
 }
 
@@ -2561,14 +2561,14 @@ func BenchmarkAudit_RealisticFields(b *testing.B) {
 		},
 	}
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(taxonomy),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":     "success",
@@ -2586,21 +2586,21 @@ func BenchmarkAudit_RealisticFields(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("api_request", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("api_request", fields))
 	}
 }
 
 func BenchmarkAudit_Parallel(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -2613,7 +2613,7 @@ func BenchmarkAudit_Parallel(b *testing.B) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+			_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 		}
 	})
 }
@@ -2626,7 +2626,7 @@ func BenchmarkAudit_Parallel(b *testing.B) {
 func BenchmarkAudit_PoolAmortised(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
@@ -2634,7 +2634,7 @@ func BenchmarkAudit_PoolAmortised(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -2644,13 +2644,13 @@ func BenchmarkAudit_PoolAmortised(b *testing.B) {
 
 	// Warm the pool with a few iterations before measuring.
 	for range 1000 {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 }
 
@@ -2666,7 +2666,7 @@ func BenchmarkAudit_FanOut_SharedFormatter(b *testing.B) {
 	out1 := testhelper.NewMockOutput("out1")
 	out2 := testhelper.NewMockOutput("out2")
 	out3 := testhelper.NewMockOutput("out3")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out1, out2, out3),
@@ -2674,7 +2674,7 @@ func BenchmarkAudit_FanOut_SharedFormatter(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -2685,7 +2685,7 @@ func BenchmarkAudit_FanOut_SharedFormatter(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 }
 
@@ -2698,7 +2698,7 @@ func BenchmarkAudit_FanOut_MixedFormatters(b *testing.B) {
 	out2 := testhelper.NewMockOutput("cef")
 	out3 := testhelper.NewMockOutput("json2")
 	cefFmt := &audit.CEFFormatter{Vendor: "V", Product: "P", Version: "1"}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out1),                                // default JSON
@@ -2708,7 +2708,7 @@ func BenchmarkAudit_FanOut_MixedFormatters(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -2719,7 +2719,7 @@ func BenchmarkAudit_FanOut_MixedFormatters(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 }
 
@@ -2732,7 +2732,7 @@ func BenchmarkAudit_FanOut_FilteredOutputs(b *testing.B) {
 	out1 := testhelper.NewMockOutput("all")
 	out2 := testhelper.NewMockOutput("write-only")
 	out3 := testhelper.NewMockOutput("security-only")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out1), // receives all events
@@ -2746,7 +2746,7 @@ func BenchmarkAudit_FanOut_FilteredOutputs(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -2759,7 +2759,7 @@ func BenchmarkAudit_FanOut_FilteredOutputs(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// schema_register is "write" category — out1 and out2 receive it,
 		// out3 filters it.
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 }
 
@@ -2771,7 +2771,7 @@ func BenchmarkAudit_FanOut_5Outputs(b *testing.B) {
 	for i := range outputs {
 		outputs[i] = testhelper.NewMockOutput("out" + string(rune('0'+i)))
 	}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(outputs...),
@@ -2779,7 +2779,7 @@ func BenchmarkAudit_FanOut_5Outputs(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -2790,7 +2790,7 @@ func BenchmarkAudit_FanOut_5Outputs(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 }
 
@@ -2829,23 +2829,23 @@ func TestLogger_DisableEvent_UncategorisedEvent(t *testing.T) {
 	}
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
 	// health_check is uncategorised — always delivered by default.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("health_check", audit.Fields{"outcome": "ok"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("health_check", audit.Fields{"outcome": "ok"})))
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 	assert.Equal(t, 1, out.EventCount())
 
 	// Disable it explicitly.
-	require.NoError(t, logger.DisableEvent("health_check"))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("health_check", audit.Fields{"outcome": "ok"})))
+	require.NoError(t, auditor.DisableEvent("health_check"))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("health_check", audit.Fields{"outcome": "ok"})))
 
 	// Close drains all pending events, guaranteeing processing is complete.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 1, out.EventCount(), "disabled uncategorised event must not be delivered")
 }
 
@@ -2857,7 +2857,7 @@ func TestLogger_DisableEvent_UncategorisedEvent(t *testing.T) {
 func BenchmarkAudit_EndToEnd(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
@@ -2875,17 +2875,17 @@ func BenchmarkAudit_EndToEnd(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 	b.StopTimer()
 
-	_ = logger.Close()
+	_ = auditor.Close()
 }
 
 func BenchmarkAudit_WithHMAC(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
@@ -2908,17 +2908,17 @@ func BenchmarkAudit_WithHMAC(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 	b.StopTimer()
 
-	_ = logger.Close()
+	_ = auditor.Close()
 }
 
 func BenchmarkStandardFieldDefaults_Applied(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out),
@@ -2940,17 +2940,17 @@ func BenchmarkStandardFieldDefaults_Applied(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 	b.StopTimer()
 
-	_ = logger.Close()
+	_ = auditor.Close()
 }
 
 func BenchmarkDeliverToOutputs_WithMetadataWriter(b *testing.B) {
 	silenceSlog(b)
 	mock := &mockMetadataOutput{name: "bench-mw"}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(mock),
@@ -2964,17 +2964,17 @@ func BenchmarkDeliverToOutputs_WithMetadataWriter(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 	b.StopTimer()
-	_ = logger.Close()
+	_ = auditor.Close()
 }
 
 func BenchmarkDeliverToOutputs_MixedOutputs(b *testing.B) {
 	silenceSlog(b)
 	mwOut := &mockMetadataOutput{name: "bench-mw"}
 	plainOut := testhelper.NewMockOutput("bench-plain")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(mwOut),
@@ -2989,10 +2989,10 @@ func BenchmarkDeliverToOutputs_MixedOutputs(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 	b.StopTimer()
-	_ = logger.Close()
+	_ = auditor.Close()
 }
 
 // ---------------------------------------------------------------------------
@@ -3062,7 +3062,7 @@ func BenchmarkProcessEntry_AsyncOutputs(b *testing.B) {
 	fileOut := newMockAsyncOutput("async-file", 100_000)
 	syslogOut := newMockAsyncOutput("async-syslog", 100_000)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(syslogOut),
@@ -3071,7 +3071,7 @@ func BenchmarkProcessEntry_AsyncOutputs(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	fields := audit.Fields{
 		"outcome":    "success",
@@ -3084,7 +3084,7 @@ func BenchmarkProcessEntry_AsyncOutputs(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for b.Loop() {
-		_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 	}
 }
 
@@ -3108,7 +3108,7 @@ func BenchmarkOutputClose_Drain(b *testing.B) {
 			for b.Loop() {
 				b.StopTimer()
 				out := testhelper.NewMockOutput("bench-drain")
-				logger, err := audit.NewLogger(
+				auditor, err := audit.New(
 					audit.WithQueueSize(n+1000), // room for all events
 					audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 					audit.WithOutputs(out),
@@ -3120,11 +3120,11 @@ func BenchmarkOutputClose_Drain(b *testing.B) {
 				// Enqueue N events. Some may be processed before Close,
 				// but the benchmark measures the Close() drain path cost.
 				for range n {
-					_ = logger.AuditEvent(audit.NewEvent("schema_register", fields))
+					_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
 				}
 
 				b.StartTimer()
-				_ = logger.Close()
+				_ = auditor.Close()
 			}
 		})
 	}
@@ -3133,19 +3133,19 @@ func BenchmarkOutputClose_Drain(b *testing.B) {
 func BenchmarkFilterCheck(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = audit.IsEnabledForTest(logger, "schema_register")
+		_ = audit.IsEnabledForTest(auditor, "schema_register")
 	}
 }
 
@@ -3156,21 +3156,21 @@ func BenchmarkFilterCheck(b *testing.B) {
 func BenchmarkFilterCheck_Parallel(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	b.SetParallelism(100)
 	b.ResetTimer()
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = audit.IsEnabledForTest(logger, "schema_register")
+			_ = audit.IsEnabledForTest(auditor, "schema_register")
 		}
 	})
 }
@@ -3182,14 +3182,14 @@ func BenchmarkFilterCheck_Parallel(b *testing.B) {
 func BenchmarkFilterCheck_ReadWriteContention(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.Cleanup(func() { _ = logger.Close() })
+	b.Cleanup(func() { _ = auditor.Close() })
 
 	// Background writer toggling a category throughout the benchmark.
 	done := make(chan struct{})
@@ -3199,8 +3199,8 @@ func BenchmarkFilterCheck_ReadWriteContention(b *testing.B) {
 			case <-done:
 				return
 			default:
-				_ = logger.DisableCategory("read")
-				_ = logger.EnableCategory("read")
+				_ = auditor.DisableCategory("read")
+				_ = auditor.EnableCategory("read")
 			}
 		}
 	}()
@@ -3211,7 +3211,7 @@ func BenchmarkFilterCheck_ReadWriteContention(b *testing.B) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = audit.IsEnabledForTest(logger, "schema_register")
+			_ = audit.IsEnabledForTest(auditor, "schema_register")
 		}
 	})
 }
@@ -3234,45 +3234,45 @@ func TestNewEvent_ImplementsInterface(t *testing.T) {
 func TestAuditEvent_WithNewEvent(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	evt := audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"subject":  "test-schema",
 	})
-	require.NoError(t, logger.AuditEvent(evt))
+	require.NoError(t, auditor.AuditEvent(evt))
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 	assert.Equal(t, "success", out.GetEvent(0)["outcome"])
 }
 
 func TestAuditEvent_UnknownEventType(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
-	err = logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	err = auditor.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown event type")
 }
 
 func TestAuditEvent_NilEvent(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
-	err = logger.AuditEvent(nil)
+	err = auditor.AuditEvent(nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "event must not be nil")
 }
@@ -3407,16 +3407,16 @@ func TestEventCategory_SingleCategory_JSON(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	ev := out.GetEvent(0)
 	assert.Equal(t, "security", ev["event_category"])
@@ -3438,16 +3438,16 @@ func TestEventCategory_MultiCategory_SeparateDeliveries(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("admin_update", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("admin_update", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(2, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	cat0, ok0 := out.GetEvent(0)["event_category"].(string)
 	require.True(t, ok0, "event_category should be a string")
@@ -3472,16 +3472,16 @@ func TestEventCategory_Uncategorised_NoField(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("uncat_event", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("uncat_event", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	ev := out.GetEvent(0)
 	_, hasCategory := ev["event_category"]
@@ -3501,16 +3501,16 @@ func TestEventCategory_EmitFalse_NoField(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	ev := out.GetEvent(0)
 	_, hasCategory := ev["event_category"]
@@ -3530,7 +3530,7 @@ func TestEventCategory_UserSupplied_Skipped(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
@@ -3538,13 +3538,13 @@ func TestEventCategory_UserSupplied_Skipped(t *testing.T) {
 	require.NoError(t, err)
 
 	// User tries to set event_category — framework value should win.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":        "failure",
 		"event_category": "user_custom",
 	}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	ev := out.GetEvent(0)
 	assert.Equal(t, "security", ev["event_category"], "framework category should override user-supplied")
@@ -3602,7 +3602,7 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
@@ -3613,10 +3613,10 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	ev := out.GetEvent(0)
 	assert.NotEmpty(t, ev["_hmac"], "HMAC should be present")
@@ -3632,16 +3632,16 @@ func TestHMAC_Disabled_NoFields(t *testing.T) {
 		Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"outcome"}}},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	ev := out.GetEvent(0)
 	_, hasHMAC := ev["_hmac"]
@@ -3657,7 +3657,7 @@ func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 		Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"outcome"}}},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
@@ -3668,10 +3668,10 @@ func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	ev := out.GetEvent(0)
 	assert.Equal(t, "2026-Q1", ev["_hmac_v"])
@@ -3745,7 +3745,7 @@ events:
 	fullOut := testhelper.NewMockOutput("full")
 	strippedOut := testhelper.NewMockOutput("stripped")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// "full" output: no label exclusions — gets all fields including email.
 		audit.WithNamedOutput(fullOut, audit.OutputHMAC(fullHMACCfg)),
@@ -3754,7 +3754,7 @@ events:
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"email":    "alice@example.com",
@@ -3763,7 +3763,7 @@ events:
 
 	require.True(t, fullOut.WaitForEvents(1, 2*time.Second))
 	require.True(t, strippedOut.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	fullEvent := fullOut.GetEvent(0)
 	strippedEvent := strippedOut.GetEvent(0)
@@ -3814,7 +3814,7 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(hmacOut, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
@@ -3826,7 +3826,7 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "eve",
 	}))
@@ -3834,7 +3834,7 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 
 	require.True(t, hmacOut.WaitForEvents(1, 2*time.Second))
 	require.True(t, baseOut.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// Extract the HMAC from the HMAC output.
 	hmacEvent := hmacOut.GetEvent(0)
@@ -3890,7 +3890,7 @@ events:
 	hmacOut := testhelper.NewMockOutput("hmac-stripped")
 	baseOut := testhelper.NewMockOutput("base-stripped")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// Both outputs exclude PII — same payload, one with HMAC.
 		audit.WithNamedOutput(hmacOut, audit.OutputExcludeLabels("pii"), audit.OutputHMAC(&audit.HMACConfig{
@@ -3903,7 +3903,7 @@ events:
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"email":    "alice@example.com",
@@ -3913,7 +3913,7 @@ events:
 
 	require.True(t, hmacOut.WaitForEvents(1, 2*time.Second))
 	require.True(t, baseOut.WaitForEvents(1, 2*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// Verify email and phone are stripped from both outputs.
 	hmacEvent := hmacOut.GetEvent(0)
@@ -3943,7 +3943,7 @@ events:
 // mockMetadataOutput implements both audit.Output and audit.MetadataWriter.
 // It captures whether Write or WriteWithMetadata was called and records the
 // last data and metadata received. All fields are guarded by mu so that the
-// mock is safe to read from the test goroutine after logger.Close() returns.
+// mock is safe to read from the test goroutine after auditor.Close() returns.
 type mockMetadataOutput struct { //nolint:govet // fieldalignment: test mock
 	mu                      sync.Mutex
 	lastMeta                audit.EventMetadata
@@ -4054,20 +4054,20 @@ func TestMetadataWriter_ImplementingOutput_ReceivesMetadata(t *testing.T) {
 	t.Parallel()
 	out := newMockMetadataOutput("meta-out")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
 	// Close flushes all pending events before returning.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.True(t, out.getWriteWithMetadataCalled(),
 		"WriteWithMetadata must be called for an output implementing MetadataWriter")
@@ -4081,19 +4081,19 @@ func TestMetadataWriter_NonImplementingOutput_ReceivesPlainWrite(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("plain-out")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 1, out.EventCount(),
 		"plain Write must be called for an output that does not implement MetadataWriter")
@@ -4121,19 +4121,19 @@ func TestMetadataWriter_EventMetadata_FieldsCorrect(t *testing.T) {
 	out := newMockMetadataOutput("meta-fields")
 	before := time.Now()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	after := time.Now()
 
 	require.True(t, out.getWriteWithMetadataCalled(), "WriteWithMetadata must have been called")
@@ -4173,18 +4173,18 @@ func TestMetadataWriter_MultiCategory_CategoryVaries(t *testing.T) {
 
 	out := newMockMetadataOutput("multi-cat")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome": "failure",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	calls := out.getCalls()
 	require.Equal(t, 2, len(calls),
@@ -4221,18 +4221,18 @@ func TestMetadataWriter_UncategorisedEvent_EmptyCategory(t *testing.T) {
 
 	out := newMockMetadataOutput("uncat")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("data_export", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("data_export", audit.Fields{
 		"outcome": "success",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	require.True(t, out.getWriteWithMetadataCalled())
 
@@ -4243,7 +4243,7 @@ func TestMetadataWriter_UncategorisedEvent_EmptyCategory(t *testing.T) {
 }
 
 // TestMetadataWriter_MetricsPreserved verifies that when WriteWithMetadata
-// succeeds, the core logger records RecordEvent(name, "success"). This mirrors
+// succeeds, the core auditor records RecordEvent(name, "success"). This mirrors
 // the same metrics contract that Write has.
 func TestMetadataWriter_MetricsPreserved(t *testing.T) {
 	t.Parallel()
@@ -4251,20 +4251,20 @@ func TestMetadataWriter_MetricsPreserved(t *testing.T) {
 	out := newMockMetadataOutput("mw-metrics")
 	metrics := testhelper.NewMockMetrics()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Greater(t, metrics.GetEventCount("mw-metrics", "success"), 0,
 		"RecordEvent(name, \"success\") must be called after a successful WriteWithMetadata")
@@ -4275,7 +4275,7 @@ func TestMetadataWriter_MetricsPreserved(t *testing.T) {
 }
 
 // TestMetadataWriter_WriteError_RecordsMetrics verifies that when
-// WriteWithMetadata returns an error, the core logger calls both
+// WriteWithMetadata returns an error, the core auditor calls both
 // RecordOutputError and RecordEvent(name, "error"), and does NOT call
 // RecordEvent(name, "success").
 func TestMetadataWriter_WriteError_RecordsMetrics(t *testing.T) {
@@ -4285,20 +4285,20 @@ func TestMetadataWriter_WriteError_RecordsMetrics(t *testing.T) {
 	out.WriteErr = errors.New("write failed")
 	metrics := testhelper.NewMockMetrics()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Greater(t, metrics.GetEventCount("mw-err-out", "error"), 0,
 		"RecordEvent(name, \"error\") must be called when WriteWithMetadata returns an error")
@@ -4310,7 +4310,7 @@ func TestMetadataWriter_WriteError_RecordsMetrics(t *testing.T) {
 
 // TestMetadataWriter_DeliveryReporter_SkipsMetrics verifies that when an
 // output implements all three interfaces (Output, MetadataWriter, and
-// DeliveryReporter), the core logger skips its own RecordEvent and
+// DeliveryReporter), the core auditor skips its own RecordEvent and
 // RecordOutputError calls — regardless of whether WriteWithMetadata
 // succeeds or fails.
 func TestMetadataWriter_DeliveryReporter_SkipsMetrics(t *testing.T) {
@@ -4319,32 +4319,32 @@ func TestMetadataWriter_DeliveryReporter_SkipsMetrics(t *testing.T) {
 	out := newMockMetadataDeliveryOutput("mw-dr")
 	metrics := testhelper.NewMockMetrics()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// The event must have been delivered via WriteWithMetadata.
 	assert.True(t, out.getWriteWithMetadataCalled(),
 		"WriteWithMetadata must be called for an output that also implements DeliveryReporter")
 
-	// The core logger must not have called any metrics for this output.
+	// The core auditor must not have called any metrics for this output.
 	assert.Equal(t, 0, metrics.GetEventCount("mw-dr", "success"),
-		"core logger must not call RecordEvent(success) for a MetadataWriter+DeliveryReporter output")
+		"core auditor must not call RecordEvent(success) for a MetadataWriter+DeliveryReporter output")
 	assert.Equal(t, 0, metrics.GetEventCount("mw-dr", "error"),
-		"core logger must not call RecordEvent(error) for a MetadataWriter+DeliveryReporter output")
+		"core auditor must not call RecordEvent(error) for a MetadataWriter+DeliveryReporter output")
 	assert.Equal(t, 0, metrics.GetOutputErrorCount("mw-dr"),
-		"core logger must not call RecordOutputError for a MetadataWriter+DeliveryReporter output")
+		"core auditor must not call RecordOutputError for a MetadataWriter+DeliveryReporter output")
 }
 
 // TestMetadataWriter_WithHMAC_ReceivesHMACData verifies that when HMAC is
@@ -4362,7 +4362,7 @@ func TestMetadataWriter_WithHMAC_ReceivesHMACData(t *testing.T) {
 		Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"outcome"}}},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 			Enabled:     true,
@@ -4373,10 +4373,10 @@ func TestMetadataWriter_WithHMAC_ReceivesHMACData(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("ev1", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	require.True(t, out.getWriteWithMetadataCalled())
 
@@ -4422,21 +4422,21 @@ events:
 	tax, err := audit.ParseTaxonomyYAML([]byte(taxYAML))
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// Exclude PII — email must not appear in the data received by WriteWithMetadata.
 		audit.WithNamedOutput(out, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"email":    "alice@example.com",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	require.True(t, out.getWriteWithMetadataCalled())
 
@@ -4474,18 +4474,18 @@ func TestMetadataWriter_WithEventCategory_DataAndMetaConsistent(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome": "failure",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	require.True(t, out.getWriteWithMetadataCalled())
 
@@ -4517,20 +4517,20 @@ func TestMetadataWriter_MixedOutputs_IsolationOnError(t *testing.T) {
 	// Standard output that should always succeed regardless.
 	successOut := testhelper.NewMockOutput("standard-out")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(failingMW),
 		audit.WithNamedOutput(successOut),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// The MetadataWriter output attempted delivery and failed.
 	assert.True(t, failingMW.getWriteWithMetadataCalled(),
@@ -4552,20 +4552,20 @@ func TestMetadataWriter_CachedAssertion_Correct(t *testing.T) {
 	mwOut := newMockMetadataOutput("mw-cached")
 	plainOut := testhelper.NewMockOutput("plain-cached")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(mwOut),
 		audit.WithNamedOutput(plainOut),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// The MetadataWriter output must have gone through WriteWithMetadata.
 	assert.True(t, mwOut.getWriteWithMetadataCalled(),
@@ -4579,7 +4579,7 @@ func TestMetadataWriter_CachedAssertion_Correct(t *testing.T) {
 }
 
 func TestTimezoneAlwaysPopulated(t *testing.T) {
-	// Create a logger with NO timezone config — it should auto-detect.
+	// Create an auditor with NO timezone config — it should auto-detect.
 	tax := &audit.Taxonomy{
 		Version: 1,
 		Events:  map[string]*audit.EventDef{"test_event": {}},
@@ -4591,7 +4591,7 @@ func TestTimezoneAlwaysPopulated(t *testing.T) {
 	out, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: &buf})
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
@@ -4600,8 +4600,8 @@ func TestTimezoneAlwaysPopulated(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("test_event", audit.Fields{})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("test_event", audit.Fields{})))
+	require.NoError(t, auditor.Close())
 
 	assert.Contains(t, buf.String(), `"timezone":`,
 		"timezone must always be present in output even when not explicitly configured")
@@ -4619,7 +4619,7 @@ func TestTimezoneAutoDetect(t *testing.T) {
 	out, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: &buf})
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
@@ -4628,8 +4628,8 @@ func TestTimezoneAutoDetect(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("test_event", audit.Fields{})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("test_event", audit.Fields{})))
+	require.NoError(t, auditor.Close())
 
 	// Auto-detected timezone should match the system timezone.
 	expected := time.Now().Location().String()
@@ -4649,7 +4649,7 @@ func TestTimezoneOverride(t *testing.T) {
 	out, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: &buf})
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
@@ -4658,8 +4658,8 @@ func TestTimezoneOverride(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("test_event", audit.Fields{})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("test_event", audit.Fields{})))
+	require.NoError(t, auditor.Close())
 
 	assert.Contains(t, buf.String(), `"timezone":"America/New_York"`,
 		"timezone override should appear in output")
@@ -4712,7 +4712,7 @@ events:
 	out := testhelper.NewMockOutput("excluded")
 	metrics := testhelper.NewMockMetrics()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// Excluding "pii" triggers formatWithExclusion (FormatOptions non-nil).
 		audit.WithNamedOutput(out, audit.OutputFormatter(&exclusionErrorFormatter{}), audit.OutputExcludeLabels("pii")),
@@ -4720,12 +4720,12 @@ events:
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome": "success",
 		"email":   "alice@example.com",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// The event should be dropped — formatter returned error on exclusion path.
 	assert.Equal(t, 0, out.EventCount(),
@@ -4772,7 +4772,7 @@ func TestDrainLoop_SlowOutput_DoesNotBlockOthers(t *testing.T) {
 	slow := &slowOutput{delay: 100 * time.Millisecond}
 	fast := testhelper.NewMockOutput("fast")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(slow, fast),
 	)
@@ -4780,12 +4780,12 @@ func TestDrainLoop_SlowOutput_DoesNotBlockOthers(t *testing.T) {
 
 	const n = 5
 	for range n {
-		require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 			"outcome": "success",
 		})))
 	}
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, n, fast.EventCount(),
 		"fast output must receive all %d events despite slow output", n)
@@ -4796,7 +4796,7 @@ func TestDrainLoop_AllOutputsAsync_NoSequentialBlocking(t *testing.T) {
 	outA := testhelper.NewMockOutput("output-a")
 	outB := testhelper.NewMockOutput("output-b")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(outA, outB),
 	)
@@ -4804,12 +4804,12 @@ func TestDrainLoop_AllOutputsAsync_NoSequentialBlocking(t *testing.T) {
 
 	const n = 3
 	for range n {
-		require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 			"outcome": "success",
 		})))
 	}
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, n, outA.EventCount(),
 		"output-a must receive all %d events", n)
@@ -4821,7 +4821,7 @@ func TestCoreMetrics_RecordSubmitted_CalledPerAuditEvent(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	metrics := testhelper.NewMockMetrics()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -4830,12 +4830,12 @@ func TestCoreMetrics_RecordSubmitted_CalledPerAuditEvent(t *testing.T) {
 
 	const n = 5
 	for range n {
-		require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 			"outcome": "success",
 		})))
 	}
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, n, metrics.GetSubmitted(),
 		"RecordSubmitted must be called once per AuditEvent call")
@@ -4845,7 +4845,7 @@ func TestCoreMetrics_RecordSubmitted_CalledBeforeFiltering(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	metrics := testhelper.NewMockMetrics()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -4853,14 +4853,14 @@ func TestCoreMetrics_RecordSubmitted_CalledBeforeFiltering(t *testing.T) {
 	require.NoError(t, err)
 
 	// Disable "read" category so events in it are filtered.
-	require.NoError(t, logger.DisableCategory("read"))
+	require.NoError(t, auditor.DisableCategory("read"))
 
 	// Audit an event in the disabled category.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_get", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_get", audit.Fields{
 		"outcome": "success",
 	})))
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// RecordSubmitted is called BEFORE filtering — so count is 1
 	// even though the event was filtered and not delivered.
@@ -4874,7 +4874,7 @@ func TestCoreMetrics_RecordQueueDepth_SampledEveryNEvents(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	metrics := testhelper.NewMockMetrics()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
@@ -4884,12 +4884,12 @@ func TestCoreMetrics_RecordQueueDepth_SampledEveryNEvents(t *testing.T) {
 	// Audit 65 events — RecordQueueDepth is sampled every 64.
 	const n = 65
 	for range n {
-		require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 			"outcome": "success",
 		})))
 	}
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	depths := metrics.GetQueueDepths()
 	assert.NotEmpty(t, depths,

--- a/audittest/audittest.go
+++ b/audittest/audittest.go
@@ -20,7 +20,7 @@ import (
 	"github.com/axonops/audit"
 )
 
-// Option configures the test logger created by [NewLogger].
+// Option configures the test auditor created by [New].
 type Option func(*config)
 
 type config struct {
@@ -28,7 +28,7 @@ type config struct {
 	async     bool // opt out of default synchronous delivery
 }
 
-// WithConfig applies a [audit.Config] struct to the test logger.
+// WithConfig applies a [audit.Config] struct to the test auditor.
 // Non-zero fields override the test defaults (QueueSize=100).
 func WithConfig(cfg audit.Config) Option {
 	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithConfig(cfg)) }
@@ -40,43 +40,43 @@ func WithValidationMode(mode audit.ValidationMode) Option {
 	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithValidationMode(mode)) }
 }
 
-// WithDisabled creates a disabled (no-op) test logger. Events are
+// WithDisabled creates a disabled (no-op) test auditor. Events are
 // accepted without error but not delivered.
 func WithDisabled() Option {
 	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithDisabled()) }
 }
 
-// WithSync creates a synchronous test logger where events are
-// available in the [Recorder] immediately after [audit.Logger.AuditEvent]
+// WithSync creates a synchronous test auditor where events are
+// available in the [Recorder] immediately after [audit.Auditor.AuditEvent]
 // returns. No Close-before-assert ceremony is needed.
 //
-// Both [NewLogger] and [NewLoggerQuick] default to synchronous delivery,
+// Both [New] and [NewQuick] default to synchronous delivery,
 // so this option is only needed to re-enable sync after [WithAsync].
 func WithSync() Option {
 	return func(c *config) { c.extraOpts = append(c.extraOpts, audit.WithSynchronousDelivery()) }
 }
 
-// WithAsync creates an asynchronous test logger. Events are delivered
-// by a background goroutine, so callers MUST call logger.Close()
+// WithAsync creates an asynchronous test auditor. Events are delivered
+// by a background goroutine, so callers MUST call auditor.Close()
 // before making assertions. Use this only when testing async-specific
 // behaviour such as drain timeout or buffer backpressure.
 func WithAsync() Option {
 	return func(c *config) { c.async = true }
 }
 
-// NewLogger creates a test audit logger with an in-memory [Recorder]
+// New creates a test auditor with an in-memory [Recorder]
 // and [MetricsRecorder]. The taxonomy is parsed from YAML bytes.
 //
-// The logger defaults to synchronous delivery — events are available
-// in the Recorder immediately after [audit.Logger.AuditEvent] returns,
+// The auditor defaults to synchronous delivery — events are available
+// in the Recorder immediately after [audit.Auditor.AuditEvent] returns,
 // with no Close-before-assert ceremony needed. Use [WithAsync] to opt
 // into asynchronous delivery for tests that exercise drain timeout or
 // buffer backpressure.
 //
 // QueueSize defaults to 100 (intentionally small — the in-memory
 // recorder has no I/O cost). tb.Cleanup is registered to call
-// logger.Close() as a safety net against goroutine leaks.
-func NewLogger(tb testing.TB, taxonomyYAML []byte, opts ...Option) (*audit.Logger, *Recorder, *MetricsRecorder) {
+// auditor.Close() as a safety net against goroutine leaks.
+func New(tb testing.TB, taxonomyYAML []byte, opts ...Option) (*audit.Auditor, *Recorder, *MetricsRecorder) {
 	tb.Helper()
 	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
 	if err != nil {
@@ -85,11 +85,11 @@ func NewLogger(tb testing.TB, taxonomyYAML []byte, opts ...Option) (*audit.Logge
 	return newTestLogger(tb, tax, opts...)
 }
 
-// NewLoggerQuick creates a test audit logger with a permissive
+// NewQuick creates a test auditor with a permissive
 // taxonomy containing the named event types. No required fields, no
 // unknown field validation. Defaults to synchronous delivery — events
 // are available in the Recorder immediately without calling Close.
-func NewLoggerQuick(tb testing.TB, eventTypes ...string) (*audit.Logger, *Recorder, *MetricsRecorder) {
+func NewQuick(tb testing.TB, eventTypes ...string) (*audit.Auditor, *Recorder, *MetricsRecorder) {
 	tb.Helper()
 	return newTestLogger(tb, QuickTaxonomy(eventTypes...), WithValidationMode(audit.ValidationPermissive), WithSync())
 }
@@ -97,7 +97,7 @@ func NewLoggerQuick(tb testing.TB, eventTypes ...string) (*audit.Logger, *Record
 // QuickTaxonomy builds a minimal [*audit.Taxonomy] where every listed
 // event type accepts any fields. All events are in a single enabled
 // category ("test"). The returned taxonomy does not enforce required
-// fields; pair it with [audit.ValidationPermissive] (as [NewLoggerQuick]
+// fields; pair it with [audit.ValidationPermissive] (as [NewQuick]
 // does) for fully unconstrained testing.
 func QuickTaxonomy(eventTypes ...string) *audit.Taxonomy {
 	events := make(map[string]*audit.EventDef, len(eventTypes))
@@ -113,7 +113,7 @@ func QuickTaxonomy(eventTypes ...string) *audit.Taxonomy {
 	}
 }
 
-func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.Logger, *Recorder, *MetricsRecorder) {
+func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.Auditor, *Recorder, *MetricsRecorder) {
 	tb.Helper()
 
 	c := &config{}
@@ -135,12 +135,12 @@ func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.L
 	}
 	auditOpts = append(auditOpts, c.extraOpts...)
 
-	logger, err := audit.NewLogger(auditOpts...)
+	auditor, err := audit.New(auditOpts...)
 	if err != nil {
-		tb.Fatalf("audittest: create logger: %v", err)
+		tb.Fatalf("audittest: create auditor: %v", err)
 	}
 
-	tb.Cleanup(func() { _ = logger.Close() })
+	tb.Cleanup(func() { _ = auditor.Close() })
 
-	return logger, rec, met
+	return auditor, rec, met
 }

--- a/audittest/audittest_test.go
+++ b/audittest/audittest_test.go
@@ -53,72 +53,72 @@ events:
 
 func TestNewLogger(t *testing.T) {
 	t.Parallel()
-	logger, events, metrics := audittest.NewLogger(t, testTaxonomyYAML)
+	auditor, events, metrics := audittest.New(t, testTaxonomyYAML)
 
-	err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	require.Equal(t, 1, events.Count())
 	assert.Equal(t, "user_create", events.Events()[0].EventType)
 	assert.Equal(t, 1, metrics.EventDeliveries("recorder", "success"))
 }
 
-func TestNewLoggerQuick(t *testing.T) {
+func TestNewQuick(t *testing.T) {
 	t.Parallel()
-	logger, events, _ := audittest.NewLoggerQuick(t, "user_create", "user_delete")
+	auditor, events, _ := audittest.NewQuick(t, "user_create", "user_delete")
 
-	err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":   "success",
 		"any_field": "any_value",
 		"extra":     42,
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	require.Equal(t, 1, events.Count())
 	assert.Equal(t, "user_create", events.Events()[0].EventType)
 }
 
-func TestNewLogger_ValidationError(t *testing.T) {
+func TestNew_ValidationError(t *testing.T) {
 	t.Parallel()
-	logger, events, metrics := audittest.NewLogger(t, testTaxonomyYAML)
+	auditor, events, metrics := audittest.New(t, testTaxonomyYAML)
 
 	// Missing required field "actor_id".
-	err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome": "success",
 	}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required")
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 0, events.Count())
 	assert.Equal(t, 1, metrics.ValidationErrors("user_create"))
 }
 
-func TestNewLogger_WithDisabled(t *testing.T) {
+func TestNew_WithDisabled(t *testing.T) {
 	t.Parallel()
-	logger, events, _ := audittest.NewLogger(t, testTaxonomyYAML,
+	auditor, events, _ := audittest.New(t, testTaxonomyYAML,
 		audittest.WithDisabled(),
 	)
 
-	// Disabled logger accepts events without error but does not deliver.
-	err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	// Disabled auditor accepts events without error but does not deliver.
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 0, events.Count())
 }
 
-func TestNewLogger_TableDriven_WithReset(t *testing.T) {
-	// Not parallel — subtests share a logger and use Reset.
-	logger, events, _ := audittest.NewLogger(t, testTaxonomyYAML)
+func TestNew_TableDriven_WithReset(t *testing.T) {
+	// Not parallel — subtests share an auditor and use Reset.
+	auditor, events, _ := audittest.New(t, testTaxonomyYAML)
 
 	tests := []struct {
 		fields    audit.Fields
@@ -131,9 +131,9 @@ func TestNewLogger_TableDriven_WithReset(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			events.Reset()
-			err := logger.AuditEvent(audit.NewEvent(tc.eventType, tc.fields))
+			err := auditor.AuditEvent(audit.NewEvent(tc.eventType, tc.fields))
 			require.NoError(t, err)
-			// Wait for drain to process — logger stays open across sub-tests.
+			// Wait for drain to process — auditor stays open across sub-tests.
 			require.Eventually(t, func() bool { return events.Count() == 1 }, 2*time.Second, 10*time.Millisecond)
 			assert.Equal(t, tc.eventType, events.Events()[0].EventType)
 		})

--- a/audittest/doc.go
+++ b/audittest/doc.go
@@ -17,21 +17,21 @@
 // events for assertion, a [MetricsRecorder] that captures all metrics
 // calls, and convenience constructors that eliminate test boilerplate.
 //
-// The test logger is a fully functional [audit.Logger] — same
+// The test auditor is a fully functional [audit.Auditor] — same
 // validation, same taxonomy enforcement — but events land in memory
 // instead of being written to a file, syslog, or webhook.
 //
-// Both [NewLogger] and [NewLoggerQuick] default to synchronous
+// Both [New] and [NewQuick] default to synchronous
 // delivery: events are available in the [Recorder] immediately after
-// [audit.Logger.AuditEvent] returns. No Close-before-assert ceremony
+// [audit.Auditor.AuditEvent] returns. No Close-before-assert ceremony
 // is needed. Use [WithAsync] to opt into asynchronous delivery for
 // tests that exercise drain timeout or buffer backpressure.
 //
 // # Quick Start
 //
 //	func TestMyHandler(t *testing.T) {
-//	    logger, events, metrics := audittest.NewLogger(t, taxonomyYAML)
-//	    myHandler(logger) // code under test
+//	    auditor, events, metrics := audittest.New(t, taxonomyYAML)
+//	    myHandler(auditor) // code under test
 //
 //	    // Assert immediately — synchronous delivery means events are already available.
 //	    require.Equal(t, 1, events.Count())
@@ -42,7 +42,7 @@
 // # Table-Driven Tests
 //
 // Use [Recorder.Reset] to clear captured events between sub-tests
-// without creating a new logger:
+// without creating a new auditor:
 //
 //	for _, tc := range tests {
 //	    t.Run(tc.name, func(t *testing.T) {

--- a/audittest/example_test.go
+++ b/audittest/example_test.go
@@ -34,17 +34,17 @@ events:
       actor_id: {required: true}
 `)
 
-func ExampleNewLogger() {
+func ExampleNew() {
 	// Use a real *testing.T in actual tests — this is for runnable doc only.
 	t := &testing.T{}
 
-	logger, events, metrics := audittest.NewLogger(t, exampleTaxonomyYAML)
+	auditor, events, metrics := audittest.New(t, exampleTaxonomyYAML)
 
-	_ = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	}))
-	_ = logger.Close()
+	_ = auditor.Close()
 
 	fmt.Println("count:", events.Count())
 	fmt.Println("type:", events.Events()[0].EventType)
@@ -55,15 +55,15 @@ func ExampleNewLogger() {
 	// deliveries: 1
 }
 
-func ExampleNewLoggerQuick() {
+func ExampleNewQuick() {
 	t := &testing.T{}
 
-	logger, events, _ := audittest.NewLoggerQuick(t, "user_create", "user_delete")
+	auditor, events, _ := audittest.NewQuick(t, "user_create", "user_delete")
 
-	_ = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"any_field": "any_value",
 	}))
-	_ = logger.Close()
+	_ = auditor.Close()
 
 	fmt.Println("count:", events.Count())
 	fmt.Println("type:", events.Events()[0].EventType)
@@ -75,12 +75,12 @@ func ExampleNewLoggerQuick() {
 func ExampleRecorder_FindByType() {
 	t := &testing.T{}
 
-	logger, events, _ := audittest.NewLoggerQuick(t, "user_create", "auth_failure")
+	auditor, events, _ := audittest.NewQuick(t, "user_create", "auth_failure")
 
-	_ = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"actor_id": "alice"}))
-	_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"actor_id": "bob"}))
-	_ = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"actor_id": "charlie"}))
-	_ = logger.Close()
+	_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"actor_id": "alice"}))
+	_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"actor_id": "bob"}))
+	_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"actor_id": "charlie"}))
+	_ = auditor.Close()
 
 	creates := events.FindByType("user_create")
 	fmt.Println("user_create count:", len(creates))

--- a/audittest/metrics.go
+++ b/audittest/metrics.go
@@ -155,7 +155,7 @@ func (m *MetricsRecorder) BufferDrops() int {
 }
 
 // SubmittedCount returns the total number of events submitted via
-// [audit.Logger.AuditEvent], before any filtering or buffering.
+// [audit.Auditor.AuditEvent], before any filtering or buffering.
 func (m *MetricsRecorder) SubmittedCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/audittest/recorder.go
+++ b/audittest/recorder.go
@@ -129,8 +129,8 @@ type Recorder struct {
 }
 
 // NewRecorder creates a Recorder. Use it with [audit.WithOutputs] or
-// [audit.WithNamedOutput] when composing a logger manually. For the
-// common case, use [NewLogger] or [NewLoggerQuick] instead.
+// [audit.WithNamedOutput] when composing an auditor manually. For the
+// common case, use [New] or [NewQuick] instead.
 func NewRecorder() *Recorder {
 	return &Recorder{}
 }
@@ -154,7 +154,7 @@ func (r *Recorder) Close() error { return nil }
 
 // Events returns a snapshot of all recorded events in drain order.
 // The returned slice is a copy; later Reset calls do not affect it.
-// Call after [audit.Logger.Close] to ensure all events have been processed.
+// Call after [audit.Auditor.Close] to ensure all events have been processed.
 func (r *Recorder) Events() []RecordedEvent {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -183,9 +183,9 @@ func (r *Recorder) Count() int {
 	return len(r.events)
 }
 
-// Reset clears all recorded events. The underlying logger remains
+// Reset clears all recorded events. The underlying auditor remains
 // open and functional. Use Reset between sub-tests to isolate
-// assertions without creating a new logger.
+// assertions without creating a new auditor.
 func (r *Recorder) Reset() {
 	r.mu.Lock()
 	r.events = r.events[:0]

--- a/audittest/recorder_test.go
+++ b/audittest/recorder_test.go
@@ -139,17 +139,17 @@ func TestRecorder_ConcurrentWriteAndRead(t *testing.T) {
 }
 
 // TestRecorder_FullPipeline verifies the recorder works end-to-end
-// with a real audit logger.
+// with a real audit auditor.
 func TestRecorder_FullPipeline(t *testing.T) {
 	t.Parallel()
-	logger, events, metrics := audittest.NewLoggerQuick(t, "user_create")
+	auditor, events, metrics := audittest.NewQuick(t, "user_create")
 
-	err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	require.Equal(t, 1, events.Count())
 	evt := events.Events()[0]

--- a/cmd/audit-gen/template.go
+++ b/cmd/audit-gen/template.go
@@ -35,8 +35,8 @@ const (
 {{- end }}
 )
 {{ end }}{{ if .HasCategories }}
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 {{- range .Categories }}
 	{{ .Name }} = {{ .QuotedValue }}
@@ -135,7 +135,7 @@ func (e *{{ $b.StructName }}) {{ .SetterName }}(v {{ .GoType }}) *{{ $b.StructNa
 // EventType returns the event type name.
 func (e *{{ $b.StructName }}) EventType() string { return {{ $b.EventConst }} }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *{{ $b.StructName }}) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ import (
 	"time"
 )
 
-// ValidationMode controls how [Logger.AuditEvent] handles unknown fields
+// ValidationMode controls how [Auditor.AuditEvent] handles unknown fields
 // (fields not listed in the event's Required or Optional lists).
 type ValidationMode string
 
@@ -39,24 +39,24 @@ const (
 	DefaultQueueSize = 10_000
 
 	// MaxQueueSize is the maximum allowed async intake queue capacity.
-	// Values above this limit cause [NewLogger] to return an error
+	// Values above this limit cause [New] to return an error
 	// wrapping [ErrConfigInvalid].
 	MaxQueueSize = 1_000_000
 
-	// DefaultDrainTimeout is the default graceful shutdown deadline.
-	DefaultDrainTimeout = 5 * time.Second
+	// DefaultShutdownTimeout is the default graceful shutdown deadline.
+	DefaultShutdownTimeout = 5 * time.Second
 
-	// MaxDrainTimeout is the maximum allowed graceful shutdown deadline.
-	// Values above this limit cause [NewLogger] to return an error
-	// wrapping [ErrConfigInvalid]. Setting DrainTimeout too low on a
+	// MaxShutdownTimeout is the maximum allowed graceful shutdown deadline.
+	// Values above this limit cause [New] to return an error
+	// wrapping [ErrConfigInvalid]. Setting ShutdownTimeout too low on a
 	// high-throughput system causes events to be lost at shutdown.
-	MaxDrainTimeout = 60 * time.Second
+	MaxShutdownTimeout = 60 * time.Second
 )
 
-// Config holds tuning parameters for the audit [Logger]. The zero
-// value is a valid configuration: buffer=10,000, drain=5s,
+// Config holds tuning parameters for the audit [Auditor]. The zero
+// value is a valid configuration: buffer=10,000, shutdown=5s,
 // validation=strict, omit_empty=false. Pass individual fields via
-// [WithQueueSize], [WithDrainTimeout], [WithValidationMode], or
+// [WithQueueSize], [WithShutdownTimeout], [WithValidationMode], or
 // [WithOmitEmpty], or pass the whole struct via [WithConfig].
 type Config struct {
 	// ValidationMode controls how unknown fields are handled.
@@ -64,12 +64,12 @@ type Config struct {
 	// [ValidationPermissive]. Empty defaults to [ValidationStrict].
 	ValidationMode ValidationMode
 
-	// DrainTimeout is the maximum time [Logger.Close] waits for
-	// pending events to flush. Zero means [DefaultDrainTimeout] (5s).
-	// Values above [MaxDrainTimeout] (60s) cause [NewLogger] to
+	// ShutdownTimeout is the maximum time [Auditor.Close] waits for
+	// pending events to flush. Zero means [DefaultShutdownTimeout] (5s).
+	// Values above [MaxShutdownTimeout] (60s) cause [New] to
 	// return an error. Setting this too low on a high-throughput
 	// system will cause events to be lost at shutdown.
-	DrainTimeout time.Duration
+	ShutdownTimeout time.Duration
 
 	// version is the config schema version. Defaults to 1 via
 	// [Config.applyDefaults]. Unexported because consumers should
@@ -78,7 +78,7 @@ type Config struct {
 
 	// QueueSize is the async intake queue capacity. Zero means
 	// [DefaultQueueSize] (10,000). Values above [MaxQueueSize]
-	// (1,000,000) cause [NewLogger] to return an error.
+	// (1,000,000) cause [New] to return an error.
 	QueueSize int
 
 	// OmitEmpty controls whether empty/nil/zero-value fields are
@@ -97,8 +97,8 @@ func (c *Config) applyDefaults() {
 	if c.QueueSize <= 0 {
 		c.QueueSize = DefaultQueueSize
 	}
-	if c.DrainTimeout <= 0 {
-		c.DrainTimeout = DefaultDrainTimeout
+	if c.ShutdownTimeout <= 0 {
+		c.ShutdownTimeout = DefaultShutdownTimeout
 	}
 	if c.ValidationMode == "" {
 		c.ValidationMode = ValidationStrict
@@ -117,9 +117,9 @@ func validateConfig(c *Config) error {
 			ErrConfigInvalid, c.QueueSize, MaxQueueSize)
 	}
 
-	if c.DrainTimeout > MaxDrainTimeout {
-		return fmt.Errorf("%w: drain_timeout %s exceeds maximum %s",
-			ErrConfigInvalid, c.DrainTimeout, MaxDrainTimeout)
+	if c.ShutdownTimeout > MaxShutdownTimeout {
+		return fmt.Errorf("%w: shutdown_timeout %s exceeds maximum %s",
+			ErrConfigInvalid, c.ShutdownTimeout, MaxShutdownTimeout)
 	}
 
 	switch c.ValidationMode {

--- a/config_test.go
+++ b/config_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewLogger_InvalidValidationMode(t *testing.T) {
-	_, err := audit.NewLogger(
+func TestNew_InvalidValidationMode(t *testing.T) {
+	_, err := audit.New(
 		audit.WithValidationMode("bogus"),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
@@ -34,59 +34,59 @@ func TestNewLogger_InvalidValidationMode(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid validation mode")
 }
 
-func TestNewLogger_QueueSizeDefault(t *testing.T) {
+func TestNew_QueueSizeDefault(t *testing.T) {
 	// QueueSize 0 should not cause an error; it defaults to 10,000.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(0),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_DrainTimeoutDefault(t *testing.T) {
-	// DrainTimeout 0 should not cause an error; it defaults to 5s.
-	logger, err := audit.NewLogger(
+func TestNew_ShutdownTimeoutDefault(t *testing.T) {
+	// ShutdownTimeout 0 should not cause an error; it defaults to 5s.
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_CustomDrainTimeout(t *testing.T) {
-	logger, err := audit.NewLogger(
-		audit.WithDrainTimeout(10*time.Second),
+func TestNew_CustomShutdownTimeout(t *testing.T) {
+	auditor, err := audit.New(
+		audit.WithShutdownTimeout(10*time.Second),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_DisabledNoOp(t *testing.T) {
+func TestNew_DisabledNoOp(t *testing.T) {
 	out := testhelper.NewMockOutput("disabled-check")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, logger)
+	require.NotNil(t, auditor)
 
-	// Audit on disabled logger returns nil.
-	err = logger.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
+	// Audit on disabled auditor returns nil.
+	err = auditor.AuditEvent(audit.NewEvent("schema_register", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"subject":  "test",
 	}))
 	assert.NoError(t, err)
 
-	require.NoError(t, logger.Close())
-	assert.Equal(t, 0, out.EventCount(), "disabled logger must not deliver events")
+	require.NoError(t, auditor.Close())
+	assert.Equal(t, 0, out.EventCount(), "disabled auditor must not deliver events")
 }
 
-func TestNewLogger_NegativeQueueSize_DefaultsCorrectly(t *testing.T) {
+func TestNew_NegativeQueueSize_DefaultsCorrectly(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(-1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
@@ -94,29 +94,29 @@ func TestNewLogger_NegativeQueueSize_DefaultsCorrectly(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the defaulted buffer actually works by sending an event.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "alice",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 1, out.EventCount(), "event should be delivered through defaulted buffer")
 }
 
-func TestNewLogger_NegativeDrainTimeout_DefaultsCorrectly(t *testing.T) {
+func TestNew_NegativeShutdownTimeout_DefaultsCorrectly(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
-		audit.WithDrainTimeout(-1),
+	auditor, err := audit.New(
+		audit.WithShutdownTimeout(-1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "alice",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 1, out.EventCount(), "event should be delivered with defaulted drain timeout")
 }

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -95,12 +95,12 @@ func TestDevTaxonomy_WarnsAtConstruction(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(audit.DevTaxonomy("ev1")),
 		audit.WithOutputs(testhelper.NewMockOutput("test")),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Contains(t, buf.String(), "DevTaxonomy",
 		"slog.Warn should mention DevTaxonomy for production warning")
@@ -115,15 +115,15 @@ func TestFileFreePath_EndToEnd(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	// DevTaxonomy auto-forces permissive validation — no explicit
 	// WithValidationMode needed.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(audit.DevTaxonomy("user_create")),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEventKV("user_create", "outcome", "success", "actor_id", "alice"))
+	err = auditor.AuditEvent(audit.NewEventKV("user_create", "outcome", "success", "actor_id", "alice"))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 1, out.EventCount())
 }
 

--- a/doc.go
+++ b/doc.go
@@ -44,25 +44,25 @@
 // # Quick Start
 //
 // Define your events in a YAML taxonomy, configure outputs in a second YAML
-// file, and create a logger with a single call:
+// file, and create an auditor with a single call:
 //
 //	//go:embed taxonomy.yaml
 //	var taxonomyYAML []byte
 //
-//	logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml", nil)
+//	auditor, err := outputconfig.New(ctx, taxonomyYAML, "outputs.yaml", nil)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	defer func() { _ = logger.Close() }()
+//	defer func() { _ = auditor.Close() }()
 //
-//	err = logger.AuditEvent(audit.NewEventKV("user_create",
+//	err = auditor.AuditEvent(audit.NewEventKV("user_create",
 //	    "outcome", "success",
 //	    "actor_id", "alice",
 //	))
 //
 // For exploration without YAML files, use [DevTaxonomy] and [Stdout]:
 //
-//	logger, err := audit.NewLogger(
+//	auditor, err := audit.New(
 //	    audit.WithTaxonomy(audit.DevTaxonomy("user_create")),
 //	    audit.WithOutputs(audit.Stdout()),
 //	)
@@ -72,16 +72,16 @@
 //
 // # Core API
 //
-//   - [Logger] — core audit logger; created via [NewLogger]
-//   - [Config] — logger configuration (buffer size, drain timeout, validation mode)
-//   - [Option] — functional option for [NewLogger]: [WithTaxonomy], [WithOutputs], [WithFormatter], [WithMetrics]
+//   - [Auditor] — core type; created via [New]
+//   - [Config] — auditor configuration (buffer size, shutdown timeout, validation mode)
+//   - [Option] — functional option for [New]: [WithTaxonomy], [WithOutputs], [WithFormatter], [WithMetrics]
 //
 // # Events
 //
-//   - [Event] — interface for typed audit events; pass to [Logger.AuditEvent]
+//   - [Event] — interface for typed audit events; pass to [Auditor.AuditEvent]
 //   - [NewEvent] — creates an event for dynamic use without code generation
 //   - [NewEventKV] — creates an event from alternating key-value pairs (slog-style)
-//   - [EventHandle] — pre-validated handle for zero-allocation audit calls; see [Logger.MustHandle]
+//   - [EventHandle] — pre-validated handle for zero-allocation audit calls; see [Auditor.MustHandle]
 //   - [Fields] — defined type over map[string]any with [Fields.Has], [Fields.String], [Fields.Int] accessors
 //
 // # Outputs
@@ -131,7 +131,7 @@
 //
 // # Error Discrimination
 //
-// Validation errors returned by [Logger.AuditEvent] wrap [ErrValidation]
+// Validation errors returned by [Auditor.AuditEvent] wrap [ErrValidation]
 // as a parent sentinel. Specific sub-sentinels identify the failure:
 //
 //   - [ErrUnknownEventType] — event type not in taxonomy
@@ -174,7 +174,7 @@
 //
 // The framework does not hardcode event types, field names, or categories.
 // Consumers register their entire audit taxonomy at bootstrap via
-// [WithTaxonomy]. The framework then validates every [Logger.AuditEvent] call
+// [WithTaxonomy]. The framework then validates every [Auditor.AuditEvent] call
 // against the registered definitions, catching missing required fields,
 // unknown event types, and unrecognised field names at runtime.
 //
@@ -209,15 +209,15 @@
 //
 // Events are enqueued to a buffered channel (configurable capacity, default
 // 10,000) and drained by a single background goroutine. If the buffer is
-// full, [Logger.AuditEvent] returns [ErrQueueFull] and the drop is recorded via
+// full, [Auditor.AuditEvent] returns [ErrQueueFull] and the drop is recorded via
 // the [Metrics] interface.
 //
 // # Graceful Shutdown
 //
-// [Logger.Close] MUST be called when the logger is no longer needed. Failing
+// [Auditor.Close] MUST be called when the auditor is no longer needed. Failing
 // to call Close leaks the drain goroutine and causes any buffered events to be
 // lost. Close signals the drain goroutine to stop, waits up to
-// [Config.DrainTimeout] for pending events to flush, then closes all outputs
-// in parallel. Events still in the buffer when DrainTimeout expires are lost;
+// [Config.ShutdownTimeout] for pending events to flush, then closes all outputs
+// in parallel. Events still in the buffer when ShutdownTimeout expires are lost;
 // a warning is emitted via [log/slog]. Close is idempotent via [sync.Once].
 package audit

--- a/docs/async-delivery.md
+++ b/docs/async-delivery.md
@@ -83,36 +83,36 @@ outputs can write them.
 
 ### Configuration
 
-Buffer and drain settings are configured in the `logger:` section of
+Buffer and drain settings are configured in the `auditor:` section of
 your output YAML:
 
 ```yaml
-logger:
+auditor:
   queue_size: 50000          # default: 10,000, max: 1,000,000
-  drain_timeout: "30s"       # default: "5s", max: "60s"
+  shutdown_timeout: "30s"       # default: "5s", max: "60s"
 ```
 
 Or programmatically via functional options:
 
 ```go
-logger, err := audit.NewLogger(
+auditor, err := audit.New(
     audit.WithQueueSize(50_000),
-    audit.WithDrainTimeout(30 * time.Second),
+    audit.WithShutdownTimeout(30 * time.Second),
     audit.WithTaxonomy(tax),
     audit.WithOutputs(out),
 )
 ```
 
 When using `outputconfig.Load`, `result.Options` includes
-config-equivalent options (`WithQueueSize`, `WithDrainTimeout`, etc.)
-from your YAML — pass them directly to `NewLogger`.
+config-equivalent options (`WithQueueSize`, `WithShutdownTimeout`, etc.)
+from your YAML — pass them directly to `New`.
 
 | Field | Default | Max | What It Does |
 |-------|---------|-----|-------------|
 | `QueueSize` | 10,000 | 1,000,000 | Capacity of the core intake queue. When full, `AuditEvent()` returns `ErrQueueFull` and the event is lost. |
-| `DrainTimeout` | 5 seconds | 60 seconds | How long `Close()` waits for remaining events to flush before giving up. Events still in the buffer after this timeout are lost. |
+| `ShutdownTimeout` | 5 seconds | 60 seconds | How long `Close()` waits for remaining events to flush before giving up. Events still in the buffer after this timeout are lost. |
 
-**Note:** `DrainTimeout` only applies during shutdown (when you call
+**Note:** `ShutdownTimeout` only applies during shutdown (when you call
 `Close()`). During normal operation, the drain goroutine processes
 events continuously with no timeout.
 
@@ -130,7 +130,7 @@ or your outputs are too slow.
 audit has a two-level buffering architecture. Understanding it is
 essential for tuning performance and diagnosing event drops.
 
-### Level 1: Core Logger Buffer
+### Level 1: Core Auditor Buffer
 
 Every `AuditEvent()` call validates the event and enqueues it into a
 buffered Go channel. A single drain goroutine reads from this channel,
@@ -213,7 +213,7 @@ Loki is down, Loki drops events but the core queue and all other
 outputs are unaffected.
 
 **`queue_size` and `buffer_size` are different things.**
-`logger.queue_size` (or `Config.QueueSize`) is the Level 1 core
+`auditor.queue_size` (or `Config.QueueSize`) is the Level 1 core
 intake queue. `buffer_size` on any output (file, syslog, webhook,
 Loki) is that output's Level 2 channel. They are independent. Both
 default to 10,000 but they serve different purposes.
@@ -228,7 +228,7 @@ drops begin.
 ### Memory Sizing
 
 The core library uses a package-level `sync.Pool` shared across all
-`Logger` instances to reuse `auditEntry` structs, reducing GC pressure
+`Auditor` instances to reuse `auditEntry` structs, reducing GC pressure
 on the hot path. Pool entries are returned after the drain goroutine
 finishes processing each event. The channel holds pointers to
 pool-allocated structs, not copies.
@@ -264,7 +264,7 @@ memory-constrained environments.
 
 | Symptom | Diagnosis | Fix |
 |---------|-----------|-----|
-| `ErrQueueFull` from `AuditEvent()` | Core queue (Level 1) full — drain goroutine can't keep up | Increase `logger.queue_size` |
+| `ErrQueueFull` from `AuditEvent()` | Core queue (Level 1) full — drain goroutine can't keep up | Increase `auditor.queue_size` |
 | `OutputMetrics.RecordDrop()` firing | Per-output buffer (Level 2) full — destination too slow or down | Increase output `buffer_size`, decrease `flush_interval`, check destination health |
 | High event latency | Events queued too long before flushing | Decrease `flush_interval` or `batch_size` for faster delivery |
 | Excessive memory | Large buffers with large events | Decrease `buffer_size` on outputs you can afford to drop from |
@@ -286,10 +286,10 @@ has its own at-least-once retry semantics for HTTP delivery — see
 
 ## 🛑 Graceful Shutdown
 
-`Logger.Close()` MUST be called when the logger is no longer needed:
+`Auditor.Close()` MUST be called when the auditor is no longer needed:
 
 1. Signals the drain goroutine to stop accepting new events
-2. Flushes pending events from the buffer (up to `DrainTimeout`)
+2. Flushes pending events from the buffer (up to `ShutdownTimeout`)
 3. Closes all outputs in parallel
 4. Returns any close errors
 
@@ -303,7 +303,7 @@ is called before the process exits:
 
 ```go
 func main() {
-    logger, err := audit.NewLogger(opts...)
+    auditor, err := audit.New(opts...)
     if err != nil {
         log.Fatal(err)
     }
@@ -327,8 +327,8 @@ func main() {
     defer cancel()
     srv.Shutdown(ctx)
 
-    // 2. Close the logger — flushes all pending audit events.
-    if err := logger.Close(); err != nil {
+    // 2. Close the auditor — flushes all pending audit events.
+    if err := auditor.Close(); err != nil {
         log.Printf("audit close: %v", err)
     }
 
@@ -337,18 +337,18 @@ func main() {
 ```
 
 **Key ordering:** Stop the HTTP server first (so no new audit events
-are generated), then close the logger (so all pending events flush).
+are generated), then close the auditor (so all pending events flush).
 
 For simpler applications without an HTTP server, `defer` works:
 
 ```go
 func main() {
-    logger, err := audit.NewLogger(opts...)
+    auditor, err := audit.New(opts...)
     if err != nil {
         log.Fatal(err)
     }
     defer func() {
-        if err := logger.Close(); err != nil {
+        if err := auditor.Close(); err != nil {
             log.Printf("audit close: %v", err)
         }
     }()

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -20,7 +20,7 @@ constructors.
 Without code generation, emitting an audit event looks like this:
 
 ```go
-logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
     "actor_id": "alice",
     "outcom":   "success",  // typo — runtime validation catches it, but only if tested
 }))
@@ -29,7 +29,7 @@ logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 With code generation:
 
 ```go
-logger.AuditEvent(NewUserCreateEvent("alice", "success"))
+auditor.AuditEvent(NewUserCreateEvent("alice", "success"))
 // "outcom" typo is impossible — required fields are constructor parameters
 // Unknown field "NewUserCrateEvent" fails at compile time
 ```
@@ -122,7 +122,7 @@ func NewUserCreateEvent(actorID any, outcome any) *UserCreateEvent
 func (e *UserCreateEvent) SetTargetID(v any) *UserCreateEvent
 func (e *UserCreateEvent) SetReason(v any) *UserCreateEvent
 
-// Implements audit.Event — pass directly to logger.AuditEvent()
+// Implements audit.Event — pass directly to auditor.AuditEvent()
 func (e *UserCreateEvent) EventType() string      // returns "user_create"
 func (e *UserCreateEvent) Fields() audit.Fields    // returns the constructed field map
 
@@ -136,7 +136,7 @@ func (e *UserCreateEvent) Description() string
 
 ```go
 // Type-safe — typos fail at compile time
-err := logger.AuditEvent(
+err := auditor.AuditEvent(
     NewUserCreateEvent("alice", "success").
         SetTargetID("user-42").
         SetReason("admin request"),

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -15,12 +15,12 @@ All audit errors are sentinel values. Use `errors.Is` to check
 for specific error types — never compare error strings:
 
 ```go
-err := logger.AuditEvent(event)
+err := auditor.AuditEvent(event)
 if errors.Is(err, audit.ErrQueueFull) {
     // handle buffer full
 }
 if errors.Is(err, audit.ErrClosed) {
-    // logger was already closed
+    // auditor was already closed
 }
 ```
 
@@ -43,20 +43,20 @@ audit: queue full
 | **When** | `AuditEvent()` is called but the async buffer channel is at capacity |
 | **Meaning** | The event was **dropped** — it will not be delivered to any output |
 | **Transient?** | Yes — resolves when the drain goroutine catches up |
-| **What to do** | Log a warning, increment a metric (`RecordBufferDrop` fires automatically). Do NOT retry immediately — the queue is full and retrying worsens the backlog. If this happens frequently, increase `Config.QueueSize` (or `logger.queue_size` in YAML) or investigate slow outputs. See [Two-Level Buffering](async-delivery.md#two-level-buffering) for the pipeline architecture. |
+| **What to do** | Log a warning, increment a metric (`RecordBufferDrop` fires automatically). Do NOT retry immediately — the queue is full and retrying worsens the backlog. If this happens frequently, increase `Config.QueueSize` (or `auditor.queue_size` in YAML) or investigate slow outputs. See [Two-Level Buffering](async-delivery.md#two-level-buffering) for the pipeline architecture. |
 
 ### `ErrClosed`
 
 ```
-audit: logger is closed
+audit: auditor is closed
 ```
 
 | | |
 |---|---|
-| **When** | `AuditEvent()` is called after `Logger.Close()` has been called |
-| **Meaning** | The logger has been shut down — no more events can be emitted |
-| **Transient?** | No — permanent. The logger cannot be reopened. |
-| **What to do** | This usually means your shutdown ordering is wrong. Make sure you stop generating events (e.g., stop the HTTP server) before calling `logger.Close()`. See [Graceful Shutdown](async-delivery.md#-graceful-shutdown). |
+| **When** | `AuditEvent()` is called after `Auditor.Close()` has been called |
+| **Meaning** | The auditor has been shut down — no more events can be emitted |
+| **Transient?** | No — permanent. The auditor cannot be reopened. |
+| **What to do** | This usually means your shutdown ordering is wrong. Make sure you stop generating events (e.g., stop the HTTP server) before calling `auditor.Close()`. See [Graceful Shutdown](async-delivery.md#-graceful-shutdown). |
 
 ### `ErrDuplicateDestination`
 
@@ -66,8 +66,8 @@ audit: duplicate destination
 
 | | |
 |---|---|
-| **When** | `NewLogger()` is called with two outputs that write to the same destination (e.g., two file outputs with the same path, two syslog outputs with the same address) |
-| **Meaning** | Logger creation failed — duplicate outputs would cause data corruption or interleaved writes |
+| **When** | `New()` is called with two outputs that write to the same destination (e.g., two file outputs with the same path, two syslog outputs with the same address) |
+| **Meaning** | Auditor creation failed — duplicate outputs would cause data corruption or interleaved writes |
 | **Transient?** | No — permanent configuration error |
 | **What to do** | Check your output configuration for duplicate paths, addresses, or URLs. Each output must write to a unique destination. |
 
@@ -83,10 +83,10 @@ audit: config validation failed
 
 | | |
 |---|---|
-| **When** | `NewLogger()` is called with an invalid `Config` struct |
-| **Meaning** | Logger creation failed — one or more config values are out of range |
+| **When** | `New()` is called with an invalid `Config` struct |
+| **Meaning** | Auditor creation failed — one or more config values are out of range |
 | **Transient?** | No — permanent configuration error |
-| **What to do** | Check the error message for details. Common causes: `QueueSize` exceeds 1,000,000, `DrainTimeout` exceeds 60 seconds, `Version` is not 1. The wrapped error message tells you which field is invalid. |
+| **What to do** | Check the error message for details. Common causes: `QueueSize` exceeds 1,000,000, `ShutdownTimeout` exceeds 60 seconds, `Version` is not 1. The wrapped error message tells you which field is invalid. |
 
 ### `ErrOutputConfigInvalid`
 
@@ -148,7 +148,7 @@ receives invalid HMAC parameters.
 | `hmac salt must be at least` | Salt is shorter than `audit.MinSaltLength` (currently 16) bytes |
 | `unknown hmac algorithm` | Algorithm is not in `audit.SupportedHMACAlgorithms()` (currently: HMAC-SHA-256, HMAC-SHA-384, HMAC-SHA-512, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512) |
 
-All HMAC configuration validation errors (from `ValidateHMACConfig`, `outputconfig.Load()`, and `NewLogger`) wrap `audit.ErrConfigInvalid`. Use `errors.Is(err, audit.ErrConfigInvalid)` to detect them programmatically. Errors returned by `ComputeHMAC` and `VerifyHMAC` do not wrap this sentinel and must be handled separately.
+All HMAC configuration validation errors (from `ValidateHMACConfig`, `outputconfig.Load()`, and `New`) wrap `audit.ErrConfigInvalid`. Use `errors.Is(err, audit.ErrConfigInvalid)` to detect them programmatically. Errors returned by `ComputeHMAC` and `VerifyHMAC` do not wrap this sentinel and must be handled separately.
 
 ---
 
@@ -340,7 +340,7 @@ audit: event type not found
 
 | | |
 |---|---|
-| **When** | `Logger.Handle()` or `Logger.MustHandle()` is called with an event type name not registered in the taxonomy |
+| **When** | `Auditor.Handle()` or `Auditor.MustHandle()` is called with an event type name not registered in the taxonomy |
 | **Meaning** | The event type string does not match any event defined in the taxonomy |
 | **Transient?** | No — permanent. The event type must exist in the taxonomy. |
 | **What to do** | Check for typos in the event type name. Use generated constants (`EventUserCreate`) instead of string literals to catch this at compile time. If using `MustHandle()`, note that it **panics** instead of returning an error — use `Handle()` if you want to handle the error gracefully. |

--- a/docs/event-routing.md
+++ b/docs/event-routing.md
@@ -158,19 +158,19 @@ all events.
 
 ## 🔄 Runtime Route Changes
 
-Routes can be modified at runtime without restarting the logger:
+Routes can be modified at runtime without restarting the auditor:
 
 ```go
 // Restrict an output to security events only.
-err := logger.SetOutputRoute("siem", &audit.EventRoute{
+err := auditor.SetOutputRoute("siem", &audit.EventRoute{
     IncludeCategories: []string{"security"},
 })
 
 // Remove the route — output receives all events again.
-err = logger.ClearOutputRoute("siem")
+err = auditor.ClearOutputRoute("siem")
 
 // Query the current route.
-route, err := logger.OutputRoute("siem")
+route, err := auditor.OutputRoute("siem")
 ```
 
 The output name must match the key used in your output YAML

--- a/docs/http-middleware.md
+++ b/docs/http-middleware.md
@@ -165,7 +165,7 @@ builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string,
 }
 
 // 2. Wrap your router with the audit middleware.
-auditedRouter := audit.Middleware(logger, builder)(router)
+auditedRouter := audit.Middleware(auditor, builder)(router)
 
 // 3. Use the wrapped router as your HTTP handler.
 http.ListenAndServe(":8080", auditedRouter)
@@ -202,7 +202,7 @@ handlers. All are optional — set only what applies to your request.
 
 Middleware audit events include all configured framework fields
 (`app_name`, `host`, `timezone`, `pid`) just like any other event.
-These are set once at logger construction and appear automatically
+These are set once at auditor construction and appear automatically
 in every serialised event — no middleware configuration needed.
 
 The 31 [reserved standard fields](../examples/13-standard-fields/)

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -36,7 +36,7 @@ Fields are emitted in a deterministic order:
    - `app_name` — application name (when configured via `WithAppName` or outputs YAML)
    - `host` — hostname (when configured via `WithHost` or outputs YAML)
    - `timezone` — timezone name (auto-detected from system, or set via `WithTimezone` / outputs YAML)
-   - `pid` — process ID (always present, auto-captured at logger construction)
+   - `pid` — process ID (always present, auto-captured at auditor construction)
 
 2. **Required fields** — sorted alphabetically
 3. **Optional fields** — sorted alphabetically

--- a/docs/loki-output.md
+++ b/docs/loki-output.md
@@ -71,7 +71,7 @@ When you audit an event, here's what happens:
 ```
 Your code                    audit core              Loki output
 ─────────                    ──────────────             ───────────
-logger.AuditEvent(event) →   validate + serialize →     WriteWithMetadata()
+auditor.AuditEvent(event) →   validate + serialize →     WriteWithMetadata()
                                                           ↓
                                                         enqueue in buffer
                                                           ↓ (non-blocking)
@@ -149,7 +149,7 @@ drop — use metrics, not log lines, for precise monitoring.
 
 ### Relationship to Core Buffer
 
-The Loki `buffer_size` is independent of the core `logger.queue_size`
+The Loki `buffer_size` is independent of the core `auditor.queue_size`
 (`Config.QueueSize`). Both default to 10,000 but they serve different
 pipeline stages. See
 [Two-Level Buffering](async-delivery.md#two-level-buffering) for the
@@ -173,7 +173,7 @@ audit generates labels from three sources:
 | Source | Labels | Set when | Example |
 |--------|--------|----------|---------|
 | **Static** | Configured in YAML | Config load | `job="audit"`, `environment="prod"` |
-| **Framework** | From logger options | Logger construction | `app_name="myservice"`, `host="prod-01"`, `pid="12345"` |
+| **Framework** | From auditor options | Auditor construction | `app_name="myservice"`, `host="prod-01"`, `pid="12345"` |
 | **Per-event** | From event metadata | Each audit event | `event_type="user_create"`, `event_category="write"`, `severity="5"` |
 
 ### The Seven Dynamic Labels
@@ -553,7 +553,7 @@ conditions is met:
 | **Count** | 100 events | `batch_size` events accumulated |
 | **Bytes** | 1 MiB | `max_batch_bytes` uncompressed bytes |
 | **Timer** | 5 seconds | `flush_interval` elapsed since last flush |
-| **Shutdown** | — | `logger.Close()` flushes remaining events |
+| **Shutdown** | — | `auditor.Close()` flushes remaining events |
 
 ### Delivery Guarantee
 
@@ -835,7 +835,7 @@ for the factory pattern and complete interface documentation.
 
 The `timezone` field is a framework field that is **always** populated
 in every audit event — either from the user's YAML configuration or
-auto-detected from the system timezone at logger construction.
+auto-detected from the system timezone at auditor construction.
 
 Timezone is included because:
 

--- a/docs/metrics-monitoring.md
+++ b/docs/metrics-monitoring.md
@@ -40,7 +40,7 @@ type Metrics interface {
 ### Wiring Metrics
 
 ```go
-logger, err := audit.NewLogger(
+auditor, err := audit.New(
     audit.WithTaxonomy(tax),
     audit.WithMetrics(myPrometheusMetrics),
     audit.WithOutputs(fileOutput),
@@ -204,9 +204,9 @@ versions will be absorbed by the embedded no-op.
 The `audittest.MetricsRecorder` captures all metrics calls in memory:
 
 ```go
-logger, _, metrics := audittest.NewLogger(t, taxonomyYAML)
+auditor, _, metrics := audittest.New(t, taxonomyYAML)
 // ... emit events ...
-logger.Close()
+auditor.Close()
 
 assert.Equal(t, 1, metrics.EventDeliveries("recorder", "success"))
 assert.Equal(t, 0, metrics.BufferDrops())

--- a/docs/migrating-from-application-logging.md
+++ b/docs/migrating-from-application-logging.md
@@ -23,7 +23,7 @@ audit and your application logger run independently:
 slog.Info("handling request", "method", r.Method, "path", r.URL.Path)
 
 // Audit logger (audit)
-logger.AuditEvent(audit.NewEventKV("user_create",
+auditor.AuditEvent(audit.NewEventKV("user_create",
     "outcome", "success",
     "actor_id", userID,
     "target_id", newUser.ID,
@@ -37,10 +37,10 @@ different formats.
 
 | slog/zap Pattern | audit Equivalent |
 |------------------|---------------------|
-| `slog.Info("user created", ...)` | `logger.AuditEvent(NewUserCreateEvent(...))` |
+| `slog.Info("user created", ...)` | `auditor.AuditEvent(NewUserCreateEvent(...))` |
 | `zap.String("user_id", id)` | `.SetActorID(id)` on the generated builder |
 | `logger.With("request_id", rid)` | `.SetRequestID(rid)` on the event |
-| `slog.Error("auth failed", ...)` | `logger.AuditEvent(NewAuthFailureEvent(...))` |
+| `slog.Error("auth failed", ...)` | `auditor.AuditEvent(NewAuthFailureEvent(...))` |
 
 ## When to Audit vs When to Log
 
@@ -62,7 +62,7 @@ different formats.
 
 audit uses `log/slog` for its own diagnostic messages (startup,
 shutdown, buffer drops). By default these go to `slog.Default()`.
-Redirect them with `WithLogger`:
+Redirect them with `WithDiagnosticLogger`:
 
 ```go
 // Send audit library diagnostics to a specific logger
@@ -70,8 +70,8 @@ auditDiag := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
     Level: slog.LevelWarn, // only warnings and errors
 }))
 
-logger, err := audit.NewLogger(
-    audit.WithLogger(auditDiag),
+auditor, err := audit.New(
+    audit.WithDiagnosticLogger(auditDiag),
     // ... other options
 )
 ```

--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -14,13 +14,13 @@ This is a complete reference for everything that can go in an
 ```yaml
 version: 1
 
-# ── Logger Configuration (optional) ────────────────────────
-# Core logger settings. If omitted, sensible defaults are used.
+# ── Auditor Configuration (optional) ────────────────────────
+# Core auditor settings. If omitted, sensible defaults are used.
 
-logger:
+auditor:
   enabled: true                    # default: true (set false to disable auditing)
   queue_size: 10000                # default: 10,000 (max: 1,000,000)
-  drain_timeout: "5s"              # default: "5s" (max: "60s")
+  shutdown_timeout: "5s"              # default: "5s" (max: "60s")
   validation_mode: strict          # "strict" (default), "warn", "permissive"
   omit_empty: false                # default: false
 
@@ -169,29 +169,29 @@ outputs:
 | `timezone` | No | Timezone name (e.g. `UTC`, `America/New_York`). Max 64 bytes. Auto-detected from system when absent. |
 | `standard_fields` | No | Map of reserved standard field names to deployment-wide default values. Keys must be [reserved standard field names](../examples/13-standard-fields/#the-solution-reserved-standard-fields). |
 | `secrets` | No | Secret provider configuration. Constructs providers from YAML instead of programmatic setup. See [Secrets Configuration](#secrets-configuration). |
-| `logger` | No | Logger configuration. All fields optional; defaults applied if omitted. |
+| `auditor` | No | Auditor configuration. All fields optional; defaults applied if omitted. |
 | `tls_policy` | No | Global TLS policy for all TLS-enabled outputs. Per-output `tls_policy` overrides. Does NOT apply to secret providers — each provider defaults to TLS 1.3 independently. |
 | `outputs` | Yes | Map of named outputs. At least one must be defined. Maximum: 100. |
 
 ## ⚙️ Logger Configuration
 
-The optional `logger:` section configures the core audit logger. All
+The optional `auditor:` section configures the core auditor. All
 fields are optional — omitted fields use sensible defaults.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `enabled` | `true` | Set `false` to disable audit logging entirely (no-op logger). |
+| `enabled` | `true` | Set `false` to disable audit logging entirely (no-op auditor). |
 | `queue_size` | `10000` | Core async channel capacity (Level 1). Events dropped when full. Maximum: 1,000,000. See [Two-Level Buffering](async-delivery.md#two-level-buffering). |
-| `drain_timeout` | `"5s"` | How long `Close()` waits for pending events to flush. Maximum: `"60s"`. |
+| `shutdown_timeout` | `"5s"` | How long `Close()` waits for pending events to flush. Maximum: `"60s"`. |
 | `validation_mode` | `"strict"` | `"strict"` rejects unknown fields, `"warn"` logs them, `"permissive"` accepts all. |
 | `omit_empty` | `false` | `true` to skip zero-value fields in output. Consumers under compliance regimes that require all registered fields SHOULD leave this `false`. Only applies when no per-output `formatter` is configured — when an explicit formatter is present, the formatter's own `omit_empty` takes precedence. |
 
 All values support environment variable substitution:
 
 ```yaml
-logger:
+auditor:
   queue_size: ${AUDIT_QUEUE_SIZE:-10000}
-  drain_timeout: "${AUDIT_DRAIN_TIMEOUT:-5s}"
+  shutdown_timeout: "${AUDIT_DRAIN_TIMEOUT:-5s}"
   enabled: ${AUDIT_ENABLED:-true}
 ```
 
@@ -565,18 +565,18 @@ available (built into core).
 
 ## 📦 Loading Output Configuration
 
-The simplest way to create a logger from YAML is the
-`outputconfig.NewLogger` facade — one call, no manual wiring:
+The simplest way to create an auditor from YAML is the
+`outputconfig.New` facade — one call, no manual wiring:
 
 ```go
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
-logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml", nil)
+auditor, err := outputconfig.New(ctx, taxonomyYAML, "outputs.yaml", nil)
 if err != nil {
     return fmt.Errorf("audit: %w", err)
 }
-defer func() { _ = logger.Close() }()
+defer func() { _ = auditor.Close() }()
 ```
 
 For advanced control (custom metrics, secret providers, per-call
@@ -595,7 +595,7 @@ if err != nil {
 
 opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
 opts = append(opts, result.Options...)
-logger, err := audit.NewLogger(opts...)
+auditor, err := audit.New(opts...)
 ```
 
 ## 📚 Further Reading

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -337,7 +337,7 @@ ensure `make check` passes on your branch.
 
 Requires **Go 1.26.2+**.
 
-Install only the modules you need. The core module provides the logger,
+Install only the modules you need. The core module provides the auditor,
 taxonomy validation, formatters, stdout output, HTTP middleware, and the
 `audittest` testing package. Output modules are separate to keep the core
 dependency footprint minimal.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -570,13 +570,13 @@ result, err := outputconfig.Load(ctx, yamlData, taxonomy,
 
 Secrets are resolved once, at `outputconfig.Load` time. The resolved
 plaintext values are embedded in the constructed outputs for the
-lifetime of the `Logger`.
+lifetime of the `Auditor`.
 
 To rotate a secret (e.g. an HMAC salt or webhook bearer token):
 
 1. Update the secret in OpenBao/Vault.
 2. Restart the application process (or the component that creates the
-   `Logger`).
+   `Auditor`).
 
 There is no built-in hot-reload mechanism. A reload pattern for
 long-running services:
@@ -592,8 +592,8 @@ import (
 	"github.com/axonops/audit/secrets/openbao"
 )
 
-// reload rebuilds the logger with fresh secrets.
-func reload(ctx context.Context, yamlData []byte, taxonomy *audit.Taxonomy) (*audit.Logger, error) {
+// reload rebuilds the auditor with fresh secrets.
+func reload(ctx context.Context, yamlData []byte, taxonomy *audit.Taxonomy) (*audit.Auditor, error) {
 	provider, err := openbao.New(&openbao.Config{
 		Address: os.Getenv("BAO_ADDR"),
 		Token:   os.Getenv("BAO_TOKEN"),
@@ -612,7 +612,7 @@ func reload(ctx context.Context, yamlData []byte, taxonomy *audit.Taxonomy) (*au
 
 	opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
 	opts = append(opts, result.Options...)
-	return audit.NewLogger(opts...)
+	return audit.New(opts...)
 }
 ```
 

--- a/docs/stdout-output.md
+++ b/docs/stdout-output.md
@@ -85,7 +85,7 @@ The drain goroutine is the sole writer — `StdoutOutput.Write()` is
 called sequentially from the drain loop, not concurrently. The mutex
 guards against concurrent `Close()` calls.
 
-**Important:** You MUST call `logger.Close()` before your program
+**Important:** You MUST call `auditor.Close()` before your program
 exits. Close drains the internal buffer and flushes all pending events.
 Without it, events still in the buffer are lost silently.
 
@@ -230,7 +230,7 @@ go run . 2>/dev/null | grep '"event_type":"auth_login"'
 | Problem | Cause | Fix |
 |---------|-------|-----|
 | `stdout does not accept configuration` | Added a `stdout:` block in YAML | Remove the type-specific block; stdout takes no config |
-| Events not appearing | Logger not closed before program exits | You MUST call `logger.Close()` to flush the drain buffer |
+| Events not appearing | Auditor not closed before program exits | You MUST call `auditor.Close()` to flush the drain buffer |
 | Events interleaved with log output | `log.Printf` writes to stderr by default, but some setups redirect both | Use `2>/dev/null` when piping, or configure log output to a file |
 | JSON not parseable by jq | Multiple outputs writing to stdout, or log messages mixed in | Ensure only one stdout output; redirect log to stderr or file |
 

--- a/docs/syslog-output.md
+++ b/docs/syslog-output.md
@@ -410,7 +410,7 @@ flowchart TD
 ```
 
 During reconnection:
-- The mutex is **released** during backoff sleep, so `logger.Close()`
+- The mutex is **released** during backoff sleep, so `auditor.Close()`
   can interrupt the reconnection and shut down cleanly
 - The old `srslog.Writer` is closed before the new connection is
   dialled — this avoids conflicts with srslog's internal retry-on-write

--- a/docs/taxonomy-validation.md
+++ b/docs/taxonomy-validation.md
@@ -322,7 +322,7 @@ for practical guidance on choosing severity values.
 | `permissive` | Accepts any fields without warning |
 
 Set via `audit.WithValidationMode(audit.ValidationWarn)` on
-`NewLogger`, the `validation_mode` key in your outputs YAML, or
+`New`, the `validation_mode` key in your outputs YAML, or
 `audittest.WithValidationMode(audit.ValidationWarn)` in tests.
 
 ## 📦 Loading a Taxonomy

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,19 +27,19 @@ asserting on `map[string]interface{}`.
 `audittest` reduces this to one line:
 
 ```go
-logger, events, metrics := audittest.NewLogger(t, taxonomyYAML)
+auditor, events, metrics := audittest.New(t, taxonomyYAML)
 ```
 
 ## 🚀 Quick Start
 
 ```go
 func TestCreateUser(t *testing.T) {
-    logger, events, metrics := audittest.NewLogger(t, taxonomyYAML)
+    auditor, events, metrics := audittest.New(t, taxonomyYAML)
 
-    svc := NewUserService(logger)
+    svc := NewUserService(auditor)
     svc.CreateUser("alice", "alice@example.com")
 
-    // Assert immediately — NewLogger uses synchronous delivery by default.
+    // Assert immediately — New uses synchronous delivery by default.
     require.Equal(t, 1, events.Count())
     evt := events.Events()[0]
     assert.Equal(t, "user_create", evt.EventType)
@@ -50,40 +50,40 @@ func TestCreateUser(t *testing.T) {
 
 ### Synchronous Delivery (Default)
 
-Both `NewLogger` and `NewLoggerQuick` default to synchronous delivery:
+Both `New` and `NewQuick` default to synchronous delivery:
 events are available in the `Recorder` immediately after `AuditEvent()`
 returns. No `Close()` call is needed before assertions.
-`NewLogger` registers `t.Cleanup(logger.Close)` to clean up resources
+`New` registers `t.Cleanup(auditor.Close)` to clean up resources
 after the test completes. Use `WithAsync()` to opt into asynchronous
 delivery for tests that exercise drain timeout or buffer backpressure.
 
 ## 💉 Dependency Injection
 
-The Quick Start above uses `NewUserService(logger)` — this is the
-correct pattern. Your service takes a `*audit.Logger` as a constructor
+The Quick Start above uses `NewUserService(auditor)` — this is the
+correct pattern. Your service takes a `*audit.Auditor` as a constructor
 parameter, not from a package-level global:
 
 ```go
-// ✅ Correct: inject the logger
+// ✅ Correct: inject the auditor
 type UserService struct {
-    audit *audit.Logger
+    audit *audit.Auditor
 }
 
-func NewUserService(logger *audit.Logger) *UserService {
-    return &UserService{audit: logger}
+func NewUserService(auditor *audit.Auditor) *UserService {
+    return &UserService{audit: auditor}
 }
 ```
 
 ```go
 // ❌ Wrong: package-level global logger
-var logger *audit.Logger // data races in parallel tests
+var auditor *audit.Auditor // data races in parallel tests
 
 type UserService struct{}
 ```
 
 Why this matters for testing:
 
-- **Injected logger**: each test creates its own `audittest.NewLogger`,
+- **Injected logger**: each test creates its own `audittest.New`,
   passes it to the service, and asserts on its own events. Tests run in
   parallel safely.
 - **Global logger**: all tests share the same logger. Events from one
@@ -94,22 +94,22 @@ the only pattern that makes audit testing reliable.
 
 ## 🔧 Two Constructor Patterns
 
-### NewLogger — full integration test
+### New — full integration test
 
 Uses your real taxonomy YAML. Generated typed builders work because
 they compile from the same taxonomy:
 
 ```go
-logger, events, metrics := audittest.NewLogger(t, taxonomyYAML)
+auditor, events, metrics := audittest.New(t, taxonomyYAML)
 ```
 
-### NewLoggerQuick — quick smoke test
+### NewQuick — quick smoke test
 
 Creates a permissive logger — any fields accepted, no required field
 enforcement:
 
 ```go
-logger, events, _ := audittest.NewLoggerQuick(t, "user_create", "auth_failure")
+auditor, events, _ := audittest.NewQuick(t, "user_create", "auth_failure")
 ```
 
 ## 📋 Recorded Event API
@@ -140,7 +140,7 @@ metrics.OutputErrors("recorder")               // output write errors
 ## 📊 Table-Driven Tests
 
 Use `events.Reset()` to clear captured events between sub-tests
-without creating a new logger:
+without creating a new auditor:
 
 ```go
 for _, tc := range tests {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,8 +21,8 @@ This is the most common problem. Work through this checklist:
 
 | Check | How to Verify | Fix |
 |-------|--------------|-----|
-| **`logger.Close()` not called** | Events are async — they sit in the buffer until the drain goroutine processes them. If your program exits without calling `Close()`, buffered events are lost. | Call `logger.Close()` before exit. See [Graceful Shutdown](async-delivery.md#-graceful-shutdown). |
-| **Logger disabled** | A disabled logger silently discards all events. | Remove `WithDisabled()` from your `NewLogger` call, or set `logger: { enabled: true }` in your outputs YAML. |
+| **`auditor.Close()` not called** | Events are async — they sit in the buffer until the drain goroutine processes them. If your program exits without calling `Close()`, buffered events are lost. | Call `auditor.Close()` before exit. See [Graceful Shutdown](async-delivery.md#-graceful-shutdown). |
+| **Auditor disabled** | A disabled logger silently discards all events. | Remove `WithDisabled()` from your `New` call, or set `auditor: { enabled: true }` in your outputs YAML. |
 | **Category disabled at runtime** | If `DisableCategory()` was called, events in that category are silently discarded. | Check your code for `DisableCategory()` calls. All categories are enabled by default. |
 | **Per-output route filtering** | An output with `route: include_categories: [security]` only receives security events — write events are silently filtered. | Check your output YAML `route:` block. Remove the route to receive all events. See [Event Routing](event-routing.md). |
 | **Output disabled in YAML** | `enabled: false` on an output silently disables it. | Check your output YAML for `enabled: false`. |
@@ -46,7 +46,7 @@ faster than the drain goroutine can process them.
 
 | Cause | Fix |
 |-------|-----|
-| **Burst of events** | Increase `queue_size` in your outputs YAML `logger:` section, or use `WithQueueSize()` (default: 10,000, max: 1,000,000) |
+| **Burst of events** | Increase `queue_size` in your outputs YAML `auditor:` section, or use `WithQueueSize()` (default: 10,000, max: 1,000,000) |
 | **Output error loop** | If an output is failing on every write, the drain goroutine spends time on error handling. Check `RecordOutputError` metrics. |
 
 All non-stdout outputs now have their own internal async buffers, so
@@ -68,14 +68,14 @@ INFO audit: shutdown started
 WARN audit: drain timeout expired, N events lost
 ```
 
-`Logger.Close()` waited up to `DrainTimeout` (default: 5 seconds)
+`Auditor.Close()` waited up to `ShutdownTimeout` (default: 5 seconds)
 but couldn't flush all buffered events in time.
 
 | Cause | Fix |
 |-------|-----|
-| **Too many buffered events** | Reduce event volume before shutdown, or increase `Config.DrainTimeout` (max: 60s) |
+| **Too many buffered events** | Reduce event volume before shutdown, or increase `Config.ShutdownTimeout` (max: 60s) |
 | **Slow output during shutdown** | A syslog server or webhook endpoint is slow to accept the final batch. Check connectivity. |
-| **`DrainTimeout` too short** | Increase `Config.DrainTimeout` for high-volume applications |
+| **`ShutdownTimeout` too short** | Increase `Config.ShutdownTimeout` for high-volume applications |
 
 > ⚠️ Events lost to drain timeout are gone permanently. This is the
 > at-most-once delivery guarantee. Monitor this via your metrics.
@@ -110,7 +110,7 @@ audit: output "siem": dial tcp syslog.example.com:6514: connection refused
 ```
 
 The syslog output dials the server immediately at startup. If the
-server is unreachable, `NewLogger()` (or `outputconfig.Load()`) fails.
+server is unreachable, `New()` (or `outputconfig.Load()`) fails.
 
 | Cause | Fix |
 |-------|-----|
@@ -183,9 +183,9 @@ goroutine will cause test failures.
 
 | Cause | Fix |
 |-------|-----|
-| **`logger.Close()` not called** | The drain goroutine runs until `Close()` is called. Always call `Close()` in tests. |
+| **`auditor.Close()` not called** | The drain goroutine runs until `Close()` is called. Always call `Close()` in tests. |
 | **`Close()` called too late** | `goleak` checks at test end. If `Close()` is deferred but another deferred function runs first, the goroutine may still be active. Put `Close()` as the first defer or use `t.Cleanup()`. |
-| **Using `audittest.NewLogger`** | The `audittest` constructors register `t.Cleanup(logger.Close)` automatically — but you MUST call `logger.Close()` explicitly before assertions. The cleanup is a safety net, not a substitute. See [Testing](testing.md#️-close-before-assert--critical). |
+| **Using `audittest.New`** | The `audittest` constructors register `t.Cleanup(auditor.Close)` automatically — but you MUST call `auditor.Close()` explicitly before assertions. The cleanup is a safety net, not a substitute. See [Testing](testing.md#️-close-before-assert--critical). |
 
 ---
 

--- a/docs/webhook-output.md
+++ b/docs/webhook-output.md
@@ -77,7 +77,7 @@ flowchart LR
     G -->|4xx| J[Drop batch]
 ```
 
-1. `AuditEvent()` enqueues the event in the logger's internal buffer
+1. `AuditEvent()` enqueues the event in the auditor's internal buffer
 2. The drain goroutine serialises the event and sends it to the
    webhook's buffer channel
 3. The batch loop accumulates events until a flush trigger fires
@@ -136,7 +136,7 @@ drop — use metrics, not log lines, for precise monitoring.
 ### Relationship to Core Buffer
 
 The webhook `buffer_size` is independent of the core
-`logger.queue_size` (`Config.QueueSize`). Both default to 10,000
+`auditor.queue_size` (`Config.QueueSize`). Both default to 10,000
 but they serve different pipeline stages. See
 [Two-Level Buffering](async-delivery.md#two-level-buffering) for the
 full architecture diagram and memory sizing guidance.
@@ -270,7 +270,7 @@ A batch is flushed when ANY of these conditions is met:
 |---------|--------|---------|
 | Event count reaches `batch_size` | `batch_size` | 100 |
 | Timer reaches `flush_interval` | `flush_interval` | 5s |
-| `logger.Close()` called | — | Final flush |
+| `auditor.Close()` called | — | Final flush |
 
 The timer resets after every flush, whether triggered by count or timer.
 

--- a/docs/writing-custom-outputs.md
+++ b/docs/writing-custom-outputs.md
@@ -22,7 +22,7 @@ optional interfaces add capabilities:
 Output (required)
 ├── MetadataWriter         — receive structured event metadata (type, severity, category)
 ├── FrameworkFieldReceiver — receive app_name, host, timezone, pid at startup
-├── LoggerReceiver         — receive the library's slog.Logger for diagnostics
+├── DiagnosticLoggerReceiver         — receive the library's slog.Logger for diagnostics
 ├── DestinationKeyer       — prevent duplicate outputs to the same destination
 ├── OutputMetricsReceiver  — receive per-output delivery metrics
 └── DeliveryReporter       — signal that delivery metrics are recorded after actual I/O
@@ -34,7 +34,7 @@ Output (required)
 |----------|-----------|
 | Do you need event type, severity, or category? | Implement `MetadataWriter` |
 | Do you need app_name/host for labelling? | Implement `FrameworkFieldReceiver` |
-| Do you want the library's diagnostic logger? | Implement `LoggerReceiver` |
+| Do you want the library's diagnostic logger? | Implement `DiagnosticLoggerReceiver` |
 | Can two outputs point to the same destination? | Implement `DestinationKeyer` |
 | Does your output want per-output drop/flush/error metrics? | Implement `OutputMetricsReceiver` |
 | Does your output use a background goroutine that records delivery outcomes after actual I/O? | Implement `DeliveryReporter` |
@@ -261,7 +261,7 @@ func (o *AsyncOutput) Close() error {
     return nil
 }
 
-// ReportsDelivery signals the core logger to skip RecordEvent for
+// ReportsDelivery signals the core auditor to skip RecordEvent for
 // this output — delivery accounting is handled by OutputMetrics in
 // writeLoop.
 func (o *AsyncOutput) ReportsDelivery() bool { return true }
@@ -292,7 +292,7 @@ background goroutine may already be running at this point (started
 in the output constructor). The `atomic.Pointer` storage pattern
 ensures safe handoff: the goroutine checks for nil before using
 `outputMetrics`, and `SetOutputMetrics` stores atomically. Because
-`NewLogger` is not called until after `Load` returns, no `Write`
+`New` is not called until after `Load` returns, no `Write`
 calls are made before `SetOutputMetrics` completes. This happens
 only when the consumer passes `WithOutputMetrics(factory)` as a
 load option:
@@ -415,7 +415,7 @@ type DeliveryReporter interface {
 
 ### What It Controls
 
-When `ReportsDelivery()` returns `true`, the core logger's post-write
+When `ReportsDelivery()` returns `true`, the core auditor's post-write
 logic skips `Metrics.RecordEvent(outputName, "success"|"error")` and
 `Metrics.RecordOutputError(outputName)` for that output. Delivery
 accounting is left entirely to the output via `OutputMetrics`:

--- a/drain.go
+++ b/drain.go
@@ -20,18 +20,18 @@ import (
 	"time"
 )
 
-func (l *Logger) drainLoop(ctx context.Context) {
-	defer close(l.drainDone)
-	defer l.logger.Debug("audit: drain loop exiting")
-	l.logger.Debug("audit: drain loop started")
+func (a *Auditor) drainLoop(ctx context.Context) {
+	defer close(a.drainDone)
+	defer a.logger.Debug("audit: drain loop exiting")
+	a.logger.Debug("audit: drain loop started")
 	for {
 		select {
-		case entry := <-l.ch:
+		case entry := <-a.ch:
 			if entry != nil {
-				l.processEntry(entry)
+				a.processEntry(entry)
 			}
 		case <-ctx.Done():
-			l.drainRemaining()
+			a.drainRemaining()
 			return
 		}
 	}
@@ -39,12 +39,12 @@ func (l *Logger) drainLoop(ctx context.Context) {
 
 // drainRemaining flushes any events left in the channel after the
 // context is cancelled.
-func (l *Logger) drainRemaining() {
+func (a *Auditor) drainRemaining() {
 	for {
 		select {
-		case entry := <-l.ch:
+		case entry := <-a.ch:
 			if entry != nil {
-				l.processEntry(entry)
+				a.processEntry(entry)
 			}
 		default:
 			return
@@ -55,11 +55,11 @@ func (l *Logger) drainRemaining() {
 // processEntry fans out an audit entry to all matching outputs. Events
 // are serialised once per unique Formatter; per-output routes are
 // checked before delivery. Output failures are isolated.
-func (l *Logger) processEntry(entry *auditEntry) { //nolint:gocognit,gocyclo,cyclop // queue depth sampling adds 1 to baseline complexity
+func (a *Auditor) processEntry(entry *auditEntry) { //nolint:gocognit,gocyclo,cyclop // queue depth sampling adds 1 to baseline complexity
 	// Sample queue depth every 64 events for metrics gauges.
-	l.drainCount++
-	if l.metrics != nil && l.drainCount%64 == 0 {
-		l.metrics.RecordQueueDepth(len(l.ch), cap(l.ch))
+	a.drainCount++
+	if a.metrics != nil && a.drainCount%64 == 0 {
+		a.metrics.RecordQueueDepth(len(a.ch), cap(a.ch))
 	}
 
 	// Defers execute LIFO. The pool return must happen after the
@@ -72,22 +72,22 @@ func (l *Logger) processEntry(entry *auditEntry) { //nolint:gocognit,gocyclo,cyc
 	}()
 	defer func() {
 		if r := recover(); r != nil {
-			l.logger.Error("audit: panic in processEntry",
+			a.logger.Error("audit: panic in processEntry",
 				"event_type", entry.eventType,
 				"panic", r)
-			if l.metrics != nil {
-				l.metrics.RecordSerializationError(entry.eventType)
+			if a.metrics != nil {
+				a.metrics.RecordSerializationError(entry.eventType)
 			}
 		}
 	}()
 
 	ts := time.Now()
-	def := l.taxonomy.Events[entry.eventType]
+	def := a.taxonomy.Events[entry.eventType]
 
 	if len(def.Categories) == 0 {
 		// Uncategorised event: single pass, no category context.
 		var fc formatCache
-		l.deliverToOutputs(entry, "", ts, def, &fc)
+		a.deliverToOutputs(entry, "", ts, def, &fc)
 		return
 	}
 
@@ -95,8 +95,8 @@ func (l *Logger) processEntry(entry *auditEntry) { //nolint:gocognit,gocyclo,cyc
 	// If EnableEvent was called, iterate ALL categories.
 	// The atomic flag guards the sync.Map lookup on the hot path.
 	eventForceEnabled := false
-	if l.filter.hasEventOverrides.Load() {
-		if override, ok := l.filter.eventOverrides.Load(entry.eventType); ok && override {
+	if a.filter.hasEventOverrides.Load() {
+		if override, ok := a.filter.eventOverrides.Load(entry.eventType); ok && override {
 			eventForceEnabled = true
 		}
 	}
@@ -107,17 +107,17 @@ func (l *Logger) processEntry(entry *auditEntry) { //nolint:gocognit,gocyclo,cyc
 	var fc formatCache
 
 	for _, category := range def.Categories {
-		if !eventForceEnabled && !l.filter.isCategoryEnabled(category) {
+		if !eventForceEnabled && !a.filter.isCategoryEnabled(category) {
 			continue
 		}
-		l.deliverToOutputs(entry, category, ts, def, &fc)
+		a.deliverToOutputs(entry, category, ts, def, &fc)
 	}
 }
 
 // deliverToOutputs fans out a single event to all matching outputs
 // for a given category. An empty category means the event is
 // uncategorised.
-func (l *Logger) deliverToOutputs(entry *auditEntry, category string, ts time.Time, def *EventDef, fc *formatCache) {
+func (a *Auditor) deliverToOutputs(entry *auditEntry, category string, ts time.Time, def *EventDef, fc *formatCache) {
 	severity := def.ResolvedSeverity()
 	meta := EventMetadata{
 		EventType: entry.eventType,
@@ -126,8 +126,8 @@ func (l *Logger) deliverToOutputs(entry *auditEntry, category string, ts time.Ti
 		Timestamp: ts,
 	}
 
-	for _, oe := range l.entries {
-		l.deliverToOutput(oe, entry, category, ts, def, fc, meta)
+	for _, oe := range a.entries {
+		a.deliverToOutput(oe, entry, category, ts, def, fc, meta)
 	}
 }
 
@@ -136,12 +136,12 @@ func (l *Logger) deliverToOutputs(entry *auditEntry, category string, ts time.Ti
 // does not prevent delivery to subsequent outputs. This is critical
 // for the fan-out guarantee: a buggy output must not take down the
 // entire delivery pipeline.
-func (l *Logger) deliverToOutput(oe *outputEntry, entry *auditEntry, category string, ts time.Time, def *EventDef, fc *formatCache, meta EventMetadata) { //nolint:gocyclo,gocognit,cyclop // per-output delivery with panic recovery
+func (a *Auditor) deliverToOutput(oe *outputEntry, entry *auditEntry, category string, ts time.Time, def *EventDef, fc *formatCache, meta EventMetadata) { //nolint:gocyclo,gocognit,cyclop // per-output delivery with panic recovery
 	defer func() {
 		if r := recover(); r != nil {
 			buf := make([]byte, 4096)
 			n := runtime.Stack(buf, false)
-			l.logger.Error("audit: panic in output write",
+			a.logger.Error("audit: panic in output write",
 				"output", oe.output.Name(),
 				"event_type", entry.eventType,
 				"panic", r,
@@ -149,32 +149,32 @@ func (l *Logger) deliverToOutput(oe *outputEntry, entry *auditEntry, category st
 			// Always record the panic in core metrics, even for
 			// DeliveryReporter outputs — the output clearly did not
 			// self-report if it panicked.
-			if l.metrics != nil {
-				l.metrics.RecordOutputError(oe.output.Name())
+			if a.metrics != nil {
+				a.metrics.RecordOutputError(oe.output.Name())
 			}
 		}
 	}()
 
 	if !oe.matchesEvent(entry.eventType, category, meta.Severity) {
-		if l.metrics != nil {
-			l.metrics.RecordOutputFiltered(oe.output.Name())
+		if a.metrics != nil {
+			a.metrics.RecordOutputFiltered(oe.output.Name())
 		}
 		return
 	}
 
 	var data []byte
 	if oe.formatOpts != nil && def.FieldLabels != nil {
-		data = l.formatWithExclusion(oe, entry, ts, def)
+		data = a.formatWithExclusion(oe, entry, ts, def)
 	} else {
-		data = l.formatCached(oe, entry, ts, def, fc)
+		data = a.formatCached(oe, entry, ts, def, fc)
 	}
 	if data == nil {
 		return
 	}
 
 	// Append event_category if enabled and the event has a category.
-	if category != "" && !l.taxonomy.SuppressEventCategory {
-		data = appendEventCategory(data, oe.effectiveFormatter(l.formatter), category)
+	if category != "" && !a.taxonomy.SuppressEventCategory {
+		data = appendEventCategory(data, oe.effectiveFormatter(a.formatter), category)
 	}
 
 	// Compute and append HMAC if configured for this output.
@@ -182,7 +182,7 @@ func (l *Logger) deliverToOutput(oe *outputEntry, entry *auditEntry, category st
 	// (after field stripping + event_category).
 	if oe.hmac != nil {
 		hmacHex := oe.hmac.computeHMACFast(data)
-		fmtr := oe.effectiveFormatter(l.formatter)
+		fmtr := oe.effectiveFormatter(a.formatter)
 		data = AppendPostField(data, fmtr, PostField{
 			JSONKey: "_hmac", CEFKey: "_hmac", Value: string(hmacHex),
 		})
@@ -197,14 +197,14 @@ func (l *Logger) deliverToOutput(oe *outputEntry, entry *auditEntry, category st
 	} else {
 		writeErr = oe.output.Write(data)
 	}
-	l.recordWrite(oe.output.Name(), entry.eventType, oe.selfReports, writeErr)
+	a.recordWrite(oe.output.Name(), entry.eventType, oe.selfReports, writeErr)
 }
 
 // prepareOutputEntries caches interface assertions and pre-constructs
 // per-output state (MetadataWriter, DeliveryReporter, FormatOptions,
 // HMAC). Called once at construction time after all options are applied.
-func (l *Logger) prepareOutputEntries() {
-	for _, oe := range l.entries {
+func (a *Auditor) prepareOutputEntries() {
+	for _, oe := range a.entries {
 		if mw, ok := oe.output.(MetadataWriter); ok {
 			oe.metadataWriter = mw
 		}
@@ -222,22 +222,22 @@ func (l *Logger) prepareOutputEntries() {
 	}
 }
 
-// propagateFrameworkFields propagates logger-wide framework
+// propagateFrameworkFields propagates auditor-wide framework
 // metadata to all formatters that implement [FrameworkFieldSetter]
 // and all outputs that implement [FrameworkFieldReceiver].
-func (l *Logger) propagateFrameworkFields() {
+func (a *Auditor) propagateFrameworkFields() {
 	set := func(f Formatter) {
 		if setter, ok := f.(FrameworkFieldSetter); ok {
-			setter.SetFrameworkFields(l.appName, l.host, l.timezone, l.pid)
+			setter.SetFrameworkFields(a.appName, a.host, a.timezone, a.pid)
 		}
 	}
-	set(l.formatter)
-	for _, oe := range l.entries {
+	set(a.formatter)
+	for _, oe := range a.entries {
 		if oe.formatter != nil {
 			set(oe.formatter)
 		}
 		if recv, ok := oe.output.(FrameworkFieldReceiver); ok {
-			recv.SetFrameworkFields(l.appName, l.host, l.timezone, l.pid)
+			recv.SetFrameworkFields(a.appName, a.host, a.timezone, a.pid)
 		}
 	}
 }
@@ -245,17 +245,17 @@ func (l *Logger) propagateFrameworkFields() {
 // formatWithExclusion serialises an event with sensitivity-labelled
 // fields excluded. It bypasses the format cache because different
 // outputs may exclude different label sets.
-func (l *Logger) formatWithExclusion(oe *outputEntry, entry *auditEntry, ts time.Time, def *EventDef) []byte {
+func (a *Auditor) formatWithExclusion(oe *outputEntry, entry *auditEntry, ts time.Time, def *EventDef) []byte {
 	// Safe: drain loop is single-goroutine. FieldLabels is read-only
 	// after taxonomy registration; we assign the pointer per-event
 	// to avoid allocating a new FormatOptions on every call.
 	oe.formatOpts.FieldLabels = def.FieldLabels
-	f := oe.effectiveFormatter(l.formatter)
+	f := oe.effectiveFormatter(a.formatter)
 	data, err := f.Format(ts, entry.eventType, entry.fields, def, oe.formatOpts)
 	if err != nil {
-		l.logger.Error("audit: format error (filtered)", "event", entry.eventType, "output", oe.output.Name(), "error", err)
-		if l.metrics != nil {
-			l.metrics.RecordSerializationError(entry.eventType)
+		a.logger.Error("audit: format error (filtered)", "event", entry.eventType, "output", oe.output.Name(), "error", err)
+		if a.metrics != nil {
+			a.metrics.RecordSerializationError(entry.eventType)
 		}
 		return nil
 	}
@@ -309,18 +309,18 @@ func (c *formatCache) put(f Formatter, data []byte) {
 // formatCached returns the serialised bytes for the output's formatter,
 // using the cache to avoid redundant serialisation. Returns nil if
 // serialisation failed.
-func (l *Logger) formatCached(oe *outputEntry, entry *auditEntry, ts time.Time, def *EventDef, cache *formatCache) []byte {
-	f := oe.effectiveFormatter(l.formatter)
+func (a *Auditor) formatCached(oe *outputEntry, entry *auditEntry, ts time.Time, def *EventDef, cache *formatCache) []byte {
+	f := oe.effectiveFormatter(a.formatter)
 	if data, ok := cache.get(f); ok {
 		return data // may be nil if serialisation failed
 	}
 	data, err := f.Format(ts, entry.eventType, entry.fields, def, nil)
 	if err != nil {
-		l.logger.Error("audit: serialisation failed",
+		a.logger.Error("audit: serialisation failed",
 			"event_type", entry.eventType,
 			"error", err)
-		if l.metrics != nil {
-			l.metrics.RecordSerializationError(entry.eventType)
+		if a.metrics != nil {
+			a.metrics.RecordSerializationError(entry.eventType)
 		}
 		cache.put(f, nil) // mark as failed
 		return nil
@@ -333,19 +333,19 @@ func (l *Logger) formatCached(oe *outputEntry, entry *auditEntry, ts time.Time, 
 // the plain Write and MetadataWriter paths. Called once per output per
 // event with the result of the write call. No closures, no interface
 // dispatch — all parameters are concrete values.
-func (l *Logger) recordWrite(outputName, eventType string, selfReports bool, writeErr error) {
+func (a *Auditor) recordWrite(outputName, eventType string, selfReports bool, writeErr error) {
 	if writeErr != nil {
-		l.logger.Error("audit: output write failed",
+		a.logger.Error("audit: output write failed",
 			"output", outputName,
 			"event_type", eventType,
 			"error", writeErr)
-		if l.metrics != nil && !selfReports {
-			l.metrics.RecordOutputError(outputName)
-			l.metrics.RecordEvent(outputName, "error")
+		if a.metrics != nil && !selfReports {
+			a.metrics.RecordOutputError(outputName)
+			a.metrics.RecordEvent(outputName, "error")
 		}
 		return
 	}
-	if l.metrics != nil && !selfReports {
-		l.metrics.RecordEvent(outputName, "success")
+	if a.metrics != nil && !selfReports {
+		a.metrics.RecordEvent(outputName, "success")
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -22,12 +22,12 @@ import (
 // Sentinel errors returned by the audit package.
 // Use [errors.Is] to test for these in consumer code.
 var (
-	// ErrClosed is returned by [Logger.AuditEvent] when the logger has
-	// been shut down via [Logger.Close]. Once returned, all subsequent
-	// [Logger.AuditEvent] calls return ErrClosed immediately.
-	ErrClosed = errors.New("audit: logger is closed")
+	// ErrClosed is returned by [Auditor.AuditEvent] when the auditor has
+	// been shut down via [Auditor.Close]. Once returned, all subsequent
+	// [Auditor.AuditEvent] calls return ErrClosed immediately.
+	ErrClosed = errors.New("audit: auditor is closed")
 
-	// ErrQueueFull is returned by [Logger.AuditEvent] when the async
+	// ErrQueueFull is returned by [Auditor.AuditEvent] when the async
 	// intake queue is at capacity and the event is dropped. Consumers
 	// SHOULD treat this as a drop notification rather than a fatal error.
 	// Increasing [Config.QueueSize] or reducing event emission rate
@@ -46,8 +46,8 @@ var (
 	//	if errors.Is(err, audit.ErrConfigInvalid) { ... }
 	ErrConfigInvalid = errors.New("audit: config validation failed")
 
-	// ErrHandleNotFound is returned by [Logger.Handle], and wrapped in
-	// the panic value of [Logger.MustHandle], when the requested event
+	// ErrHandleNotFound is returned by [Auditor.Handle], and wrapped in
+	// the panic value of [Auditor.MustHandle], when the requested event
 	// type is not registered in the taxonomy.
 	ErrHandleNotFound = errors.New("audit: event type not found")
 
@@ -56,11 +56,11 @@ var (
 	ErrOutputClosed = errors.New("audit: output is closed")
 
 	// ErrDisabled is returned by methods that require a taxonomy
-	// ([Logger.EnableCategory], [Logger.DisableCategory],
-	// [Logger.EnableEvent], [Logger.DisableEvent],
-	// [Logger.SetOutputRoute]) when called on a disabled logger.
-	// [Logger.Handle] returns a valid no-op handle instead.
-	ErrDisabled = errors.New("audit: logger is disabled")
+	// ([Auditor.EnableCategory], [Auditor.DisableCategory],
+	// [Auditor.EnableEvent], [Auditor.DisableEvent],
+	// [Auditor.SetOutputRoute]) when called on a disabled auditor.
+	// [Auditor.Handle] returns a valid no-op handle instead.
+	ErrDisabled = errors.New("audit: auditor is disabled")
 
 	// ErrTaxonomyInvalid is the sentinel error wrapped by taxonomy
 	// validation failures. Use [errors.Is] to test for it:
@@ -74,7 +74,7 @@ var (
 	// content validation errors wrap [ErrTaxonomyInvalid] instead.
 	ErrInvalidInput = errors.New("audit: invalid input")
 
-	// ErrValidation is the parent sentinel for all [Logger.AuditEvent]
+	// ErrValidation is the parent sentinel for all [Auditor.AuditEvent]
 	// validation failures (unknown event type, missing required fields,
 	// unknown fields in strict mode). Use [errors.Is] to catch any
 	// validation failure:
@@ -84,24 +84,24 @@ var (
 	// [ErrQueueFull] and [ErrClosed] are NOT validation errors.
 	ErrValidation = errors.New("audit: validation error")
 
-	// ErrUnknownEventType is returned by [Logger.AuditEvent] when the
+	// ErrUnknownEventType is returned by [Auditor.AuditEvent] when the
 	// event type is not registered in the taxonomy. Always wrapped
 	// alongside [ErrValidation] via [ValidationError].
 	ErrUnknownEventType = errors.New("audit: unknown event type")
 
-	// ErrMissingRequiredField is returned by [Logger.AuditEvent] when
+	// ErrMissingRequiredField is returned by [Auditor.AuditEvent] when
 	// one or more required fields are absent. Always wrapped alongside
 	// [ErrValidation] via [ValidationError].
 	ErrMissingRequiredField = errors.New("audit: missing required field")
 
-	// ErrUnknownField is returned by [Logger.AuditEvent] in strict
+	// ErrUnknownField is returned by [Auditor.AuditEvent] in strict
 	// validation mode when one or more fields are not declared in the
 	// taxonomy. Always wrapped alongside [ErrValidation] via
 	// [ValidationError].
 	ErrUnknownField = errors.New("audit: unknown field")
 )
 
-// ValidationError is returned by [Logger.AuditEvent] for event
+// ValidationError is returned by [Auditor.AuditEvent] for event
 // validation failures. It wraps both [ErrValidation] and a specific
 // sentinel ([ErrUnknownEventType], [ErrMissingRequiredField], or
 // [ErrUnknownField]). Use [errors.Is] to match broadly or narrowly,

--- a/event.go
+++ b/event.go
@@ -95,31 +95,31 @@ func NewEventKV(eventType string, keysAndValues ...any) Event {
 }
 
 // EventHandle is a pre-validated reference to a registered event type.
-// It carries the event type name and a reference to the owning [Logger],
+// It carries the event type name and a reference to the owning [Auditor],
 // enabling audit calls without repeated string lookup. Use generated
-// builders for static event types; use [Logger.Handle] or
-// [Logger.MustHandle] for dynamically-determined event types (e.g.
+// builders for static event types; use [Auditor.Handle] or
+// [Auditor.MustHandle] for dynamically-determined event types (e.g.
 // event type names from configuration or a database).
 type EventHandle struct {
-	logger *Logger
-	name   string
+	auditor *Auditor
+	name    string
 }
 
 // Audit emits an audit event using this handle's bound event type.
 // This method bypasses [NewEvent] to avoid a per-event heap allocation
 // from interface escape, calling the internal audit path directly.
 func (e *EventHandle) Audit(fields Fields) error {
-	return e.logger.auditInternal(e.name, fields)
+	return e.auditor.auditInternal(e.name, fields)
 }
 
 // AuditEvent emits an [Event] (typically a generated builder) using
-// the logger bound to this handle. Unlike [EventHandle.Audit], the
+// the auditor bound to this handle. Unlike [EventHandle.Audit], the
 // event type is taken from evt.EventType(), not from the handle's
-// bound type — the handle provides the logger binding only. This
+// bound type — the handle provides the auditor binding only. This
 // method accepts any [Event] implementation, making it composable
 // with code-generated typed builders.
 func (e *EventHandle) AuditEvent(evt Event) error {
-	return e.logger.AuditEvent(evt)
+	return e.auditor.AuditEvent(evt)
 }
 
 // EventType returns the event type name this handle represents.

--- a/example_middleware_test.go
+++ b/example_middleware_test.go
@@ -36,13 +36,13 @@ func ExampleMiddleware() {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(taxonomy),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	// The EventBuilder transforms per-request hints into an audit event.
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -54,7 +54,7 @@ func ExampleMiddleware() {
 		}, false
 	}
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	_ = mw // wrap your http.Handler with mw(handler)
 
 	fmt.Println("middleware created")
@@ -94,13 +94,13 @@ func ExampleMiddleware_skip() {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(taxonomy),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	// Skip health-check endpoints to reduce noise.
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -113,7 +113,7 @@ func ExampleMiddleware_skip() {
 		}, false
 	}
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	_ = mw
 
 	fmt.Println("skip middleware created")

--- a/example_test.go
+++ b/example_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/axonops/audit"
 )
 
-func ExampleNewLogger() {
+func ExampleNew() {
 	// Create a stdout output that writes to a buffer for this example.
 	var buf bytes.Buffer
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: &buf})
@@ -30,7 +30,7 @@ func ExampleNewLogger() {
 		log.Fatal(err)
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
@@ -47,7 +47,7 @@ func ExampleNewLogger() {
 	}
 
 	// Emit an event — it will be written to the buffer as a JSON line.
-	if err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	if err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	})); err != nil {
@@ -55,7 +55,7 @@ func ExampleNewLogger() {
 	}
 
 	// Close drains the async buffer so all events are flushed.
-	if err := logger.Close(); err != nil {
+	if err := auditor.Close(); err != nil {
 		log.Fatal(err)
 	}
 
@@ -67,14 +67,14 @@ func ExampleNewLogger() {
 	// has actor_id: true
 }
 
-func ExampleLogger_AuditEvent() {
+func ExampleAuditor_AuditEvent() {
 	var buf bytes.Buffer
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: &buf})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
@@ -88,12 +88,12 @@ func ExampleLogger_AuditEvent() {
 		log.Fatal(err)
 	}
 
-	if err = logger.AuditEvent(audit.NewEvent("doc_create", audit.Fields{"outcome": "success"})); err != nil {
+	if err = auditor.AuditEvent(audit.NewEvent("doc_create", audit.Fields{"outcome": "success"})); err != nil {
 		fmt.Println("audit error:", err)
 		return
 	}
 
-	if err = logger.Close(); err != nil {
+	if err = auditor.Close(); err != nil {
 		log.Fatal(err)
 	}
 
@@ -105,8 +105,8 @@ func ExampleLogger_AuditEvent() {
 	// has outcome: true
 }
 
-func ExampleLogger_MustHandle() {
-	logger, err := audit.NewLogger(
+func ExampleAuditor_MustHandle() {
+	auditor, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
@@ -119,13 +119,13 @@ func ExampleLogger_MustHandle() {
 		log.Fatal(err)
 	}
 	defer func() {
-		if closeErr := logger.Close(); closeErr != nil {
+		if closeErr := auditor.Close(); closeErr != nil {
 			log.Printf("audit close: %v", closeErr)
 		}
 	}()
 
 	// Get a handle for zero-allocation audit calls.
-	docCreate := logger.MustHandle("doc_create")
+	docCreate := auditor.MustHandle("doc_create")
 
 	if err = docCreate.Audit(audit.Fields{"outcome": "success"}); err != nil {
 		fmt.Println("audit error:", err)
@@ -136,8 +136,8 @@ func ExampleLogger_MustHandle() {
 	// Output: handle event type: doc_create
 }
 
-func ExampleLogger_EnableCategory() {
-	logger, err := audit.NewLogger(
+func ExampleAuditor_EnableCategory() {
+	auditor, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
@@ -154,13 +154,13 @@ func ExampleLogger_EnableCategory() {
 		log.Fatal(err)
 	}
 	defer func() {
-		if err := logger.Close(); err != nil {
+		if err := auditor.Close(); err != nil {
 			log.Printf("audit close: %v", err)
 		}
 	}()
 
 	// "read" category is disabled by default. Enable it at runtime.
-	if err := logger.EnableCategory("read"); err != nil {
+	if err := auditor.EnableCategory("read"); err != nil {
 		fmt.Println("enable error:", err)
 		return
 	}
@@ -169,8 +169,8 @@ func ExampleLogger_EnableCategory() {
 	// Output: read category enabled
 }
 
-func ExampleLogger_Close() {
-	logger, err := audit.NewLogger(
+func ExampleAuditor_Close() {
+	auditor, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"doc_create"}}},
@@ -185,13 +185,13 @@ func ExampleLogger_Close() {
 
 	// Best practice: defer Close immediately after creation.
 	defer func() {
-		if err := logger.Close(); err != nil {
+		if err := auditor.Close(); err != nil {
 			log.Printf("audit close: %v", err)
 		}
 	}()
 
-	fmt.Println("logger will be closed on function exit")
-	// Output: logger will be closed on function exit
+	fmt.Println("auditor will be closed on function exit")
+	// Output: auditor will be closed on function exit
 }
 
 func ExampleWithFormatter() {
@@ -207,7 +207,7 @@ func ExampleWithFormatter() {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    1,
 			Categories: map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
@@ -221,7 +221,7 @@ func ExampleWithFormatter() {
 		log.Fatal(err)
 	}
 	defer func() {
-		if err := logger.Close(); err != nil {
+		if err := auditor.Close(); err != nil {
 			log.Printf("audit close: %v", err)
 		}
 	}()
@@ -264,14 +264,14 @@ func ExampleEventRoute_exclude() {
 	// Output: empty: false
 }
 
-func ExampleLogger_SetOutputRoute() {
+func ExampleAuditor_SetOutputRoute() {
 	var buf bytes.Buffer
 	out, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: &buf})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
@@ -289,13 +289,13 @@ func ExampleLogger_SetOutputRoute() {
 		log.Fatal(err)
 	}
 	defer func() {
-		if closeErr := logger.Close(); closeErr != nil {
+		if closeErr := auditor.Close(); closeErr != nil {
 			log.Printf("audit close: %v", closeErr)
 		}
 	}()
 
 	// Restrict output to security events only at runtime.
-	if err := logger.SetOutputRoute("stdout", &audit.EventRoute{
+	if err := auditor.SetOutputRoute("stdout", &audit.EventRoute{
 		IncludeCategories: []string{"security"},
 	}); err != nil {
 		fmt.Println("route error:", err)

--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -4,7 +4,7 @@
 
 # Example 01: Basic Audit Logging (Programmatic)
 
-The minimum viable audit event: create a logger, emit an event, and see
+The minimum viable audit event: create an auditor, emit an event, and see
 the JSON output. No YAML files, no code generation, no configuration —
 just Go code.
 
@@ -15,9 +15,9 @@ use audit in a real application.
 
 ## What You'll Learn
 
-- Creating a logger with two lines of setup
+- Creating an auditor with two lines of setup
 - Emitting events with `NewEventKV()` (slog-style) and `NewEvent()` (map-style)
-- How the logger delivers events asynchronously
+- How the auditor delivers events asynchronously
 - Why `Close()` matters
 
 ## Prerequisites
@@ -39,13 +39,13 @@ on the listed event types. It exists so you can experiment without
 writing YAML or worrying about field validation:
 
 ```go
-logger, err := audit.NewLogger(
+auditor, err := audit.New(
     audit.WithTaxonomy(audit.DevTaxonomy("user_create", "auth_failure")),
     audit.WithOutputs(audit.Stdout()),
 )
 ```
 
-`NewLogger()` takes functional options. `WithTaxonomy()` tells the logger
+`New()` takes functional options. `WithTaxonomy()` tells the auditor
 what events are valid. `WithOutputs()` tells it where to send them.
 `Stdout()` writes JSON to stdout — no file rotation, no network, no
 configuration.
@@ -60,7 +60,7 @@ Two styles, same result:
 
 **slog-style key-value pairs** (concise):
 ```go
-err := logger.AuditEvent(audit.NewEventKV("user_create",
+err := auditor.AuditEvent(audit.NewEventKV("user_create",
     "outcome", "success",
     "actor_id", "alice",
 ))
@@ -68,7 +68,7 @@ err := logger.AuditEvent(audit.NewEventKV("user_create",
 
 **Fields map** (explicit):
 ```go
-err := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
     "outcome":  "failure",
     "actor_id": "unknown",
 }))
@@ -85,7 +85,7 @@ precedes it in your code.
 ### Closing the Logger
 
 ```go
-defer func() { _ = logger.Close() }()
+defer func() { _ = auditor.Close() }()
 ```
 
 `Close()` waits for buffered events to flush, then shuts down the
@@ -114,7 +114,7 @@ This is deliberate — audit logging must not silently drop events. Your
 application decides how to handle back-pressure:
 
 ```go
-if err := logger.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
+if err := auditor.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
     if errors.Is(err, audit.ErrQueueFull) {
         // Buffer is full — outputs can't keep up.
         // Log to stderr, increment a metric, or slow down.

--- a/examples/01-basic/main.go
+++ b/examples/01-basic/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Basic demonstrates the absolute minimum: a file-free logger that
+// Basic demonstrates the absolute minimum: a file-free auditor that
 // requires no YAML, no go:embed, and no output configuration. This is
 // the fastest way to evaluate audit in a playground or single-file
 // program. For production use, see examples 02+ which use YAML
@@ -27,20 +27,20 @@ import (
 )
 
 func main() {
-	// Create a logger with a development taxonomy and stdout output.
+	// Create an auditor with a development taxonomy and stdout output.
 	// DevTaxonomy accepts any event type with any fields — not for production.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(audit.DevTaxonomy("user_create", "auth_failure")),
 		audit.WithOutputs(audit.Stdout()),
 	)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	// Emit a valid event using slog-style key-value pairs.
 	fmt.Println("--- Valid event ---")
-	if auditErr := logger.AuditEvent(audit.NewEventKV("user_create",
+	if auditErr := auditor.AuditEvent(audit.NewEventKV("user_create",
 		"outcome", "success",
 		"actor_id", "alice",
 	)); auditErr != nil {
@@ -49,7 +49,7 @@ func main() {
 
 	// Emit another event using the Fields map style.
 	fmt.Println("\n--- Auth failure event ---")
-	if auditErr := logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	if auditErr := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "unknown",
 	})); auditErr != nil {

--- a/examples/02-code-generation/README.md
+++ b/examples/02-code-generation/README.md
@@ -185,7 +185,7 @@ func (e *UserCreateEvent) SetTargetID(v any) *UserCreateEvent {
 ```
 
 Each builder implements the `audit.Event` interface (`EventType()`,
-`Fields()`), so it passes directly to `logger.AuditEvent()`.
+`Fields()`), so it passes directly to `auditor.AuditEvent()`.
 
 Now a typo like `NewUserCrateEvent` fails the build instead of silently
 passing as a runtime validation error. The metadata vars reference
@@ -238,7 +238,7 @@ result, err := outputconfig.Load(ctx, outputsYAML, &tax, nil)
 Or use the facade — one call instead of three steps:
 
 ```go
-logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml", nil)
+auditor, err := outputconfig.New(ctx, taxonomyYAML, "outputs.yaml", nil)
 ```
 
 ### Two Files, Two Purposes
@@ -261,18 +261,18 @@ type. Required fields are constructor parameters (compile-time
 enforcement); optional fields use chainable setters:
 
 ```go
-if err := logger.AuditEvent(NewUserCreateEvent("alice", "success").
+if err := auditor.AuditEvent(NewUserCreateEvent("alice", "success").
     SetTargetID("user-42")); err != nil {
     log.Printf("audit error: %v", err)
 }
 
-if err := logger.AuditEvent(NewAuthFailureEvent("unknown", "failure").
+if err := auditor.AuditEvent(NewAuthFailureEvent("unknown", "failure").
     SetReason("invalid credentials").
     SetSourceIP("192.168.1.100")); err != nil {
     log.Printf("audit error: %v", err)
 }
 
-if err := logger.AuditEvent(NewUserReadEvent("success").
+if err := auditor.AuditEvent(NewUserReadEvent("success").
     SetActorID("bob")); err != nil {
     log.Printf("audit error: %v", err)
 }
@@ -281,7 +281,7 @@ if err := logger.AuditEvent(NewUserReadEvent("success").
 Compare with the raw-string approach from the basic example:
 
 ```go
-logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
     "outcome":  "success",
     "actor_id": "alice",
 }))
@@ -305,7 +305,7 @@ go generate .
 ## Expected Output
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=1
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1
 --- Using typed event builders ---
 INFO audit: shutdown started
 {"timestamp":"...","event_type":"user_create","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"alice","outcome":"success","target_id":"user-42","event_category":"write"}

--- a/examples/02-code-generation/audit_generated.go
+++ b/examples/02-code-generation/audit_generated.go
@@ -20,8 +20,8 @@ const (
 	EventUserRead = "user_read"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategoryRead     = "read"
 	CategorySecurity = "security"
@@ -325,7 +325,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -602,7 +602,7 @@ func (e *AuthSuccessEvent) SetUserAgent(v string) *AuthSuccessEvent {
 // EventType returns the event type name.
 func (e *AuthSuccessEvent) EventType() string { return EventAuthSuccess }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthSuccessEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -879,7 +879,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1156,7 +1156,7 @@ func (e *UserDeleteEvent) SetUserAgent(v string) *UserDeleteEvent {
 // EventType returns the event type name.
 func (e *UserDeleteEvent) EventType() string { return EventUserDelete }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserDeleteEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1438,7 +1438,7 @@ func (e *UserReadEvent) SetUserAgent(v string) *UserReadEvent {
 // EventType returns the event type name.
 func (e *UserReadEvent) EventType() string { return EventUserRead }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserReadEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -35,16 +35,16 @@ import (
 var taxonomyYAML []byte
 
 func main() {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	// All event types, field names, and categories are generated constants.
 	// A typo like "NewUserCrateEvent" would fail at compile time.
-	if auditErr := logger.AuditEvent(
+	if auditErr := auditor.AuditEvent(
 		NewUserCreateEvent("alice", "success").
 			SetTargetID("user-42"),
 	); auditErr != nil {

--- a/examples/03-file-output/README.md
+++ b/examples/03-file-output/README.md
@@ -91,7 +91,7 @@ If you reference `type: file` in YAML without this import,
 
 ### Close Flushes to Disk
 
-For file outputs, `Close()` is especially important. The logger buffers
+For file outputs, `Close()` is especially important. The auditor buffers
 events in memory and writes them asynchronously. If you exit without
 `Close()`, events still in the buffer never reach the file.
 
@@ -104,7 +104,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=1
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1
 INFO audit: shutdown started
 INFO audit: shutdown complete duration=...
 --- Contents of audit.log ---

--- a/examples/03-file-output/audit_generated.go
+++ b/examples/03-file-output/audit_generated.go
@@ -12,8 +12,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategoryWrite = "write"
 )
@@ -297,7 +297,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/03-file-output/main.go
+++ b/examples/03-file-output/main.go
@@ -34,23 +34,23 @@ import (
 var taxonomyYAML []byte
 
 func main() {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// Emit five events.
 	users := []string{"alice", "bob", "carol", "dave", "eve"}
 	for _, user := range users {
-		if auditErr := logger.AuditEvent(NewUserCreateEvent(user, "success")); auditErr != nil {
+		if auditErr := auditor.AuditEvent(NewUserCreateEvent(user, "success")); auditErr != nil {
 			log.Printf("audit error: %v", auditErr)
 		}
 	}
 
 	// Close flushes buffered events to disk.
-	if closeErr := logger.Close(); closeErr != nil {
-		log.Printf("close logger: %v", closeErr)
+	if closeErr := auditor.Close(); closeErr != nil {
+		log.Printf("close auditor: %v", closeErr)
 	}
 
 	// Read and print the file contents.

--- a/examples/04-testing/README.md
+++ b/examples/04-testing/README.md
@@ -10,8 +10,8 @@ an in-memory test logger that captures events and metrics for assertion.
 
 ## What You'll Learn
 
-- Using `audittest.NewLogger` for full integration tests
-- Using `audittest.NewLoggerQuick` for smoke tests with a permissive taxonomy
+- Using `audittest.New` for full integration tests
+- Using `audittest.NewQuick` for smoke tests with a permissive taxonomy
 - Asserting on captured events and metrics
 - Table-driven tests with `Reset()`
 - Testing validation error paths
@@ -58,13 +58,13 @@ taxonomy.
 
 ```go
 func TestCreateUser(t *testing.T) {
-    logger, events, metrics := audittest.NewLogger(t, taxonomyYAML)
+    logger, events, metrics := audittest.New(t, taxonomyYAML)
 
     svc := NewUserService(logger)
     err := svc.CreateUser("alice", "alice@example.com")
     require.NoError(t, err)
 
-    logger.Close() // drain async buffer
+    auditor.Close() // drain async buffer
 
     require.Equal(t, 1, events.Count())
     evt := events.Events()[0]
@@ -81,17 +81,17 @@ about field validation:
 
 ```go
 func TestAuditHappens(t *testing.T) {
-    logger, events, _ := audittest.NewLoggerQuick(t, "user_create")
+    logger, events, _ := audittest.NewQuick(t, "user_create")
 
     svc := NewUserService(logger)
     _ = svc.CreateUser("alice", "alice@example.com")
 
-    logger.Close()
+    auditor.Close()
     assert.Equal(t, 1, events.Count())
 }
 ```
 
-`NewLoggerQuick` creates a permissive logger — any fields accepted,
+`NewQuick` creates a permissive logger — any fields accepted,
 no required field enforcement.
 
 ### Pattern 3: Metrics Assertions
@@ -101,17 +101,17 @@ buffer drops, delivery counts:
 
 ```go
 func TestValidationError(t *testing.T) {
-    logger, _, metrics := audittest.NewLogger(t, taxonomyYAML)
+    logger, _, metrics := audittest.New(t, taxonomyYAML)
 
     // Emit event missing required field "actor_id"
-    err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+    err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
         "outcome": "success",
         // actor_id missing — validation error
     }))
     require.Error(t, err)
     assert.Contains(t, err.Error(), "missing required")
 
-    logger.Close()
+    auditor.Close()
     assert.Equal(t, 1, metrics.ValidationErrors("user_create"))
 }
 ```
@@ -119,8 +119,8 @@ func TestValidationError(t *testing.T) {
 ### Close Before Assert
 
 The audit logger delivers events asynchronously. Call
-`logger.Close()` before making assertions to drain the buffer.
-`NewLogger` registers `t.Cleanup(logger.Close)` as a safety net
+`auditor.Close()` before making assertions to drain the buffer.
+`New` registers `t.Cleanup(auditor.Close)` as a safety net
 against goroutine leaks, but your assertions need the explicit
 Close to see events.
 
@@ -139,7 +139,7 @@ for _, tc := range tests {
 }
 ```
 
-When sharing a logger across sub-tests without calling Close(), use
+When sharing an auditor across sub-tests without calling Close(), use
 `require.Eventually` to wait for the async drain.
 
 ### RecordedEvent API
@@ -160,15 +160,15 @@ Each captured event provides structured access:
 ### Dependency Injection
 
 The key to testable audit logging is dependency injection. Your
-service takes `*audit.Logger` as a parameter — in production you
+service takes `*audit.Auditor` as a parameter — in production you
 pass a real logger, in tests you pass the audittest logger:
 
 ```go
 type UserService struct {
-    logger *audit.Logger
+    logger *audit.Auditor
 }
 
-func NewUserService(logger *audit.Logger) *UserService {
+func NewUserService(logger *audit.Auditor) *UserService {
     return &UserService{logger: logger}
 }
 ```

--- a/examples/04-testing/audit_generated.go
+++ b/examples/04-testing/audit_generated.go
@@ -14,8 +14,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -306,7 +306,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -590,7 +590,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/04-testing/main.go
+++ b/examples/04-testing/main.go
@@ -33,21 +33,21 @@ import (
 var taxonomyYAML []byte
 
 // UserService is a simple service that emits audit events.
-// It takes a *audit.Logger as a dependency — making it testable.
+// It takes a *audit.Auditor as a dependency — making it testable.
 type UserService struct {
-	logger *audit.Logger
+	auditor *audit.Auditor
 }
 
-// NewUserService creates a UserService with the given logger.
-func NewUserService(logger *audit.Logger) *UserService {
-	return &UserService{logger: logger}
+// NewUserService creates a UserService with the given auditor.
+func NewUserService(auditor *audit.Auditor) *UserService {
+	return &UserService{auditor: auditor}
 }
 
 // CreateUser creates a user and emits an audit event.
 func (s *UserService) CreateUser(actorID, email string) error {
 	// ... business logic would go here ...
 
-	return s.logger.AuditEvent(
+	return s.auditor.AuditEvent(
 		NewUserCreateEvent(actorID, "success").
 			SetEmail(email),
 	)
@@ -57,7 +57,7 @@ func (s *UserService) CreateUser(actorID, email string) error {
 func (s *UserService) Login(username, password string) error {
 	// Simulate failed authentication.
 	if password != "correct" {
-		return s.logger.AuditEvent(
+		return s.auditor.AuditEvent(
 			NewAuthFailureEvent(username, "failure").
 				SetReason("invalid password"),
 		)
@@ -66,14 +66,14 @@ func (s *UserService) Login(username, password string) error {
 }
 
 func main() {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
-	svc := NewUserService(logger)
+	svc := NewUserService(auditor)
 	_ = svc.CreateUser("alice", "alice@example.com")
 	_ = svc.Login("bob", "wrong")
 

--- a/examples/04-testing/main_test.go
+++ b/examples/04-testing/main_test.go
@@ -28,14 +28,14 @@ import (
 
 func TestCreateUser_EmitsAuditEvent(t *testing.T) {
 	// Use the same taxonomy YAML that production code uses.
-	logger, events, metrics := audittest.NewLogger(t, taxonomyYAML)
+	auditor, events, metrics := audittest.New(t, taxonomyYAML)
 
-	svc := NewUserService(logger)
+	svc := NewUserService(auditor)
 	err := svc.CreateUser("alice", "alice@example.com")
 	require.NoError(t, err)
 
 	// Close drains the async buffer — events are now in the recorder.
-	_ = logger.Close()
+	_ = auditor.Close()
 
 	// Assert on captured events.
 	require.Equal(t, 1, events.Count())
@@ -49,13 +49,13 @@ func TestCreateUser_EmitsAuditEvent(t *testing.T) {
 }
 
 func TestLogin_Failure_EmitsAuthEvent(t *testing.T) {
-	logger, events, _ := audittest.NewLogger(t, taxonomyYAML)
+	auditor, events, _ := audittest.New(t, taxonomyYAML)
 
-	svc := NewUserService(logger)
+	svc := NewUserService(auditor)
 	err := svc.Login("bob", "wrong-password")
 	require.NoError(t, err) // AuditEvent itself shouldn't error
 
-	_ = logger.Close()
+	_ = auditor.Close()
 
 	require.Equal(t, 1, events.Count())
 	evt := events.Events()[0]
@@ -65,13 +65,13 @@ func TestLogin_Failure_EmitsAuthEvent(t *testing.T) {
 }
 
 func TestLogin_Success_NoAuditEvent(t *testing.T) {
-	logger, events, _ := audittest.NewLogger(t, taxonomyYAML)
+	auditor, events, _ := audittest.New(t, taxonomyYAML)
 
-	svc := NewUserService(logger)
+	svc := NewUserService(auditor)
 	err := svc.Login("alice", "correct")
 	require.NoError(t, err)
 
-	_ = logger.Close()
+	_ = auditor.Close()
 
 	// Successful login does not emit an audit event.
 	assert.Equal(t, 0, events.Count())
@@ -80,13 +80,13 @@ func TestLogin_Success_NoAuditEvent(t *testing.T) {
 // --- Pattern 2: Quick smoke test (permissive taxonomy, any fields accepted) ---
 
 func TestAuditEventEmitted_Quick(t *testing.T) {
-	// NewLoggerQuick creates a permissive logger — any fields accepted.
-	logger, events, _ := audittest.NewLoggerQuick(t, "user_create")
+	// NewQuick creates a permissive auditor — any fields accepted.
+	auditor, events, _ := audittest.NewQuick(t, "user_create")
 
-	svc := NewUserService(logger)
+	svc := NewUserService(auditor)
 	_ = svc.CreateUser("charlie", "charlie@example.com")
 
-	_ = logger.Close()
+	_ = auditor.Close()
 
 	// Just verify the event was emitted — no field validation.
 	assert.Equal(t, 1, events.Count())
@@ -96,17 +96,17 @@ func TestAuditEventEmitted_Quick(t *testing.T) {
 // --- Pattern 3: Validation error testing ---
 
 func TestValidationError_MissingRequiredField(t *testing.T) {
-	logger, _, metrics := audittest.NewLogger(t, taxonomyYAML)
+	auditor, _, metrics := audittest.New(t, taxonomyYAML)
 
 	// Emit event missing required field "actor_id" using NewEvent directly.
-	err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome": "success",
 		// actor_id missing — validation error
 	}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required")
 
-	_ = logger.Close()
+	_ = auditor.Close()
 
 	assert.Equal(t, 1, metrics.ValidationErrors("user_create"))
 }

--- a/examples/05-formatters/README.md
+++ b/examples/05-formatters/README.md
@@ -120,7 +120,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=2
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=2
 INFO audit: shutdown started
 INFO audit: shutdown complete duration=...
 

--- a/examples/05-formatters/audit_generated.go
+++ b/examples/05-formatters/audit_generated.go
@@ -16,8 +16,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -311,7 +311,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -588,7 +588,7 @@ func (e *AuthSuccessEvent) SetUserAgent(v string) *AuthSuccessEvent {
 // EventType returns the event type name.
 func (e *AuthSuccessEvent) EventType() string { return EventAuthSuccess }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthSuccessEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -865,7 +865,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/05-formatters/main.go
+++ b/examples/05-formatters/main.go
@@ -34,27 +34,27 @@ import (
 var taxonomyYAML []byte
 
 func main() {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// Emit events.
-	if err := logger.AuditEvent(NewUserCreateEvent("alice", "success")); err != nil {
+	if err := auditor.AuditEvent(NewUserCreateEvent("alice", "success")); err != nil {
 		log.Printf("audit error: %v", err)
 	}
 
-	if err := logger.AuditEvent(NewAuthFailureEvent("unknown", "failure")); err != nil {
+	if err := auditor.AuditEvent(NewAuthFailureEvent("unknown", "failure")); err != nil {
 		log.Printf("audit error: %v", err)
 	}
 
-	if err := logger.AuditEvent(NewAuthSuccessEvent("bob", "success")); err != nil {
+	if err := auditor.AuditEvent(NewAuthSuccessEvent("bob", "success")); err != nil {
 		log.Printf("audit error: %v", err)
 	}
 
-	if err := logger.Close(); err != nil {
-		log.Printf("close logger: %v", err)
+	if err := auditor.Close(); err != nil {
+		log.Printf("close auditor: %v", err)
 	}
 
 	// Print both files side by side.

--- a/examples/06-middleware/README.md
+++ b/examples/06-middleware/README.md
@@ -102,7 +102,7 @@ mux.HandleFunc("POST /items", func(w http.ResponseWriter, r *http.Request) {
 })
 ```
 
-The handler doesn't import the logger or construct audit events. It just
+The handler doesn't import the auditor or construct audit events. It just
 sets hints — who did it, did it succeed, what was affected.
 
 Available hints:
@@ -149,7 +149,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=1
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1
 GET http://127.0.0.1:.../healthz -> 200
 GET http://127.0.0.1:.../items -> 200
 POST http://127.0.0.1:.../items -> 201

--- a/examples/06-middleware/audit_generated.go
+++ b/examples/06-middleware/audit_generated.go
@@ -12,8 +12,8 @@ const (
 	EventHTTPRequest = "http_request"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategoryAccess = "access"
 )
@@ -308,7 +308,7 @@ func (e *HTTPRequestEvent) SetUserAgent(v string) *HTTPRequestEvent {
 // EventType returns the event type name.
 func (e *HTTPRequestEvent) EventType() string { return EventHTTPRequest }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *HTTPRequestEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/06-middleware/main.go
+++ b/examples/06-middleware/main.go
@@ -66,10 +66,10 @@ func buildEvent(hints *audit.Hints, transport *audit.TransportMetadata) (eventTy
 }
 
 func main() {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// Set up HTTP routes.
@@ -100,7 +100,7 @@ func main() {
 	})
 
 	// Wrap with audit middleware.
-	handler := audit.Middleware(logger, buildEvent)(mux)
+	handler := audit.Middleware(auditor, buildEvent)(mux)
 
 	// Start a test server and make programmatic requests.
 	server := httptest.NewServer(handler)
@@ -111,9 +111,9 @@ func main() {
 	makeRequest(client, "GET", server.URL+"/items")
 	makeRequest(client, "POST", server.URL+"/items")
 
-	// Close the logger to flush buffered events.
-	if err := logger.Close(); err != nil {
-		log.Printf("close logger: %v", err)
+	// Close the auditor to flush buffered events.
+	if err := auditor.Close(); err != nil {
+		log.Printf("close auditor: %v", err)
 	}
 
 	fmt.Println("\nNote: /healthz produced no audit event (skipped by EventBuilder).")

--- a/examples/07-syslog-output/README.md
+++ b/examples/07-syslog-output/README.md
@@ -32,7 +32,7 @@ RFC 5424-compatible receiver).
 
 | File | Purpose |
 |------|---------|
-| [`main.go`](main.go) | Creates a logger with syslog output, starts a local TCP receiver, emits 4 events |
+| [`main.go`](main.go) | Creates an auditor with syslog output, starts a local TCP receiver, emits 4 events |
 | [`outputs.yaml`](outputs.yaml) | Syslog output YAML configuration |
 | [`taxonomy.yaml`](taxonomy.yaml) | 4 event types across 2 categories (security and write) |
 | [`audit_generated.go`](audit_generated.go) | Generated typed builders |
@@ -193,7 +193,7 @@ reconnects with bounded exponential backoff:
 - **Backoff factor:** 2× with random jitter ([0.5, 1.0) multiplier)
 - **Max attempts:** Configurable via `max_retries` (default: 10)
 
-During reconnection, the mutex is released so `logger.Close()` can
+During reconnection, the mutex is released so `auditor.Close()` can
 interrupt the backoff sleep. The event that triggered the reconnection
 is retried once on the new connection.
 

--- a/examples/07-syslog-output/audit_generated.go
+++ b/examples/07-syslog-output/audit_generated.go
@@ -18,8 +18,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -315,7 +315,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -592,7 +592,7 @@ func (e *AuthLoginEvent) SetUserAgent(v string) *AuthLoginEvent {
 // EventType returns the event type name.
 func (e *AuthLoginEvent) EventType() string { return EventAuthLogin }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthLoginEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -875,7 +875,7 @@ func (e *ConfigChangeEvent) SetUserAgent(v string) *ConfigChangeEvent {
 // EventType returns the event type name.
 func (e *ConfigChangeEvent) EventType() string { return EventConfigChange }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *ConfigChangeEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1155,7 +1155,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/07-syslog-output/main.go
+++ b/examples/07-syslog-output/main.go
@@ -48,10 +48,10 @@ func main() {
 	time.Sleep(50 * time.Millisecond)
 
 	// 2. Parse taxonomy and load output config.
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// 4. Emit audit events — they are formatted as RFC 5424 and sent
@@ -64,14 +64,14 @@ func main() {
 	}
 
 	for _, e := range events {
-		if auditErr := logger.AuditEvent(e); auditErr != nil {
+		if auditErr := auditor.AuditEvent(e); auditErr != nil {
 			log.Printf("audit error: %v", auditErr)
 		}
 	}
 
 	// 5. Close flushes and delivers all pending events.
-	if closeErr := logger.Close(); closeErr != nil {
-		log.Printf("close logger: %v", closeErr)
+	if closeErr := auditor.Close(); closeErr != nil {
+		log.Printf("close auditor: %v", closeErr)
 	}
 
 	// 6. Print what the syslog receiver captured, highlighting the

--- a/examples/08-webhook-output/README.md
+++ b/examples/08-webhook-output/README.md
@@ -32,7 +32,7 @@ log aggregator, or any HTTP-based receiver.
 
 | File | Purpose |
 |------|---------|
-| [`main.go`](main.go) | Creates a logger with webhook output, starts a local HTTP receiver, emits 4 events |
+| [`main.go`](main.go) | Creates an auditor with webhook output, starts a local HTTP receiver, emits 4 events |
 | [`outputs.yaml`](outputs.yaml) | Webhook output YAML configuration with batching and custom headers |
 | [`taxonomy.yaml`](taxonomy.yaml) | 4 event types across 2 categories with varying severity levels |
 | [`audit_generated.go`](audit_generated.go) | Generated typed builders |
@@ -90,9 +90,9 @@ conditions is met:
 |---------|-------------|---------|--------------|
 | **Event count** | `batch_size` | 100 | 10 |
 | **Time elapsed** | `flush_interval` | 5s | 1s |
-| **Logger closed** | `logger.Close()` | — | Triggers final flush |
+| **Logger closed** | `auditor.Close()` | — | Triggers final flush |
 
-In this example, `logger.Close()` triggers the flush because we emit
+In this example, `auditor.Close()` triggers the flush because we emit
 only 4 events (below the batch_size threshold of 10) and close
 immediately (before the 1s timer fires).
 

--- a/examples/08-webhook-output/audit_generated.go
+++ b/examples/08-webhook-output/audit_generated.go
@@ -18,8 +18,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -314,7 +314,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -591,7 +591,7 @@ func (e *AuthLoginEvent) SetUserAgent(v string) *AuthLoginEvent {
 // EventType returns the event type name.
 func (e *AuthLoginEvent) EventType() string { return EventAuthLogin }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthLoginEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -872,7 +872,7 @@ func (e *DataExportEvent) SetUserAgent(v string) *DataExportEvent {
 // EventType returns the event type name.
 func (e *DataExportEvent) EventType() string { return EventDataExport }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *DataExportEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1151,7 +1151,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/08-webhook-output/main.go
+++ b/examples/08-webhook-output/main.go
@@ -50,10 +50,10 @@ func main() {
 	time.Sleep(50 * time.Millisecond)
 
 	// 2. Parse taxonomy and load output config.
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// 4. Emit audit events — they are batched internally and POSTed
@@ -66,14 +66,14 @@ func main() {
 	}
 
 	for _, e := range events {
-		if auditErr := logger.AuditEvent(e); auditErr != nil {
+		if auditErr := auditor.AuditEvent(e); auditErr != nil {
 			log.Printf("audit error: %v", auditErr)
 		}
 	}
 
 	// 5. Close triggers a final flush of any buffered events.
-	if closeErr := logger.Close(); closeErr != nil {
-		log.Printf("close logger: %v", closeErr)
+	if closeErr := auditor.Close(); closeErr != nil {
+		log.Printf("close auditor: %v", closeErr)
 	}
 
 	// 6. Print what the webhook receiver captured.

--- a/examples/09-multi-output/README.md
+++ b/examples/09-multi-output/README.md
@@ -73,7 +73,7 @@ The output's full config is preserved so you don't need to rewrite it.
 
 ### How Fan-Out Works
 
-The logger serializes each event once, then writes the same bytes to
+The auditor serializes each event once, then writes the same bytes to
 each output in the order they appear in the YAML. If one output's write
 fails, the error is recorded in metrics but the other outputs still
 receive the event.
@@ -96,7 +96,7 @@ Three JSON events appear on stdout, followed by the same three events
 read back from `audit.log`:
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=2
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=2
 INFO audit: shutdown started
 {"timestamp":"...","event_type":"user_create","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"alice","outcome":"success","event_category":"write"}
 {"timestamp":"...","event_type":"auth_failure","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"unknown","outcome":"failure","event_category":"security"}
@@ -110,7 +110,7 @@ INFO audit: shutdown complete duration=...
 ```
 
 Both outputs received identical events — that's fan-out. Note `outputs=2`
-in the logger-created message confirms both outputs are registered.
+in the auditor-created message confirms both outputs are registered.
 
 ## Further Reading
 

--- a/examples/09-multi-output/audit_generated.go
+++ b/examples/09-multi-output/audit_generated.go
@@ -14,8 +14,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -305,7 +305,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -582,7 +582,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/09-multi-output/main.go
+++ b/examples/09-multi-output/main.go
@@ -35,10 +35,10 @@ import (
 var taxonomyYAML []byte
 
 func main() {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// Emit events — each goes to both stdout and the file.
@@ -49,13 +49,13 @@ func main() {
 	}
 
 	for _, evt := range events {
-		if auditErr := logger.AuditEvent(evt); auditErr != nil {
+		if auditErr := auditor.AuditEvent(evt); auditErr != nil {
 			log.Printf("audit error: %v", auditErr)
 		}
 	}
 
-	if closeErr := logger.Close(); closeErr != nil {
-		log.Printf("close logger: %v", closeErr)
+	if closeErr := auditor.Close(); closeErr != nil {
+		log.Printf("close auditor: %v", closeErr)
 	}
 
 	// Show that the file also received all events.

--- a/examples/10-event-routing/README.md
+++ b/examples/10-event-routing/README.md
@@ -188,7 +188,7 @@ categories:
       - admin_delete
 ```
 
-When a multi-category event is emitted, the logger processes it once
+When a multi-category event is emitted, the auditor processes it once
 per enabled category. If `write` routes to a file output and `admin`
 routes to a webhook, the event is delivered to both — each with the
 severity from its respective category. This means the same event can
@@ -207,7 +207,7 @@ All three events appear on stdout (all events). Each file contains only
 the events matching its route:
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=4
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=4
 INFO audit: shutdown started
 ... (stdout shows all three events)
 INFO audit: shutdown complete duration=...

--- a/examples/10-event-routing/audit_generated.go
+++ b/examples/10-event-routing/audit_generated.go
@@ -16,8 +16,8 @@ const (
 	EventUserRead = "user_read"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategoryRead     = "read"
 	CategorySecurity = "security"
@@ -313,7 +313,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -590,7 +590,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -872,7 +872,7 @@ func (e *UserReadEvent) SetUserAgent(v string) *UserReadEvent {
 // EventType returns the event type name.
 func (e *UserReadEvent) EventType() string { return EventUserRead }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserReadEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/10-event-routing/main.go
+++ b/examples/10-event-routing/main.go
@@ -34,27 +34,27 @@ import (
 var taxonomyYAML []byte
 
 func main() {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// Emit one event per category.
-	if err := logger.AuditEvent(NewUserCreateEvent("alice", "success")); err != nil {
+	if err := auditor.AuditEvent(NewUserCreateEvent("alice", "success")); err != nil {
 		log.Printf("audit error: %v", err)
 	}
 
-	if err := logger.AuditEvent(NewUserReadEvent("success")); err != nil {
+	if err := auditor.AuditEvent(NewUserReadEvent("success")); err != nil {
 		log.Printf("audit error: %v", err)
 	}
 
-	if err := logger.AuditEvent(NewAuthFailureEvent("unknown", "failure")); err != nil {
+	if err := auditor.AuditEvent(NewAuthFailureEvent("unknown", "failure")); err != nil {
 		log.Printf("audit error: %v", err)
 	}
 
-	if err := logger.Close(); err != nil {
-		log.Printf("close logger: %v", err)
+	if err := auditor.Close(); err != nil {
+		log.Printf("close auditor: %v", err)
 	}
 
 	// Show filtered output.

--- a/examples/11-sensitivity-labels/README.md
+++ b/examples/11-sensitivity-labels/README.md
@@ -222,7 +222,7 @@ func (e *PaymentProcessEvent) SetCardNumber(v any) *PaymentProcessEvent { ... }
 Using the builders to emit events with sensitive fields:
 
 ```go
-if err := logger.AuditEvent(NewUserCreateEvent("admin", "success").
+if err := auditor.AuditEvent(NewUserCreateEvent("admin", "success").
     SetEmail("alice@example.com").
     SetPhone("555-0100").
     SetUserName("alice_smith").
@@ -230,7 +230,7 @@ if err := logger.AuditEvent(NewUserCreateEvent("admin", "success").
     log.Printf("audit error: %v", err)
 }
 
-if err := logger.AuditEvent(NewPaymentProcessEvent("alice", "success").
+if err := auditor.AuditEvent(NewPaymentProcessEvent("alice", "success").
     SetCardNumber("4111111111111111").
     SetCardExpiry("12/28").
     SetAmount("99.99")); err != nil {
@@ -256,7 +256,7 @@ Three log files are created, each receiving the same events with
 different field subsets:
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=3
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=3
 INFO audit: shutdown started
 INFO audit: shutdown complete duration=...
 

--- a/examples/11-sensitivity-labels/audit_generated.go
+++ b/examples/11-sensitivity-labels/audit_generated.go
@@ -14,8 +14,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategoryWrite = "write"
 )
@@ -353,7 +353,7 @@ func (e *PaymentProcessEvent) SetUserAgent(v string) *PaymentProcessEvent {
 // EventType returns the event type name.
 func (e *PaymentProcessEvent) EventType() string { return EventPaymentProcess }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *PaymentProcessEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -664,7 +664,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/11-sensitivity-labels/main.go
+++ b/examples/11-sensitivity-labels/main.go
@@ -38,28 +38,28 @@ var taxonomyYAML []byte
 var logFiles = []string{"full-audit.log", "public-audit.log", "pci-audit.log"}
 
 func main() {
-	logger := createLogger()
-	emitEvents(logger)
+	auditor := createAuditor()
+	emitEvents(auditor)
 
-	if err := logger.Close(); err != nil {
-		log.Printf("close logger: %v", err)
+	if err := auditor.Close(); err != nil {
+		log.Printf("close auditor: %v", err)
 	}
 
 	printLogFiles()
 	cleanupLogFiles()
 }
 
-func createLogger() *audit.Logger {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+func createAuditor() *audit.Auditor {
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
-	return logger
+	return auditor
 }
 
-func emitEvents(logger *audit.Logger) {
-	if err := logger.AuditEvent(NewUserCreateEvent("admin", "success").
+func emitEvents(auditor *audit.Auditor) {
+	if err := auditor.AuditEvent(NewUserCreateEvent("admin", "success").
 		SetEmail("alice@example.com").
 		SetPhone("555-0100").
 		SetUserName("alice_smith").
@@ -67,7 +67,7 @@ func emitEvents(logger *audit.Logger) {
 		log.Printf("audit error: %v", err)
 	}
 
-	if err := logger.AuditEvent(NewPaymentProcessEvent("alice", "success").
+	if err := auditor.AuditEvent(NewPaymentProcessEvent("alice", "success").
 		SetCardNumber("4111111111111111").
 		SetCardExpiry("12/28").
 		SetAmount("99.99")); err != nil {

--- a/examples/12-hmac-integrity/README.md
+++ b/examples/12-hmac-integrity/README.md
@@ -113,7 +113,7 @@ A `user_create` event (category `write`) lands on two outputs:
 ### Salt Requirements
 
 The salt MUST be at least 16 bytes (128 bits), per NIST SP 800-224.
-`ValidateHMACConfig` enforces this — `NewLogger` returns an error if
+`ValidateHMACConfig` enforces this — `New` returns an error if
 the salt is too short.
 
 Never hardcode salts in production — use `${ENV_VAR}` substitution.
@@ -163,7 +163,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=3
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=3
 --- Security event ---
 
 --- Write event ---

--- a/examples/12-hmac-integrity/audit_generated.go
+++ b/examples/12-hmac-integrity/audit_generated.go
@@ -16,8 +16,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -311,7 +311,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -588,7 +588,7 @@ func (e *AuthSuccessEvent) SetUserAgent(v string) *AuthSuccessEvent {
 // EventType returns the event type name.
 func (e *AuthSuccessEvent) EventType() string { return EventAuthSuccess }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthSuccessEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -865,7 +865,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/12-hmac-integrity/main.go
+++ b/examples/12-hmac-integrity/main.go
@@ -35,10 +35,10 @@ var taxonomyYAML []byte
 
 func main() {
 	// 1. Parse taxonomy.
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// 4. Emit events using generated typed builders.
@@ -51,7 +51,7 @@ func main() {
 	authEvt := NewAuthFailureEvent("unknown", "failure").
 		SetReason("invalid credentials").
 		SetSourceIP("192.168.1.100")
-	if auditErr := logger.AuditEvent(authEvt); auditErr != nil {
+	if auditErr := auditor.AuditEvent(authEvt); auditErr != nil {
 		log.Printf("audit error: %v", auditErr)
 	}
 
@@ -62,15 +62,15 @@ func main() {
 	fmt.Println("\n--- Write event ---")
 	userEvt := NewUserCreateEvent("admin", "success").
 		SetTargetID("user-42")
-	if auditErr := logger.AuditEvent(userEvt); auditErr != nil {
+	if auditErr := auditor.AuditEvent(userEvt); auditErr != nil {
 		log.Printf("audit error: %v", auditErr)
 	}
 
 	fmt.Println("\n--- Compare the three outputs below ---")
 
-	// Close the logger to flush all events before reading files.
-	if closeErr := logger.Close(); closeErr != nil {
-		log.Printf("close logger: %v", closeErr)
+	// Close the auditor to flush all events before reading files.
+	if closeErr := auditor.Close(); closeErr != nil {
+		log.Printf("close auditor: %v", closeErr)
 	}
 
 	// Show what landed in each file.

--- a/examples/13-standard-fields/README.md
+++ b/examples/13-standard-fields/README.md
@@ -35,7 +35,7 @@ available on every event without taxonomy declaration:
 | **File** | `file_name`, `file_path`, `file_hash`, `file_size` |
 
 These fields:
-- Are accepted by the logger in any validation mode (strict, warn, permissive)
+- Are accepted by the auditor in any validation mode (strict, warn, permissive)
 - Have generated setter methods on every builder (`.SetSourceIP()`, `.SetReason()`, etc.)
 - Map to standard ArcSight CEF extension keys for automatic SIEM integration
 - Can be made mandatory per-event by declaring them `required: true` in the taxonomy
@@ -124,14 +124,14 @@ outputs:
 ## Wiring Standard Field Defaults
 
 The `standard_fields` YAML section is handled automatically by
-`outputconfig.NewLogger` — no manual wiring needed:
+`outputconfig.New` — no manual wiring needed:
 
 ```go
-logger, err := outputconfig.NewLogger(ctx, taxonomyYAML, "outputs.yaml", nil)
+auditor, err := outputconfig.New(ctx, taxonomyYAML, "outputs.yaml", nil)
 ```
 
 The facade reads the `standard_fields` map, creates a
-`WithStandardFieldDefaults` option, and passes it to `NewLogger`
+`WithStandardFieldDefaults` option, and passes it to `New`
 alongside the output registrations and config options.
 
 ## Using Standard Field Setters
@@ -143,7 +143,7 @@ regardless of whether the field appears in your taxonomy:
 // SetTargetID, SetSourceIP, SetReason are generated on every builder.
 // They are available because target_id, source_ip, reason are
 // reserved standard fields — no taxonomy declaration needed.
-err := logger.AuditEvent(
+err := auditor.AuditEvent(
     NewUserCreateEvent("alice", "success").
         SetTargetID("user-42").
         SetReason("admin request"),
@@ -154,7 +154,7 @@ Standard field defaults from `outputs.yaml` are applied automatically:
 
 ```go
 // source_ip is not set here — the default "10.0.0.1" applies.
-err := logger.AuditEvent(
+err := auditor.AuditEvent(
     NewAuthFailureEvent("unknown", "failure").
         SetReason("invalid credentials"),
 )
@@ -164,7 +164,7 @@ Per-event values override defaults:
 
 ```go
 // Explicit source_ip overrides the default.
-err := logger.AuditEvent(
+err := auditor.AuditEvent(
     NewAuthFailureEvent("bob", "failure").
         SetReason("expired token").
         SetSourceIP("192.168.1.100"),
@@ -180,7 +180,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: logger created queue_size=10000 drain_timeout=5s validation_mode=strict outputs=1
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1
 --- Event with standard fields ---
 --- Event with default source_ip ---
 --- Event with explicit source_ip ---

--- a/examples/13-standard-fields/audit_generated.go
+++ b/examples/13-standard-fields/audit_generated.go
@@ -14,8 +14,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -305,7 +305,7 @@ func (e *AuthFailureEvent) SetUserAgent(v any) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -582,7 +582,7 @@ func (e *UserCreateEvent) SetUserAgent(v any) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/13-standard-fields/main.go
+++ b/examples/13-standard-fields/main.go
@@ -38,14 +38,14 @@ func main() {
 	// Parse taxonomy — only outcome and actor_id are declared.
 	// All 31 standard fields (source_ip, reason, target_id, etc.)
 	// are available automatically.
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 	defer func() {
-		if closeErr := logger.Close(); closeErr != nil {
-			log.Printf("close logger: %v", closeErr)
+		if closeErr := auditor.Close(); closeErr != nil {
+			log.Printf("close auditor: %v", closeErr)
 		}
 	}()
 
@@ -53,7 +53,7 @@ func main() {
 	// SetTargetID, SetSourceIP, SetReason are available on every builder
 	// because they are reserved standard fields.
 	fmt.Println("--- Event with standard fields ---")
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewUserCreateEvent("alice", "success").
 			SetTargetID("user-42").
 			SetReason("admin request"),
@@ -63,7 +63,7 @@ func main() {
 
 	// source_ip is not set here — the standard_fields default applies.
 	fmt.Println("--- Event with default source_ip ---")
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewAuthFailureEvent("unknown", "failure").
 			SetReason("invalid credentials"),
 	); err != nil {
@@ -72,7 +72,7 @@ func main() {
 
 	// Per-event source_ip overrides the default.
 	fmt.Println("--- Event with explicit source_ip ---")
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewAuthFailureEvent("bob", "failure").
 			SetReason("expired token").
 			SetSourceIP("192.168.1.100"),

--- a/examples/14-loki-output/README.md
+++ b/examples/14-loki-output/README.md
@@ -30,7 +30,7 @@ docker run -d --name loki -p 3100:3100 grafana/loki:3.0.0
 
 | File | Purpose |
 |------|---------|
-| [`main.go`](main.go) | Creates a logger with a Loki output and audits 5 events |
+| [`main.go`](main.go) | Creates an auditor with a Loki output and audits 5 events |
 | [`outputs.yaml`](outputs.yaml) | YAML configuration for the Loki output |
 | [`taxonomy.yaml`](taxonomy.yaml) | Event type definitions with required fields |
 | [`README.md`](README.md) | This file |
@@ -72,7 +72,7 @@ When you run this example, here's what happens:
    2 categories (`write` and `security`), each with required fields
 2. **Loki output created** — `outputs.yaml` configures the Loki push
    URL, stream labels, batching, and compression
-3. **Events audited** — 5 events are sent through the logger. Each
+3. **Events audited** — 5 events are sent through the auditor. Each
    event is validated against the taxonomy, serialised as JSON, and
    enqueued in the Loki output's internal buffer
 4. **Batch flushed** — the batch loop groups events by their stream
@@ -123,7 +123,7 @@ The labels come from three sources:
 | Source | Labels | Set when |
 |--------|--------|----------|
 | **Static** (config) | `job="audit-example"`, `environment="development"` | Config load time |
-| **Framework** (logger) | `app_name="audit-example"`, `host="dev-machine"`, `pid="12345"` | Logger construction |
+| **Framework** (logger) | `app_name="audit-example"`, `host="dev-machine"`, `pid="12345"` | Auditor construction |
 | **Per-event** (metadata) | `event_type`, `event_category`, `severity` | Each audit event |
 
 ### PID — Why It Matters for Auditing

--- a/examples/14-loki-output/audit_generated.go
+++ b/examples/14-loki-output/audit_generated.go
@@ -15,8 +15,8 @@ const (
 	EventUserUpdate       = "user_update"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -316,7 +316,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -595,7 +595,7 @@ func (e *HealthCheckEvent) SetUserAgent(v string) *HealthCheckEvent {
 // EventType returns the event type name.
 func (e *HealthCheckEvent) EventType() string { return EventHealthCheck }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *HealthCheckEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -873,7 +873,7 @@ func (e *PermissionDeniedEvent) SetUserAgent(v string) *PermissionDeniedEvent {
 // EventType returns the event type name.
 func (e *PermissionDeniedEvent) EventType() string { return EventPermissionDenied }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *PermissionDeniedEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1158,7 +1158,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1443,7 +1443,7 @@ func (e *UserUpdateEvent) SetUserAgent(v string) *UserUpdateEvent {
 // EventType returns the event type name.
 func (e *UserUpdateEvent) EventType() string { return EventUserUpdate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserUpdateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/14-loki-output/main.go
+++ b/examples/14-loki-output/main.go
@@ -48,47 +48,47 @@ import (
 var taxonomyYAML []byte
 
 func main() {
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 	defer func() {
-		if err := logger.Close(); err != nil {
-			log.Printf("close logger: %v", err)
+		if err := auditor.Close(); err != nil {
+			log.Printf("close auditor: %v", err)
 		}
 	}()
 
 	// Categorised events — these get event_category labels in Loki.
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewUserCreateEvent("alice", "success").SetResourceID("user-42"),
 	); err != nil {
 		log.Printf("audit: %v", err)
 	}
 	fmt.Println("Audited: user_create by alice")
 
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewUserCreateEvent("bob", "success").SetResourceID("user-43"),
 	); err != nil {
 		log.Printf("audit: %v", err)
 	}
 	fmt.Println("Audited: user_create by bob")
 
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewAuthFailureEvent("mallory", "failure", "invalid_password"),
 	); err != nil {
 		log.Printf("audit: %v", err)
 	}
 	fmt.Println("Audited: auth_failure by mallory")
 
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewPermissionDeniedEvent("mallory", "failure", "admin_panel"),
 	); err != nil {
 		log.Printf("audit: %v", err)
 	}
 	fmt.Println("Audited: permission_denied by mallory")
 
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewUserUpdateEvent("alice", "success").SetResourceID("user-42"),
 	); err != nil {
 		log.Printf("audit: %v", err)
@@ -97,7 +97,7 @@ func main() {
 
 	// Uncategorised events — no event_category label in Loki.
 	// Useful for operational events that don't need compliance routing.
-	if err := logger.AuditEvent(
+	if err := auditor.AuditEvent(
 		NewHealthCheckEvent("alice", "success", "database"),
 	); err != nil {
 		log.Printf("audit: %v", err)

--- a/examples/15-tls-policy/audit_generated.go
+++ b/examples/15-tls-policy/audit_generated.go
@@ -14,8 +14,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -305,7 +305,7 @@ func (e *AuthLoginEvent) SetUserAgent(v string) *AuthLoginEvent {
 // EventType returns the event type name.
 func (e *AuthLoginEvent) EventType() string { return EventAuthLogin }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthLoginEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -582,7 +582,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/15-tls-policy/main.go
+++ b/examples/15-tls-policy/main.go
@@ -42,22 +42,22 @@ var taxonomyYAML []byte
 
 func main() {
 	// 1. Parse taxonomy and load output config.
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// 3. Emit a couple of events to stdout.
-	if auditErr := logger.AuditEvent(NewAuthLoginEvent("alice", "success")); auditErr != nil {
+	if auditErr := auditor.AuditEvent(NewAuthLoginEvent("alice", "success")); auditErr != nil {
 		log.Printf("audit error: %v", auditErr)
 	}
-	if auditErr := logger.AuditEvent(NewUserCreateEvent("bob", "success")); auditErr != nil {
+	if auditErr := auditor.AuditEvent(NewUserCreateEvent("bob", "success")); auditErr != nil {
 		log.Printf("audit error: %v", auditErr)
 	}
 
-	if closeErr := logger.Close(); closeErr != nil {
-		log.Printf("close logger: %v", closeErr)
+	if closeErr := auditor.Close(); closeErr != nil {
+		log.Printf("close auditor: %v", closeErr)
 	}
 
 	// 4. Demonstrate TLS policy application programmatically.

--- a/examples/16-buffering/README.md
+++ b/examples/16-buffering/README.md
@@ -65,7 +65,7 @@ Three different configs that mean different things:
 
 | Config | Where | Default | What It Controls |
 |--------|-------|---------|------------------|
-| `logger.queue_size` | YAML `logger:` section | 10,000 | Level 1 core queue capacity |
+| `auditor.queue_size` | YAML `logger:` section | 10,000 | Level 1 core queue capacity |
 | output `buffer_size` | Per output (file, syslog, webhook, Loki) | 10,000 | Level 2 per-output channel capacity |
 | output `batch_size` | Per webhook/Loki output | 100 | Events grouped per HTTP POST |
 
@@ -100,9 +100,9 @@ outputs.
 
 ```yaml
 # Level 1 — core queue
-logger:
+auditor:
   queue_size: 5            # Tiny queue to trigger ErrQueueFull
-  drain_timeout: "2s"
+  shutdown_timeout: "2s"
 
 outputs:
   # Async file output — has its own internal buffer
@@ -134,12 +134,12 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: logger created queue_size=5 drain_timeout=2s validation_mode=strict outputs=2
+INFO audit: auditor created queue_size=5 shutdown_timeout=2s validation_mode=strict outputs=2
 --- Level 1: Core Queue (queue_size: 5) ---
 Emitting 20 events in a tight loop...
 WARN audit: queue full, events dropped dropped=1 queue_size=5
   Delivered: 6, Dropped (ErrQueueFull): 14
-  → Core queue was full. In production, increase logger.queue_size.
+  → Core queue was full. In production, increase auditor.queue_size.
 
 --- Level 2: Webhook Buffer (buffer_size: 10) ---
 The webhook points at an unreachable endpoint.
@@ -166,7 +166,7 @@ affecting the file output.
 
 | Symptom | Fix |
 |---------|-----|
-| `ErrQueueFull` from `AuditEvent()` | Increase `logger.queue_size` (default 10,000, max 1,000,000) |
+| `ErrQueueFull` from `AuditEvent()` | Increase `auditor.queue_size` (default 10,000, max 1,000,000) |
 | `OutputMetrics.RecordDrop()` | Increase output `buffer_size`, decrease `flush_interval` |
 | High event latency | Decrease `flush_interval` or `batch_size` |
 | Excessive memory | Decrease `buffer_size` (each 10,000 events ≈ 5 MB with typical events) |

--- a/examples/16-buffering/audit_generated.go
+++ b/examples/16-buffering/audit_generated.go
@@ -14,8 +14,8 @@ const (
 	EventUserCreate = "user_create"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategorySecurity = "security"
 	CategoryWrite    = "write"
@@ -305,7 +305,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -582,7 +582,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/16-buffering/main.go
+++ b/examples/16-buffering/main.go
@@ -50,15 +50,15 @@ var taxonomyYAML []byte
 
 func main() {
 	// Parse taxonomy.
-	// Single-call facade: parse taxonomy, load outputs, create logger.
-	logger, err := outputconfig.NewLogger(context.Background(), taxonomyYAML, "outputs.yaml", nil)
+	// Single-call facade: parse taxonomy, load outputs, create auditor.
+	auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml", nil)
 	if err != nil {
-		log.Fatalf("create logger: %v", err)
+		log.Fatalf("create auditor: %v", err)
 	}
 
 	// --- Level 1: Core Buffer Backpressure ---
 	//
-	// The core queue is set to 5 (outputs.yaml: logger.queue_size: 5).
+	// The core queue is set to 5 (outputs.yaml: auditor.queue_size: 5).
 	// We emit 20 events in a tight loop. Some AuditEvent() calls will
 	// find the channel full and return ErrQueueFull.
 	fmt.Println("--- Level 1: Core Queue (queue_size: 5) ---")
@@ -68,7 +68,7 @@ func main() {
 	for i := range 20 {
 		actor := fmt.Sprintf("user-%d", i)
 		evt := NewUserCreateEvent(actor, "success")
-		if auditErr := logger.AuditEvent(evt); auditErr != nil {
+		if auditErr := auditor.AuditEvent(evt); auditErr != nil {
 			if errors.Is(auditErr, audit.ErrQueueFull) {
 				dropped++
 			} else {
@@ -81,7 +81,7 @@ func main() {
 
 	fmt.Printf("  Delivered: %d, Dropped (ErrQueueFull): %d\n", delivered, dropped)
 	if dropped > 0 {
-		fmt.Println("  → Core queue was full. In production, increase logger.queue_size.")
+		fmt.Println("  → Core queue was full. In production, increase auditor.queue_size.")
 	}
 
 	// --- Level 2: Per-Output Buffer Drops ---
@@ -110,9 +110,9 @@ func main() {
 Two levels of buffering exist in the pipeline:
 
   Level 1: Core Intake Queue
-    AuditEvent() → channel (logger.queue_size) → drain goroutine
+    AuditEvent() → channel (auditor.queue_size) → drain goroutine
     Drop signal: ErrQueueFull returned to caller
-    Tuning: increase logger.queue_size (default 10,000)
+    Tuning: increase auditor.queue_size (default 10,000)
 
   Level 2: Per-Output Buffer (all outputs except stdout)
     Drain goroutine → output channel (output buffer_size) → writeLoop/batchLoop
@@ -127,7 +127,7 @@ See docs/async-delivery.md for the full architecture reference.
 
 	// Close flushes remaining events. The file output will have all
 	// delivered events. The webhook will have dropped most of them.
-	if closeErr := logger.Close(); closeErr != nil {
+	if closeErr := auditor.Close(); closeErr != nil {
 		log.Printf("close: %v", closeErr)
 	}
 

--- a/examples/16-buffering/outputs.yaml
+++ b/examples/16-buffering/outputs.yaml
@@ -1,6 +1,6 @@
 # Buffering example — demonstrates the two-level buffering architecture.
 #
-# Level 1 (core queue): the logger section controls the channel between
+# Level 1 (core queue): the auditor section controls the channel between
 # AuditEvent() and the drain goroutine. We set queue_size to 5 to
 # trigger ErrQueueFull with a small burst.
 #
@@ -13,16 +13,16 @@
 # The file output also has an internal async buffer (default 10,000).
 # It writes one event at a time from its own writeLoop goroutine.
 #
-# In production, use the defaults (logger queue_size: 10000,
-# drain_timeout: 5s, per-output buffer_size: 10000, batch_size: 100).
+# In production, use the defaults (auditor queue_size: 10000,
+# shutdown_timeout: 5s, per-output buffer_size: 10000, batch_size: 100).
 
 version: 1
 app_name: "buffering-example"
 host: "localhost"
 
-logger:
+auditor:
   queue_size: 5            # Tiny core queue to demonstrate ErrQueueFull.
-  drain_timeout: "2s"      # Short drain for fast shutdown.
+  shutdown_timeout: "2s"   # Short shutdown for fast shutdown.
 
 outputs:
   # Async file output — has its own internal buffer and writeLoop goroutine.

--- a/examples/17-capstone/README.md
+++ b/examples/17-capstone/README.md
@@ -230,16 +230,16 @@ are critical for compliance — auditors need to know when the system
 was running, and gaps in the audit trail need to be explainable.
 
 ```go
-// Emit on startup — after the logger is created, before serving.
-logger.AuditEvent(NewAppStartupEvent("success").
+// Emit on startup — after the auditor is created, before serving.
+auditor.AuditEvent(NewAppStartupEvent("success").
     SetMessage("inventory demo started on " + addr))
 
-// Emit on shutdown — after stopping HTTP, before logger.Close().
-logger.AuditEvent(NewAppShutdownEvent("success").
+// Emit on shutdown — after stopping HTTP, before auditor.Close().
+auditor.AuditEvent(NewAppShutdownEvent("success").
     SetMessage("graceful shutdown initiated"))
 ```
 
-The shutdown event only reaches outputs because `logger.Close()`
+The shutdown event only reaches outputs because `auditor.Close()`
 drains the buffer before returning. If you skip `Close()`, the
 shutdown event is lost — along with any other buffered events.
 
@@ -251,7 +251,7 @@ Auth and audit middleware are composed as HTTP handler layers:
 
 ```go
 authed := authMiddleware()(mux)
-audited := audit.Middleware(logger, buildAuditEvent)(authed)
+audited := audit.Middleware(auditor, buildAuditEvent)(authed)
 ```
 
 When authentication fails, the auth middleware sets
@@ -259,33 +259,33 @@ When authentication fails, the auth middleware sets
 middleware automatically emits the failure event. When authentication
 succeeds, it sets `Hints.ActorID` so the audit event records who made
 the request. Neither the auth middleware nor the handlers need a direct
-reference to the audit logger.
+reference to the auditor.
 
 ### Graceful Shutdown
 
 The shutdown sequence matters:
 
 1. **Stop the HTTP server** — no new requests, no new audit events
-2. **Close the audit logger** — flushes all buffered events to outputs
+2. **Close the auditor** — flushes all buffered events to outputs
 3. **Exit**
 
-Without `logger.Close()`, buffered events are lost and the drain
+Without `auditor.Close()`, buffered events are lost and the drain
 goroutine leaks. See `main.go` for the signal handling pattern.
 
 ## Testing Audit Events
 
 The `main_test.go` file demonstrates how to test audit events in a
-real application using `audittest.NewLogger`. This is the pattern you
+real application using `audittest.New`. This is the pattern you
 should follow in your own tests.
 
 ### Test setup
 
 ```go
 func newTestServer(t *testing.T, dbSetup func(mock sqlmock.Sqlmock)) *testEnv {
-    logger, rec, _ := audittest.NewLogger(t, taxonomyYAML)
-    handler := newServer(logger, db, sessions, rl, settings)
+    auditor, rec, _ := audittest.New(t, taxonomyYAML)
+    handler := newServer(auditor, db, sessions, rl, settings)
     srv := httptest.NewServer(handler)
-    return &testEnv{srv: srv, rec: rec, logger: logger}
+    return &testEnv{srv: srv, rec: rec, auditor: auditor}
 }
 ```
 
@@ -301,7 +301,7 @@ func TestAuthFailure_InvalidAPIKey(t *testing.T) {
     env := newTestServer(t, nil)
     doRequest(t, env.srv.URL, "GET", "/items", "bad-key", nil)
 
-    // NewLogger defaults to synchronous delivery — events are
+    // New defaults to synchronous delivery — events are
     // available immediately without calling Close.
     require.Equal(t, 1, env.rec.Count())
     evt := env.rec.Events()[0]
@@ -311,7 +311,7 @@ func TestAuthFailure_InvalidAPIKey(t *testing.T) {
 ```
 
 Key points:
-- **No `Close()` needed before assertions** — `audittest.NewLogger`
+- **No `Close()` needed before assertions** — `audittest.New`
   defaults to synchronous delivery since #425
 - **Same validation as production** — missing required fields are
   rejected, unknown event types fail
@@ -339,7 +339,7 @@ go test -v -race ./examples/17-capstone/...
 ```
 
 See [Example 04 — Testing](../04-testing/) for the fundamentals of
-`audittest.NewLogger` and `audittest.NewLoggerQuick`.
+`audittest.New` and `audittest.NewQuick`.
 
 ## Running Without Docker
 

--- a/examples/17-capstone/audit_generated.go
+++ b/examples/17-capstone/audit_generated.go
@@ -60,8 +60,8 @@ const (
 	EventUserUpdate = "user_update"
 )
 
-// Category constants — use with Logger.EnableCategory and
-// Logger.DisableCategory.
+// Category constants — use with Auditor.EnableCategory and
+// Auditor.DisableCategory.
 const (
 	CategoryCompliance = "compliance"
 	CategoryLifecycle  = "lifecycle"
@@ -478,7 +478,7 @@ func (e *AppShutdownEvent) SetUserAgent(v string) *AppShutdownEvent {
 // EventType returns the event type name.
 func (e *AppShutdownEvent) EventType() string { return EventAppShutdown }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AppShutdownEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -760,7 +760,7 @@ func (e *AppStartupEvent) SetUserAgent(v string) *AppStartupEvent {
 // EventType returns the event type name.
 func (e *AppStartupEvent) EventType() string { return EventAppStartup }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AppStartupEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1039,7 +1039,7 @@ func (e *AuthFailureEvent) SetUserAgent(v string) *AuthFailureEvent {
 // EventType returns the event type name.
 func (e *AuthFailureEvent) EventType() string { return EventAuthFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1316,7 +1316,7 @@ func (e *AuthLogoutEvent) SetUserAgent(v string) *AuthLogoutEvent {
 // EventType returns the event type name.
 func (e *AuthLogoutEvent) EventType() string { return EventAuthLogout }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthLogoutEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1593,7 +1593,7 @@ func (e *AuthSuccessEvent) SetUserAgent(v string) *AuthSuccessEvent {
 // EventType returns the event type name.
 func (e *AuthSuccessEvent) EventType() string { return EventAuthSuccess }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthSuccessEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -1870,7 +1870,7 @@ func (e *AuthorizationFailureEvent) SetUserAgent(v string) *AuthorizationFailure
 // EventType returns the event type name.
 func (e *AuthorizationFailureEvent) EventType() string { return EventAuthorizationFailure }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *AuthorizationFailureEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -2156,7 +2156,7 @@ func (e *BulkDeleteEvent) SetUserAgent(v string) *BulkDeleteEvent {
 // EventType returns the event type name.
 func (e *BulkDeleteEvent) EventType() string { return EventBulkDelete }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *BulkDeleteEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -2455,7 +2455,7 @@ func (e *ConfigChangeEvent) SetUserAgent(v string) *ConfigChangeEvent {
 // EventType returns the event type name.
 func (e *ConfigChangeEvent) EventType() string { return EventConfigChange }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *ConfigChangeEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -2742,7 +2742,7 @@ func (e *DataExportEvent) SetUserAgent(v string) *DataExportEvent {
 // EventType returns the event type name.
 func (e *DataExportEvent) EventType() string { return EventDataExport }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *DataExportEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -3020,7 +3020,7 @@ func (e *ItemCreateEvent) SetUserAgent(v string) *ItemCreateEvent {
 // EventType returns the event type name.
 func (e *ItemCreateEvent) EventType() string { return EventItemCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *ItemCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -3297,7 +3297,7 @@ func (e *ItemDeleteEvent) SetUserAgent(v string) *ItemDeleteEvent {
 // EventType returns the event type name.
 func (e *ItemDeleteEvent) EventType() string { return EventItemDelete }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *ItemDeleteEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -3579,7 +3579,7 @@ func (e *ItemListEvent) SetUserAgent(v string) *ItemListEvent {
 // EventType returns the event type name.
 func (e *ItemListEvent) EventType() string { return EventItemList }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *ItemListEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -3861,7 +3861,7 @@ func (e *ItemReadEvent) SetUserAgent(v string) *ItemReadEvent {
 // EventType returns the event type name.
 func (e *ItemReadEvent) EventType() string { return EventItemRead }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *ItemReadEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -4138,7 +4138,7 @@ func (e *ItemUpdateEvent) SetUserAgent(v string) *ItemUpdateEvent {
 // EventType returns the event type name.
 func (e *ItemUpdateEvent) EventType() string { return EventItemUpdate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *ItemUpdateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -4415,7 +4415,7 @@ func (e *OrderCreateEvent) SetUserAgent(v string) *OrderCreateEvent {
 // EventType returns the event type name.
 func (e *OrderCreateEvent) EventType() string { return EventOrderCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *OrderCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -4697,7 +4697,7 @@ func (e *OrderListEvent) SetUserAgent(v string) *OrderListEvent {
 // EventType returns the event type name.
 func (e *OrderListEvent) EventType() string { return EventOrderList }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *OrderListEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -4979,7 +4979,7 @@ func (e *OrderReadEvent) SetUserAgent(v string) *OrderReadEvent {
 // EventType returns the event type name.
 func (e *OrderReadEvent) EventType() string { return EventOrderRead }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *OrderReadEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -5256,7 +5256,7 @@ func (e *OrderUpdateEvent) SetUserAgent(v string) *OrderUpdateEvent {
 // EventType returns the event type name.
 func (e *OrderUpdateEvent) EventType() string { return EventOrderUpdate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *OrderUpdateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -5538,7 +5538,7 @@ func (e *RateLimitExceededEvent) SetUserAgent(v string) *RateLimitExceededEvent 
 // EventType returns the event type name.
 func (e *RateLimitExceededEvent) EventType() string { return EventRateLimitExceeded }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *RateLimitExceededEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -5817,7 +5817,7 @@ func (e *TokenExpiredEvent) SetUserAgent(v string) *TokenExpiredEvent {
 // EventType returns the event type name.
 func (e *TokenExpiredEvent) EventType() string { return EventTokenExpired }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *TokenExpiredEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -6110,7 +6110,7 @@ func (e *UserCreateEvent) SetUserAgent(v string) *UserCreateEvent {
 // EventType returns the event type name.
 func (e *UserCreateEvent) EventType() string { return EventUserCreate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserCreateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -6389,7 +6389,7 @@ func (e *UserDeleteEvent) SetUserAgent(v string) *UserDeleteEvent {
 // EventType returns the event type name.
 func (e *UserDeleteEvent) EventType() string { return EventUserDelete }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserDeleteEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -6671,7 +6671,7 @@ func (e *UserListEvent) SetUserAgent(v string) *UserListEvent {
 // EventType returns the event type name.
 func (e *UserListEvent) EventType() string { return EventUserList }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserListEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -6953,7 +6953,7 @@ func (e *UserReadEvent) SetUserAgent(v string) *UserReadEvent {
 // EventType returns the event type name.
 func (e *UserReadEvent) EventType() string { return EventUserRead }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserReadEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.
@@ -7246,7 +7246,7 @@ func (e *UserUpdateEvent) SetUserAgent(v string) *UserUpdateEvent {
 // EventType returns the event type name.
 func (e *UserUpdateEvent) EventType() string { return EventUserUpdate }
 
-// Fields returns the event fields for [audit.Logger.AuditEvent].
+// Fields returns the event fields for [audit.Auditor.AuditEvent].
 func (e *UserUpdateEvent) Fields() audit.Fields { return e.fields }
 
 // Description returns the taxonomy description.

--- a/examples/17-capstone/audit_setup.go
+++ b/examples/17-capstone/audit_setup.go
@@ -23,7 +23,7 @@ import (
 	"github.com/axonops/audit/outputconfig"
 )
 
-// setupAuditLogger creates a logger using the NewLogger facade.
+// setupAuditor creates an auditor using the outputconfig.New facade.
 // The taxonomy is embedded (compile-time contract), and output
 // configuration is loaded from the filesystem at runtime so it can
 // change per environment without rebuilding the binary.
@@ -38,9 +38,9 @@ import (
 // from OpenBao at startup via ref+openbao:// URIs in outputs.yaml.
 // The OpenBao provider is configured declaratively in the outputs.yaml
 // secrets: section — no programmatic provider setup is needed.
-func setupAuditLogger(m *auditMetrics) (*audit.Logger, error) {
+func setupAuditor(m *auditMetrics) (*audit.Auditor, error) {
 	configPath := envOr("AUDIT_CONFIG_PATH", "outputs.yaml")
-	return outputconfig.NewLogger(context.Background(), taxonomyYAML, configPath,
+	return outputconfig.New(context.Background(), taxonomyYAML, configPath,
 		[]outputconfig.LoadOption{
 			outputconfig.WithCoreMetrics(m),
 			outputconfig.WithOutputMetrics(m.newOutputMetricsFactory()),

--- a/examples/17-capstone/auth.go
+++ b/examples/17-capstone/auth.go
@@ -153,7 +153,7 @@ var credentials = map[string]string{
 // they ARE the security action, not a business action that happens
 // to need auth.
 type authHandlers struct {
-	logger   *audit.Logger
+	auditor  *audit.Auditor
 	sessions *sessionStore
 	rl       *rateLimiter
 	log      *slog.Logger
@@ -168,7 +168,7 @@ func (a *authHandlers) login(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		a.log.Warn("login: invalid request body", "ip", clientIP(r), "error", err)
 		a.rl.record(clientIP(r))
-		if auditErr := a.logger.AuditEvent(NewAuthFailureEvent("anonymous", "failure").
+		if auditErr := a.auditor.AuditEvent(NewAuthFailureEvent("anonymous", "failure").
 			SetReason("invalid request body").
 			SetSourceIP(clientIP(r))); auditErr != nil {
 			a.log.Error("audit event failed", "event_type", EventAuthFailure, "error", auditErr)
@@ -185,7 +185,7 @@ func (a *authHandlers) login(w http.ResponseWriter, r *http.Request) {
 	if !exists || subtle.ConstantTimeCompare(got[:], want[:]) != 1 {
 		a.log.Warn("login failed", "username", req.Username, "ip", clientIP(r))
 		a.rl.record(clientIP(r))
-		if auditErr := a.logger.AuditEvent(NewAuthFailureEvent(req.Username, "failure").
+		if auditErr := a.auditor.AuditEvent(NewAuthFailureEvent(req.Username, "failure").
 			SetReason("invalid credentials").
 			SetSourceIP(clientIP(r))); auditErr != nil {
 			a.log.Error("audit event failed", "event_type", EventAuthFailure, "error", auditErr)
@@ -196,7 +196,7 @@ func (a *authHandlers) login(w http.ResponseWriter, r *http.Request) {
 
 	a.log.Info("login successful", "username", req.Username, "ip", clientIP(r))
 	token := a.sessions.createToken(req.Username)
-	if auditErr := a.logger.AuditEvent(NewAuthSuccessEvent(req.Username, "success").
+	if auditErr := a.auditor.AuditEvent(NewAuthSuccessEvent(req.Username, "success").
 		SetSourceIP(clientIP(r))); auditErr != nil {
 		a.log.Error("audit event failed", "event_type", EventAuthSuccess, "error", auditErr)
 	}
@@ -225,7 +225,7 @@ func (a *authHandlers) logout(w http.ResponseWriter, r *http.Request) {
 				SetReason("invalid session").
 				SetSourceIP(clientIP(r))
 		}
-		if auditErr := a.logger.AuditEvent(ev); auditErr != nil {
+		if auditErr := a.auditor.AuditEvent(ev); auditErr != nil {
 			a.log.Error("audit event failed", "event_type", ev.EventType(), "error", auditErr)
 		}
 		writeLoginError(w, http.StatusUnauthorized, "invalid session")
@@ -233,7 +233,7 @@ func (a *authHandlers) logout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	a.sessions.revoke(token)
-	if auditErr := a.logger.AuditEvent(NewAuthLogoutEvent(username, "success").
+	if auditErr := a.auditor.AuditEvent(NewAuthLogoutEvent(username, "success").
 		SetSourceIP(clientIP(r))); auditErr != nil {
 		a.log.Error("audit event failed", "event_type", EventAuthLogout, "error", auditErr)
 	}

--- a/examples/17-capstone/main.go
+++ b/examples/17-capstone/main.go
@@ -52,10 +52,10 @@ func main() {
 	// Set up Prometheus metrics.
 	metrics := newMetrics()
 
-	// Set up audit logger with four outputs.
-	logger, err := setupAuditLogger(metrics)
+	// Set up audit auditor with four outputs.
+	auditor, err := setupAuditor(metrics)
 	if err != nil {
-		appLogger.Error("fatal: setup audit logger", "error", err)
+		appLogger.Error("fatal: setup audit auditor", "error", err)
 		return
 	}
 
@@ -81,7 +81,7 @@ func main() {
 	addr := envOr("LISTEN_ADDR", ":8080")
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           newServer(logger, db, sessions, rl, settings, withAppLogger(appLogger)),
+		Handler:           newServer(auditor, db, sessions, rl, settings, withAppLogger(appLogger)),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
@@ -90,7 +90,7 @@ func main() {
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 
 	// Emit startup audit event — good practice for compliance.
-	emitLifecycleEvent(logger, appLogger, NewAppStartupEvent("success").
+	emitLifecycleEvent(auditor, appLogger, NewAppStartupEvent("success").
 		SetMessage("inventory demo started on "+addr))
 
 	go func() {
@@ -111,21 +111,21 @@ func main() {
 	}
 
 	// Emit shutdown audit event — good practice for compliance.
-	emitLifecycleEvent(logger, appLogger, NewAppShutdownEvent("success").
+	emitLifecycleEvent(auditor, appLogger, NewAppShutdownEvent("success").
 		SetMessage("graceful shutdown initiated"))
 
-	// CRITICAL: Close the audit logger. This flushes all buffered events
+	// CRITICAL: Close the audit auditor. This flushes all buffered events
 	// to every output. Without this call, pending events are lost and the
 	// drain goroutine leaks. The shutdown event above is only delivered
 	// because Close() drains the buffer before returning.
-	if err := logger.Close(); err != nil {
-		appLogger.Warn("close logger", "error", err)
+	if err := auditor.Close(); err != nil {
+		appLogger.Warn("close auditor", "error", err)
 	}
 
 	appLogger.Info("shutdown complete")
 }
 
-// setupAppLogger creates a structured JSON logger writing to both
+// setupAppLogger creates a structured JSON application logger writing to both
 // a file (for Promtail → Loki) and stderr (for docker compose logs).
 func setupAppLogger() (*os.File, *slog.Logger) {
 	logPath := envOr("APP_LOG_PATH", "/data/app.log")
@@ -133,18 +133,18 @@ func setupAppLogger() (*os.File, *slog.Logger) {
 	if err != nil {
 		// Fall back to stderr only — Promtail won't see these logs
 		// but the app still works.
-		logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
-		logger.Warn("could not open app log file, using stderr only",
+		auditor := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+		auditor.Warn("could not open app log file, using stderr only",
 			"path", logPath, "error", err)
-		return nil, logger
+		return nil, auditor
 	}
 	// Write to both the file (for Promtail) and stderr (for docker compose logs).
 	w := io.MultiWriter(f, os.Stderr)
 	return f, slog.New(slog.NewJSONHandler(w, nil))
 }
 
-func emitLifecycleEvent(logger *audit.Logger, appLogger *slog.Logger, evt audit.Event) {
-	if err := logger.AuditEvent(evt); err != nil {
+func emitLifecycleEvent(auditor *audit.Auditor, appLogger *slog.Logger, evt audit.Event) {
+	if err := auditor.AuditEvent(evt); err != nil {
 		appLogger.Warn("audit lifecycle event failed", "error", err)
 	}
 }

--- a/examples/17-capstone/main_test.go
+++ b/examples/17-capstone/main_test.go
@@ -15,9 +15,9 @@
 // Unit tests for the CRUD API capstone example using audittest.
 //
 // These tests demonstrate how to verify audit events in a realistic
-// HTTP application using audittest.NewLogger and the full middleware
-// stack. The audit logger is wired with the production middleware,
-// so events flow through buildAuditEvent → collectFields → Logger
+// HTTP application using audittest.New and the full middleware
+// stack. The audit auditor is wired with the production middleware,
+// so events flow through buildAuditEvent → collectFields → Auditor
 // exactly as they do in the running application.
 package main
 
@@ -39,19 +39,19 @@ import (
 // on the recorder — events are async and need the drain goroutine
 // to flush.
 type testEnv struct {
-	srv    *httptest.Server
-	rec    *audittest.Recorder
-	logger interface{ Close() error }
+	srv     *httptest.Server
+	rec     *audittest.Recorder
+	auditor interface{ Close() error }
 }
 
-// Flush stops the HTTP server and closes the audit logger so all
+// Flush stops the HTTP server and closes the audit auditor so all
 // buffered events are visible in the recorder. Call this before
 // any assertions on the recorder. Safe to call multiple times.
 func (e *testEnv) Flush(t *testing.T) {
 	t.Helper()
 	e.srv.Close()
-	if closeErr := e.logger.Close(); closeErr != nil {
-		t.Errorf("logger close: %v", closeErr)
+	if closeErr := e.auditor.Close(); closeErr != nil {
+		t.Errorf("auditor close: %v", closeErr)
 	}
 }
 
@@ -71,16 +71,16 @@ func newTestServer(t *testing.T, dbSetup func(mock sqlmock.Sqlmock)) *testEnv {
 		}
 	})
 
-	logger, rec, _ := audittest.NewLogger(t, taxonomyYAML) // metrics not asserted
+	auditor, rec, _ := audittest.New(t, taxonomyYAML) // metrics not asserted
 	sessions := newSessionStore(30 * time.Minute)
 	rl := newRateLimiter(1*time.Minute, 5)
 	settings := newSettingsStore()
-	handler := newServer(logger, db, sessions, rl, settings)
+	handler := newServer(auditor, db, sessions, rl, settings)
 
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close) // safety net — prevents server leak on early failure
 
-	return &testEnv{srv: srv, rec: rec, logger: logger}
+	return &testEnv{srv: srv, rec: rec, auditor: auditor}
 }
 
 // doRequest makes an HTTP request with optional auth and body.

--- a/examples/17-capstone/outputs.yaml
+++ b/examples/17-capstone/outputs.yaml
@@ -24,9 +24,9 @@ secrets:
     allow_insecure_http: true    # Dev-only — NEVER in production
     allow_private_ranges: true   # Docker internal network
 
-logger:
+auditor:
   queue_size: ${AUDIT_QUEUE_SIZE:-10000}
-  drain_timeout: "${AUDIT_DRAIN_TIMEOUT:-5s}"
+  shutdown_timeout: "${AUDIT_SHUTDOWN_TIMEOUT:-5s}"
 
 outputs:
   # 1. Developer debugging — all events, full PII, no HMAC.

--- a/examples/17-capstone/ratelimit.go
+++ b/examples/17-capstone/ratelimit.go
@@ -75,7 +75,7 @@ func (rl *rateLimiter) allow(ip string) bool {
 // rateLimitMiddleware wraps a handler (typically /login) and blocks
 // requests from IPs that have exceeded the auth failure threshold.
 // When blocked, it emits a rate_limit_exceeded audit event directly.
-func rateLimitMiddleware(logger *audit.Logger, rl *rateLimiter, appLog ...*slog.Logger) func(http.Handler) http.Handler {
+func rateLimitMiddleware(auditor *audit.Auditor, rl *rateLimiter, appLog ...*slog.Logger) func(http.Handler) http.Handler {
 	var lg *slog.Logger
 	if len(appLog) > 0 {
 		lg = appLog[0]
@@ -92,7 +92,7 @@ func rateLimitMiddleware(logger *audit.Logger, rl *rateLimiter, appLog ...*slog.
 				if ip != "" {
 					ev.SetSourceIP(ip)
 				}
-				if err := logger.AuditEvent(ev); err != nil {
+				if err := auditor.AuditEvent(ev); err != nil {
 					lg.Error("audit event failed", "event_type", EventRateLimitExceeded, "error", err)
 				}
 				lg.Warn("rate limit exceeded", "ip", ip)

--- a/examples/17-capstone/server.go
+++ b/examples/17-capstone/server.go
@@ -64,7 +64,7 @@ func withAppLogger(l *slog.Logger) func(*serverOpts) {
 //
 // Login/logout emit audit events directly because they ARE the
 // security action. CRUD routes emit events via the audit middleware.
-func newServer(logger *audit.Logger, db *sql.DB, sessions *sessionStore, rl *rateLimiter, settings *settingsStore, opts ...func(*serverOpts)) http.Handler {
+func newServer(auditor *audit.Auditor, db *sql.DB, sessions *sessionStore, rl *rateLimiter, settings *settingsStore, opts ...func(*serverOpts)) http.Handler {
 	so := &serverOpts{log: slog.Default()}
 	for _, o := range opts {
 		o(so)
@@ -81,16 +81,16 @@ func newServer(logger *audit.Logger, db *sql.DB, sessions *sessionStore, rl *rat
 
 	// Apply middleware: auth first, then audit.
 	authed := authMiddleware(sessions)(innerMux)
-	audited := audit.Middleware(logger, buildAuditEvent)(authed)
+	audited := audit.Middleware(auditor, buildAuditEvent)(authed)
 
 	// --- Outer mux: auth endpoints (self-auditing, no middleware) ---
 	outerMux := http.NewServeMux()
 
-	authH := &authHandlers{logger: logger, sessions: sessions, rl: rl, log: so.log}
+	authH := &authHandlers{auditor: auditor, sessions: sessions, rl: rl, log: so.log}
 
 	// Login is wrapped by rate limiter. Logout is not.
 	outerMux.Handle("POST /login",
-		rateLimitMiddleware(logger, rl)(http.HandlerFunc(authH.login)))
+		rateLimitMiddleware(auditor, rl)(http.HandlerFunc(authH.login)))
 	outerMux.HandleFunc("POST /logout", authH.logout)
 
 	// Web UI — served directly, not audited (page loads are not audit events).

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,10 +9,10 @@ Each example introduces one new concept and builds on the previous.
 
 | # | Example | What it teaches |
 |---|---------|-----------------|
-| 1 | [basic](01-basic/) | Taxonomy, Logger, AuditEvent(), Fields, validation — programmatic setup |
+| 1 | [basic](01-basic/) | Taxonomy, Auditor, AuditEvent(), Fields, validation — programmatic setup |
 | 2 | [code-generation](02-code-generation/) | YAML taxonomy, audit-gen, typed builders, go:embed, outputconfig.Load |
 | 3 | [file-output](03-file-output/) | File output with rotation and permissions in YAML |
-| 4 | [testing](04-testing/) | Testing audit events with audittest.NewLogger |
+| 4 | [testing](04-testing/) | Testing audit events with audittest.New |
 | 5 | [formatters](05-formatters/) | JSON vs CEF with category severity levels |
 | 6 | [middleware](06-middleware/) | Automatic HTTP audit logging with Hints |
 | 7 | [syslog-output](07-syslog-output/) | Syslog output with RFC 5424, TCP/UDP/TLS, facility values |

--- a/fanout.go
+++ b/fanout.go
@@ -37,11 +37,11 @@ import (
 
 // outputEntry bundles an [Output] with its per-output [EventRoute] and
 // optional [Formatter] override. The route may be changed at runtime
-// via [Logger.SetOutputRoute]; access is lock-free via atomic.Pointer.
+// via [Auditor.SetOutputRoute]; access is lock-free via atomic.Pointer.
 type outputEntry struct {
 	output         Output
 	metadataWriter MetadataWriter      // cached at construction; nil if output doesn't implement
-	formatter      Formatter           // nil = use logger's default formatter
+	formatter      Formatter           // nil = use auditor's default formatter
 	excludedLabels map[string]struct{} // nil = no sensitivity exclusions
 	formatOpts     *FormatOptions      // pre-allocated; nil when no exclusions
 	hmacConfig     *HMACConfig         // nil = no HMAC for this output
@@ -51,7 +51,7 @@ type outputEntry struct {
 }
 
 // hmacState holds a pre-constructed hash.Hash and reusable buffers for
-// HMAC computation. Created once at logger construction; used
+// HMAC computation. Created once at auditor construction; used
 // exclusively by the single drain goroutine — no synchronisation needed.
 type hmacState struct {
 	mac     hash.Hash // reset+reuse per event

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -30,15 +30,15 @@ func TestFanout_DeliverToAll(t *testing.T) {
 	out1 := testhelper.NewMockOutput("out1")
 	out2 := testhelper.NewMockOutput("out2")
 	out3 := testhelper.NewMockOutput("out3")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1, out2, out3),
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	for _, out := range []*testhelper.MockOutput{out1, out2, out3} {
 		assert.Equal(t, 1, out.EventCount(),
@@ -50,15 +50,15 @@ func TestFanout_OutputFailureIsolation(t *testing.T) {
 	failing := testhelper.NewMockOutput("failing")
 	failing.SetWriteErr(assert.AnError)
 	healthy := testhelper.NewMockOutput("healthy")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(failing, healthy),
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 1, healthy.EventCount(),
 		"healthy output should receive event despite failing output")
@@ -130,7 +130,7 @@ func TestFanout_RouteFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := testhelper.NewMockOutput("routed")
-			logger, err := audit.NewLogger(
+			auditor, err := audit.New(
 				audit.WithValidationMode(audit.ValidationPermissive),
 				audit.WithTaxonomy(testhelper.TestTaxonomy()),
 				audit.WithNamedOutput(out, audit.OutputRoute(&tt.route)),
@@ -138,9 +138,9 @@ func TestFanout_RouteFiltering(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, evt := range tt.events {
-				require.NoError(t, logger.AuditEvent(audit.NewEvent(evt, audit.Fields{"outcome": "success"})))
+				require.NoError(t, auditor.AuditEvent(audit.NewEvent(evt, audit.Fields{"outcome": "success"})))
 			}
-			require.NoError(t, logger.Close())
+			require.NoError(t, auditor.Close())
 
 			assert.Equal(t, tt.wantCount, out.EventCount())
 		})
@@ -150,7 +150,7 @@ func TestFanout_RouteFiltering(t *testing.T) {
 func TestFanout_DuplicateOutputName_Error(t *testing.T) {
 	out1 := testhelper.NewMockOutput("same-name")
 	out2 := testhelper.NewMockOutput("same-name")
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1, out2),
 	)
@@ -161,7 +161,7 @@ func TestFanout_DuplicateOutputName_Error(t *testing.T) {
 func TestFanout_WithOutputs_AfterWithNamedOutput_Error(t *testing.T) {
 	out1 := testhelper.NewMockOutput("named")
 	out2 := testhelper.NewMockOutput("plain")
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out1, audit.OutputRoute(&audit.EventRoute{})),
 		audit.WithOutputs(out2), // should error
@@ -173,7 +173,7 @@ func TestFanout_WithOutputs_AfterWithNamedOutput_Error(t *testing.T) {
 func TestFanout_WithNamedOutput_AfterWithOutputs_Error(t *testing.T) {
 	out1 := testhelper.NewMockOutput("plain")
 	out2 := testhelper.NewMockOutput("named")
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1),
 		audit.WithNamedOutput(out2, audit.OutputRoute(&audit.EventRoute{})), // should error
@@ -184,7 +184,7 @@ func TestFanout_WithNamedOutput_AfterWithOutputs_Error(t *testing.T) {
 
 func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
@@ -196,7 +196,7 @@ func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 
 func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
@@ -209,7 +209,7 @@ func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 
 func TestFanout_SetOutputRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("routed")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
@@ -217,17 +217,17 @@ func TestFanout_SetOutputRoute(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initially receives all events.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 
 	// Set route to security only.
-	require.NoError(t, logger.SetOutputRoute("routed", &audit.EventRoute{
+	require.NoError(t, auditor.SetOutputRoute("routed", &audit.EventRoute{
 		IncludeCategories: []string{"security"},
 	}))
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_delete", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_delete", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
+	require.NoError(t, auditor.Close())
 
 	// Should have: 1 initial + 1 auth_failure = 2 (user_delete filtered).
 	assert.Equal(t, 2, out.EventCount())
@@ -236,7 +236,7 @@ func TestFanout_SetOutputRoute(t *testing.T) {
 func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 	outA := testhelper.NewMockOutput("a")
 	outB := testhelper.NewMockOutput("b")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(outA, audit.OutputRoute(&audit.EventRoute{})),
@@ -245,40 +245,40 @@ func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Restrict A to security only.
-	require.NoError(t, logger.SetOutputRoute("a", &audit.EventRoute{
+	require.NoError(t, auditor.SetOutputRoute("a", &audit.EventRoute{
 		IncludeCategories: []string{"security"},
 	}))
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 1, outA.EventCount(), "A should only get auth_failure")
 	assert.Equal(t, 2, outB.EventCount(), "B should get both events")
 }
 
 func TestFanout_SetOutputRoute_UnknownOutput(t *testing.T) {
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.SetOutputRoute("nonexistent", &audit.EventRoute{})
+	err = auditor.SetOutputRoute("nonexistent", &audit.EventRoute{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown output")
 }
 
 func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.SetOutputRoute("test", &audit.EventRoute{
+	err = auditor.SetOutputRoute("test", &audit.EventRoute{
 		IncludeCategories: []string{"bogus"},
 	})
 	require.Error(t, err)
@@ -287,7 +287,7 @@ func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 
 func TestFanout_ClearOutputRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("routed")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
@@ -297,22 +297,22 @@ func TestFanout_ClearOutputRoute(t *testing.T) {
 	require.NoError(t, err)
 
 	// Clear route — now receives all events.
-	require.NoError(t, logger.ClearOutputRoute("routed"))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.ClearOutputRoute("routed"))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 2, out.EventCount(), "should receive all events after clearing route")
 }
 
 func TestFanout_ClearOutputRoute_UnknownOutput(t *testing.T) {
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.ClearOutputRoute("nonexistent")
+	err = auditor.ClearOutputRoute("nonexistent")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown output")
 }
@@ -320,62 +320,62 @@ func TestFanout_ClearOutputRoute_UnknownOutput(t *testing.T) {
 func TestFanout_OutputRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	route := audit.EventRoute{IncludeCategories: []string{"security"}}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&route)),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	got, err := logger.OutputRoute("test")
+	got, err := auditor.OutputRoute("test")
 	require.NoError(t, err)
 	assert.Equal(t, route.IncludeCategories, got.IncludeCategories)
 
 	// Mutating the returned route must not affect the stored route.
 	got.IncludeCategories = append(got.IncludeCategories, "write")
-	got2, err := logger.OutputRoute("test")
+	got2, err := auditor.OutputRoute("test")
 	require.NoError(t, err)
 	assert.Len(t, got2.IncludeCategories, 1, "stored route should not be mutated")
 }
 
 func TestFanout_OutputRoute_UnknownOutput(t *testing.T) {
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	_, err = logger.OutputRoute("nonexistent")
+	_, err = auditor.OutputRoute("nonexistent")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown output")
 }
 
 func TestFanout_OutputRoute_ReflectsSetAndClear(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// Set a route.
 	newRoute := audit.EventRoute{IncludeCategories: []string{"write"}}
-	require.NoError(t, logger.SetOutputRoute("test", &newRoute))
-	got, err := logger.OutputRoute("test")
+	require.NoError(t, auditor.SetOutputRoute("test", &newRoute))
+	got, err := auditor.OutputRoute("test")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"write"}, got.IncludeCategories)
 
 	// Clear.
-	require.NoError(t, logger.ClearOutputRoute("test"))
-	got, err = logger.OutputRoute("test")
+	require.NoError(t, auditor.ClearOutputRoute("test"))
+	got, err = auditor.OutputRoute("test")
 	require.NoError(t, err)
 	assert.True(t, got.IsEmpty())
 }
 
 func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 	out := testhelper.NewMockOutput("concurrent")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
@@ -388,22 +388,22 @@ func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for range 100 {
-			_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+			_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 		}
 	}()
 
 	go func() {
 		defer wg.Done()
 		for range 50 {
-			_ = logger.SetOutputRoute("concurrent", &audit.EventRoute{
+			_ = auditor.SetOutputRoute("concurrent", &audit.EventRoute{
 				IncludeCategories: []string{"security"},
 			})
-			_ = logger.ClearOutputRoute("concurrent")
+			_ = auditor.ClearOutputRoute("concurrent")
 		}
 	}()
 
 	wg.Wait()
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// All events are security category, so they should all arrive
 	// regardless of route toggling (include security = match, empty = match).
@@ -413,7 +413,7 @@ func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 
 func TestFanout_GlobalFilterTakesPrecedence(t *testing.T) {
 	out := testhelper.NewMockOutput("all")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
@@ -433,9 +433,9 @@ func TestFanout_GlobalFilterTakesPrecedence(t *testing.T) {
 	require.NoError(t, err)
 
 	// Disable security globally — should not reach output even though route includes it.
-	require.NoError(t, logger.DisableCategory("security"))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.DisableCategory("security"))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 0, out.EventCount(),
 		"globally disabled event should not reach any output")
@@ -451,7 +451,7 @@ func TestFanout_PerOutputFormatter(t *testing.T) {
 		Version: "1.0",
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(jsonOut, audit.OutputRoute(&audit.EventRoute{})),
@@ -459,8 +459,8 @@ func TestFanout_PerOutputFormatter(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	require.Equal(t, 1, jsonOut.EventCount())
 	require.Equal(t, 1, cefOut.EventCount())
@@ -474,7 +474,7 @@ func TestFanout_PerOutputFormatter(t *testing.T) {
 
 func TestFanout_PanicInFormatter_DrainLoopSurvives(t *testing.T) {
 	out := testhelper.NewMockOutput("survivor")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{}), audit.OutputFormatter(&panicFormatter{})),
@@ -482,10 +482,10 @@ func TestFanout_PanicInFormatter_DrainLoopSurvives(t *testing.T) {
 	require.NoError(t, err)
 
 	// The panic is recovered by processEntry — drain loop survives.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
 	// Second event also processed (drain loop not dead).
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_delete", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_delete", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	// Events are lost due to panic, but the drain loop is alive.
 	assert.Equal(t, 0, out.EventCount())
@@ -502,7 +502,7 @@ func TestFanout_PanicInOutputWrite_OtherOutputsStillReceive(t *testing.T) {
 	panicOut := &panicOnWriteOutput{MockOutput: *testhelper.NewMockOutput("panicker")}
 	survivor := testhelper.NewMockOutput("survivor")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(panicOut, survivor),
 	)
@@ -510,11 +510,11 @@ func TestFanout_PanicInOutputWrite_OtherOutputsStillReceive(t *testing.T) {
 
 	// The panic in panicOut.Write is recovered per-output.
 	// The survivor output must still receive the event.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 0, panicOut.EventCount(), "panicking output should have 0 events (panic before recording)")
 	assert.Equal(t, 1, survivor.EventCount(), "survivor output must receive the event despite earlier panic")
@@ -533,15 +533,15 @@ func TestFanout_SharedFormatter_DeliversSameBytes(t *testing.T) {
 	out1 := testhelper.NewMockOutput("a")
 	out2 := testhelper.NewMockOutput("b")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1, out2), // same default formatter
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	require.Equal(t, 1, out1.EventCount())
 	require.Equal(t, 1, out2.EventCount())
@@ -555,7 +555,7 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 	out := testhelper.NewMockOutput("filtered")
 	metrics := testhelper.NewMockMetrics()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithMetrics(metrics),
@@ -566,8 +566,8 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 	require.NoError(t, err)
 
 	// This write event will be filtered by the per-output route.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 0, out.EventCount())
 	assert.Greater(t, metrics.GetOutputFiltered("filtered"), 0,
@@ -576,7 +576,7 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 
 func TestFanout_ExcludeEventType_EndToEnd(t *testing.T) {
 	out := testhelper.NewMockOutput("no-config-get")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
@@ -585,10 +585,10 @@ func TestFanout_ExcludeEventType_EndToEnd(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("config_get", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_get", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("config_get", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_get", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 2, out.EventCount(), "config_get should be excluded")
 }
@@ -604,7 +604,7 @@ func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 	goodOut := testhelper.NewMockOutput("good")
 	badOut := testhelper.NewMockOutput("bad")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithNamedOutput(goodOut, audit.OutputRoute(&audit.EventRoute{})),
@@ -612,8 +612,8 @@ func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 1, goodOut.EventCount(),
 		"good output should receive event despite error formatter on other output")
@@ -627,7 +627,7 @@ func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 // detector verifies no data races on the syncmap.
 func TestFanout_ConcurrentEventOverrideAndAudit(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out),
@@ -641,8 +641,8 @@ func TestFanout_ConcurrentEventOverrideAndAudit(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for range 100 {
-			_ = logger.DisableEvent("auth_failure")
-			_ = logger.EnableEvent("auth_failure")
+			_ = auditor.DisableEvent("auth_failure")
+			_ = auditor.EnableEvent("auth_failure")
 		}
 	}()
 
@@ -650,12 +650,12 @@ func TestFanout_ConcurrentEventOverrideAndAudit(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for range 100 {
-			_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+			_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 		}
 	}()
 
 	wg.Wait()
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	// Count is non-deterministic due to concurrent enable/disable.
 	// The test passes iff the race detector reports no data race.
 }

--- a/file/file.go
+++ b/file/file.go
@@ -152,8 +152,8 @@ type Output struct {
 	mu            sync.Mutex
 }
 
-// SetLogger receives the library's diagnostic logger.
-func (f *Output) SetLogger(l *slog.Logger) {
+// SetDiagnosticLogger receives the library's diagnostic logger.
+func (f *Output) SetDiagnosticLogger(l *slog.Logger) {
 	f.logger = l
 }
 
@@ -204,7 +204,7 @@ func New(cfg Config, fileMetrics Metrics) (*Output, error) { //nolint:gocyclo,cy
 		return nil, fmt.Errorf("audit: file output permissions %q: %w", cfg.Permissions, err)
 	}
 
-	// Default logger — replaced by SetLogger when the core calls it.
+	// Default logger — replaced by SetDiagnosticLogger when the core calls it.
 	logger := slog.Default()
 
 	// Warn if permissions grant group or world access to audit data.

--- a/format.go
+++ b/format.go
@@ -82,7 +82,7 @@ type Formatter interface {
 }
 
 // FrameworkFieldSetter is implemented by formatters that emit
-// logger-wide framework metadata (app_name, host, timezone, pid) in
+// auditor-wide framework metadata (app_name, host, timezone, pid) in
 // serialised output. The library calls SetFrameworkFields once at
 // construction time, after all options are applied and before the
 // first Format call.

--- a/format_cef.go
+++ b/format_cef.go
@@ -343,7 +343,7 @@ func (cf *CEFFormatter) fieldMapping() map[string]string {
 	return cf.resolvedMapping
 }
 
-// SetFrameworkFields stores logger-wide framework metadata for
+// SetFrameworkFields stores auditor-wide framework metadata for
 // emission in every CEF event. Called once at construction time.
 func (cf *CEFFormatter) SetFrameworkFields(appName, host, timezone string, pid int) {
 	cf.appName = appName

--- a/format_json.go
+++ b/format_json.go
@@ -138,7 +138,7 @@ func (jf *JSONFormatter) writeDuration(enc *jsonEncoder, fields Fields) {
 	}
 }
 
-// SetFrameworkFields stores logger-wide framework metadata for
+// SetFrameworkFields stores auditor-wide framework metadata for
 // emission in every JSON event. Called once at construction time.
 func (jf *JSONFormatter) SetFrameworkFields(appName, host, timezone string, pid int) {
 	jf.appName = appName

--- a/format_test.go
+++ b/format_test.go
@@ -796,7 +796,7 @@ func TestCEFFormatter_HeaderPipeInjection(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Logger integration tests
+// Auditor integration tests
 // ---------------------------------------------------------------------------
 
 func TestLogger_WithFormatter_Custom(t *testing.T) {
@@ -809,15 +809,15 @@ func TestLogger_WithFormatter_Custom(t *testing.T) {
 		},
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithFormatter(custom),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
@@ -836,14 +836,14 @@ func (s *stubFormatter) Format(ts time.Time, eventType string, fields audit.Fiel
 
 func TestLogger_DefaultJSONFormatter(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
@@ -864,15 +864,15 @@ func TestLogger_CEFViaWithFormatter(t *testing.T) {
 		Version: "2.0",
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithFormatter(cef),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
@@ -884,7 +884,7 @@ func TestLogger_CEFViaWithFormatter(t *testing.T) {
 }
 
 func TestLogger_WithFormatter_Nil(t *testing.T) {
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithFormatter(nil),
 	)

--- a/hmac.go
+++ b/hmac.go
@@ -125,11 +125,11 @@ func ValidateHMACConfig(cfg *HMACConfig) error {
 }
 
 // newHMACState creates a pre-constructed hmacState for drain-loop reuse.
-// Called once at logger construction per HMAC-enabled output.
+// Called once at auditor construction per HMAC-enabled output.
 func newHMACState(cfg *HMACConfig) *hmacState {
 	hashFunc := hmacHashFunc(cfg.Algorithm)
 	if hashFunc == nil {
-		return nil // unreachable: ValidateHMACConfig rejects unknown algorithms during NewLogger
+		return nil // unreachable: ValidateHMACConfig rejects unknown algorithms during New
 	}
 	mac := hmac.New(hashFunc, cfg.SaltValue)
 	return &hmacState{

--- a/introspect.go
+++ b/introspect.go
@@ -17,32 +17,32 @@ package audit
 import "slices"
 
 // QueueLen returns the number of events currently queued in the async
-// intake queue. Returns 0 for disabled or synchronous loggers.
-func (l *Logger) QueueLen() int {
-	if l.ch == nil {
+// intake queue. Returns 0 for disabled or synchronous auditors.
+func (a *Auditor) QueueLen() int {
+	if a.ch == nil {
 		return 0
 	}
-	return len(l.ch)
+	return len(a.ch)
 }
 
 // QueueCap returns the configured async intake queue capacity. Returns
-// 0 for disabled or synchronous loggers.
-func (l *Logger) QueueCap() int {
-	if l.ch == nil {
+// 0 for disabled or synchronous auditors.
+func (a *Auditor) QueueCap() int {
+	if a.ch == nil {
 		return 0
 	}
-	return cap(l.ch)
+	return cap(a.ch)
 }
 
 // OutputNames returns a sorted list of all configured output names.
-// Safe for concurrent use. Returns nil for disabled loggers with no
+// Safe for concurrent use. Returns nil for disabled auditors with no
 // outputs.
-func (l *Logger) OutputNames() []string {
-	if len(l.entries) == 0 {
+func (a *Auditor) OutputNames() []string {
+	if len(a.entries) == 0 {
 		return nil
 	}
-	names := make([]string, len(l.entries))
-	for i, oe := range l.entries {
+	names := make([]string, len(a.entries))
+	for i, oe := range a.entries {
 		names[i] = oe.output.Name()
 	}
 	slices.Sort(names)
@@ -51,17 +51,17 @@ func (l *Logger) OutputNames() []string {
 
 // IsCategoryEnabled reports whether events in the named category
 // would be delivered. This accounts for both category-level state
-// and per-event overrides. Returns false for disabled loggers or
+// and per-event overrides. Returns false for disabled auditors or
 // unknown categories.
-func (l *Logger) IsCategoryEnabled(category string) bool {
-	if l.disabled || l.taxonomy == nil || l.filter == nil {
+func (a *Auditor) IsCategoryEnabled(category string) bool {
+	if a.disabled || a.taxonomy == nil || a.filter == nil {
 		return false
 	}
-	if _, ok := l.taxonomy.Categories[category]; !ok {
+	if _, ok := a.taxonomy.Categories[category]; !ok {
 		return false
 	}
 	// Check category state via the filter's atomic map.
-	if enabled, ok := l.filter.enabledCategories.Load(category); ok {
+	if enabled, ok := a.filter.enabledCategories.Load(category); ok {
 		return enabled
 	}
 	return true // default-enabled
@@ -69,23 +69,23 @@ func (l *Logger) IsCategoryEnabled(category string) bool {
 
 // IsEventEnabled reports whether the named event type would be
 // delivered. This accounts for category state, per-event overrides,
-// and the global filter. Returns false for disabled loggers or
+// and the global filter. Returns false for disabled auditors or
 // unknown event types.
-func (l *Logger) IsEventEnabled(eventType string) bool {
-	if l.disabled || l.taxonomy == nil || l.filter == nil {
+func (a *Auditor) IsEventEnabled(eventType string) bool {
+	if a.disabled || a.taxonomy == nil || a.filter == nil {
 		return false
 	}
-	return l.filter.isEnabled(eventType, l.taxonomy)
+	return a.filter.isEnabled(eventType, a.taxonomy)
 }
 
-// IsDisabled reports whether the logger is a no-op (created with
+// IsDisabled reports whether the auditor is a no-op (created with
 // [WithDisabled]).
-func (l *Logger) IsDisabled() bool {
-	return l.disabled
+func (a *Auditor) IsDisabled() bool {
+	return a.disabled
 }
 
-// IsSynchronous reports whether the logger delivers events inline
-// within [Logger.AuditEvent] (created with [WithSynchronousDelivery]).
-func (l *Logger) IsSynchronous() bool {
-	return l.synchronous
+// IsSynchronous reports whether the auditor delivers events inline
+// within [Auditor.AuditEvent] (created with [WithSynchronousDelivery]).
+func (a *Auditor) IsSynchronous() bool {
+	return a.synchronous
 }

--- a/introspect_test.go
+++ b/introspect_test.go
@@ -26,117 +26,117 @@ import (
 
 func TestQueueCap_ReturnsConfiguredSize(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(500),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	assert.Equal(t, 500, logger.QueueCap())
+	assert.Equal(t, 500, auditor.QueueCap())
 }
 
 func TestQueueLen_ReturnsCurrentOccupancy(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// QueueLen starts at 0 (drain goroutine may process immediately).
-	assert.GreaterOrEqual(t, logger.QueueLen(), 0)
+	assert.GreaterOrEqual(t, auditor.QueueLen(), 0)
 }
 
 func TestOutputNames_ReturnsSortedNames(t *testing.T) {
 	t.Parallel()
 	outB := testhelper.NewMockOutput("beta")
 	outA := testhelper.NewMockOutput("alpha")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(outB, outA),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	names := logger.OutputNames()
+	names := auditor.OutputNames()
 	assert.Equal(t, []string{"alpha", "beta"}, names)
 }
 
 func TestIsCategoryEnabled_ReturnsCorrectState(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	assert.True(t, logger.IsCategoryEnabled("security"), "security category should be enabled by default")
-	assert.False(t, logger.IsCategoryEnabled("nonexistent"), "unknown category should return false")
+	assert.True(t, auditor.IsCategoryEnabled("security"), "security category should be enabled by default")
+	assert.False(t, auditor.IsCategoryEnabled("nonexistent"), "unknown category should return false")
 
-	require.NoError(t, logger.DisableCategory("security"))
-	assert.False(t, logger.IsCategoryEnabled("security"), "disabled category should return false")
+	require.NoError(t, auditor.DisableCategory("security"))
+	assert.False(t, auditor.IsCategoryEnabled("security"), "disabled category should return false")
 }
 
 func TestIsEventEnabled_ReturnsCorrectState(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	assert.True(t, logger.IsEventEnabled("auth_failure"), "registered event should be enabled")
-	assert.False(t, logger.IsEventEnabled("nonexistent"), "unknown event should return false")
+	assert.True(t, auditor.IsEventEnabled("auth_failure"), "registered event should be enabled")
+	assert.False(t, auditor.IsEventEnabled("nonexistent"), "unknown event should return false")
 }
 
 func TestIntrospection_DisabledLogger_ReturnsZero(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	assert.Equal(t, 0, logger.QueueLen())
-	assert.Equal(t, 0, logger.QueueCap())
-	assert.True(t, logger.IsDisabled())
-	assert.False(t, logger.IsCategoryEnabled("security"))
-	assert.False(t, logger.IsEventEnabled("auth_failure"))
+	assert.Equal(t, 0, auditor.QueueLen())
+	assert.Equal(t, 0, auditor.QueueCap())
+	assert.True(t, auditor.IsDisabled())
+	assert.False(t, auditor.IsCategoryEnabled("security"))
+	assert.False(t, auditor.IsEventEnabled("auth_failure"))
 }
 
-func TestIntrospection_SyncLogger(t *testing.T) {
+func TestIntrospection_SyncAuditor(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithSynchronousDelivery(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	assert.True(t, logger.IsSynchronous())
-	assert.False(t, logger.IsDisabled())
-	assert.Equal(t, 0, logger.QueueLen(), "sync logger has no buffer")
-	assert.Equal(t, 0, logger.QueueCap(), "sync logger has no buffer")
+	assert.True(t, auditor.IsSynchronous())
+	assert.False(t, auditor.IsDisabled())
+	assert.Equal(t, 0, auditor.QueueLen(), "sync auditor has no buffer")
+	assert.Equal(t, 0, auditor.QueueCap(), "sync auditor has no buffer")
 }
 
 func TestIntrospection_ConcurrentWithAuditEvent_NoRace(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	var wg sync.WaitGroup
 	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+			_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 				"outcome":  "failure",
 				"actor_id": "bob",
 			}))
@@ -144,13 +144,13 @@ func TestIntrospection_ConcurrentWithAuditEvent_NoRace(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = logger.QueueLen()
-			_ = logger.QueueCap()
-			_ = logger.OutputNames()
-			_ = logger.IsCategoryEnabled("security")
-			_ = logger.IsEventEnabled("auth_failure")
-			_ = logger.IsDisabled()
-			_ = logger.IsSynchronous()
+			_ = auditor.QueueLen()
+			_ = auditor.QueueCap()
+			_ = auditor.OutputNames()
+			_ = auditor.IsCategoryEnabled("security")
+			_ = auditor.IsEventEnabled("auth_failure")
+			_ = auditor.IsDisabled()
+			_ = auditor.IsSynchronous()
 		}()
 	}
 	wg.Wait()

--- a/loki/loki.go
+++ b/loki/loki.go
@@ -57,7 +57,7 @@ type lokiEntry struct { //nolint:govet // fieldalignment: readability preferred
 	metadata audit.EventMetadata // per-event fields for stream labels
 }
 
-// frameworkFields holds logger-wide constant metadata used for Loki
+// frameworkFields holds auditor-wide constant metadata used for Loki
 // stream labels. Stored atomically to avoid data races between the
 // core library's SetFrameworkFields call and the batchLoop goroutine.
 type frameworkFields struct {
@@ -177,16 +177,16 @@ func New(cfg *Config, metrics audit.Metrics) (*Output, error) {
 	return o, nil
 }
 
-// SetFrameworkFields receives logger-wide framework metadata for use
-// as Loki stream labels. Called once by the core library at logger
+// SetFrameworkFields receives auditor-wide framework metadata for use
+// as Loki stream labels. Called once by the core library at auditor
 // construction time. The data is stored atomically, safe for
 // concurrent access from the batchLoop goroutine.
 func (o *Output) SetFrameworkFields(appName, host, timezone string, pid int) {
 	o.fw.Store(&frameworkFields{appName: appName, host: host, timezone: timezone, pid: pid})
 }
 
-// SetLogger receives the library's diagnostic logger.
-func (o *Output) SetLogger(l *slog.Logger) {
+// SetDiagnosticLogger receives the library's diagnostic logger.
+func (o *Output) SetDiagnosticLogger(l *slog.Logger) {
 	o.logger = l
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -28,7 +28,7 @@ import "time"
 //
 // # Ownership: Metrics vs OutputMetrics
 //
-// [Metrics] records pipeline-level counters that span the entire logger:
+// [Metrics] records pipeline-level counters that span the entire auditor:
 //
 //   - RecordSubmitted — total events entering the pipeline
 //   - RecordEvent — per-output delivery outcome (for non-self-reporting outputs)
@@ -46,11 +46,11 @@ import "time"
 //
 // For outputs that implement [DeliveryReporter] (webhook, loki, file,
 // syslog), the output itself calls RecordEvent after actual delivery.
-// The core logger skips RecordEvent for these outputs to avoid
+// The core auditor skips RecordEvent for these outputs to avoid
 // phantom success counting.
 type Metrics interface {
 	// RecordSubmitted records that an event was submitted to the
-	// pipeline via [Logger.AuditEvent]. Called once per AuditEvent
+	// pipeline via [Auditor.AuditEvent]. Called once per AuditEvent
 	// call, before any filtering or buffering. This is the "total
 	// events in" counter.
 	RecordSubmitted()
@@ -69,7 +69,7 @@ type Metrics interface {
 	// global category/event filter drops before any output is reached.
 	RecordOutputFiltered(output string)
 
-	// RecordValidationError records that [Logger.AuditEvent] rejected an
+	// RecordValidationError records that [Auditor.AuditEvent] rejected an
 	// event due to a validation failure: unknown event type, missing
 	// required fields, or unknown fields in strict mode. The
 	// eventType parameter is the event type string that was passed to

--- a/middleware.go
+++ b/middleware.go
@@ -123,7 +123,7 @@ type TransportMetadata struct {
 // after the handler returns (or panics).
 //
 // Return values:
-//   - eventType: the taxonomy event type name to pass to [Logger.AuditEvent]
+//   - eventType: the taxonomy event type name to pass to [Auditor.AuditEvent]
 //   - fields: the audit event fields
 //   - skip: if true, no audit event is emitted for this request
 type EventBuilder func(hints *Hints, transport *TransportMetadata) (eventType string, fields Fields, skip bool)
@@ -140,17 +140,17 @@ func HintsFromContext(ctx context.Context) *Hints {
 // returns. The builder transforms [Hints] (populated by the handler)
 // and [TransportMetadata] into an audit event.
 //
-// If logger is nil, the returned middleware is an identity function
+// If auditor is nil, the returned middleware is an identity function
 // that passes requests through without auditing. This allows
 // consumers to conditionally disable audit middleware without
 // nil-checking at every call site.
 //
 // Middleware panics if builder is nil. Passing a nil builder is a
 // programming error: there is no recoverable behaviour when the
-// event-building callback is absent. Pass a nil *[Logger] instead
+// event-building callback is absent. Pass a nil *[Auditor] instead
 // to disable auditing without removing the middleware.
-func Middleware(logger *Logger, builder EventBuilder) func(http.Handler) http.Handler {
-	if logger == nil {
+func Middleware(auditor *Auditor, builder EventBuilder) func(http.Handler) http.Handler {
+	if auditor == nil {
 		return func(next http.Handler) http.Handler { return next }
 	}
 	if builder == nil {
@@ -158,14 +158,14 @@ func Middleware(logger *Logger, builder EventBuilder) func(http.Handler) http.Ha
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			serveAudit(w, r, next, logger, builder)
+			serveAudit(w, r, next, auditor, builder)
 		})
 	}
 }
 
 // serveAudit is the per-request handler logic extracted from
 // [Middleware] to keep cognitive complexity within bounds.
-func serveAudit(w http.ResponseWriter, r *http.Request, next http.Handler, logger *Logger, builder EventBuilder) {
+func serveAudit(w http.ResponseWriter, r *http.Request, next http.Handler, auditor *Auditor, builder EventBuilder) {
 	hints := &Hints{}
 	ctx := context.WithValue(r.Context(), hintsKey{}, hints)
 	r = r.WithContext(ctx)
@@ -196,7 +196,7 @@ func serveAudit(w http.ResponseWriter, r *http.Request, next http.Handler, logge
 		Duration:          time.Since(start),
 	}
 
-	emitAuditEvent(logger, builder, hints, transport)
+	emitAuditEvent(auditor, builder, hints, transport)
 
 	if panicked {
 		panic(panicVal)
@@ -223,7 +223,7 @@ func invokeHandler(next http.Handler, rw *responseWriter, r *http.Request) (pani
 
 // emitAuditEvent calls the EventBuilder and, if not skipped, emits
 // the audit event. Builder panics are recovered and logged.
-func emitAuditEvent(logger *Logger, builder EventBuilder, hints *Hints, transport *TransportMetadata) {
+func emitAuditEvent(auditor *Auditor, builder EventBuilder, hints *Hints, transport *TransportMetadata) {
 	var (
 		eventType string
 		fields    Fields
@@ -234,7 +234,7 @@ func emitAuditEvent(logger *Logger, builder EventBuilder, hints *Hints, transpor
 		defer func() {
 			if v := recover(); v != nil {
 				panicStr := truncateString(fmt.Sprintf("%v", v), 512)
-				logger.logger.Error("audit: EventBuilder panicked",
+				auditor.logger.Error("audit: EventBuilder panicked",
 					"panic", panicStr,
 					"request_id", transport.RequestID)
 				skip = true
@@ -247,8 +247,8 @@ func emitAuditEvent(logger *Logger, builder EventBuilder, hints *Hints, transpor
 		return
 	}
 
-	if err := logger.AuditEvent(NewEvent(eventType, fields)); err != nil {
-		logger.logger.Warn("audit: middleware event failed",
+	if err := auditor.AuditEvent(NewEvent(eventType, fields)); err != nil {
+		auditor.logger.Warn("audit: middleware event failed",
 			"event_type", eventType,
 			"request_id", transport.RequestID,
 			"error", err)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -71,19 +71,19 @@ func middlewareBuilder(hints *audit.Hints, transport *audit.TransportMetadata) (
 	return "http_request", fields, false
 }
 
-// newMiddlewareTestLogger creates a Logger with a mockOutput for middleware tests.
-func newMiddlewareTestLogger(t *testing.T) (*audit.Logger, *testhelper.MockOutput) {
+// newMiddlewareTestAuditor creates an Auditor with a mockOutput for middleware tests.
+func newMiddlewareTestAuditor(t *testing.T) (*audit.Auditor, *testhelper.MockOutput) {
 	t.Helper()
 	out := testhelper.NewMockOutput("mw-test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(middlewareTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = logger.Close()
+		_ = auditor.Close()
 	})
-	return logger, out
+	return auditor, out
 }
 
 // --- Middleware tests ---
@@ -107,15 +107,15 @@ func TestMiddleware_NilLogger_PassThrough(t *testing.T) {
 }
 
 func TestMiddleware_NilBuilder_Panics(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	assert.PanicsWithValue(t, "audit: EventBuilder must not be nil", func() {
-		audit.Middleware(logger, nil)
+		audit.Middleware(auditor, nil)
 	})
 }
 
 func TestMiddleware_BasicFlow(t *testing.T) {
-	logger, out := newMiddlewareTestLogger(t)
+	auditor, out := newMiddlewareTestAuditor(t)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hints := audit.HintsFromContext(r.Context())
@@ -124,7 +124,7 @@ func TestMiddleware_BasicFlow(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(logger, middlewareBuilder)
+	mw := audit.Middleware(auditor, middlewareBuilder)
 	wrapped := mw(handler)
 
 	rec := httptest.NewRecorder()
@@ -133,13 +133,13 @@ func TestMiddleware_BasicFlow(t *testing.T) {
 	wrapped.ServeHTTP(rec, req)
 
 	// Wait for async delivery.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	assert.Equal(t, 1, out.EventCount())
 }
 
 func TestMiddleware_HintsPopulatedByHandler(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedHints *audit.Hints
 	var capturedTransport audit.TransportMetadata
@@ -164,7 +164,7 @@ func TestMiddleware_HintsPopulatedByHandler(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/docs/99", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -185,7 +185,7 @@ func TestMiddleware_HintsPopulatedByHandler(t *testing.T) {
 }
 
 func TestMiddleware_HintsExtra(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedExtra map[string]any
 
@@ -203,7 +203,7 @@ func TestMiddleware_HintsExtra(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -215,7 +215,7 @@ func TestMiddleware_HintsExtra(t *testing.T) {
 }
 
 func TestMiddleware_SkipTrue(t *testing.T) {
-	logger, out := newMiddlewareTestLogger(t)
+	auditor, out := newMiddlewareTestAuditor(t)
 
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
 		return "", nil, true // skip
@@ -225,18 +225,18 @@ func TestMiddleware_SkipTrue(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
 	mw(handler).ServeHTTP(rec, req)
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 0, out.EventCount())
 }
 
 func TestMiddleware_PanicRecovery(t *testing.T) {
-	logger, out := newMiddlewareTestLogger(t)
+	auditor, out := newMiddlewareTestAuditor(t)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hints := audit.HintsFromContext(r.Context())
@@ -244,7 +244,7 @@ func TestMiddleware_PanicRecovery(t *testing.T) {
 		panic("handler exploded")
 	})
 
-	mw := audit.Middleware(logger, middlewareBuilder)
+	mw := audit.Middleware(auditor, middlewareBuilder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/boom", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -254,12 +254,12 @@ func TestMiddleware_PanicRecovery(t *testing.T) {
 	})
 
 	// Audit event should still have been emitted before re-panic.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 1, out.EventCount())
 }
 
 func TestMiddleware_TransportMetadata_Complete(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var captured audit.TransportMetadata
 
@@ -272,7 +272,7 @@ func TestMiddleware_TransportMetadata_Complete(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/items", http.NoBody)
 	req.RemoteAddr = "192.168.1.1:9999"
@@ -291,7 +291,7 @@ func TestMiddleware_TransportMetadata_Complete(t *testing.T) {
 }
 
 func TestMiddleware_RequestID_FromHeader(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedID string
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -299,7 +299,7 @@ func TestMiddleware_RequestID_FromHeader(t *testing.T) {
 		return "http_request", audit.Fields{"outcome": "success"}, false
 	}
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -310,7 +310,7 @@ func TestMiddleware_RequestID_FromHeader(t *testing.T) {
 }
 
 func TestMiddleware_RequestID_Generated(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedID string
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -318,7 +318,7 @@ func TestMiddleware_RequestID_Generated(t *testing.T) {
 		return "http_request", audit.Fields{"outcome": "success"}, false
 	}
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -329,7 +329,7 @@ func TestMiddleware_RequestID_Generated(t *testing.T) {
 }
 
 func TestMiddleware_AuditError_LoggedNotPropagated(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	// Return an unknown event type to trigger an Audit error.
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -340,7 +340,7 @@ func TestMiddleware_AuditError_LoggedNotPropagated(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -357,7 +357,7 @@ func TestMiddleware_ConcurrentRequests(t *testing.T) {
 	// goleak.VerifyTestMain. Per-test goleak.VerifyNone is unreliable
 	// in a shared binary where other tests' drain loops may still be
 	// running during this test's cleanup.
-	logger, out := newMiddlewareTestLogger(t)
+	auditor, out := newMiddlewareTestAuditor(t)
 
 	var calls atomic.Int64
 
@@ -373,7 +373,7 @@ func TestMiddleware_ConcurrentRequests(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	wrapped := mw(handler)
 
 	var wg sync.WaitGroup
@@ -392,12 +392,12 @@ func TestMiddleware_ConcurrentRequests(t *testing.T) {
 
 	assert.Equal(t, int64(100), calls.Load())
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 100, out.EventCount())
 }
 
 func TestMiddleware_StatusCode_FromHandler(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedStatus int
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -409,7 +409,7 @@ func TestMiddleware_StatusCode_FromHandler(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/missing", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -419,7 +419,7 @@ func TestMiddleware_StatusCode_FromHandler(t *testing.T) {
 }
 
 func TestMiddleware_Duration_Positive(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedDuration time.Duration
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -431,7 +431,7 @@ func TestMiddleware_Duration_Positive(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -442,7 +442,7 @@ func TestMiddleware_Duration_Positive(t *testing.T) {
 }
 
 func TestMiddleware_BuilderPanic_Recovered(t *testing.T) {
-	logger, out := newMiddlewareTestLogger(t)
+	auditor, out := newMiddlewareTestAuditor(t)
 
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
 		panic("builder exploded")
@@ -452,7 +452,7 @@ func TestMiddleware_BuilderPanic_Recovered(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -463,12 +463,12 @@ func TestMiddleware_BuilderPanic_Recovered(t *testing.T) {
 	})
 
 	// Event should be skipped due to builder panic.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 0, out.EventCount())
 }
 
 func TestMiddleware_RequestID_InvalidHeader_GeneratesUUID(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedID string
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -476,7 +476,7 @@ func TestMiddleware_RequestID_InvalidHeader_GeneratesUUID(t *testing.T) {
 		return "http_request", audit.Fields{"outcome": "success"}, false
 	}
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -488,7 +488,7 @@ func TestMiddleware_RequestID_InvalidHeader_GeneratesUUID(t *testing.T) {
 }
 
 func TestMiddleware_UserAgent_Truncated(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedUA string
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -496,7 +496,7 @@ func TestMiddleware_UserAgent_Truncated(t *testing.T) {
 		return "http_request", audit.Fields{"outcome": "success"}, false
 	}
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -508,7 +508,7 @@ func TestMiddleware_UserAgent_Truncated(t *testing.T) {
 }
 
 func TestMiddleware_NilLoggerNilBuilder_NoPanic(t *testing.T) {
-	// When logger is nil, builder is never checked — Middleware(nil, nil) must not panic.
+	// When auditor is nil, builder is never checked — Middleware(nil, nil) must not panic.
 	assert.NotPanics(t, func() {
 		mw := audit.Middleware(nil, nil)
 		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -534,11 +534,11 @@ func TestMiddleware_NilLogger_HintsFromContextReturnsNil(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
 	mw(handler).ServeHTTP(rec, req)
 
-	assert.Nil(t, hintsInHandler, "HintsFromContext should return nil when logger is nil")
+	assert.Nil(t, hintsInHandler, "HintsFromContext should return nil when auditor is nil")
 }
 
 func TestMiddleware_HintsError_PassedToBuilder(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedError string
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -552,7 +552,7 @@ func TestMiddleware_HintsError_PassedToBuilder(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden)
 	})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/secret", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -562,7 +562,7 @@ func TestMiddleware_HintsError_PassedToBuilder(t *testing.T) {
 }
 
 func TestMiddleware_HandlerWritesNothing_Status200(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedStatus int
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -573,7 +573,7 @@ func TestMiddleware_HandlerWritesNothing_Status200(t *testing.T) {
 	// Handler returns without calling Write or WriteHeader.
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req.RemoteAddr = "10.0.0.1:12345"
@@ -583,7 +583,7 @@ func TestMiddleware_HandlerWritesNothing_Status200(t *testing.T) {
 }
 
 func TestMiddleware_Path_Truncated(t *testing.T) {
-	logger, _ := newMiddlewareTestLogger(t)
+	auditor, _ := newMiddlewareTestAuditor(t)
 
 	var capturedPath string
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
@@ -591,7 +591,7 @@ func TestMiddleware_Path_Truncated(t *testing.T) {
 		return "http_request", audit.Fields{"outcome": "success"}, false
 	}
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	rec := httptest.NewRecorder()
 	longPath := "/" + strings.Repeat("x", 3000)
 	req := httptest.NewRequest(http.MethodGet, longPath, http.NoBody)
@@ -606,7 +606,7 @@ func TestMiddleware_Path_Truncated(t *testing.T) {
 func BenchmarkMiddleware(b *testing.B) {
 	taxonomy := middlewareTaxonomy()
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(1_000_000),
 		audit.WithTaxonomy(taxonomy),
 		audit.WithOutputs(out),
@@ -614,13 +614,13 @@ func BenchmarkMiddleware(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	builder := func(hints *audit.Hints, transport *audit.TransportMetadata) (string, audit.Fields, bool) {
 		return "http_request", audit.Fields{"outcome": "success"}, false
 	}
 
-	mw := audit.Middleware(logger, builder)
+	mw := audit.Middleware(auditor, builder)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/multicat_severity_test.go
+++ b/multicat_severity_test.go
@@ -69,14 +69,14 @@ events:
 		"pre-condition: resolved severity must be 3 (compliance wins alphabetically)")
 
 	out := testhelper.NewMockOutput("pipeline")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "alice",
 	}))
@@ -129,14 +129,14 @@ events:
 		"pre-condition: alpha (3) < beta (7) alphabetically, so severity must be 3")
 
 	out := testhelper.NewMockOutput("consistent")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("shared_event", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("shared_event", audit.Fields{"outcome": "success"})))
 
 	require.True(t, out.WaitForEvents(2, 2*time.Second),
 		"expected 2 deliveries, got %d", out.EventCount())
@@ -175,14 +175,14 @@ events:
 	require.NoError(t, err)
 
 	out := testhelper.NewMockOutput("three-cats")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("multi_event", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("multi_event", audit.Fields{"outcome": "success"})))
 
 	require.True(t, out.WaitForEvents(3, 2*time.Second),
 		"expected 3 deliveries (one per category), got %d", out.EventCount())
@@ -215,7 +215,7 @@ events:
 	require.NoError(t, err)
 
 	out := testhelper.NewMockOutput("concurrent-filter")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
@@ -233,7 +233,7 @@ events:
 	for i := 0; i < writers; i++ {
 		go func(n int) {
 			defer wg.Done()
-			_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+			_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 				"outcome":  "failure",
 				"actor_id": fmt.Sprintf("writer-%d", n),
 			}))
@@ -245,11 +245,11 @@ events:
 		go func(n int) {
 			defer wg.Done()
 			if n%2 == 0 {
-				_ = logger.EnableCategory("security")
-				_ = logger.DisableCategory("compliance")
+				_ = auditor.EnableCategory("security")
+				_ = auditor.DisableCategory("compliance")
 			} else {
-				_ = logger.DisableCategory("security")
-				_ = logger.EnableCategory("compliance")
+				_ = auditor.DisableCategory("security")
+				_ = auditor.EnableCategory("compliance")
 			}
 		}(i)
 	}
@@ -258,7 +258,7 @@ events:
 
 	// Close drains remaining events. If there is a data race the -race
 	// detector will have already fired before we reach this point.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 // ---------------------------------------------------------------------------
@@ -426,7 +426,7 @@ events:
 }
 
 // ---------------------------------------------------------------------------
-// JSON output: severity field parsing via full logger pipeline
+// JSON output: severity field parsing via full auditor pipeline
 // ---------------------------------------------------------------------------
 
 // TestPipeline_SeverityInJSONOutput exercises the complete async pipeline
@@ -497,14 +497,14 @@ events:
 			require.NoError(t, err)
 
 			out := testhelper.NewMockOutput("sev-pipeline")
-			logger, err := audit.NewLogger(
+			auditor, err := audit.New(
 				audit.WithTaxonomy(tax),
 				audit.WithOutputs(out),
 			)
 			require.NoError(t, err)
-			t.Cleanup(func() { _ = logger.Close() })
+			t.Cleanup(func() { _ = auditor.Close() })
 
-			require.NoError(t, logger.AuditEvent(audit.NewEvent(tt.eventType, audit.Fields{"outcome": "ok"})))
+			require.NoError(t, auditor.AuditEvent(audit.NewEvent(tt.eventType, audit.Fields{"outcome": "ok"})))
 			require.True(t, out.WaitForEvents(1, 2*time.Second))
 
 			ev := out.GetEvent(0)
@@ -566,14 +566,14 @@ events:
 
 	// Drive the full pipeline and check the JSON output.
 	out := testhelper.NewMockOutput("mixed-fmt")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"})))
 
 	// Two categories, both enabled → two deliveries.
 	require.True(t, out.WaitForEvents(2, 2*time.Second),

--- a/noop_metrics_test.go
+++ b/noop_metrics_test.go
@@ -43,15 +43,15 @@ func TestNoOpMetrics_Embedding_OverrideSingleMethod(t *testing.T) {
 	// Verify it satisfies the interface.
 	var _ audit.Metrics = m
 
-	// Use it in a real logger.
+	// Use it in a real auditor.
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 		audit.WithMetrics(m),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// The embedded NoOpMetrics handles all other methods silently.
 	assert.Equal(t, int64(0), m.drops.Load())
@@ -79,10 +79,10 @@ func TestNoOpOutputMetrics_AllMethodsCallable(t *testing.T) {
 
 func TestNoOpMetrics_WithMetrics_Accepted(t *testing.T) {
 	t.Parallel()
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithMetrics(audit.NoOpMetrics{}),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }

--- a/options.go
+++ b/options.go
@@ -20,20 +20,20 @@ import (
 	"time"
 )
 
-// Option configures a [Logger] during construction via [NewLogger].
-type Option func(*Logger) error
+// Option configures a [Auditor] during construction via [New].
+type Option func(*Auditor) error
 
 // WithTaxonomy registers the event taxonomy for validation. This option
-// is required; [NewLogger] returns an error if no taxonomy is provided.
-// WithTaxonomy SHOULD be called exactly once per [NewLogger] call.
+// is required; [New] returns an error if no taxonomy is provided.
+// WithTaxonomy SHOULD be called exactly once per [New] call.
 // Calling it more than once replaces the taxonomy and resets all
 // runtime category and event overrides established by the previous call.
 //
 // WithTaxonomy makes a deep copy of t; mutations to t after this call
-// have no effect on the logger. When t was returned by
+// have no effect on the auditor. When t was returned by
 // [ParseTaxonomyYAML], redundant re-validation is skipped.
 func WithTaxonomy(t *Taxonomy) Option {
-	return func(l *Logger) error {
+	return func(a *Auditor) error {
 		if t == nil {
 			return fmt.Errorf("%w: taxonomy must not be nil", ErrTaxonomyInvalid)
 		}
@@ -49,19 +49,19 @@ func WithTaxonomy(t *Taxonomy) Option {
 				return err
 			}
 		}
-		l.taxonomy = cp
-		l.filter = newFilterState(cp)
+		a.taxonomy = cp
+		a.filter = newFilterState(cp)
 		return nil
 	}
 }
 
-// WithMetrics sets the metrics recorder for the logger. If m is nil,
+// WithMetrics sets the metrics recorder for the auditor. If m is nil,
 // or if WithMetrics is not called, metrics are silently discarded.
 // Implementations MUST be safe for concurrent calls from the drain
 // goroutine.
 func WithMetrics(m Metrics) Option {
-	return func(l *Logger) error {
-		l.metrics = m
+	return func(a *Auditor) error {
+		a.metrics = m
 		return nil
 	}
 }
@@ -69,14 +69,14 @@ func WithMetrics(m Metrics) Option {
 // WithAppName sets the application name emitted as a framework field
 // in every serialised event. The value must be non-empty.
 func WithAppName(name string) Option {
-	return func(l *Logger) error {
+	return func(a *Auditor) error {
 		if name == "" {
 			return fmt.Errorf("audit: app_name must not be empty")
 		}
 		if len(name) > 255 {
 			return fmt.Errorf("audit: app_name exceeds maximum length of 255 bytes")
 		}
-		l.appName = name
+		a.appName = name
 		return nil
 	}
 }
@@ -84,14 +84,14 @@ func WithAppName(name string) Option {
 // WithHost sets the hostname emitted as a framework field in every
 // serialised event. The value must be non-empty and at most 255 bytes.
 func WithHost(host string) Option {
-	return func(l *Logger) error {
+	return func(a *Auditor) error {
 		if host == "" {
 			return fmt.Errorf("audit: host must not be empty")
 		}
 		if len(host) > 255 {
 			return fmt.Errorf("audit: host exceeds maximum length of 255 bytes")
 		}
-		l.host = host
+		a.host = host
 		return nil
 	}
 }
@@ -100,52 +100,52 @@ func WithHost(host string) Option {
 // every serialised event. The value must be non-empty and at most 64
 // bytes. If not set, no timezone field is emitted.
 func WithTimezone(tz string) Option {
-	return func(l *Logger) error {
+	return func(a *Auditor) error {
 		if tz == "" {
 			return fmt.Errorf("audit: timezone must not be empty")
 		}
 		if len(tz) > 64 {
 			return fmt.Errorf("audit: timezone exceeds maximum length of 64 bytes")
 		}
-		l.timezone = tz
+		a.timezone = tz
 		return nil
 	}
 }
 
-// WithSynchronousDelivery configures the logger to deliver events
-// inline within [Logger.AuditEvent] instead of via the async channel
+// WithSynchronousDelivery configures the auditor to deliver events
+// inline within [Auditor.AuditEvent] instead of via the async channel
 // and drain goroutine. Events are immediately available in outputs
 // after AuditEvent returns.
 //
 // This mode is useful for testing (no Close-before-assert ceremony)
 // and for simple deployments (CLI tools, Lambda functions) where
-// async complexity is unwanted. [Logger.Close] is still safe to call
+// async complexity is unwanted. [Auditor.Close] is still safe to call
 // but is not required before reading output.
 func WithSynchronousDelivery() Option {
-	return func(l *Logger) error {
-		l.synchronous = true
+	return func(a *Auditor) error {
+		a.synchronous = true
 		return nil
 	}
 }
 
-// WithLogger sets the [log/slog.Logger] used for library diagnostics
+// WithDiagnosticLogger sets the [log/slog.Logger] used for library diagnostics
 // (lifecycle messages, buffer drops, format errors). When not set or
 // when l is nil, [slog.Default] is used. Pass
 // slog.New(slog.DiscardHandler) to silence all library output.
-func WithLogger(l *slog.Logger) Option {
-	return func(lg *Logger) error {
-		lg.logger = l
+func WithDiagnosticLogger(l *slog.Logger) Option {
+	return func(a *Auditor) error {
+		a.logger = l
 		return nil
 	}
 }
 
 // WithStandardFieldDefaults sets deployment-wide default values for
-// reserved standard fields. Defaults are applied in [Logger.AuditEvent]
+// reserved standard fields. Defaults are applied in [Auditor.AuditEvent]
 // before validation — a default satisfies required: true constraints.
 // Per-event values always override defaults (key existence check, not
 // zero value). When called multiple times, the last call wins.
 func WithStandardFieldDefaults(defaults map[string]string) Option {
-	return func(l *Logger) error {
+	return func(a *Auditor) error {
 		for k := range defaults {
 			if !IsReservedStandardField(k) {
 				return fmt.Errorf("audit: standard field default key %q is not a reserved standard field", k)
@@ -156,7 +156,7 @@ func WithStandardFieldDefaults(defaults map[string]string) Option {
 		for k, v := range defaults {
 			cp[k] = v
 		}
-		l.standardFieldDefaults = cp
+		a.standardFieldDefaults = cp
 		return nil
 	}
 }
@@ -165,16 +165,16 @@ func WithStandardFieldDefaults(defaults map[string]string) Option {
 // provided, a [JSONFormatter] is created from the [Config]. Use this
 // to configure a [CEFFormatter] or a custom [Formatter] implementation.
 func WithFormatter(f Formatter) Option {
-	return func(l *Logger) error {
+	return func(a *Auditor) error {
 		if f == nil {
 			return fmt.Errorf("audit: formatter must not be nil")
 		}
-		l.formatter = f
+		a.formatter = f
 		return nil
 	}
 }
 
-// WithOutputs sets the output destinations for the logger. Events are
+// WithOutputs sets the output destinations for the auditor. Events are
 // fanned out to all provided outputs. Each output receives all
 // globally-enabled events (no per-output filtering). Use
 // [WithNamedOutput] to configure per-output event routes or formatters.
@@ -185,8 +185,8 @@ func WithFormatter(f Formatter) Option {
 // the same key, WithOutputs returns an error. If no outputs are
 // configured, events are validated and filtered but silently discarded.
 func WithOutputs(outputs ...Output) Option {
-	return func(l *Logger) error {
-		if len(l.entries) > 0 {
+	return func(a *Auditor) error {
+		if len(a.entries) > 0 {
 			return fmt.Errorf("audit: WithOutputs cannot be used with WithNamedOutput")
 		}
 		byName := make(map[string]*outputEntry, len(outputs))
@@ -204,9 +204,9 @@ func WithOutputs(outputs ...Output) Option {
 			entries[i] = oe
 			byName[name] = oe
 		}
-		l.entries = entries
-		l.outputsByName = byName
-		l.usedWithOutputs = true
+		a.entries = entries
+		a.outputsByName = byName
+		a.usedWithOutputs = true
 		return nil
 	}
 }
@@ -218,7 +218,7 @@ func WithOutputs(outputs ...Output) Option {
 type OutputOption func(*outputEntryBuilder)
 
 // outputEntryBuilder accumulates per-output configuration before
-// the output entry is registered on the logger.
+// the output entry is registered on the auditor.
 type outputEntryBuilder struct {
 	formatter     Formatter
 	route         *EventRoute
@@ -235,8 +235,8 @@ func OutputRoute(r *EventRoute) OutputOption {
 	}
 }
 
-// OutputFormatter overrides the logger's default formatter for this
-// output. Nil means the logger's default formatter is used.
+// OutputFormatter overrides the auditor's default formatter for this
+// output. Nil means the auditor's default formatter is used.
 func OutputFormatter(f Formatter) OutputOption {
 	return func(b *outputEntryBuilder) {
 		b.formatter = f
@@ -246,7 +246,7 @@ func OutputFormatter(f Formatter) OutputOption {
 // OutputExcludeLabels specifies sensitivity labels whose fields should
 // be stripped from events before delivery to this output. When
 // non-empty, the taxonomy MUST define a [SensitivityConfig] and every
-// label MUST be defined within it; [NewLogger] returns an error if
+// label MUST be defined within it; [New] returns an error if
 // either condition is violated. An empty call means no field stripping.
 // Framework fields are never stripped.
 func OutputExcludeLabels(labels ...string) OutputOption {
@@ -256,8 +256,8 @@ func OutputExcludeLabels(labels ...string) OutputOption {
 }
 
 // OutputHMAC configures per-output HMAC integrity. The config is
-// validated eagerly during [NewLogger] option application — invalid
-// configs (short salt, unknown algorithm) cause [NewLogger] to return
+// validated eagerly during [New] option application — invalid
+// configs (short salt, unknown algorithm) cause [New] to return
 // an error. Nil means no HMAC for this output.
 func OutputHMAC(cfg *HMACConfig) OutputOption {
 	return func(b *outputEntryBuilder) {
@@ -273,12 +273,12 @@ func OutputHMAC(cfg *HMACConfig) OutputOption {
 // [WithOutputs] was already applied, WithNamedOutput returns an error.
 //
 // Output names MUST be unique across all outputs; duplicate names
-// cause [NewLogger] to return an error. Duplicate destinations are
+// cause [New] to return an error. Duplicate destinations are
 // also detected via [DestinationKeyer]. Routes are validated against
 // the taxonomy after all options have been applied.
 func WithNamedOutput(output Output, opts ...OutputOption) Option {
-	return func(l *Logger) error {
-		if l.usedWithOutputs {
+	return func(a *Auditor) error {
+		if a.usedWithOutputs {
 			return fmt.Errorf("audit: WithNamedOutput cannot be used with WithOutputs")
 		}
 		var b outputEntryBuilder
@@ -290,24 +290,24 @@ func WithNamedOutput(output Output, opts ...OutputOption) Option {
 				return err
 			}
 		}
-		return l.addNamedOutput(output, &b)
+		return a.addNamedOutput(output, &b)
 	}
 }
 
 // addNamedOutput registers a named output with dedup checking and
 // optional route/formatter/exclude-label/HMAC configuration.
-func (l *Logger) addNamedOutput(output Output, b *outputEntryBuilder) error {
+func (a *Auditor) addNamedOutput(output Output, b *outputEntryBuilder) error {
 	name := output.Name()
-	if l.outputsByName == nil {
-		l.outputsByName = make(map[string]*outputEntry)
+	if a.outputsByName == nil {
+		a.outputsByName = make(map[string]*outputEntry)
 	}
-	if l.destKeys == nil {
-		l.destKeys = make(map[string]string)
+	if a.destKeys == nil {
+		a.destKeys = make(map[string]string)
 	}
-	if _, dup := l.outputsByName[name]; dup {
+	if _, dup := a.outputsByName[name]; dup {
 		return fmt.Errorf("audit: duplicate output name %q", name)
 	}
-	if err := checkDestinationDup(output, name, l.destKeys); err != nil {
+	if err := checkDestinationDup(output, name, a.destKeys); err != nil {
 		return err
 	}
 	oe := &outputEntry{
@@ -323,41 +323,41 @@ func (l *Logger) addNamedOutput(output Output, b *outputEntryBuilder) error {
 	if b.hmacConfig != nil {
 		oe.hmacConfig = b.hmacConfig
 	}
-	l.entries = append(l.entries, oe)
-	l.outputsByName[name] = oe
+	a.entries = append(a.entries, oe)
+	a.outputsByName[name] = oe
 	return nil
 }
 
-// WithQueueSize sets the async intake queue capacity for the logger.
+// WithQueueSize sets the async intake queue capacity for the auditor.
 // Zero or negative values are ignored (the default of
 // [DefaultQueueSize] applies). Values above [MaxQueueSize] cause
-// [NewLogger] to return an error wrapping [ErrConfigInvalid].
+// [New] to return an error wrapping [ErrConfigInvalid].
 func WithQueueSize(n int) Option {
-	return func(l *Logger) error {
-		l.cfg.QueueSize = n
+	return func(a *Auditor) error {
+		a.cfg.QueueSize = n
 		return nil
 	}
 }
 
-// WithDrainTimeout sets the maximum time [Logger.Close] waits for
+// WithShutdownTimeout sets the maximum time [Auditor.Close] waits for
 // pending events to flush. Zero or negative values are ignored (the
-// default of [DefaultDrainTimeout] applies). Values above
-// [MaxDrainTimeout] cause [NewLogger] to return an error wrapping
+// default of [DefaultShutdownTimeout] applies). Values above
+// [MaxShutdownTimeout] cause [New] to return an error wrapping
 // [ErrConfigInvalid].
-func WithDrainTimeout(d time.Duration) Option {
-	return func(l *Logger) error {
-		l.cfg.DrainTimeout = d
+func WithShutdownTimeout(d time.Duration) Option {
+	return func(a *Auditor) error {
+		a.cfg.ShutdownTimeout = d
 		return nil
 	}
 }
 
-// WithValidationMode sets how [Logger.AuditEvent] handles unknown
+// WithValidationMode sets how [Auditor.AuditEvent] handles unknown
 // fields. Must be one of [ValidationStrict], [ValidationWarn], or
-// [ValidationPermissive]. An invalid mode causes [NewLogger] to
+// [ValidationPermissive]. An invalid mode causes [New] to
 // return an error wrapping [ErrConfigInvalid].
 func WithValidationMode(m ValidationMode) Option {
-	return func(l *Logger) error {
-		l.cfg.ValidationMode = m
+	return func(a *Auditor) error {
+		a.cfg.ValidationMode = m
 		return nil
 	}
 }
@@ -367,20 +367,20 @@ func WithValidationMode(m ValidationMode) Option {
 // serialised. Consumers operating under compliance regimes that
 // require all registered fields SHOULD NOT use this option.
 func WithOmitEmpty() Option {
-	return func(l *Logger) error {
-		l.cfg.OmitEmpty = true
+	return func(a *Auditor) error {
+		a.cfg.OmitEmpty = true
 		return nil
 	}
 }
 
-// WithDisabled creates a no-op logger that discards all events without
-// validation or delivery. [Logger.AuditEvent] returns nil immediately.
+// WithDisabled creates a no-op auditor that discards all events without
+// validation or delivery. [Auditor.AuditEvent] returns nil immediately.
 // This is the explicit opt-out for audit logging — the default is
 // enabled, because silent audit disablement is worse than noisy audit
 // failure.
 func WithDisabled() Option {
-	return func(l *Logger) error {
-		l.disabled = true
+	return func(a *Auditor) error {
+		a.disabled = true
 		return nil
 	}
 }
@@ -393,18 +393,18 @@ func WithDisabled() Option {
 // from unset — use [WithOmitEmpty] or [WithDisabled] for explicit
 // opt-in to boolean behaviours.
 func WithConfig(cfg Config) Option {
-	return func(l *Logger) error {
+	return func(a *Auditor) error {
 		if cfg.QueueSize > 0 {
-			l.cfg.QueueSize = cfg.QueueSize
+			a.cfg.QueueSize = cfg.QueueSize
 		}
-		if cfg.DrainTimeout > 0 {
-			l.cfg.DrainTimeout = cfg.DrainTimeout
+		if cfg.ShutdownTimeout > 0 {
+			a.cfg.ShutdownTimeout = cfg.ShutdownTimeout
 		}
 		if cfg.ValidationMode != "" {
-			l.cfg.ValidationMode = cfg.ValidationMode
+			a.cfg.ValidationMode = cfg.ValidationMode
 		}
 		if cfg.OmitEmpty {
-			l.cfg.OmitEmpty = true
+			a.cfg.OmitEmpty = true
 		}
 		return nil
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -27,34 +27,34 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// NewLogger default config (#388 AC-1)
+// New default config (#388 AC-1)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_NoConfigOptions_UsesDefaults(t *testing.T) {
+func TestNew_NoConfigOptions_UsesDefaults(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	out := testhelper.NewMockOutput("defaults")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	// Emit an event to verify the logger works with defaults.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	// Emit an event to verify the auditor works with defaults.
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
-	assert.Equal(t, 1, out.EventCount(), "default logger should deliver events")
+	require.NoError(t, auditor.Close())
+	assert.Equal(t, 1, out.EventCount(), "default auditor should deliver events")
 }
 
 // ---------------------------------------------------------------------------
-// NewLogger without taxonomy (#388 AC-2)
+// New without taxonomy (#388 AC-2)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_WithoutTaxonomy_ReturnsError(t *testing.T) {
-	_, err := audit.NewLogger()
+func TestNew_WithoutTaxonomy_ReturnsError(t *testing.T) {
+	_, err := audit.New()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "taxonomy is required")
 }
@@ -63,60 +63,60 @@ func TestNewLogger_WithoutTaxonomy_ReturnsError(t *testing.T) {
 // WithDisabled (#388 AC-3)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_WithDisabled_CreatesNoOpLogger(t *testing.T) {
+func TestNew_WithDisabled_CreatesNoOpLogger(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	out := testhelper.NewMockOutput("disabled")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, logger)
+	require.NotNil(t, auditor)
 
-	// Disabled logger returns nil without delivering.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	// Disabled auditor returns nil without delivering.
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	assert.NoError(t, err)
-	require.NoError(t, logger.Close())
-	assert.Equal(t, 0, out.EventCount(), "disabled logger must not deliver events")
+	require.NoError(t, auditor.Close())
+	assert.Equal(t, 0, out.EventCount(), "disabled auditor must not deliver events")
 }
 
-func TestNewLogger_WithDisabled_NoTaxonomy(t *testing.T) {
+func TestNew_WithDisabled_NoTaxonomy(t *testing.T) {
 	defer goleak.VerifyNone(t)
-	logger, err := audit.NewLogger(audit.WithDisabled())
-	require.NoError(t, err, "disabled logger must not require a taxonomy")
-	require.NotNil(t, logger)
-	assert.True(t, logger.IsDisabled())
+	auditor, err := audit.New(audit.WithDisabled())
+	require.NoError(t, err, "disabled auditor must not require a taxonomy")
+	require.NotNil(t, auditor)
+	assert.True(t, auditor.IsDisabled())
 
 	// AuditEvent silently discards.
-	err = logger.AuditEvent(audit.NewEvent("anything", audit.Fields{"k": "v"}))
+	err = auditor.AuditEvent(audit.NewEvent("anything", audit.Fields{"k": "v"}))
 	assert.NoError(t, err)
 
 	// Close is safe.
-	assert.NoError(t, logger.Close())
+	assert.NoError(t, auditor.Close())
 }
 
-func TestDisabledLogger_EnableCategory_ReturnsErrDisabled(t *testing.T) {
-	logger, err := audit.NewLogger(audit.WithDisabled())
+func TestDisabledAuditor_EnableCategory_ReturnsErrDisabled(t *testing.T) {
+	auditor, err := audit.New(audit.WithDisabled())
 	require.NoError(t, err)
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
-	assert.ErrorIs(t, logger.EnableCategory("foo"), audit.ErrDisabled)
-	assert.ErrorIs(t, logger.DisableCategory("foo"), audit.ErrDisabled)
-	assert.ErrorIs(t, logger.EnableEvent("foo"), audit.ErrDisabled)
-	assert.ErrorIs(t, logger.DisableEvent("foo"), audit.ErrDisabled)
-	assert.ErrorIs(t, logger.SetOutputRoute("foo", nil), audit.ErrDisabled)
+	assert.ErrorIs(t, auditor.EnableCategory("foo"), audit.ErrDisabled)
+	assert.ErrorIs(t, auditor.DisableCategory("foo"), audit.ErrDisabled)
+	assert.ErrorIs(t, auditor.EnableEvent("foo"), audit.ErrDisabled)
+	assert.ErrorIs(t, auditor.DisableEvent("foo"), audit.ErrDisabled)
+	assert.ErrorIs(t, auditor.SetOutputRoute("foo", nil), audit.ErrDisabled)
 }
 
-func TestDisabledLogger_Handle_ReturnsValidHandle(t *testing.T) {
-	logger, err := audit.NewLogger(audit.WithDisabled())
+func TestDisabledAuditor_Handle_ReturnsValidHandle(t *testing.T) {
+	auditor, err := audit.New(audit.WithDisabled())
 	require.NoError(t, err)
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
-	handle, handleErr := logger.Handle("anything")
+	handle, handleErr := auditor.Handle("anything")
 	require.NoError(t, handleErr)
 	require.NotNil(t, handle)
 	assert.Equal(t, "anything", handle.EventType())
@@ -125,13 +125,13 @@ func TestDisabledLogger_Handle_ReturnsValidHandle(t *testing.T) {
 	assert.NoError(t, handle.Audit(audit.Fields{"k": "v"}))
 }
 
-func TestDisabledLogger_MustHandle_DoesNotPanic(t *testing.T) {
-	logger, err := audit.NewLogger(audit.WithDisabled())
+func TestDisabledAuditor_MustHandle_DoesNotPanic(t *testing.T) {
+	auditor, err := audit.New(audit.WithDisabled())
 	require.NoError(t, err)
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	assert.NotPanics(t, func() {
-		h := logger.MustHandle("anything")
+		h := auditor.MustHandle("anything")
 		assert.NotNil(t, h)
 	})
 }
@@ -140,18 +140,18 @@ func TestDisabledLogger_MustHandle_DoesNotPanic(t *testing.T) {
 // WithQueueSize (#388 AC-4)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_WithQueueSize_SetsCustomSize(t *testing.T) {
+func TestNew_WithQueueSize_SetsCustomSize(t *testing.T) {
 	defer goleak.VerifyNone(t)
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithQueueSize(50000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_WithQueueSize_RejectsOverMax(t *testing.T) {
-	_, err := audit.NewLogger(
+func TestNew_WithQueueSize_RejectsOverMax(t *testing.T) {
+	_, err := audit.New(
 		audit.WithQueueSize(audit.MaxQueueSize+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
@@ -161,22 +161,22 @@ func TestNewLogger_WithQueueSize_RejectsOverMax(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// WithDrainTimeout (#388 AC-5)
+// WithShutdownTimeout (#388 AC-5)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_WithDrainTimeout_SetsCustomTimeout(t *testing.T) {
+func TestNew_WithShutdownTimeout_SetsCustomTimeout(t *testing.T) {
 	defer goleak.VerifyNone(t)
-	logger, err := audit.NewLogger(
-		audit.WithDrainTimeout(30*time.Second),
+	auditor, err := audit.New(
+		audit.WithShutdownTimeout(30*time.Second),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_WithDrainTimeout_RejectsOverMax(t *testing.T) {
-	_, err := audit.NewLogger(
-		audit.WithDrainTimeout(audit.MaxDrainTimeout+1),
+func TestNew_WithShutdownTimeout_RejectsOverMax(t *testing.T) {
+	_, err := audit.New(
+		audit.WithShutdownTimeout(audit.MaxShutdownTimeout+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.Error(t, err)
@@ -188,10 +188,10 @@ func TestNewLogger_WithDrainTimeout_RejectsOverMax(t *testing.T) {
 // WithValidationMode (#388 AC-6)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_WithValidationMode_SetsMode(t *testing.T) {
+func TestNew_WithValidationMode_SetsMode(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	out := testhelper.NewMockOutput("permissive")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
@@ -199,23 +199,23 @@ func TestNewLogger_WithValidationMode_SetsMode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Unknown fields accepted in permissive mode.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 		"bogus":    "value",
 	}))
 	assert.NoError(t, err, "permissive mode should accept unknown fields")
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 // ---------------------------------------------------------------------------
 // WithOmitEmpty (#388 AC-7)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_WithOmitEmpty_OmitsZeroFields(t *testing.T) {
+func TestNew_WithOmitEmpty_OmitsZeroFields(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	out := testhelper.NewMockOutput("omit-empty")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithOmitEmpty(),
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
@@ -223,13 +223,13 @@ func TestNewLogger_WithOmitEmpty_OmitsZeroFields(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 		"empty":    "",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	require.Equal(t, 1, out.EventCount())
 
 	ev := out.GetEvent(0)
@@ -241,27 +241,27 @@ func TestNewLogger_WithOmitEmpty_OmitsZeroFields(t *testing.T) {
 // WithConfig (#388 AC-8, AC-9)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_WithConfig_AppliesStructFields(t *testing.T) {
+func TestNew_WithConfig_AppliesStructFields(t *testing.T) {
 	defer goleak.VerifyNone(t)
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithConfig(audit.Config{QueueSize: 50000}),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_WithConfig_IndividualOptionOverrides(t *testing.T) {
+func TestNew_WithConfig_IndividualOptionOverrides(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	// WithConfig sets QueueSize=100, then WithQueueSize(200) overrides.
 	// Last option wins.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithConfig(audit.Config{QueueSize: 100}),
 		audit.WithQueueSize(200),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 // ---------------------------------------------------------------------------
@@ -325,18 +325,18 @@ func TestSuppressEventCategory_True_SuppressesCategory(t *testing.T) {
 		Categories:            map[string]*audit.CategoryDef{"security": {Events: []string{"auth_failure"}}},
 		Events:                map[string]*audit.EventDef{"auth_failure": {Required: []string{"outcome", "actor_id"}}},
 	}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	require.Equal(t, 1, out.EventCount())
 
 	ev := out.GetEvent(0)
@@ -348,7 +348,7 @@ func TestSuppressEventCategory_True_SuppressesCategory(t *testing.T) {
 // Concurrent construction (#388 AC-16 subset)
 // ---------------------------------------------------------------------------
 
-func TestNewLogger_ConcurrentConstruction_NoRace(t *testing.T) {
+func TestNew_ConcurrentConstruction_NoRace(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	var wg sync.WaitGroup
@@ -360,14 +360,14 @@ func TestNewLogger_ConcurrentConstruction_NoRace(t *testing.T) {
 			// on internal precomputation (precomputeTaxonomy mutates
 			// EventDef slices/maps).
 			tax := testhelper.ValidTaxonomy()
-			logger, err := audit.NewLogger(
+			auditor, err := audit.New(
 				audit.WithTaxonomy(tax),
 			)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-			_ = logger.Close()
+			_ = auditor.Close()
 		}()
 	}
 	wg.Wait()
@@ -377,18 +377,18 @@ func TestNewLogger_ConcurrentConstruction_NoRace(t *testing.T) {
 // Benchmark: NewLogger construction (#388)
 // ---------------------------------------------------------------------------
 
-func BenchmarkNewLogger_Construction(b *testing.B) {
+func BenchmarkNew_Construction(b *testing.B) {
 	tax := testhelper.ValidTaxonomy()
 	out := testhelper.NewMockOutput("bench")
 
 	for b.Loop() {
-		logger, err := audit.NewLogger(
+		auditor, err := audit.New(
 			audit.WithTaxonomy(tax),
 			audit.WithOutputs(out),
 		)
 		if err != nil {
 			b.Fatal(err)
 		}
-		_ = logger.Close()
+		_ = auditor.Close()
 	}
 }

--- a/output.go
+++ b/output.go
@@ -34,7 +34,7 @@ type Output interface {
 
 	// Close flushes any buffered data and releases resources. The
 	// library guarantees Write will not be called after Close. Close
-	// is called exactly once by [Logger.Close].
+	// is called exactly once by [Auditor.Close].
 	Close() error
 
 	// Name returns a human-readable identifier for the output,
@@ -64,7 +64,7 @@ type DestinationKeyer interface {
 // DeliveryReporter is an optional interface that [Output] implementations
 // may satisfy to indicate they handle their own delivery metrics
 // reporting. When satisfied and [DeliveryReporter.ReportsDelivery]
-// returns true, the core logger skips its default per-event
+// returns true, the core auditor skips its default per-event
 // [Metrics.RecordEvent] calls for that output — the output is
 // responsible for calling them after actual delivery.
 type DeliveryReporter interface {
@@ -110,7 +110,7 @@ type MetadataWriter interface {
 }
 
 // FrameworkFieldReceiver is an optional interface that [Output]
-// implementations may satisfy to receive logger-wide framework fields
+// implementations may satisfy to receive auditor-wide framework fields
 // (app_name, host, timezone, pid) at construction time. The library
 // calls SetFrameworkFields once after all options are applied and
 // before the first Write or WriteWithMetadata call.
@@ -123,12 +123,12 @@ type FrameworkFieldReceiver interface {
 	SetFrameworkFields(appName, host, timezone string, pid int)
 }
 
-// LoggerReceiver is an optional interface that [Output] implementations
+// DiagnosticLoggerReceiver is an optional interface that [Output] implementations
 // may satisfy to receive the library's [log/slog.Logger] for diagnostic
-// output. The library calls SetLogger once after all options are applied.
+// output. The library calls SetDiagnosticLogger once after all options are applied.
 // Outputs that do not implement it use the package-level [slog.Default].
-type LoggerReceiver interface {
-	SetLogger(l *slog.Logger)
+type DiagnosticLoggerReceiver interface {
+	SetDiagnosticLogger(l *slog.Logger)
 }
 
 // OutputMetricsReceiver is an optional interface that [Output]
@@ -137,7 +137,7 @@ type LoggerReceiver interface {
 // first Write call. Outputs that do not implement it operate without
 // per-output metrics.
 //
-// This is the output-side analogue of [LoggerReceiver] and
+// This is the output-side analogue of [DiagnosticLoggerReceiver] and
 // [FrameworkFieldReceiver]. The [OutputMetrics] value is created by
 // the [OutputMetricsFactory] registered via
 // outputconfig.WithOutputMetrics.

--- a/outputconfig/auditor_config.go
+++ b/outputconfig/auditor_config.go
@@ -21,20 +21,20 @@ import (
 	"github.com/axonops/audit"
 )
 
-// loggerConfigResult holds both the Config and the disabled flag parsed
-// from the YAML logger: section. Disabled is tracked separately because
+// auditorConfigResult holds both the Config and the disabled flag parsed
+// from the YAML auditor: section. Disabled is tracked separately because
 // Config no longer has an Enabled field.
-type loggerConfigResult struct {
+type auditorConfigResult struct {
 	config   audit.Config
 	disabled bool
 }
 
-func parseLoggerConfig(raw any) (loggerConfigResult, error) { //nolint:gocyclo,gocognit,cyclop // YAML field dispatch
+func parseAuditorConfig(raw any) (auditorConfigResult, error) { //nolint:gocyclo,gocognit,cyclop // YAML field dispatch
 	m, ok := raw.(map[string]any)
 	if !ok {
-		return loggerConfigResult{}, fmt.Errorf("expected mapping, got %T", raw)
+		return auditorConfigResult{}, fmt.Errorf("expected mapping, got %T", raw)
 	}
-	var result loggerConfigResult
+	var result auditorConfigResult
 	for key, val := range m {
 		switch key {
 		case "enabled":
@@ -57,23 +57,23 @@ func parseLoggerConfig(raw any) (loggerConfigResult, error) { //nolint:gocyclo,g
 				return result, fmt.Errorf("queue_size: %d exceeds maximum %d", v, audit.MaxQueueSize)
 			}
 			result.config.QueueSize = v
-		case "drain_timeout":
+		case "shutdown_timeout":
 			s, err := toString(val)
 			if err != nil {
-				return result, fmt.Errorf("drain_timeout: %w", err)
+				return result, fmt.Errorf("shutdown_timeout: %w", err)
 			}
 			if s != "" {
 				d, err := time.ParseDuration(s)
 				if err != nil {
-					return result, fmt.Errorf("drain_timeout: invalid duration %q: %w", s, err)
+					return result, fmt.Errorf("shutdown_timeout: invalid duration %q: %w", s, err)
 				}
 				if d < 0 {
-					return result, fmt.Errorf("drain_timeout: must be non-negative, got %s", s)
+					return result, fmt.Errorf("shutdown_timeout: must be non-negative, got %s", s)
 				}
-				if d > audit.MaxDrainTimeout {
-					return result, fmt.Errorf("drain_timeout: %s exceeds maximum %s", d, audit.MaxDrainTimeout)
+				if d > audit.MaxShutdownTimeout {
+					return result, fmt.Errorf("shutdown_timeout: %s exceeds maximum %s", d, audit.MaxShutdownTimeout)
 				}
-				result.config.DrainTimeout = d
+				result.config.ShutdownTimeout = d
 			}
 		case "validation_mode":
 			s, err := toString(val)
@@ -94,6 +94,8 @@ func parseLoggerConfig(raw any) (loggerConfigResult, error) { //nolint:gocyclo,g
 				return result, fmt.Errorf("omit_empty: %w", err)
 			}
 			result.config.OmitEmpty = v
+		case "drain_timeout":
+			return result, fmt.Errorf("unknown field %q (renamed to %q in this version)", "drain_timeout", "shutdown_timeout")
 		default:
 			return result, fmt.Errorf("unknown field %q", key)
 		}
@@ -101,10 +103,10 @@ func parseLoggerConfig(raw any) (loggerConfigResult, error) { //nolint:gocyclo,g
 	return result, nil
 }
 
-// defaultLoggerConfigResult returns a default logger config result
-// for when the logger: section is omitted from YAML.
-func defaultLoggerConfigResult() loggerConfigResult {
-	return loggerConfigResult{}
+// defaultAuditorConfigResult returns a default auditor config result
+// for when the auditor: section is omitted from YAML.
+func defaultAuditorConfigResult() auditorConfigResult {
+	return auditorConfigResult{}
 }
 
 func parseStandardFields(raw any) (map[string]string, error) {

--- a/outputconfig/doc.go
+++ b/outputconfig/doc.go
@@ -14,7 +14,7 @@
 
 // Package outputconfig loads audit output configuration from a YAML
 // document and returns ready-to-use [audit.Option] values for
-// [audit.NewLogger].
+// [audit.New].
 //
 // # Registry Pattern
 //
@@ -41,10 +41,10 @@
 //	app_name: "my-service"          # required, application name (max 255 bytes)
 //	host: "${HOSTNAME:-localhost}"   # required, hostname (max 255 bytes; env vars supported)
 //	timezone: "UTC"                 # optional, overrides auto-detected timezone
-//	logger:                         # optional, core logger settings
+//	auditor:                         # optional, core auditor settings
 //	  enabled: true                 # default: true
 //	  queue_size: 10000             # default: 10,000 (max: 1,000,000)
-//	  drain_timeout: "5s"           # default: "5s" (max: "60s")
+//	  shutdown_timeout: "5s"           # default: "5s" (max: "60s")
 //	  validation_mode: strict       # "strict" (default), "warn", "permissive"
 //	  omit_empty: false             # default: false
 //	tls_policy:                     # optional, global TLS policy
@@ -101,7 +101,7 @@
 //
 //	opts := []audit.Option{audit.WithTaxonomy(taxonomy)}
 //	opts = append(opts, result.Options...)
-//	logger, err := audit.NewLogger(opts...)
+//	auditor, err := audit.New(opts...)
 //
 // [Load] fails hard on any configuration error — partial configurations
 // are never returned. This ensures that a misconfigured output does not

--- a/outputconfig/facade.go
+++ b/outputconfig/facade.go
@@ -24,13 +24,13 @@ import (
 	"github.com/axonops/audit"
 )
 
-// NewLogger is a convenience facade that creates a ready-to-use
-// [audit.Logger] from embedded taxonomy YAML and a filesystem path
+// New is a convenience facade that creates a ready-to-use
+// [audit.Auditor] from embedded taxonomy YAML and a filesystem path
 // to the outputs configuration. It combines [audit.ParseTaxonomyYAML],
-// [Load], and [audit.NewLogger] into a single call.
+// [Load], and [audit.New] into a single call.
 //
-// When outputsConfigPath is empty, NewLogger creates a stdout-only
-// development logger with app_name derived from [os.Args] and host
+// When outputsConfigPath is empty, New creates a stdout-only
+// development auditor with app_name derived from [os.Args] and host
 // from [os.Hostname]. This is useful for local development and
 // quick evaluation.
 //
@@ -49,21 +49,21 @@ import (
 //	import _ "github.com/axonops/audit/syslog"  // syslog output
 //	import _ "github.com/axonops/audit/webhook" // webhook output
 //	import _ "github.com/axonops/audit/loki"    // loki output
-func NewLogger(ctx context.Context, taxonomyYAML []byte, outputsConfigPath string, loadOpts []LoadOption, opts ...audit.Option) (*audit.Logger, error) {
+func New(ctx context.Context, taxonomyYAML []byte, outputsConfigPath string, loadOpts []LoadOption, opts ...audit.Option) (*audit.Auditor, error) {
 	tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
 	if err != nil {
 		return nil, fmt.Errorf("outputconfig: parse taxonomy: %w", err)
 	}
 
-	var loggerOpts []audit.Option
-	loggerOpts = append(loggerOpts, audit.WithTaxonomy(tax))
+	var auditorOpts []audit.Option
+	auditorOpts = append(auditorOpts, audit.WithTaxonomy(tax))
 
 	if outputsConfigPath == "" {
 		devOpts, devErr := devModeOptions()
 		if devErr != nil {
 			return nil, fmt.Errorf("outputconfig: dev mode: %w", devErr)
 		}
-		loggerOpts = append(loggerOpts, devOpts...)
+		auditorOpts = append(auditorOpts, devOpts...)
 	} else {
 		data, readErr := readConfigFile(outputsConfigPath)
 		if readErr != nil {
@@ -73,33 +73,33 @@ func NewLogger(ctx context.Context, taxonomyYAML []byte, outputsConfigPath strin
 		if loadErr != nil {
 			return nil, fmt.Errorf("outputconfig: load: %w", loadErr)
 		}
-		loggerOpts = append(loggerOpts, result.Options...)
+		auditorOpts = append(auditorOpts, result.Options...)
 
 		// User options applied last — highest precedence.
-		loggerOpts = append(loggerOpts, opts...)
+		auditorOpts = append(auditorOpts, opts...)
 
-		logger, loggerErr := audit.NewLogger(loggerOpts...)
-		if loggerErr != nil {
+		auditor, auditorErr := audit.New(auditorOpts...)
+		if auditorErr != nil {
 			// Clean up outputs that Load constructed.
 			for _, o := range result.Outputs {
 				_ = o.Output.Close()
 			}
-			return nil, fmt.Errorf("outputconfig: create logger: %w", loggerErr)
+			return nil, fmt.Errorf("outputconfig: create auditor: %w", auditorErr)
 		}
-		return logger, nil
+		return auditor, nil
 	}
 
 	// Dev mode: user options applied after dev defaults.
-	loggerOpts = append(loggerOpts, opts...)
+	auditorOpts = append(auditorOpts, opts...)
 
-	logger, loggerErr := audit.NewLogger(loggerOpts...)
-	if loggerErr != nil {
-		return nil, fmt.Errorf("outputconfig: create logger: %w", loggerErr)
+	auditor, auditorErr := audit.New(auditorOpts...)
+	if auditorErr != nil {
+		return nil, fmt.Errorf("outputconfig: create auditor: %w", auditorErr)
 	}
-	return logger, nil
+	return auditor, nil
 }
 
-// devModeOptions returns options for a stdout-only development logger
+// devModeOptions returns options for a stdout-only development auditor
 // with auto-detected app_name and host.
 func devModeOptions() ([]audit.Option, error) {
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{})

--- a/outputconfig/facade_test.go
+++ b/outputconfig/facade_test.go
@@ -47,118 +47,118 @@ outputs:
     type: stdout
 `)
 
-func TestNewLogger_BasicEndToEnd(t *testing.T) {
+func TestNew_BasicEndToEnd(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path, nil)
+	auditor, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, path, nil)
 	require.NoError(t, err)
-	require.NotNil(t, logger)
+	require.NotNil(t, auditor)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_WithOptions_UserOptionsTakePrecedence(t *testing.T) {
+func TestNew_WithOptions_UserOptionsTakePrecedence(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
 	// User option WithDisabled should take precedence over config.
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path, nil,
+	auditor, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, path, nil,
 		audit.WithDisabled(),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, logger)
+	require.NotNil(t, auditor)
 
-	// Disabled logger returns nil without delivering.
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
+	// Disabled auditor returns nil without delivering.
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
 	assert.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_EmptyPath_StdoutDevLogger(t *testing.T) {
+func TestNew_EmptyPath_StdoutDevLogger(t *testing.T) {
 	t.Parallel()
 
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, "", nil)
+	auditor, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, "", nil)
 	require.NoError(t, err)
-	require.NotNil(t, logger)
+	require.NotNil(t, auditor)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_FileNotFound(t *testing.T) {
+func TestNew_FileNotFound(t *testing.T) {
 	t.Parallel()
 
-	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, "/nonexistent/path/outputs.yaml", nil)
+	_, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, "/nonexistent/path/outputs.yaml", nil)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, os.ErrNotExist), "should wrap os.ErrNotExist, got: %v", err)
 	assert.Contains(t, err.Error(), "nonexistent")
 }
 
-func TestNewLogger_InvalidTaxonomy(t *testing.T) {
+func TestNew_InvalidTaxonomy(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	_, err := outputconfig.NewLogger(context.Background(), []byte("not: valid: taxonomy"), path, nil)
+	_, err := outputconfig.New(context.Background(), []byte("not: valid: taxonomy"), path, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "taxonomy")
 }
 
-func TestNewLogger_InvalidOutputConfig(t *testing.T) {
+func TestNew_InvalidOutputConfig(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", []byte("not: [valid: config"))
 
-	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path, nil)
+	_, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, path, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "load")
 }
 
-func TestNewLogger_EmptyTaxonomy(t *testing.T) {
+func TestNew_EmptyTaxonomy(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	_, err := outputconfig.NewLogger(context.Background(), nil, path, nil)
+	_, err := outputconfig.New(context.Background(), nil, path, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "taxonomy")
 }
 
-func TestNewLogger_Close_FlushesEvents(t *testing.T) {
+func TestNew_Close_FlushesEvents(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path, nil)
+	auditor, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, path, nil)
 	require.NoError(t, err)
 
 	// Send events then close — should not panic or error.
 	for range 10 {
-		_ = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
+		_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"}))
 	}
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_NotRegularFile(t *testing.T) {
+func TestNew_NotRegularFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
 	// Directories are not regular files.
-	_, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, dir, nil)
+	_, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, dir, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a regular file")
 }
 
-func TestNewLogger_WithLoadOptions(t *testing.T) {
+func TestNew_WithLoadOptions(t *testing.T) {
 	t.Parallel()
 	path := writeTempFile(t, "outputs-*.yaml", facadeOutputsYAML)
 
-	logger, err := outputconfig.NewLogger(context.Background(), facadeTaxonomyYAML, path,
+	auditor, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, path,
 		[]outputconfig.LoadOption{outputconfig.WithCoreMetrics(nil)},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, logger)
-	require.NoError(t, logger.Close())
+	require.NotNil(t, auditor)
+	require.NoError(t, auditor.Close())
 }
 
 // writeTempFile creates a temporary file with the given content and

--- a/outputconfig/formatter.go
+++ b/outputconfig/formatter.go
@@ -57,7 +57,7 @@ func extractFormatterType(raw any) string {
 }
 
 // buildFormatter constructs an [audit.Formatter] from a raw YAML value.
-// Returns nil if the value is nil or empty (use logger default).
+// Returns nil if the value is nil or empty (use auditor default).
 // Returns an error for unknown formatter types or invalid options.
 func buildFormatter(raw any) (audit.Formatter, error) {
 	if raw == nil {

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -36,20 +36,20 @@ const MaxOutputConfigSize = 1 << 20 // 1 MiB
 // MaxOutputCount is the maximum number of outputs in a single config.
 const MaxOutputCount = 100
 
-// LoadResult holds the outputs, options, and logger configuration
-// produced by [Load], ready to be passed to [audit.NewLogger].
+// LoadResult holds the outputs, options, and auditor configuration
+// produced by [Load], ready to be passed to [audit.New].
 type LoadResult struct { //nolint:govet // fieldalignment: readability preferred
-	// Config is the logger configuration parsed from the optional
-	// top-level `logger:` section. Exposed for inspection; pass
-	// Options to [audit.NewLogger] instead — Options includes
+	// Config is the auditor configuration parsed from the optional
+	// top-level `auditor:` section. Exposed for inspection; pass
+	// Options to [audit.New] instead — Options includes
 	// config-equivalent options ([audit.WithQueueSize], etc.).
 	Config audit.Config
 
-	// Options contains all options needed to create the logger:
+	// Options contains all options needed to create the auditor:
 	// framework fields ([audit.WithAppName], [audit.WithHost]),
 	// config-equivalent options ([audit.WithQueueSize], etc.),
 	// and one [audit.WithNamedOutput] per configured output.
-	// Pass directly to [audit.NewLogger] along with
+	// Pass directly to [audit.New] along with
 	// [audit.WithTaxonomy].
 	Options []audit.Option
 
@@ -91,7 +91,7 @@ type NamedOutput struct {
 	// events are delivered to this output.
 	Route *audit.EventRoute
 	// Formatter is the optional per-output formatter override. Nil
-	// means the logger's default formatter is used.
+	// means the auditor's default formatter is used.
 	Formatter audit.Formatter
 	// HMACConfig is the optional per-output HMAC configuration.
 	// Nil means no HMAC for this output.
@@ -136,7 +136,7 @@ func (o *NamedOutput) String() string {
 
 // Load parses a YAML output configuration, constructs all outputs via
 // the registry, validates routes against the taxonomy, and returns
-// [audit.Option] values ready for [audit.NewLogger].
+// [audit.Option] values ready for [audit.New].
 //
 // Load fails hard on any error — unknown output types, missing factory
 // registrations, invalid YAML, unknown YAML keys, malformed routes,
@@ -310,7 +310,7 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 
 	// Phase 8: Build Options slice.
 	result := &LoadResult{
-		Config:         top.loggerResult.config,
+		Config:         top.auditorResult.config,
 		Outputs:        outputs,
 		AppName:        top.appName,
 		Host:           top.host,
@@ -318,13 +318,13 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 		StandardFields: top.standardFields,
 	}
 
-	// Config-equivalent options so callers can use NewLogger(result.Options...).
-	cfg := top.loggerResult.config
+	// Config-equivalent options so callers can use audit.New(result.Options...).
+	cfg := top.auditorResult.config
 	if cfg.QueueSize > 0 {
 		result.Options = append(result.Options, audit.WithQueueSize(cfg.QueueSize))
 	}
-	if cfg.DrainTimeout > 0 {
-		result.Options = append(result.Options, audit.WithDrainTimeout(cfg.DrainTimeout))
+	if cfg.ShutdownTimeout > 0 {
+		result.Options = append(result.Options, audit.WithShutdownTimeout(cfg.ShutdownTimeout))
 	}
 	if cfg.ValidationMode != "" {
 		result.Options = append(result.Options, audit.WithValidationMode(cfg.ValidationMode))
@@ -332,7 +332,7 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 	if cfg.OmitEmpty {
 		result.Options = append(result.Options, audit.WithOmitEmpty())
 	}
-	if top.loggerResult.disabled {
+	if top.auditorResult.disabled {
 		result.Options = append(result.Options, audit.WithDisabled())
 	}
 
@@ -375,7 +375,7 @@ type topLevel struct {
 	appName        string
 	host           string
 	timezone       string
-	loggerResult   loggerConfigResult
+	auditorResult  auditorConfigResult
 }
 
 // parseTopLevel extracts and validates top-level YAML fields.
@@ -387,9 +387,9 @@ func parseTopLevel(ctx context.Context, doc, orderedOutputs yaml.MapSlice, order
 	}
 
 	var (
-		version   int
-		loggerRaw any
-		result    topLevel
+		version    int
+		auditorRaw any
+		result     topLevel
 	)
 	for _, item := range doc {
 		key, ok := item.Key.(string)
@@ -406,8 +406,8 @@ func parseTopLevel(ctx context.Context, doc, orderedOutputs yaml.MapSlice, order
 		case "default_formatter":
 			return nil, fmt.Errorf("%w: default_formatter has been removed; set formatter on each output individually",
 				ErrOutputConfigInvalid)
-		case "logger":
-			loggerRaw = item.Value
+		case "auditor":
+			auditorRaw = item.Value
 		case "tls_policy":
 			result.tlsPolicyRaw = item.Value
 		case "outputs":
@@ -490,6 +490,9 @@ func parseTopLevel(ctx context.Context, doc, orderedOutputs yaml.MapSlice, order
 				return nil, sfErr
 			}
 			result.standardFields = sf
+		case "logger":
+			return nil, fmt.Errorf("%w: unknown top-level key %q (renamed to %q in this version)",
+				ErrOutputConfigInvalid, "logger", "auditor")
 		default:
 			return nil, fmt.Errorf("%w: unknown top-level key %q", ErrOutputConfigInvalid, key)
 		}
@@ -500,25 +503,25 @@ func parseTopLevel(ctx context.Context, doc, orderedOutputs yaml.MapSlice, order
 			ErrOutputConfigInvalid, version)
 	}
 
-	if loggerRaw != nil {
-		expanded, err := expandEnvInValue(loggerRaw, "logger")
+	if auditorRaw != nil {
+		expanded, err := expandEnvInValue(auditorRaw, "auditor")
 		if err != nil {
-			return nil, fmt.Errorf("%w: logger: %w", ErrOutputConfigInvalid, err)
+			return nil, fmt.Errorf("%w: auditor: %w", ErrOutputConfigInvalid, err)
 		}
-		resolved, rErr := expandSecretsInValue(ctx, expanded, "logger", r)
+		resolved, rErr := expandSecretsInValue(ctx, expanded, "auditor", r)
 		if rErr != nil {
-			return nil, fmt.Errorf("%w: logger: %w", ErrOutputConfigInvalid, rErr)
+			return nil, fmt.Errorf("%w: auditor: %w", ErrOutputConfigInvalid, rErr)
 		}
-		if vnErr := validateNoUnresolvedRefs(resolved, "logger"); vnErr != nil {
-			return nil, fmt.Errorf("%w: logger: %w", ErrOutputConfigInvalid, vnErr)
+		if vnErr := validateNoUnresolvedRefs(resolved, "auditor"); vnErr != nil {
+			return nil, fmt.Errorf("%w: auditor: %w", ErrOutputConfigInvalid, vnErr)
 		}
-		lr, cfgErr := parseLoggerConfig(resolved)
+		lr, cfgErr := parseAuditorConfig(resolved)
 		if cfgErr != nil {
-			return nil, fmt.Errorf("%w: logger: %w", ErrOutputConfigInvalid, cfgErr)
+			return nil, fmt.Errorf("%w: auditor: %w", ErrOutputConfigInvalid, cfgErr)
 		}
-		result.loggerResult = lr
+		result.auditorResult = lr
 	} else {
-		result.loggerResult = defaultLoggerConfigResult()
+		result.auditorResult = defaultAuditorConfigResult()
 	}
 
 	// Expand env vars and validate global TLS policy eagerly so that

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -301,7 +301,7 @@ outputs:
 
 	assert.Len(t, result.Outputs, 2)
 	// Both outputs have nil per-output formatter — they inherit the
-	// logger's default JSONFormatter at runtime via effectiveFormatter.
+	// auditor's default JSONFormatter at runtime via effectiveFormatter.
 	assert.Nil(t, result.Outputs[0].Formatter)
 	assert.Nil(t, result.Outputs[1].Formatter)
 	_ = result.Outputs[0].Output.Close()
@@ -638,12 +638,12 @@ outputs:
 	// Options should contain at least one WithNamedOutput.
 	assert.NotEmpty(t, result.Options)
 
-	// Verify options can be applied to NewLogger without error.
+	// Verify options can be applied to New without error.
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 func TestLoad_ConfigKeyMismatch(t *testing.T) {
@@ -798,13 +798,13 @@ outputs:
 
 	opts := []audit.Option{audit.WithTaxonomy(tax)}
 	opts = append(opts, result.Options...)
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	require.NoError(t, err)
 
 	// Emit a write event and a read event.
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success", "actor_id": "alice"})))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_read", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success", "actor_id": "alice"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_read", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.Close())
 
 	// all.log should have both events.
 	allData, err := os.ReadFile(filepath.Join(dir, "all.log"))
@@ -1160,14 +1160,14 @@ outputs:
 	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 
-	// The Load itself succeeds — validation happens at NewLogger time.
+	// The Load itself succeeds — validation happens at auditor creation time.
 	// Verify the labels are stored and will be passed through.
 	require.Len(t, result.Outputs, 1)
 	assert.Equal(t, []string{"pii"}, result.Outputs[0].ExcludeLabels)
 }
 
 // ---------------------------------------------------------------------------
-// Logger config from YAML (#183)
+// Auditor config from YAML (#183)
 // ---------------------------------------------------------------------------
 
 func TestLoad_LoggerConfig_Defaults(t *testing.T) {
@@ -1185,7 +1185,7 @@ outputs:
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.Config.QueueSize, "zero means applyDefaults will set 10000")
-	assert.Equal(t, time.Duration(0), result.Config.DrainTimeout, "zero means applyDefaults will set 5s")
+	assert.Equal(t, time.Duration(0), result.Config.ShutdownTimeout, "zero means applyDefaults will set 5s")
 	assert.Equal(t, audit.ValidationMode(""), result.Config.ValidationMode, "empty means applyDefaults will set strict")
 	assert.False(t, result.Config.OmitEmpty)
 }
@@ -1196,10 +1196,10 @@ func TestLoad_LoggerConfig_AllFields(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   enabled: true
   queue_size: 50000
-  drain_timeout: "30s"
+  shutdown_timeout: "30s"
   validation_mode: warn
   omit_empty: true
 outputs:
@@ -1211,7 +1211,7 @@ outputs:
 	require.NoError(t, err)
 
 	assert.Equal(t, 50000, result.Config.QueueSize)
-	assert.Equal(t, 30*time.Second, result.Config.DrainTimeout)
+	assert.Equal(t, 30*time.Second, result.Config.ShutdownTimeout)
 	assert.Equal(t, audit.ValidationMode("warn"), result.Config.ValidationMode)
 	assert.True(t, result.Config.OmitEmpty)
 }
@@ -1222,7 +1222,7 @@ func TestLoad_LoggerConfig_PartialFields(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   queue_size: 25000
 outputs:
   console:
@@ -1233,7 +1233,7 @@ outputs:
 	require.NoError(t, err)
 
 	assert.Equal(t, 25000, result.Config.QueueSize)
-	assert.Equal(t, time.Duration(0), result.Config.DrainTimeout, "default drain timeout")
+	assert.Equal(t, time.Duration(0), result.Config.ShutdownTimeout, "default drain timeout")
 }
 
 func TestLoad_LoggerConfig_EnabledFalse(t *testing.T) {
@@ -1242,7 +1242,7 @@ func TestLoad_LoggerConfig_EnabledFalse(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   enabled: false
 outputs:
   console:
@@ -1261,9 +1261,9 @@ func TestLoad_LoggerConfig_EnvVars(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   queue_size: ${TEST_BUFFER_SIZE}
-  drain_timeout: "${TEST_DRAIN_TIMEOUT}"
+  shutdown_timeout: "${TEST_DRAIN_TIMEOUT}"
 outputs:
   console:
     type: stdout
@@ -1273,7 +1273,7 @@ outputs:
 	require.NoError(t, err)
 
 	assert.Equal(t, 75000, result.Config.QueueSize)
-	assert.Equal(t, 15*time.Second, result.Config.DrainTimeout)
+	assert.Equal(t, 15*time.Second, result.Config.ShutdownTimeout)
 }
 
 func TestLoad_LoggerConfig_EnvVars_Boolean(t *testing.T) {
@@ -1284,7 +1284,7 @@ func TestLoad_LoggerConfig_EnvVars_Boolean(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   enabled: ${TEST_ENABLED}
   omit_empty: ${TEST_OMIT_EMPTY}
 outputs:
@@ -1304,7 +1304,7 @@ func TestLoad_LoggerConfig_NotAMapping(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger: "not a mapping"
+auditor: "not a mapping"
 outputs:
   console:
     type: stdout
@@ -1313,7 +1313,7 @@ outputs:
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
-	assert.Contains(t, err.Error(), "logger")
+	assert.Contains(t, err.Error(), "auditor")
 }
 
 func TestLoad_LoggerConfig_UnknownField(t *testing.T) {
@@ -1322,7 +1322,7 @@ func TestLoad_LoggerConfig_UnknownField(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   enabled: true
   bogus_field: 42
 outputs:
@@ -1333,7 +1333,7 @@ outputs:
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
-	assert.Contains(t, err.Error(), "logger")
+	assert.Contains(t, err.Error(), "auditor")
 }
 
 func TestLoad_LoggerConfig_NegativeBufferSize(t *testing.T) {
@@ -1342,7 +1342,7 @@ func TestLoad_LoggerConfig_NegativeBufferSize(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   queue_size: -1
 outputs:
   console:
@@ -1361,7 +1361,7 @@ func TestLoad_LoggerConfig_BufferSizeExceedsMax(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   queue_size: 2000000
 outputs:
   console:
@@ -1374,14 +1374,14 @@ outputs:
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }
 
-func TestLoad_LoggerConfig_NegativeDrainTimeout(t *testing.T) {
+func TestLoad_LoggerConfig_NegativeShutdownTimeout(t *testing.T) {
 	t.Parallel()
 	data := []byte(`
 version: 1
 app_name: test
 host: test
-logger:
-  drain_timeout: "-5s"
+auditor:
+  shutdown_timeout: "-5s"
 outputs:
   console:
     type: stdout
@@ -1393,14 +1393,14 @@ outputs:
 	assert.Contains(t, err.Error(), "non-negative")
 }
 
-func TestLoad_LoggerConfig_DrainTimeoutExceedsMax(t *testing.T) {
+func TestLoad_LoggerConfig_ShutdownTimeoutExceedsMax(t *testing.T) {
 	t.Parallel()
 	data := []byte(`
 version: 1
 app_name: test
 host: test
-logger:
-  drain_timeout: "120s"
+auditor:
+  shutdown_timeout: "120s"
 outputs:
   console:
     type: stdout
@@ -1412,14 +1412,14 @@ outputs:
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }
 
-func TestLoad_LoggerConfig_InvalidDrainTimeout(t *testing.T) {
+func TestLoad_LoggerConfig_InvalidShutdownTimeout(t *testing.T) {
 	t.Parallel()
 	data := []byte(`
 version: 1
 app_name: test
 host: test
-logger:
-  drain_timeout: "not-a-duration"
+auditor:
+  shutdown_timeout: "not-a-duration"
 outputs:
   console:
     type: stdout
@@ -1437,7 +1437,7 @@ func TestLoad_LoggerConfig_InvalidValidationMode(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   validation_mode: invalid
 outputs:
   console:
@@ -1459,7 +1459,7 @@ func TestLoad_LoggerConfig_ValidationModes(t *testing.T) {
 version: 1
 app_name: test
 host: test
-logger:
+auditor:
   validation_mode: %s
 outputs:
   console:
@@ -2592,10 +2592,10 @@ outputs:
 }
 
 func TestLoad_QueueSizeInLoggerSection(t *testing.T) {
-	// Exercises toInt path through logger.queue_size.
+	// Exercises toInt path through auditor.queue_size.
 	t.Parallel()
 	tax := testTaxonomy(t)
-	data := []byte("version: 1\napp_name: test\nhost: test\nlogger:\n  queue_size: 200\noutputs:\n  c:\n    type: stdout\n")
+	data := []byte("version: 1\napp_name: test\nhost: test\nauditor:\n  queue_size: 200\noutputs:\n  c:\n    type: stdout\n")
 	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/outputconfig/route.go
+++ b/outputconfig/route.go
@@ -64,7 +64,7 @@ func buildRoute(name string, raw any, taxonomy *audit.Taxonomy) (*audit.EventRou
 
 func buildOutputFormatter(name string, raw any) (audit.Formatter, error) {
 	if raw == nil {
-		return nil, nil //nolint:nilnil // nil = use logger default
+		return nil, nil //nolint:nilnil // nil = use auditor default
 	}
 	f, err := buildFormatter(raw)
 	if err != nil {

--- a/outputconfig/tests/bdd/steps/steps.go
+++ b/outputconfig/tests/bdd/steps/steps.go
@@ -50,7 +50,7 @@ func (l *lokiStub) Name() string       { return "loki-stub" }
 // TestContext holds mutable state for a single BDD scenario.
 type TestContext struct { //nolint:govet // fieldalignment: readability preferred
 	Taxonomy      *audit.Taxonomy
-	Logger        *audit.Logger
+	Auditor       *audit.Auditor
 	Options       []audit.Option
 	LoadResult    *outputconfig.LoadResult
 	LastErr       error
@@ -71,7 +71,7 @@ type TestContext struct { //nolint:govet // fieldalignment: readability preferre
 
 // Reset prepares the context for a new scenario.
 func (tc *TestContext) Reset() {
-	tc.Logger = nil
+	tc.Auditor = nil
 	tc.Options = nil
 	tc.LoadResult = nil
 	tc.LastErr = nil
@@ -98,11 +98,11 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	})
 
 	ctx.After(func(goctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
-		if tc.Logger != nil {
-			// Logger.Close drains and closes its wrapped outputs.
-			_ = tc.Logger.Close()
+		if tc.Auditor != nil {
+			// Auditor.Close drains and closes its wrapped outputs.
+			_ = tc.Auditor.Close()
 		} else if tc.LoadResult != nil {
-			// Outputs were constructed but never handed to a Logger —
+			// Outputs were constructed but never handed to an Auditor —
 			// close them directly to avoid resource leaks.
 			for _, o := range tc.LoadResult.Outputs {
 				_ = o.Output.Close()
@@ -189,52 +189,52 @@ events:
 }
 
 func registerWhenSteps(ctx *godog.ScenarioContext, tc *TestContext) {
-	ctx.Step(`^I create a logger from the YAML config$`, func() error {
+	ctx.Step(`^I create an auditor from the YAML config$`, func() error {
 		if tc.LastErr != nil {
 			return fmt.Errorf("config load already failed: %w", tc.LastErr)
 		}
 		opts := []audit.Option{audit.WithTaxonomy(tc.Taxonomy)}
 		opts = append(opts, tc.Options...)
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
+		tc.Auditor = auditor
 		return nil
 	})
 
-	ctx.Step(`^I try to create a logger from the YAML config$`, func() error {
+	ctx.Step(`^I try to create an auditor from the YAML config$`, func() error {
 		if tc.LastErr != nil {
 			return nil //nolint:nilerr // Load already set tc.LastErr
 		}
 		opts := []audit.Option{audit.WithTaxonomy(tc.Taxonomy)}
 		opts = append(opts, tc.Options...)
-		logger, logErr := audit.NewLogger(opts...)
+		auditor, logErr := audit.New(opts...)
 		if logErr != nil {
 			tc.LastErr = logErr
 			return nil //nolint:nilerr // scenario asserts on tc.LastErr
 		}
-		tc.Logger = logger
+		tc.Auditor = auditor
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with fields:$`, func(eventType string, table *godog.Table) error {
-		if tc.Logger == nil {
-			return fmt.Errorf("no logger created")
+		if tc.Auditor == nil {
+			return fmt.Errorf("no auditor created")
 		}
 		fields := audit.Fields{}
 		for _, row := range table.Rows[1:] { // skip header
 			fields[row.Cells[0].Value] = row.Cells[1].Value
 		}
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
-	ctx.Step(`^I close the logger$`, func() error {
-		if tc.Logger == nil {
+	ctx.Step(`^I close the auditor$`, func() error {
+		if tc.Auditor == nil {
 			return nil
 		}
-		tc.LastErr = tc.Logger.Close()
+		tc.LastErr = tc.Auditor.Close()
 		return nil
 	})
 }

--- a/registry.go
+++ b/registry.go
@@ -31,7 +31,7 @@ import (
 // (e.g. the content under the "file:" key). The factory MUST NOT
 // retain rawConfig after returning.
 //
-// coreMetrics is the logger-level [Metrics] recorder (may be nil).
+// coreMetrics is the auditor-level [Metrics] recorder (may be nil).
 // Forwarded to outputs that need it (e.g. webhook for delivery
 // reporting). Per-output-type metrics are auto-detected via type
 // assertion: if coreMetrics satisfies the output's specific Metrics
@@ -95,18 +95,18 @@ func RegisteredOutputTypes() []string {
 }
 
 // Compile-time assertions: namedOutput satisfies all optional output
-// interfaces so the wrapper is transparent to the core logger.
+// interfaces so the wrapper is transparent to the core auditor.
 var (
-	_ MetadataWriter         = (*namedOutput)(nil)
-	_ FrameworkFieldReceiver = (*namedOutput)(nil)
-	_ LoggerReceiver         = (*namedOutput)(nil)
-	_ OutputMetricsReceiver  = (*namedOutput)(nil)
+	_ MetadataWriter           = (*namedOutput)(nil)
+	_ FrameworkFieldReceiver   = (*namedOutput)(nil)
+	_ DiagnosticLoggerReceiver = (*namedOutput)(nil)
+	_ OutputMetricsReceiver    = (*namedOutput)(nil)
 )
 
 // namedOutput wraps an [Output] to override its [Output.Name] method
 // with a consumer-chosen name from the YAML config. All other methods
 // delegate to the inner output, including optional interfaces
-// ([MetadataWriter], [FrameworkFieldReceiver], [LoggerReceiver],
+// ([MetadataWriter], [FrameworkFieldReceiver], [DiagnosticLoggerReceiver],
 // [OutputMetricsReceiver], [DestinationKeyer], [DeliveryReporter]).
 type namedOutput struct {
 	Output
@@ -128,7 +128,7 @@ func (n *namedOutput) DestinationKey() string {
 }
 
 // ReportsDelivery forwards to the inner output if it implements
-// [DeliveryReporter]. This ensures the core logger correctly skips
+// [DeliveryReporter]. This ensures the core auditor correctly skips
 // per-event metrics for self-reporting outputs like webhook.
 func (n *namedOutput) ReportsDelivery() bool {
 	if dr, ok := n.Output.(DeliveryReporter); ok {
@@ -159,13 +159,13 @@ func (n *namedOutput) SetFrameworkFields(appName, host, timezone string, pid int
 	}
 }
 
-// SetLogger forwards to the inner output if it implements
-// [LoggerReceiver]. This ensures the library's diagnostic logger
+// SetDiagnosticLogger forwards to the inner output if it implements
+// [DiagnosticLoggerReceiver]. This ensures the library's diagnostic logger
 // propagates through the name wrapper to outputs created via YAML
 // config.
-func (n *namedOutput) SetLogger(l *slog.Logger) {
-	if lr, ok := n.Output.(LoggerReceiver); ok {
-		lr.SetLogger(l)
+func (n *namedOutput) SetDiagnosticLogger(l *slog.Logger) {
+	if lr, ok := n.Output.(DiagnosticLoggerReceiver); ok {
+		lr.SetDiagnosticLogger(l)
 	}
 }
 
@@ -186,12 +186,12 @@ func (n *namedOutput) SetOutputMetrics(m OutputMetrics) {
 //
 // The returned output always satisfies [DestinationKeyer],
 // [DeliveryReporter], [MetadataWriter], [FrameworkFieldReceiver],
-// [LoggerReceiver], and [OutputMetricsReceiver] regardless of the
+// [DiagnosticLoggerReceiver], and [OutputMetricsReceiver] regardless of the
 // inner output. When the inner
 // output does not implement these interfaces, the wrapper returns
 // zero-value behaviour: empty string for DestinationKey, false for
 // ReportsDelivery, delegation to Write for WriteWithMetadata, and
-// no-op for SetFrameworkFields and SetLogger.
+// no-op for SetFrameworkFields and SetDiagnosticLogger.
 func WrapOutput(inner Output, name string) Output {
 	return &namedOutput{Output: inner, outputName: name}
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -231,29 +231,29 @@ func TestWrapOutput_NonFrameworkFieldReceiver_NoOp(t *testing.T) {
 	fr.SetFrameworkFields("app", "host", "UTC", 1)
 }
 
-func TestWrapOutput_PreservesLoggerReceiver(t *testing.T) {
-	inner := &mockLoggerReceiver{
+func TestWrapOutput_PreservesDiagnosticLoggerReceiver(t *testing.T) {
+	inner := &mockDiagnosticLoggerReceiver{
 		MockOutput: *testhelper.NewMockOutput("syslog:localhost:514"),
 	}
 	wrapped := audit.WrapOutput(inner, "my_syslog")
 
-	lr, ok := wrapped.(audit.LoggerReceiver)
-	require.True(t, ok, "wrapped output should implement LoggerReceiver")
+	lr, ok := wrapped.(audit.DiagnosticLoggerReceiver)
+	require.True(t, ok, "wrapped output should implement DiagnosticLoggerReceiver")
 
 	customLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	lr.SetLogger(customLogger)
-	assert.Same(t, customLogger, inner.logger, "logger should be forwarded to inner")
+	lr.SetDiagnosticLogger(customLogger)
+	assert.Same(t, customLogger, inner.logger, "auditor should be forwarded to inner")
 }
 
-func TestWrapOutput_NonLoggerReceiver_NoOp(t *testing.T) {
+func TestWrapOutput_NonDiagnosticLoggerReceiver_NoOp(t *testing.T) {
 	inner := testhelper.NewMockOutput("file:/tmp/test.log")
 	wrapped := audit.WrapOutput(inner, "my_file")
 
-	lr, ok := wrapped.(audit.LoggerReceiver)
-	require.True(t, ok, "namedOutput always implements LoggerReceiver")
+	lr, ok := wrapped.(audit.DiagnosticLoggerReceiver)
+	require.True(t, ok, "namedOutput always implements DiagnosticLoggerReceiver")
 
 	// Should not panic.
-	lr.SetLogger(slog.Default())
+	lr.SetDiagnosticLogger(slog.Default())
 }
 
 // --- Test helper types ---
@@ -302,12 +302,12 @@ func (m *mockFrameworkFieldReceiver) SetFrameworkFields(appName, host, timezone 
 	m.pid = pid
 }
 
-// mockLoggerReceiver wraps MockOutput with LoggerReceiver.
-type mockLoggerReceiver struct { //nolint:govet // fieldalignment: test struct, readability preferred
+// mockDiagnosticLoggerReceiver wraps MockOutput with DiagnosticLoggerReceiver.
+type mockDiagnosticLoggerReceiver struct { //nolint:govet // fieldalignment: test struct, readability preferred
 	testhelper.MockOutput
 	logger *slog.Logger
 }
 
-func (m *mockLoggerReceiver) SetLogger(l *slog.Logger) {
+func (m *mockDiagnosticLoggerReceiver) SetDiagnosticLogger(l *slog.Logger) {
 	m.logger = l
 }

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -503,13 +503,13 @@ func TestFieldStripping_SingleLabel(t *testing.T) {
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: buf})
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":      "success",
 		"actor_id":     "alice",
 		"email":        "alice@example.com",
@@ -518,7 +518,7 @@ func TestFieldStripping_SingleLabel(t *testing.T) {
 		"nickname":     "ally",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	events := parseJSONEvents(t, buf)
 	require.Len(t, events, 1)
@@ -551,20 +551,20 @@ func TestFieldStripping_MultiLabel_AnyOverlap(t *testing.T) {
 	require.NoError(t, err)
 
 	// Exclude financial only — card_number is stripped.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("financial")),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":     "success",
 		"actor_id":    "alice",
 		"email":       "alice@example.com",
 		"card_number": "4111111111111111",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	events := parseJSONEvents(t, buf)
 	require.Len(t, events, 1)
@@ -584,20 +584,20 @@ func TestFieldStripping_DifferentOutputs(t *testing.T) {
 	outAll := testhelper.NewMockOutput("all")
 	outNoPII := testhelper.NewMockOutput("no-pii")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(outAll), // no exclusions
 		audit.WithNamedOutput(outNoPII, audit.OutputExcludeLabels("pii")), // exclude PII
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"email":    "alice@example.com",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// "all" output gets all fields.
 	require.True(t, outAll.WaitForEvents(1, 2*time.Second))
@@ -623,19 +623,19 @@ func TestFieldStripping_NoExclusion_AllFields(t *testing.T) {
 	require.NoError(t, err)
 
 	// No exclude_labels → all fields delivered.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"email":    "alice@example.com",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	events := parseJSONEvents(t, buf)
 	require.Len(t, events, 1)
@@ -669,19 +669,19 @@ events:
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: buf})
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"email":    "alice@example.com",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	events := parseJSONEvents(t, buf)
 	require.Len(t, events, 1)
@@ -698,7 +698,7 @@ events:
 	assert.Contains(t, evt, "severity")
 }
 
-func TestNewLogger_ExcludeLabels_NoSensitivity(t *testing.T) {
+func TestNew_ExcludeLabels_NoSensitivity(t *testing.T) {
 	t.Parallel()
 	tax, err := audit.ParseTaxonomyYAML([]byte(`
 version: 1
@@ -715,7 +715,7 @@ events:
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{})
 	require.NoError(t, err)
 
-	_, err = audit.NewLogger(
+	_, err = audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
@@ -723,7 +723,7 @@ events:
 	assert.Contains(t, err.Error(), "no sensitivity config")
 }
 
-func TestNewLogger_ExcludeLabels_UndefinedLabel(t *testing.T) {
+func TestNew_ExcludeLabels_UndefinedLabel(t *testing.T) {
 	t.Parallel()
 	tax, err := audit.ParseTaxonomyYAML([]byte(`
 version: 1
@@ -745,7 +745,7 @@ events:
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{})
 	require.NoError(t, err)
 
-	_, err = audit.NewLogger(
+	_, err = audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("nonexistent")),
 	)
@@ -784,18 +784,18 @@ events:
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: buf})
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	events := parseJSONEvents(t, buf)
 	require.Len(t, events, 1)
@@ -824,7 +824,7 @@ func TestFormatWithExclusion_ExclusionPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Output with exclusions — formatOpts should be pre-allocated.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
 	)
@@ -832,14 +832,14 @@ func TestFormatWithExclusion_ExclusionPath(t *testing.T) {
 
 	// Emit multiple events to verify pre-computed defs work correctly.
 	for i := range 10 {
-		err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 			"outcome":  "success",
 			"actor_id": fmt.Sprintf("user-%d", i),
 			"email":    fmt.Sprintf("user%d@example.com", i),
 		}))
 		require.NoError(t, err)
 	}
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	events := parseJSONEvents(t, buf)
 	require.Len(t, events, 10)
@@ -861,19 +861,19 @@ func TestFormatWithExclusion_NoExclusionNoOverhead(t *testing.T) {
 	require.NoError(t, err)
 
 	// Output WITHOUT exclusions — formatOpts should be nil.
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(stdout),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"email":    "alice@example.com",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	events := parseJSONEvents(t, buf)
 	require.Len(t, events, 1)
@@ -890,7 +890,7 @@ func TestFormatWithExclusion_MultipleOutputsDifferentExclusions(t *testing.T) {
 	outNoPII := testhelper.NewMockOutput("no-pii")
 	outNoFinancial := testhelper.NewMockOutput("no-financial")
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(outAll),
 		audit.WithNamedOutput(outNoPII, audit.OutputExcludeLabels("pii")),
@@ -898,14 +898,14 @@ func TestFormatWithExclusion_MultipleOutputsDifferentExclusions(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":     "success",
 		"actor_id":    "alice",
 		"email":       "alice@example.com",
 		"card_number": "4111111111111111",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// "all" gets everything.
 	require.True(t, outAll.WaitForEvents(1, 2*time.Second))
@@ -939,7 +939,7 @@ func TestFieldStripping_Concurrent(t *testing.T) {
 	require.NoError(t, err)
 
 	out := testhelper.NewMockOutput("concurrent")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputExcludeLabels("pii")),
 	)
@@ -953,7 +953,7 @@ func TestFieldStripping_Concurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range eventsPerGoroutine {
-				_ = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+				_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 					"outcome":  "success",
 					"actor_id": "alice",
 					"email":    "alice@example.com",
@@ -962,7 +962,7 @@ func TestFieldStripping_Concurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	total := goroutines * eventsPerGoroutine
 	require.True(t, out.WaitForEvents(total, 5*time.Second),
@@ -1111,7 +1111,7 @@ func BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion(b *testing.B) {
 	}
 	outAll := testhelper.NewMockOutput("all")
 	outFiltered := testhelper.NewMockOutput("filtered")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(outAll),
 		audit.WithNamedOutput(outFiltered, audit.OutputExcludeLabels("pii")),
@@ -1119,7 +1119,7 @@ func BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -1130,7 +1130,7 @@ func BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for range b.N {
-		_ = logger.AuditEvent(audit.NewEvent("user_create", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("user_create", fields))
 	}
 }
 
@@ -1141,14 +1141,14 @@ func benchAuditWithExclusions(b *testing.B, taxonomyYAML string, excludeLabels [
 		b.Fatal(err)
 	}
 	out := testhelper.NewMockOutput("bench")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputExcludeLabels(excludeLabels...)),
 	)
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
 	fields := audit.Fields{
 		"outcome":  "success",
@@ -1159,7 +1159,7 @@ func benchAuditWithExclusions(b *testing.B, taxonomyYAML string, excludeLabels [
 	b.ResetTimer()
 	b.ReportAllocs()
 	for range b.N {
-		_ = logger.AuditEvent(audit.NewEvent("user_create", fields))
+		_ = auditor.AuditEvent(audit.NewEvent("user_create", fields))
 	}
 }
 

--- a/severity_routing_test.go
+++ b/severity_routing_test.go
@@ -367,24 +367,24 @@ func TestSetRoute_CopiesMinSeverityPointer(t *testing.T) {
 	tax := testhelper.TestTaxonomy()
 
 	out := testhelper.NewMockOutput("copy-min")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// Set a severity route via the public API.
 	original := intPtr(5)
 	route := &audit.EventRoute{MinSeverity: original}
-	require.NoError(t, logger.SetOutputRoute("copy-min", route))
+	require.NoError(t, auditor.SetOutputRoute("copy-min", route))
 
 	// Mutate the original pointer after SetOutputRoute returns.
 	*original = 99
 
 	// The stored route must reflect the value at the time of the call (5),
 	// not the mutated value (99).
-	stored, err := logger.OutputRoute("copy-min")
+	stored, err := auditor.OutputRoute("copy-min")
 	require.NoError(t, err)
 	require.NotNil(t, stored.MinSeverity,
 		"stored route must have a non-nil MinSeverity")
@@ -399,21 +399,21 @@ func TestSetRoute_CopiesMaxSeverityPointer(t *testing.T) {
 	tax := testhelper.TestTaxonomy()
 
 	out := testhelper.NewMockOutput("copy-max")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	original := intPtr(8)
 	route := &audit.EventRoute{MaxSeverity: original}
-	require.NoError(t, logger.SetOutputRoute("copy-max", route))
+	require.NoError(t, auditor.SetOutputRoute("copy-max", route))
 
 	// Mutate after the call.
 	*original = 1
 
-	stored, err := logger.OutputRoute("copy-max")
+	stored, err := auditor.OutputRoute("copy-max")
 	require.NoError(t, err)
 	require.NotNil(t, stored.MaxSeverity,
 		"stored route must have a non-nil MaxSeverity")
@@ -430,21 +430,21 @@ func TestGetRoute_ReturnsIndependentSeverityPointers(t *testing.T) {
 	tax := testhelper.TestTaxonomy()
 
 	out := testhelper.NewMockOutput("get-copy")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(4)})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// First retrieval: mutate the returned copy.
-	first, err := logger.OutputRoute("get-copy")
+	first, err := auditor.OutputRoute("get-copy")
 	require.NoError(t, err)
 	require.NotNil(t, first.MinSeverity)
 	*first.MinSeverity = 77 // mutate the copy
 
 	// Second retrieval: must still reflect the original value (4).
-	second, err := logger.OutputRoute("get-copy")
+	second, err := auditor.OutputRoute("get-copy")
 	require.NoError(t, err)
 	require.NotNil(t, second.MinSeverity,
 		"second OutputRoute call must return a non-nil MinSeverity")
@@ -461,21 +461,21 @@ func TestSetRoute_NilSeverityPointersPreserved(t *testing.T) {
 	tax := testhelper.TestTaxonomy()
 
 	out := testhelper.NewMockOutput("nil-sev")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// Set a route that has no severity constraints.
 	route := &audit.EventRoute{
 		IncludeCategories: []string{"write"},
 		// MinSeverity and MaxSeverity intentionally nil.
 	}
-	require.NoError(t, logger.SetOutputRoute("nil-sev", route))
+	require.NoError(t, auditor.SetOutputRoute("nil-sev", route))
 
-	stored, err := logger.OutputRoute("nil-sev")
+	stored, err := auditor.OutputRoute("nil-sev")
 	require.NoError(t, err)
 	assert.Nil(t, stored.MinSeverity,
 		"nil MinSeverity must remain nil after setRoute/getRoute round-trip")
@@ -677,18 +677,18 @@ func TestAudit_SeverityRouteFiltersInDrainLoop(t *testing.T) {
 	require.NoError(t, err)
 
 	out := testhelper.NewMockOutput("sev-filter")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(7)})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("critical_event", audit.Fields{"outcome": "failure"})))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("medium_event", audit.Fields{"outcome": "success"})))
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("low_event", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("critical_event", audit.Fields{"outcome": "failure"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("medium_event", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("low_event", audit.Fields{"outcome": "success"})))
 
-	// t.Cleanup calls logger.Close() which flushes the drain buffer.
+	// t.Cleanup calls auditor.Close() which flushes the drain buffer.
 	// Wait for events to be processed.
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 
@@ -732,23 +732,23 @@ events:
 	require.NoError(t, err)
 
 	out := testhelper.NewMockOutput("force-enabled")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// Output route: MinSeverity 5 — only events with severity >= 5 delivered.
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(5)})),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, logger.Close()) })
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
 
 	// Force-enable the restricted event globally so it passes the global filter.
-	require.NoError(t, logger.EnableEvent("restricted_event"))
+	require.NoError(t, auditor.EnableEvent("restricted_event"))
 
 	// Emit restricted_event (severity 2 < min 5 on the output route).
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("restricted_event", audit.Fields{"outcome": "ok"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("restricted_event", audit.Fields{"outcome": "ok"})))
 	// Emit normal_event (severity 7 >= min 5 on the output route).
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("normal_event", audit.Fields{"outcome": "ok"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("normal_event", audit.Fields{"outcome": "ok"})))
 
-	// t.Cleanup calls logger.Close() which flushes the drain buffer.
+	// t.Cleanup calls auditor.Close() which flushes the drain buffer.
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 
 	// restricted_event is globally enabled but its severity (2) is below the
@@ -875,7 +875,7 @@ func TestConcurrentSetRouteWithSeverity(t *testing.T) {
 	t.Parallel()
 	tax := testhelper.TestTaxonomy()
 	out := testhelper.NewMockOutput("concurrent_sev")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
@@ -889,7 +889,7 @@ func TestConcurrentSetRouteWithSeverity(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for range 200 {
-			_ = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
+			_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"outcome": "failure"}))
 		}
 	}()
 
@@ -898,15 +898,15 @@ func TestConcurrentSetRouteWithSeverity(t *testing.T) {
 		defer wg.Done()
 		for range 100 {
 			minSev := 5
-			_ = logger.SetOutputRoute("concurrent_sev", &audit.EventRoute{
+			_ = auditor.SetOutputRoute("concurrent_sev", &audit.EventRoute{
 				MinSeverity: &minSev,
 			})
-			_ = logger.ClearOutputRoute("concurrent_sev")
+			_ = auditor.ClearOutputRoute("concurrent_sev")
 		}
 	}()
 
 	wg.Wait()
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	// Events may or may not be filtered depending on timing —
 	// the test verifies no data race, not a specific count.
 	assert.True(t, out.EventCount() > 0, "at least some events should arrive")

--- a/sync_delivery_test.go
+++ b/sync_delivery_test.go
@@ -27,30 +27,30 @@ import (
 func TestSyncLogger_EventAvailableImmediately(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithSynchronousDelivery(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 	}))
 	require.NoError(t, err)
 
 	// No Close() called — events should be available immediately.
-	assert.Equal(t, 1, out.EventCount(), "sync logger should deliver events immediately")
+	assert.Equal(t, 1, out.EventCount(), "sync auditor should deliver events immediately")
 
 	// Close is still safe.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 func TestSyncLogger_CloseIsSafe(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithSynchronousDelivery(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
@@ -58,36 +58,36 @@ func TestSyncLogger_CloseIsSafe(t *testing.T) {
 	require.NoError(t, err)
 
 	// Close without any events — should not panic.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// Double close — should not panic.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 func TestSyncLogger_ValidationStillRuns(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithSynchronousDelivery(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// Missing required field should still be rejected.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
 }
 
-func TestNewLoggerQuick_DefaultsToSync(t *testing.T) {
+func TestNewQuick_DefaultsToSync(t *testing.T) {
 	t.Parallel()
-	logger, events, _ := audittest.NewLoggerQuick(t, "user_create")
+	auditor, events, _ := audittest.NewQuick(t, "user_create")
 
-	err := logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "ok"}))
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "ok"}))
 	require.NoError(t, err)
 
 	// No Close — events available immediately because Quick defaults to sync.
-	assert.Equal(t, 1, events.Count(), "NewLoggerQuick should use synchronous delivery")
+	assert.Equal(t, 1, events.Count(), "NewQuick should use synchronous delivery")
 }

--- a/syslog/config.go
+++ b/syslog/config.go
@@ -98,7 +98,7 @@ type Config struct {
 
 	// Hostname overrides the hostname in the syslog RFC 5424 header.
 	// When empty, [os.Hostname] is used at construction time. Set this
-	// to match the logger-wide host value from [audit.WithHost].
+	// to match the auditor-wide host value from [audit.WithHost].
 	Hostname string
 
 	// MaxRetries is the maximum number of consecutive reconnection

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -82,7 +82,7 @@ var syslogSeverities = [11]srslog.Priority{
 // outside [0, 10] silently fall back to LOG_INFO (syslog severity 6).
 // The taxonomy enforces the 0–10 range at registration time, so
 // out-of-range values indicate a programming error in a custom [Output]
-// that bypasses the logger and calls this function directly.
+// that bypasses the auditor and calls this function directly.
 func mapSeverity(auditSeverity int) srslog.Priority {
 	if auditSeverity < 0 || auditSeverity > 10 {
 		return srslog.LOG_INFO
@@ -151,7 +151,7 @@ type Output struct {
 	tlsCfg        *tls.Config                         // cached for reconnection; nil for non-TLS
 	syslogMetrics atomic.Pointer[Metrics]             // extension: RecordSyslogReconnect (may be nil)
 	outputMetrics atomic.Pointer[audit.OutputMetrics] // unified per-output metrics (may be nil)
-	logger        *slog.Logger                        // diagnostic logger; set via SetLogger
+	logger        *slog.Logger                        // diagnostic logger; set via SetDiagnosticLogger
 	ch            chan syslogEntry                    // async buffer
 	closeCh       chan struct{}                       // signals writeLoop to drain and exit
 	done          chan struct{}                       // closed when writeLoop exits
@@ -169,8 +169,8 @@ type Output struct {
 	maxRetry      int
 }
 
-// SetLogger receives the library's diagnostic logger.
-func (s *Output) SetLogger(l *slog.Logger) {
+// SetDiagnosticLogger receives the library's diagnostic logger.
+func (s *Output) SetDiagnosticLogger(l *slog.Logger) {
 	s.logger = l
 }
 

--- a/taxonomy.go
+++ b/taxonomy.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Fields is the map type for audit event fields. Consumers pass
-// field values as Fields to [Logger.AuditEvent] and generated event
+// field values as Fields to [Auditor.AuditEvent] and generated event
 // builders.
 //
 // Fields is a defined type (not an alias) so it can carry convenience
@@ -126,7 +126,7 @@ type EventDef struct {
 	Severity *int
 
 	// Required lists field names that must be present in every
-	// [Logger.AuditEvent] call for this event type. Missing required
+	// [Auditor.AuditEvent] call for this event type. Missing required
 	// fields always produce an error regardless of validation mode.
 	Required []string
 
@@ -212,7 +212,7 @@ type Taxonomy struct {
 	validated bool
 
 	// dev is set by [DevTaxonomy] to signal that this is a permissive
-	// development taxonomy. [NewLogger] emits a slog.Warn when this
+	// development taxonomy. [New] emits a slog.Warn when this
 	// flag is true.
 	dev bool
 }
@@ -223,7 +223,7 @@ type Taxonomy struct {
 //
 // DevTaxonomy is for prototyping and testing only. It accepts any
 // event type with any fields and MUST NOT be used in production.
-// [NewLogger] emits a [log/slog] warning when a DevTaxonomy is used.
+// [New] emits a [log/slog] warning when a DevTaxonomy is used.
 func DevTaxonomy(eventTypes ...string) *Taxonomy {
 	events := make(map[string]*EventDef, len(eventTypes))
 	for _, et := range eventTypes {

--- a/taxonomy_pointer_test.go
+++ b/taxonomy_pointer_test.go
@@ -66,7 +66,7 @@ func TestParseTaxonomyYAML_EmptyInput_ReturnsNilAndError(t *testing.T) {
 
 func TestWithTaxonomy_NilPointer_ReturnsError(t *testing.T) {
 	t.Parallel()
-	_, err := audit.NewLogger(
+	_, err := audit.New(
 		audit.WithTaxonomy(nil),
 	)
 	require.Error(t, err)
@@ -95,20 +95,20 @@ events:
 	tax, err := audit.ParseTaxonomyYAML(yaml)
 	require.NoError(t, err)
 
-	// Create logger — should succeed without re-validating.
+	// Create auditor — should succeed without re-validating.
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	// Verify the logger works.
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	// Verify the auditor works.
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome": "success",
 	}))
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 	assert.Equal(t, 1, out.EventCount())
 }
 
@@ -116,7 +116,7 @@ events:
 // Deep copy prevents post-construction mutation (#389 AC-6)
 // ---------------------------------------------------------------------------
 
-func TestWithTaxonomy_PostConstructionMutation_DoesNotAffectLogger(t *testing.T) {
+func TestWithTaxonomy_PostConstructionMutation_DoesNotAffectAuditor(t *testing.T) {
 	t.Parallel()
 
 	tax := &audit.Taxonomy{
@@ -133,30 +133,30 @@ func TestWithTaxonomy_PostConstructionMutation_DoesNotAffectLogger(t *testing.T)
 	}
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
 
-	// Mutate the original taxonomy AFTER logger creation.
+	// Mutate the original taxonomy AFTER auditor creation.
 	delete(tax.Events, "user_create")
 	tax.Events["hacked_event"] = &audit.EventDef{Required: []string{"x"}}
 
-	// The logger should still accept user_create (uses the deep copy).
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	// The auditor should still accept user_create (uses the deep copy).
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome": "success",
 	}))
-	require.NoError(t, err, "logger should use deep copy, not the mutated original")
+	require.NoError(t, err, "auditor should use deep copy, not the mutated original")
 
-	// The logger should NOT accept hacked_event (not in the copy).
-	err = logger.AuditEvent(audit.NewEvent("hacked_event", audit.Fields{
+	// The auditor should NOT accept hacked_event (not in the copy).
+	err = auditor.AuditEvent(audit.NewEvent("hacked_event", audit.Fields{
 		"x": "y",
 	}))
-	require.Error(t, err, "hacked_event should not be in the logger's taxonomy")
+	require.Error(t, err, "hacked_event should not be in the auditor's taxonomy")
 	assert.Contains(t, err.Error(), "unknown event type")
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 // ---------------------------------------------------------------------------
@@ -166,7 +166,7 @@ func TestWithTaxonomy_PostConstructionMutation_DoesNotAffectLogger(t *testing.T)
 func TestWithTaxonomy_InlineTaxonomy_TakesAddress(t *testing.T) {
 	t.Parallel()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version: 1,
 			Categories: map[string]*audit.CategoryDef{
@@ -178,5 +178,5 @@ func TestWithTaxonomy_InlineTaxonomy_TakesAddress(t *testing.T) {
 		}),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }

--- a/taxonomy_test.go
+++ b/taxonomy_test.go
@@ -24,16 +24,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewLogger_ValidTaxonomy(t *testing.T) {
-	logger, err := audit.NewLogger(
+func TestNew_ValidTaxonomy(t *testing.T) {
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 	)
 	require.NoError(t, err)
-	require.NotNil(t, logger)
-	require.NoError(t, logger.Close())
+	require.NotNil(t, auditor)
+	require.NoError(t, auditor.Close())
 }
 
-func TestNewLogger_TaxonomyValidation(t *testing.T) {
+func TestNew_TaxonomyValidation(t *testing.T) {
 	tests := []struct { //nolint:govet // fieldalignment: test struct readability
 		name      string
 		wantError string
@@ -72,7 +72,7 @@ func TestNewLogger_TaxonomyValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := audit.NewLogger(
+			_, err := audit.New(
 				audit.WithTaxonomy(tt.taxonomy),
 			)
 			require.Error(t, err)
@@ -82,14 +82,14 @@ func TestNewLogger_TaxonomyValidation(t *testing.T) {
 	}
 }
 
-func TestNewLogger_TaxonomyRequired(t *testing.T) {
-	_, err := audit.NewLogger()
+func TestNew_TaxonomyRequired(t *testing.T) {
+	_, err := audit.New()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "taxonomy is required")
 }
 
-func TestNewLogger_TaxonomyValidation_SentinelError(t *testing.T) {
-	_, err := audit.NewLogger(
+func TestNew_TaxonomyValidation_SentinelError(t *testing.T) {
+	_, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{Version: 0}),
 	)
 	require.Error(t, err)
@@ -336,8 +336,8 @@ func TestMigrateTaxonomy(t *testing.T) {
 	})
 }
 
-func TestNewLogger_TaxonomyVersionNegative(t *testing.T) {
-	_, err := audit.NewLogger(
+func TestNew_TaxonomyVersionNegative(t *testing.T) {
+	_, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{
 			Version:    -1,
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},

--- a/taxonomy_yaml_test.go
+++ b/taxonomy_yaml_test.go
@@ -650,16 +650,16 @@ events:
 	tax, err := audit.ParseTaxonomyYAML([]byte(yaml))
 	require.NoError(t, err)
 
-	// Create a logger and audit an event — the description should not
+	// Create an auditor and audit an event — the description should not
 	// be treated as a field name. An event with only outcome + actor_id
 	// should pass strict validation (no unknown fields).
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 	)
 	require.NoError(t, err)
-	defer func() { _ = logger.Close() }()
+	defer func() { _ = auditor.Close() }()
 
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 	}))

--- a/tests/bdd/features/async_buffer_shutdown.feature
+++ b/tests/bdd/features/async_buffer_shutdown.feature
@@ -12,32 +12,32 @@ Feature: Async Buffer Shutdown
     Given a standard test taxonomy
 
   Scenario: File output drains all buffered events on close
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit 50 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 50 events
 
   Scenario: Close with async file output is idempotent
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit event "user_create" with required fields
-    And I close the logger
-    And I close the logger again
+    And I close the auditor
+    And I close the auditor again
     Then the second close should return no error
     And the file should contain exactly 1 event
 
   Scenario: Concurrent close and audit does not panic
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit event "user_create" with required fields
-    And I close the logger from 5 goroutines concurrently
+    And I close the auditor from 5 goroutines concurrently
     Then no panic should have occurred
 
   Scenario: Close with error output does not block file drain
-    Given a logger with file output and an error-returning output
+    Given an auditor with file output and an error-returning output
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the file should contain the marker
 
   Scenario: Shutdown completes within timeout when output Write blocks
-    Given a logger with a blocking output and drain timeout 1s
+    Given an auditor with a blocking output and drain timeout 1s
     When I audit event "user_create" with required fields
-    Then closing the logger should complete within 5 seconds
+    Then closing the auditor should complete within 5 seconds

--- a/tests/bdd/features/config_versioning.feature
+++ b/tests/bdd/features/config_versioning.feature
@@ -1,48 +1,48 @@
 @core @config
-Feature: Logger Configuration
+Feature: Auditor Configuration
   As a library consumer, I want the library to validate my configuration
   so that invalid settings fail fast with a clear error instead
   of producing undefined behaviour.
 
   Scenario: Default config succeeds
     Given a standard test taxonomy
-    When I create a logger
-    Then the logger should be created successfully
+    When I create an auditor
+    Then the auditor should be created successfully
 
   Scenario: BufferSize defaults to 10000 when zero
     Given a standard test taxonomy
-    When I create a logger with buffer size 0
-    Then the logger should be created successfully
+    When I create an auditor with buffer size 0
+    Then the auditor should be created successfully
 
   Scenario: QueueSize exceeding maximum is rejected with exact error
     Given a standard test taxonomy
-    When I try to create a logger with buffer size 2000000
-    Then the logger construction should fail with an error matching:
+    When I try to create an auditor with buffer size 2000000
+    Then the auditor construction should fail with an error matching:
       """
       audit: config validation failed: queue_size 2000000 exceeds maximum 1000000
       """
 
-  Scenario: DrainTimeout defaults when zero
+  Scenario: ShutdownTimeout defaults when zero
     Given a standard test taxonomy
-    When I create a logger with drain timeout 0
-    Then the logger should be created successfully
+    When I create an auditor with drain timeout 0
+    Then the auditor should be created successfully
 
-  Scenario: DrainTimeout exceeding maximum is rejected with exact error
+  Scenario: ShutdownTimeout exceeding maximum is rejected with exact error
     Given a standard test taxonomy
-    When I try to create a logger with drain timeout 120s
-    Then the logger construction should fail with an error matching:
+    When I try to create an auditor with drain timeout 120s
+    Then the auditor construction should fail with an error matching:
       """
-      audit: config validation failed: drain_timeout 2m0s exceeds maximum 1m0s
+      audit: config validation failed: shutdown_timeout 2m0s exceeds maximum 1m0s
       """
 
   Scenario: Disabled config returns no-op logger
     Given a standard test taxonomy
     When I create a disabled logger
-    Then the logger should handle audit calls without error
+    Then the auditor should handle audit calls without error
 
   Scenario: ValidationMode defaults to strict when empty
     Given a standard test taxonomy
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "user_create" with required fields and an unknown field "extra"
     Then the audit call should return an error matching:
       """

--- a/tests/bdd/features/core_audit.feature
+++ b/tests/bdd/features/core_audit.feature
@@ -9,7 +9,7 @@ Feature: Core Audit Logging
 
   Background:
     Given a standard test taxonomy
-    And a logger with stdout output
+    And an auditor with stdout output
 
   # --- Happy paths with complete payload assertion ---
 
@@ -57,7 +57,7 @@ Feature: Core Audit Logging
 
   Scenario: Framework fields appear in JSON output
     Given framework fields app_name "myapp" host "prod-01" timezone "UTC"
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -69,7 +69,7 @@ Feature: Core Audit Logging
     And the output should contain field "pid" as a positive integer
 
   Scenario: PID is always present as a positive integer
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -78,7 +78,7 @@ Feature: Core Audit Logging
     And the output should contain field "pid" as a positive integer
 
   Scenario: PID present even without app_name or host
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -89,7 +89,7 @@ Feature: Core Audit Logging
     And the output should not contain field "host"
 
   Scenario: Timezone and PID auto-detected when not configured
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -101,7 +101,7 @@ Feature: Core Audit Logging
 
   Scenario: Framework fields present with OmitEmpty true
     Given framework fields app_name "myapp" host "prod-01" timezone "UTC"
-    And a logger with stdout output and OmitEmpty "true"
+    And an auditor with stdout output and OmitEmpty "true"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -117,7 +117,7 @@ Feature: Core Audit Logging
     Given standard field defaults:
       | field     | value    |
       | source_ip | 10.0.0.1 |
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -129,7 +129,7 @@ Feature: Core Audit Logging
     Given standard field defaults:
       | field     | value    |
       | source_ip | 10.0.0.1 |
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "user_create" with fields:
       | field     | value       |
       | outcome   | success     |
@@ -142,7 +142,7 @@ Feature: Core Audit Logging
     Given standard field defaults:
       | field     | value    |
       | source_ip | 10.0.0.1 |
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "user_create" with fields:
       | field     | value   |
       | outcome   | success |
@@ -156,7 +156,7 @@ Feature: Core Audit Logging
       | field     | value     |
       | source_ip | 10.0.0.1  |
       | reason    | scheduled |
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -181,7 +181,7 @@ Feature: Core Audit Logging
     And standard field defaults:
       | field     | value    |
       | source_ip | 10.0.0.1 |
-    And a logger with stdout output and validation mode "strict"
+    And an auditor with stdout output and validation mode "strict"
     When I audit event "user_create" with fields:
       | field   | value   |
       | outcome | success |
@@ -218,7 +218,7 @@ Feature: Core Audit Logging
       """
 
   Scenario: Audit after close returns ErrClosed
-    Given I close the logger
+    Given I close the auditor
     When I try to audit event "user_create" with required fields
     Then the audit call should return an error wrapping "ErrClosed"
 
@@ -246,7 +246,7 @@ Feature: Core Audit Logging
         ping:
           fields: {}
       """
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "ping" with nil fields
     Then the event should be delivered successfully
 
@@ -271,7 +271,7 @@ Feature: Core Audit Logging
   # --- ErrQueueFull ---
 
   Scenario: Buffer full returns ErrQueueFull
-    Given a logger with stdout output and buffer size 1
+    Given an auditor with stdout output and buffer size 1
     When I fill the buffer and audit one more event
     Then the audit call should return an error wrapping "ErrQueueFull"
 
@@ -303,7 +303,7 @@ Feature: Core Audit Logging
   # --- OmitEmpty ---
 
   Scenario: OmitEmpty true omits zero-value optional fields
-    Given a logger with stdout output and OmitEmpty "true"
+    Given an auditor with stdout output and OmitEmpty "true"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -315,7 +315,7 @@ Feature: Core Audit Logging
       | actor_id   | alice       |
 
   Scenario: OmitEmpty false includes zero-value optional fields as null
-    Given a logger with stdout output and OmitEmpty "false"
+    Given an auditor with stdout output and OmitEmpty "false"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |

--- a/tests/bdd/features/error_discrimination.feature
+++ b/tests/bdd/features/error_discrimination.feature
@@ -10,7 +10,7 @@ Feature: Error Discrimination
   # --- Unknown event type ---
 
   Scenario: Unknown event type wraps ErrValidation and ErrUnknownEventType
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "nonexistent_event" with fields:
       | field   | value   |
       | outcome | success |
@@ -26,7 +26,7 @@ Feature: Error Discrimination
   # --- Missing required field ---
 
   Scenario: Missing required field wraps ErrValidation and ErrMissingRequiredField
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "auth_failure" with fields:
       | field | value |
     Then the audit call should return an error wrapping "ErrValidation"
@@ -37,7 +37,7 @@ Feature: Error Discrimination
   # --- Unknown field (strict mode) ---
 
   Scenario: Unknown field in strict mode wraps ErrValidation and ErrUnknownField
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "auth_failure" with required fields and an unknown field "bogus"
     Then the audit call should return an error wrapping "ErrValidation"
     And the audit call should return an error wrapping "ErrUnknownField"
@@ -47,8 +47,8 @@ Feature: Error Discrimination
   # --- Non-validation errors ---
 
   Scenario: ErrClosed is not ErrValidation
-    Given a logger with stdout output
-    When I close the logger
+    Given an auditor with stdout output
+    When I close the auditor
     And I audit event "auth_failure" with required fields
     Then the audit call should return an error wrapping "ErrClosed"
     And the audit call should return an error NOT wrapping "ErrValidation"

--- a/tests/bdd/features/event_count_metrics.feature
+++ b/tests/bdd/features/event_count_metrics.feature
@@ -15,42 +15,42 @@ Feature: Event Count Metrics
     And mock metrics are configured
 
   Scenario: RecordSubmitted called for every AuditEvent
-    Given a logger with stdout output and metrics
+    Given an auditor with stdout output and metrics
     When I audit 10 events rapidly
-    And I close the logger
+    And I close the auditor
     Then RecordSubmitted should have been called 10 times
 
   Scenario: RecordSubmitted called even for filtered events
-    Given a logger with stdout output and metrics
+    Given an auditor with stdout output and metrics
     And I disable category "security"
     When I audit event "auth_failure" with required fields
     And I audit event "auth_failure" with required fields
     And I audit event "auth_failure" with required fields
-    And I close the logger
+    And I close the auditor
     Then RecordSubmitted should have been called 3 times
 
   Scenario: RecordSubmitted called for validation errors
-    Given a logger with stdout output and metrics
+    Given an auditor with stdout output and metrics
     When I audit event "nonexistent_event" with fields:
       | field   | value   |
       | outcome | success |
-    And I close the logger
+    And I close the auditor
     Then RecordSubmitted should have been called 1 time
 
   Scenario: RecordQueueDepth called from drain loop
-    Given a logger with stdout output and metrics
+    Given an auditor with stdout output and metrics
     When I audit 200 events rapidly
-    And I close the logger
+    And I close the auditor
     Then RecordQueueDepth should have been called at least 1 time
 
   Scenario: DeliveryReporter output skips core RecordEvent
-    Given a logger with file output and pipeline metrics
+    Given an auditor with file output and pipeline metrics
     When I audit 5 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the pipeline metrics should not have recorded a success event for file output
 
   Scenario: Non-DeliveryReporter output records core RecordEvent
-    Given a logger with stdout output and metrics
+    Given an auditor with stdout output and metrics
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the metrics should have recorded event "success" for output "stdout"

--- a/tests/bdd/features/event_filtering.feature
+++ b/tests/bdd/features/event_filtering.feature
@@ -11,7 +11,7 @@ Feature: Event Filtering
 
   Background:
     Given a taxonomy with categories "write" and "security"
-    And a logger with stdout output
+    And an auditor with stdout output
 
   # --- Category-level filtering ---
 

--- a/tests/bdd/features/file_output.feature
+++ b/tests/bdd/features/file_output.feature
@@ -13,14 +13,14 @@ Feature: File Output
   # --- Write & format ---
 
   Scenario: Write JSON event to file with complete field verification
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit event "user_create" with fields:
       | field       | value      |
       | outcome     | success    |
       | actor_id    | alice      |
       | marker      | file_test  |
       | target_id   | user-42    |
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should contain an event matching:
       | field       | value       |
@@ -32,31 +32,31 @@ Feature: File Output
       | duration_ms |             |
 
   Scenario: Multiple writes produce one event per line
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit 5 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 5 events
     And every event in the file should be valid JSON
 
   Scenario: Concurrent writes do not interleave lines
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit 100 events from 10 concurrent goroutines
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 100 events
     And every event in the file should be valid JSON
 
   # --- Permissions ---
 
   Scenario: Default file permissions are 0600
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the file should have permissions "0600"
 
   Scenario: Custom file permissions are applied
-    Given a logger with file output with permissions "0640"
+    Given an auditor with file output with permissions "0640"
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the file should have permissions "0640"
 
   Scenario: Symlink path is rejected at construction
@@ -66,27 +66,27 @@ Feature: File Output
   # --- Rotation ---
 
   Scenario: File rotates when MaxSizeMB exceeded
-    Given a logger with file output configured for 1 MB max size
+    Given an auditor with file output configured for 1 MB max size
     When I write enough events to exceed 1 MB
-    And I close the logger
+    And I close the auditor
     Then more than one file should exist in the output directory
 
   Scenario: Rotated backup has timestamp in filename
-    Given a logger with file output configured for 1 MB max size
+    Given an auditor with file output configured for 1 MB max size
     When I write enough events to exceed 1 MB
-    And I close the logger
+    And I close the auditor
     Then a backup file with a timestamp pattern should exist in the output directory
 
   Scenario: Compressed backups have .gz extension
-    Given a logger with file output configured for 1 MB max size with compression
+    Given an auditor with file output configured for 1 MB max size with compression
     When I write enough events to exceed 1 MB
-    And I close the logger
+    And I close the auditor
     Then a .gz backup file should exist in the output directory
 
   Scenario: Compression disabled preserves plain backup
-    Given a logger with file output configured for 1 MB max size without compression
+    Given an auditor with file output configured for 1 MB max size without compression
     When I write enough events to exceed 1 MB
-    And I close the logger
+    And I close the auditor
     Then no .gz files should exist in the output directory
 
   # --- Config validation ---
@@ -117,42 +117,42 @@ Feature: File Output
   # --- Lifecycle ---
 
   Scenario: Write after close returns error
-    Given a logger with file output at a temporary path
-    When I close the logger
+    Given an auditor with file output at a temporary path
+    When I close the auditor
     And I try to audit event "user_create" with required fields
     Then the audit call should return an error wrapping "ErrClosed"
 
   Scenario: Close is idempotent
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit event "user_create" with required fields
-    And I close the logger
-    And I close the logger again
+    And I close the auditor
+    And I close the auditor again
     Then the second close should return no error
 
   # --- File-specific metrics ---
 
   Scenario: Rotation triggers RecordFileRotation callback
     Given mock file metrics are configured
-    And a logger with file output configured for 1 MB max size with file metrics
+    And an auditor with file output configured for 1 MB max size with file metrics
     When I write enough events to exceed 1 MB
-    And I close the logger
+    And I close the auditor
     Then the file metrics should have recorded at least 1 rotation
 
   Scenario: MaxBackups enforced — excess deleted
-    Given a logger with file output configured for 1 MB max size and max backups 2
+    Given an auditor with file output configured for 1 MB max size and max backups 2
     When I write enough events to exceed 4 MB
-    And I close the logger
+    And I close the auditor
     Then at most 3 files should exist in the output directory
 
   Scenario: Multiple rotations trigger multiple metric callbacks
     Given mock file metrics are configured
-    And a logger with file output configured for 1 MB max size with file metrics
+    And an auditor with file output configured for 1 MB max size with file metrics
     When I write enough events to exceed 3 MB
-    And I close the logger
+    And I close the auditor
     Then the file metrics should have recorded at least 2 rotations
 
   Scenario: Nil file metrics does not panic on rotation
-    Given a logger with file output configured for 1 MB max size
+    Given an auditor with file output configured for 1 MB max size
     When I write enough events to exceed 1 MB
-    And I close the logger
+    And I close the auditor
     Then the file should contain events

--- a/tests/bdd/features/formatters.feature
+++ b/tests/bdd/features/formatters.feature
@@ -9,12 +9,12 @@ Feature: Event Formatters
   # --- JSON Formatter ---
 
   Scenario: JSON formatter produces valid JSON with correct fields
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should contain an event matching:
       | field       | value       |
@@ -25,58 +25,58 @@ Feature: Event Formatters
       | duration_ms |             |
 
   Scenario: JSON formatter produces deterministic field ordering
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the first JSON event should have "timestamp" before "event_type"
     And the first JSON event should have "event_type" before "outcome"
 
   Scenario: JSON timestamp defaults to RFC3339 with nanosecond precision
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the first JSON event timestamp should match RFC3339Nano format
 
   Scenario: JSON timestamp can use Unix milliseconds format
-    Given a logger with file output using JSON formatter with unix millis timestamps
+    Given an auditor with file output using JSON formatter with unix millis timestamps
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the first JSON event timestamp should be a numeric value
 
   Scenario: JSON OmitEmpty true omits zero-value optional fields
-    Given a logger with file output using JSON formatter and OmitEmpty true
+    Given an auditor with file output using JSON formatter and OmitEmpty true
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the first JSON event should not contain key "marker"
 
   Scenario: JSON OmitEmpty false includes zero-value optional fields
-    Given a logger with file output using JSON formatter and OmitEmpty false
+    Given an auditor with file output using JSON formatter and OmitEmpty false
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the first JSON event should contain key "marker"
 
   Scenario: JSON duration field marshalled as integer milliseconds
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with a duration field
-    And I close the logger
+    And I close the auditor
     Then the first JSON event "duration_ms" field should be an integer
 
   Scenario: JSON preserves Unicode values
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with fields:
       | field    | value    |
       | outcome  | success  |
       | actor_id | café☕   |
-    And I close the logger
+    And I close the auditor
     Then the file should contain an event matching:
       | field       | value       |
       | event_type  | user_create |
@@ -86,227 +86,227 @@ Feature: Event Formatters
       | duration_ms |             |
 
   Scenario: JSON prevents newline injection in values
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with a field containing a newline
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should contain exactly 1 event
 
   # --- CEF Formatter ---
 
   Scenario: CEF formatter produces valid CEF header
-    Given a logger with file output using CEF formatter with vendor "AxonOps" product "AuditLib" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "AxonOps" product "AuditLib" version "1.0"
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the file should contain a line starting with "CEF:0|"
     And the CEF line should contain "AxonOps"
     And the CEF line should contain "AuditLib"
 
   Scenario: CEF default severity is 5
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the CEF line should have severity 5
 
   Scenario: CEF custom severity function maps event types
-    Given a logger with file output using CEF formatter with custom severity function
+    Given an auditor with file output using CEF formatter with custom severity function
     When I audit event "auth_failure" with required fields
-    And I close the logger
+    And I close the auditor
     Then the CEF line should have severity 8
 
   Scenario: CEF extension fields use default mapping
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the CEF line should contain "suser=alice"
     And the CEF line should contain "outcome=success"
 
   Scenario: CEF header escapes pipe characters
-    Given a logger with file output using CEF formatter with vendor "Axon|Ops" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Axon|Ops" product "Test" version "1.0"
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the CEF line should contain "Axon\|Ops"
 
   # --- Per-output formatter ---
 
   Scenario: CEF null bytes are stripped from values
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with a field containing null bytes
-    And I close the logger
+    And I close the auditor
     Then the file should contain a line starting with "CEF:0|"
     And every event in the file should have exactly 1 line
 
   Scenario: CEF severity below 0 clamped to 0
-    Given a logger with file output using CEF formatter with severity below 0
+    Given an auditor with file output using CEF formatter with severity below 0
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the CEF line should have severity 0
 
   Scenario: CEF extension escapes newlines as literal backslash-n
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with a field containing a newline
-    And I close the logger
+    And I close the auditor
     Then the file should contain a line starting with "CEF:0|"
     And every event in the file should have exactly 1 line
 
   Scenario: CEF control characters stripped from extension values
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with a field containing control characters
-    And I close the logger
+    And I close the auditor
     Then the file should contain a line starting with "CEF:0|"
     And every event in the file should have exactly 1 line
 
   Scenario: CEF invalid extension key causes serialization error without crash
-    Given a logger with file output using CEF formatter with invalid field mapping
+    Given an auditor with file output using CEF formatter with invalid field mapping
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then no panic should have occurred
     And the file should be empty
 
   Scenario: Per-output formatter overrides default
-    Given a logger with two file outputs using JSON and CEF formatters
+    Given an auditor with two file outputs using JSON and CEF formatters
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the JSON file should contain valid JSON
     And the CEF file should contain a line starting with "CEF:0|"
 
   # --- JSON encoding edge cases ---
 
   Scenario: JSON escapes HTML-unsafe characters
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with fields:
       | field    | value       |
       | outcome  | success     |
       | actor_id | alice       |
       | marker   | <script>&   |
-    And I close the logger
+    And I close the auditor
     Then the file should not contain raw "<script>"
     And every event in the file should be valid JSON
 
   Scenario: JSON HTML-safe escaping of angle brackets and ampersand
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with fields:
       | field    | value          |
       | outcome  | success        |
       | actor_id | alice          |
       | marker   | <b>bold&amp;</b> |
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should not contain raw "<b>"
 
   Scenario: JSON escapes control characters
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with a field containing a tab character
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should contain exactly 1 event
 
   # --- JSON encoding edge cases ---
 
   Scenario: JSON handles long string values without truncation
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with a 10000-character field value
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should contain exactly 1 event
 
   Scenario: JSON escapes U+2028 line separator
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with a field containing U+2028
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should contain exactly 1 event
 
   Scenario: JSON escapes U+2029 paragraph separator
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with a field containing U+2029
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should contain exactly 1 event
 
   Scenario: JSON replaces invalid UTF-8 with replacement character
-    Given a logger with file output using JSON formatter
+    Given an auditor with file output using JSON formatter
     When I audit event "user_create" with a field containing invalid UTF-8
-    And I close the logger
+    And I close the auditor
     Then every event in the file should be valid JSON
     And the file should contain exactly 1 event
 
   # --- CEF additional scenarios ---
 
   Scenario: CEF severity clamped to 0-10 range
-    Given a logger with file output using CEF formatter with severity above 10
+    Given an auditor with file output using CEF formatter with severity above 10
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the CEF line should have severity 10
 
   Scenario: CEF header escapes backslash characters
-    Given a logger with file output using CEF formatter with vendor "Axon\Ops" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Axon\Ops" product "Test" version "1.0"
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the CEF line should contain "Axon\\Ops"
 
   Scenario: CEF extension escapes equals sign
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with fields:
       | field    | value     |
       | outcome  | a=b       |
       | actor_id | alice     |
-    And I close the logger
+    And I close the auditor
     Then the file should contain a line starting with "CEF:0|"
     And the CEF line should contain "a\=b"
 
   Scenario: CEF extension escapes backslash
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with fields:
       | field    | value     |
       | outcome  | a\b       |
       | actor_id | alice     |
-    And I close the logger
+    And I close the auditor
     Then the file should contain a line starting with "CEF:0|"
     And the CEF line should contain "a\\b"
 
   Scenario: CEF event_category uses standard ArcSight cat extension key
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the CEF line should contain "cat=write"
 
   # --- CEF framework fields (#237) ---
 
   Scenario: CEF framework fields use correct extension keys
     Given framework fields app_name "myapp" host "prod-01" timezone "UTC"
-    And a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    And an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the CEF line should contain "deviceProcessName=myapp"
     And the CEF line should contain "dvchost=prod-01"
     And the CEF line should contain "dtz=UTC"
 
   Scenario: CEF pid uses dvcpid extension key
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the CEF line should contain "dvcpid="
 
   Scenario: CEF app_name and host absent when not configured but timezone and pid present
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the CEF line should not contain "deviceProcessName="
     And the CEF line should not contain "dvchost="
     And the CEF line should contain "dtz="
@@ -315,13 +315,13 @@ Feature: Event Formatters
   # --- CEF reserved standard field mapping (#237) ---
 
   Scenario Outline: CEF maps <field> to <cef_key>
-    Given a logger with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
+    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
     When I audit event "user_create" with fields:
       | field    | value    |
       | outcome  | success  |
       | actor_id | alice    |
       | <field>  | <value>  |
-    And I close the logger
+    And I close the auditor
     Then the CEF line should contain "<cef_key>=<value>"
 
     Examples:

--- a/tests/bdd/features/graceful_shutdown.feature
+++ b/tests/bdd/features/graceful_shutdown.feature
@@ -1,6 +1,6 @@
 @core @shutdown
 Feature: Graceful Shutdown
-  As a library consumer, I want the logger to drain all pending events
+  As a library consumer, I want the auditor to drain all pending events
   when I call Close so that no audit data is lost during application
   shutdown.
 
@@ -8,59 +8,59 @@ Feature: Graceful Shutdown
     Given a standard test taxonomy
 
   Scenario: Pending events are drained on close
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit 10 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 10 events
 
   Scenario: Close is idempotent
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit event "user_create" with required fields
-    And I close the logger
-    And I close the logger again
+    And I close the auditor
+    And I close the auditor again
     Then the second close should return no error
 
   Scenario: Audit after close returns ErrClosed
-    Given a logger with stdout output
-    When I close the logger
+    Given an auditor with stdout output
+    When I close the auditor
     And I try to audit event "user_create" with required fields
     Then the audit call should return an error wrapping "ErrClosed"
 
   Scenario: Close with zero outputs completes successfully
-    Given a logger with no outputs
-    When I close the logger
+    Given an auditor with no outputs
+    When I close the auditor
     Then the audit call should return no error
 
   Scenario: Multiple events all drained before close returns
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit 50 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 50 events
     And every event in the file should be valid JSON
 
   Scenario: Drain timeout does not hang indefinitely
-    Given a logger with file output at a temporary path and short drain timeout
+    Given an auditor with file output at a temporary path and short drain timeout
     When I audit 100 events rapidly
-    Then closing the logger should complete within 5 seconds
+    Then closing the auditor should complete within 5 seconds
 
   Scenario: Concurrent close calls are safe
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit event "user_create" with required fields
-    And I close the logger from 5 goroutines concurrently
+    And I close the auditor from 5 goroutines concurrently
     Then no panic should have occurred
 
   @docker @syslog
   Scenario: Close with multiple outputs closes all
-    Given a logger with file and syslog outputs
+    Given an auditor with file and syslog outputs
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the file should contain the marker
     And the syslog server should contain the marker within 10 seconds
 
   @docker @syslog
   Scenario: Per-output async buffers drained during close
-    Given a logger with file and syslog outputs
+    Given an auditor with file and syslog outputs
     When I audit 10 uniquely marked events
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 10 events
     And the syslog server should contain all 10 markers within 15 seconds

--- a/tests/bdd/features/hmac_integrity.feature
+++ b/tests/bdd/features/hmac_integrity.feature
@@ -10,33 +10,33 @@ Feature: HMAC Integrity Verification
   # --- HMAC presence ---
 
   Scenario: HMAC fields present when enabled
-    Given a logger with stdout output and HMAC enabled using salt "test-salt-sixteen-b!" version "v1" and hash "HMAC-SHA-256"
+    Given an auditor with stdout output and HMAC enabled using salt "test-salt-sixteen-b!" version "v1" and hash "HMAC-SHA-256"
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the output should contain "_hmac" field
     And the output should contain "_hmac_v" field with value "v1"
 
   Scenario: HMAC fields absent when not configured
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the output should not contain "_hmac" field
     And the output should not contain "_hmac_v" field
 
   # --- Independent verification ---
 
   Scenario: HMAC is independently verifiable with HMAC-SHA-256
-    Given a logger with stdout output and HMAC enabled using salt "verify-test-salt-16!" version "v1" and hash "HMAC-SHA-256"
+    Given an auditor with stdout output and HMAC enabled using salt "verify-test-salt-16!" version "v1" and hash "HMAC-SHA-256"
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then independently recomputing HMAC-SHA-256 over the payload with salt "verify-test-salt-16!" matches the "_hmac" value
 
   # --- Salt version ---
 
   Scenario: Salt version appears in output
-    Given a logger with stdout output and HMAC enabled using salt "version-test-salt-16" version "2026-Q1" and hash "HMAC-SHA-256"
+    Given an auditor with stdout output and HMAC enabled using salt "version-test-salt-16" version "2026-Q1" and hash "HMAC-SHA-256"
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the output should contain "_hmac_v" field with value "2026-Q1"
 
   # --- Field stripping changes the HMAC ---
@@ -68,7 +68,7 @@ Feature: HMAC Integrity Verification
       | outcome  | success           |
       | actor_id | alice             |
       | email    | alice@example.com |
-    And I close the logger
+    And I close the auditor
     Then output "full" should contain field "email" with value "alice@example.com"
     And output "stripped" should not contain field "email"
     And both outputs should have "_hmac" fields
@@ -77,13 +77,13 @@ Feature: HMAC Integrity Verification
   # --- Validation ---
 
   Scenario: Salt too short rejected at startup
-    When I try to create a logger with HMAC salt "short" version "v1" and hash "HMAC-SHA-256"
+    When I try to create an auditor with HMAC salt "short" version "v1" and hash "HMAC-SHA-256"
     Then logger creation should fail with an error containing "at least"
 
   Scenario: Unknown algorithm rejected at startup
-    When I try to create a logger with HMAC salt "valid-salt-sixteen-b!" version "v1" and hash "MD5"
+    When I try to create an auditor with HMAC salt "valid-salt-sixteen-b!" version "v1" and hash "MD5"
     Then logger creation should fail with an error containing "unknown"
 
   Scenario: Missing salt version rejected at startup
-    When I try to create a logger with HMAC salt "valid-salt-sixteen-b!" version "" and hash "HMAC-SHA-256"
+    When I try to create an auditor with HMAC salt "valid-salt-sixteen-b!" version "" and hash "HMAC-SHA-256"
     Then logger creation should fail with an error containing "version"

--- a/tests/bdd/features/http_middleware.feature
+++ b/tests/bdd/features/http_middleware.feature
@@ -6,14 +6,14 @@ Feature: HTTP Middleware
 
   Background:
     Given a middleware test taxonomy
-    And a logger with file output at a temporary path
+    And an auditor with file output at a temporary path
 
   # --- Transport metadata ---
 
   Scenario: HTTP request generates audit event with method and path
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file should contain an event with event_type "api_request"
     And the file event should have field "method" with value "GET"
     And the file event should have field "path" with value "/api/resource"
@@ -21,13 +21,13 @@ Feature: HTTP Middleware
   Scenario: POST request captures correct method
     Given an HTTP test server with audit middleware
     When I send a POST request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "method" with value "POST"
 
   Scenario: Response status code captured
     Given an HTTP test server with audit middleware returning status 201
     When I send a POST request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "status_code" with value "201"
 
   # --- Hints ---
@@ -35,13 +35,13 @@ Feature: HTTP Middleware
   Scenario: Handler populates hints for domain-specific fields
     Given an HTTP test server with audit middleware that sets actor_id
     When I send a GET request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "actor_id" with value "handler-actor"
 
   Scenario: Handler populates hints Extra fields
     Given an HTTP test server with audit middleware that sets Extra hints
     When I send a GET request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "custom_field" with value "custom_value"
 
   # --- Skip ---
@@ -49,7 +49,7 @@ Feature: HTTP Middleware
   Scenario: Skip true prevents audit event
     Given an HTTP test server with audit middleware that skips GET requests
     When I send a GET request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file should have no events
 
   # --- Nil logger ---
@@ -64,25 +64,25 @@ Feature: HTTP Middleware
   Scenario: Client IP extracted from X-Forwarded-For
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with header "X-Forwarded-For" = "10.0.0.1, 192.168.1.1"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "source_ip" with value "192.168.1.1"
 
   Scenario: Client IP falls back to X-Real-IP
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with header "X-Real-IP" = "10.0.0.55"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "source_ip" with value "10.0.0.55"
 
   Scenario: PUT request captures correct method
     Given an HTTP test server with audit middleware
     When I send a PUT request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "method" with value "PUT"
 
   Scenario: DELETE request captures correct method
     Given an HTTP test server with audit middleware
     When I send a DELETE request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "method" with value "DELETE"
 
   # --- Request ID ---
@@ -90,13 +90,13 @@ Feature: HTTP Middleware
   Scenario: Request ID extracted from header
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with header "X-Request-Id" = "req-abc-123"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "request_id" with value "req-abc-123"
 
   Scenario: Request ID generated when header missing
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "request_id" present
 
   # --- User-Agent ---
@@ -104,7 +104,7 @@ Feature: HTTP Middleware
   Scenario: User-Agent captured in audit event
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with header "User-Agent" = "test-agent/1.0"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "user_agent" with value "test-agent/1.0"
 
   # --- Default status ---
@@ -112,7 +112,7 @@ Feature: HTTP Middleware
   Scenario: Default status 200 if handler writes nothing
     Given an HTTP test server with audit middleware returning no explicit status
     When I send a GET request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "status_code" with value "200"
 
   # --- Path truncation ---
@@ -120,13 +120,13 @@ Feature: HTTP Middleware
   Scenario: Invalid request ID header replaced with generated UUID
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with header "X-Request-Id" = "has\nnewline"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "request_id" present
 
   Scenario: Too-long request ID replaced with generated UUID
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with a 200-char X-Request-Id
-    And I close the logger
+    And I close the auditor
     Then the file event request_id should be shorter than 200 characters
 
   # --- TLS state detection ---
@@ -134,13 +134,13 @@ Feature: HTTP Middleware
   Scenario: Non-TLS request reports transport security "none"
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "transport_security" with value "none"
 
   Scenario: TLS request reports transport security "tls"
     Given an HTTPS test server with audit middleware
     When I send a GET request to "/api/secure" via TLS
-    And I close the logger
+    And I close the auditor
     Then the file event should have field "transport_security" with value "tls"
 
   # --- Panic recovery ---
@@ -148,41 +148,41 @@ Feature: HTTP Middleware
   Scenario: Handler panic produces audit event and re-raises
     Given an HTTP test server with panicking handler and audit middleware
     When I send a GET request to "/api/panic" expecting panic
-    And I close the logger
+    And I close the auditor
     Then the file should contain events
 
   Scenario: Builder panic is recovered and logged
     Given an HTTP test server with panicking builder and audit middleware
     When I send a GET request to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file should have no events
 
   Scenario: Concurrent requests get independent audit events
     Given an HTTP test server with audit middleware
     When I send 10 concurrent GET requests to "/api/resource"
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 10 events
 
   Scenario: User-Agent at exactly 512 chars is not truncated
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with a 512-char User-Agent
-    And I close the logger
+    And I close the auditor
     Then the file event user_agent field should be exactly 512 characters
 
   Scenario: Long User-Agent is truncated to 512 characters
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with a 1000-char User-Agent
-    And I close the logger
+    And I close the auditor
     Then the file event user_agent field should be at most 512 characters
 
   Scenario: Multibyte UTF-8 not split at truncation boundary
     Given an HTTP test server with audit middleware
     When I send a GET request to "/api/resource" with a User-Agent ending in multibyte at 512
-    And I close the logger
+    And I close the auditor
     Then the file event user_agent should be valid UTF-8
 
   Scenario: Long path is truncated
     Given an HTTP test server with audit middleware
     When I send a GET request to a path with 3000 characters
-    And I close the logger
+    And I close the auditor
     Then the file event path field should be at most 2048 characters

--- a/tests/bdd/features/loki_hmac.feature
+++ b/tests/bdd/features/loki_hmac.feature
@@ -35,9 +35,9 @@ Feature: HMAC Integrity with Loki Output
       """
 
   Scenario: HMAC fields present on event stored in Loki
-    Given a logger with loki output and HMAC enabled using salt "loki-hmac-salt-16b!" version "v1" and hash "HMAC-SHA-256"
+    Given an auditor with loki output and HMAC enabled using salt "loki-hmac-salt-16b!" version "v1" and hash "HMAC-SHA-256"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the loki event payload should contain field "_hmac"
     And the loki event payload should contain field "_hmac_v" with value "v1"
@@ -51,33 +51,33 @@ Feature: HMAC Integrity with Loki Output
       | event_category | write        |
 
   Scenario: HMAC fields absent when HMAC not configured on Loki output
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the loki event payload should not contain field "_hmac"
     And the loki event payload should not contain field "_hmac_v"
 
   Scenario: HMAC stored in Loki is independently verifiable
-    Given a logger with loki output and HMAC enabled using salt "loki-verify-salt-16!" version "v1" and hash "HMAC-SHA-256"
+    Given an auditor with loki output and HMAC enabled using salt "loki-verify-salt-16!" version "v1" and hash "HMAC-SHA-256"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And independently recomputing HMAC-SHA-256 over the loki payload with salt "loki-verify-salt-16!" matches the "_hmac" value
 
   Scenario: Different HMAC salts produce different HMACs on same event
-    Given a logger with loki output using HMAC salt "loki-salt-alpha-16!" version "v1"
+    Given an auditor with loki output using HMAC salt "loki-salt-alpha-16!" version "v1"
     And a capture output with HMAC salt "capture-salt-beta16!" version "v2"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the capture output should contain the marker
     And the HMAC in Loki should differ from the HMAC in the capture output
 
   Scenario: Salt version stored in Loki event
-    Given a logger with loki output and HMAC enabled using salt "loki-version-salt-16" version "2026-Q2" and hash "HMAC-SHA-256"
+    Given an auditor with loki output and HMAC enabled using salt "loki-version-salt-16" version "2026-Q2" and hash "HMAC-SHA-256"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the loki event payload should contain field "_hmac_v" with value "2026-Q2"
 
@@ -102,10 +102,10 @@ Feature: HMAC Integrity with Loki Output
             email:
               labels: [pii]
       """
-    And a logger with loki output excluding label "pii" with HMAC salt "loki-strip-salt-16b!" version "v1"
+    And an auditor with loki output excluding label "pii" with HMAC salt "loki-strip-salt-16b!" version "v1"
     And a capture output with no exclusions and HMAC salt "capture-full-salt-16" version "v2"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success" and field "email" = "alice@example.com"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the loki event payload should not contain field "email"
     And the capture output event should contain field "email" with value "alice@example.com"
@@ -113,9 +113,9 @@ Feature: HMAC Integrity with Loki Output
     And the HMAC values should differ between Loki and the capture output
 
   Scenario: Complete payload preserved alongside HMAC fields in Loki
-    Given a logger with loki output and HMAC enabled using salt "loki-full-salt-16by!" version "v1" and hash "HMAC-SHA-256"
+    Given an auditor with loki output and HMAC enabled using salt "loki-full-salt-16by!" version "v1" and hash "HMAC-SHA-256"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the loki event payload should contain:
       | field          | value        |

--- a/tests/bdd/features/loki_label_search.feature
+++ b/tests/bdd/features/loki_label_search.feature
@@ -15,11 +15,11 @@ Feature: Loki Label Search and Filtering
   # --- Search by event_type label ---
 
   Scenario: Query by event_type returns matching events and excludes others
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "et_create"
     And I audit an "auth_failure" event with marker "et_auth"
     And I audit a "permission_denied" event with marker "et_perm"
-    And I close the logger
+    And I close the auditor
     Then querying Loki by label "event_type" = "user_create" should return an event with:
       | field          | value          |
       | event_type     | user_create    |
@@ -41,10 +41,10 @@ Feature: Loki Label Search and Filtering
   # --- Search by event_category label ---
 
   Scenario: Query by event_category returns matching events and excludes others
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "cat_write"
     And I audit an "auth_failure" event with marker "cat_security"
-    And I close the logger
+    And I close the auditor
     Then querying Loki by label "event_category" = "write" should return an event with:
       | field          | value          |
       | event_type     | user_create    |
@@ -66,7 +66,7 @@ Feature: Loki Label Search and Filtering
   # --- Search by app_name label ---
 
   Scenario: Query by app_name returns matching events and excludes others
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And querying Loki by label "app_name" = "bdd-audit" should return the marker event within 15 seconds
@@ -75,7 +75,7 @@ Feature: Loki Label Search and Filtering
   # --- Search by host label ---
 
   Scenario: Query by host returns matching events and excludes others
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And querying Loki by label "host" = "bdd-host" should return the marker event within 15 seconds
@@ -84,7 +84,7 @@ Feature: Loki Label Search and Filtering
   # --- Search by static label ---
 
   Scenario: Query by static label returns matching events and excludes others
-    Given a logger with loki output with static label "environment" = "label_test"
+    Given an auditor with loki output with static label "environment" = "label_test"
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And querying Loki by label "environment" = "label_test" should return the marker event within 15 seconds
@@ -93,7 +93,7 @@ Feature: Loki Label Search and Filtering
   # --- Negative: nonexistent label values return nothing ---
 
   Scenario: Query by nonexistent event_type returns no events
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And querying Loki by label "event_type" = "does_not_exist" should return no events within 3 seconds
@@ -101,7 +101,7 @@ Feature: Loki Label Search and Filtering
   # --- Excluded label is not searchable ---
 
   Scenario: Excluded dynamic label cannot be used as search criterion
-    Given a logger with loki output excluding dynamic label "severity"
+    Given an auditor with loki output excluding dynamic label "severity"
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And the loki stream should not have label "severity"
@@ -110,10 +110,10 @@ Feature: Loki Label Search and Filtering
   # --- Combined label query with payload ---
 
   Scenario: Combined label and payload verification
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "combo_create"
     And I audit an "auth_failure" event with marker "combo_auth"
-    And I close the logger
+    And I close the auditor
     Then querying Loki by label "event_type" = "user_create" should return an event with:
       | field          | value          |
       | event_type     | user_create    |
@@ -132,8 +132,8 @@ Feature: Loki Label Search and Filtering
       | host           | bdd-host       |
 
   Scenario: Timezone present in Loki event payload
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "tz_payload"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the named marker "tz_payload" within 15 seconds
     And the loki event payload should contain field "timezone"

--- a/tests/bdd/features/loki_output.feature
+++ b/tests/bdd/features/loki_output.feature
@@ -15,7 +15,7 @@ Feature: Loki Output
   # --- Basic delivery with complete payload verification ---
 
   Scenario: Single event delivered to Loki with complete payload
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And the loki event payload should contain:
@@ -28,7 +28,7 @@ Feature: Loki Output
       | event_category | write        |
 
   Scenario: Custom field values preserved in Loki log line
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "user_create" event with field "actor_id" = "alice"
     Then the loki server should contain the marker within 15 seconds
     And the loki event payload should contain:
@@ -41,7 +41,7 @@ Feature: Loki Output
       | event_category | write        |
 
   Scenario: Multiple events all delivered with complete payloads
-    Given a logger with loki output with batch size 5
+    Given an auditor with loki output with batch size 5
     When I audit 10 loki events with a shared marker
     Then the loki server should have at least 10 events within 15 seconds
     And the loki event payload should contain:
@@ -56,7 +56,7 @@ Feature: Loki Output
   # --- Stream labels with complete payload verification ---
 
   Scenario: All dynamic labels present on Loki stream with complete payload
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And the loki stream should have label "event_type" with value "user_create"
@@ -72,7 +72,7 @@ Feature: Loki Output
       | event_category | write        |
 
   Scenario: Static labels present on stream with complete payload
-    Given a logger with loki output with static label "environment" = "testing"
+    Given an auditor with loki output with static label "environment" = "testing"
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And the loki stream should have label "environment" with value "testing"
@@ -86,7 +86,7 @@ Feature: Loki Output
       | event_category | write        |
 
   Scenario: Excluded dynamic label absent from stream with payload intact
-    Given a logger with loki output excluding dynamic label "severity"
+    Given an auditor with loki output excluding dynamic label "severity"
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And the loki stream should not have label "severity"
@@ -100,7 +100,7 @@ Feature: Loki Output
       | event_category | write        |
 
   Scenario: Different event types in separate streams with payload verification
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a uniquely marked "user_create" event
     And I audit a uniquely marked "auth_failure" event
     Then the loki server should have events in stream "user_create" within 15 seconds
@@ -109,7 +109,7 @@ Feature: Loki Output
   # --- Batch delivery with complete payload verification ---
 
   Scenario: Batch flushes on count threshold with complete payload
-    Given a logger with loki output with batch size 5 and flush interval 60s
+    Given an auditor with loki output with batch size 5 and flush interval 60s
     When I audit 5 loki events with a shared marker
     Then the loki server should have at least 5 events within 15 seconds
     And the loki event payload should contain:
@@ -122,7 +122,7 @@ Feature: Loki Output
       | event_category | write        |
 
   Scenario: Batch flushes on timer with complete payload
-    Given a logger with loki output with batch size 1000 and flush interval 500ms
+    Given an auditor with loki output with batch size 1000 and flush interval 500ms
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And the loki event payload should contain:
@@ -135,9 +135,9 @@ Feature: Loki Output
       | event_category | write        |
 
   Scenario: Shutdown flushes pending events with complete payload
-    Given a logger with loki output with batch size 1000 and flush interval 60s
+    Given an auditor with loki output with batch size 1000 and flush interval 60s
     When I audit 3 loki events with a shared marker
-    And I close the logger
+    And I close the auditor
     Then the loki server should have at least 3 events within 15 seconds
     And the loki event payload should contain:
       | field          | value        |
@@ -151,7 +151,7 @@ Feature: Loki Output
   # --- Gzip compression with complete payload verification ---
 
   Scenario: Gzip-compressed events preserve complete payload in Loki
-    Given a logger with loki output with gzip enabled
+    Given an auditor with loki output with gzip enabled
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And the loki event payload should contain:
@@ -164,7 +164,7 @@ Feature: Loki Output
       | event_category | write        |
 
   Scenario: Uncompressed events preserve complete payload in Loki
-    Given a logger with loki output with gzip disabled
+    Given an auditor with loki output with gzip disabled
     When I audit a uniquely marked "user_create" event
     Then the loki server should contain the marker within 15 seconds
     And the loki event payload should contain:
@@ -179,12 +179,12 @@ Feature: Loki Output
   # --- Multi-tenancy with payload verification ---
 
   Scenario: Events delivered to specific tenant with complete payload
-    Given a logger with loki output to tenant "tenant-alpha"
+    Given an auditor with loki output to tenant "tenant-alpha"
     When I audit a uniquely marked "user_create" event
     Then the loki server for tenant "tenant-alpha" should contain the marker within 15 seconds
 
   Scenario: Tenant isolation prevents cross-tenant visibility
-    Given a logger with loki output to tenant "tenant-iso-a"
+    Given an auditor with loki output to tenant "tenant-iso-a"
     When I audit a uniquely marked "user_create" event
     Then the loki server for tenant "tenant-iso-a" should contain the marker within 15 seconds
     And the loki server for tenant "tenant-iso-b" should not contain the marker within 5 seconds
@@ -192,7 +192,7 @@ Feature: Loki Output
   # --- Large batch delivery ---
 
   Scenario: All events from large batch delivered with complete payloads
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit 10 loki events with a shared marker
     Then the loki server should have at least 10 events within 15 seconds
     And the loki event payload should contain:
@@ -207,14 +207,14 @@ Feature: Loki Output
   # --- Lifecycle ---
 
   Scenario: Close is idempotent
-    Given a logger with loki output
-    When I close the logger
-    And I close the logger again
+    Given an auditor with loki output
+    When I close the auditor
+    And I close the auditor again
     Then no error should occur
 
   Scenario: Write after close returns error
-    Given a logger with loki output
-    When I close the logger
+    Given an auditor with loki output
+    When I close the auditor
     And I try to audit a "user_create" event
     Then the audit call should return an error wrapping "ErrClosed"
 
@@ -223,7 +223,7 @@ Feature: Loki Output
   Scenario: Retry on 503 with eventual delivery
     Given a local Loki receiver returning status 503
     And mock loki metrics are configured
-    And a logger with loki output to the local receiver with max retries 3
+    And an auditor with loki output to the local receiver with max retries 3
     When I audit a uniquely marked "user_create" event
     And the local Loki receiver is reconfigured to return status 204
     Then the local Loki receiver should have at least 1 push within 10 seconds
@@ -232,7 +232,7 @@ Feature: Loki Output
   Scenario: Retry on 429 rate limit with eventual delivery
     Given a local Loki receiver returning status 429
     And mock loki metrics are configured
-    And a logger with loki output to the local receiver with max retries 3
+    And an auditor with loki output to the local receiver with max retries 3
     When I audit a uniquely marked "user_create" event
     And the local Loki receiver is reconfigured to return status 204
     Then the local Loki receiver should have at least 1 push within 10 seconds
@@ -240,36 +240,36 @@ Feature: Loki Output
   Scenario: No retry on 400 client error
     Given a local Loki receiver returning status 400
     And mock loki metrics are configured
-    And a logger with loki output to the local receiver with max retries 5
+    And an auditor with loki output to the local receiver with max retries 5
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the loki metrics should have recorded at least 1 drop within 5 seconds
     And the local Loki receiver should have received at most 1 push
 
   Scenario: No retry on 401 unauthorized
     Given a local Loki receiver returning status 401
     And mock loki metrics are configured
-    And a logger with loki output to the local receiver with max retries 5
+    And an auditor with loki output to the local receiver with max retries 5
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the loki metrics should have recorded at least 1 drop within 5 seconds
     And the local Loki receiver should have received at most 1 push
 
   Scenario: Retries exhausted drops batch
     Given a local Loki receiver returning status 503
     And mock loki metrics are configured
-    And a logger with loki output to the local receiver with max retries 1
+    And an auditor with loki output to the local receiver with max retries 1
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the loki metrics should have recorded at least 1 drop within 5 seconds
 
   # --- Loki unavailable ---
 
   Scenario: Loki unreachable drops events and records metrics
     Given mock loki metrics are configured
-    And a logger with loki output to unreachable server with metrics
+    And an auditor with loki output to unreachable server with metrics
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the loki metrics should have recorded at least 1 drop within 5 seconds
 
   # --- SSRF protection (httptest.Server, no Docker Loki) ---
@@ -277,23 +277,23 @@ Feature: Loki Output
   Scenario: Private range blocked by default drops events
     Given a local Loki receiver accepting pushes
     And mock loki metrics are configured
-    And a logger with loki output to the local Loki receiver without AllowPrivateRanges
+    And an auditor with loki output to the local Loki receiver without AllowPrivateRanges
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the loki metrics should have recorded at least 1 drop within 5 seconds
 
   Scenario: AllowPrivateRanges permits private addresses
     Given a local Loki receiver accepting pushes
-    And a logger with loki output to the local Loki receiver with AllowPrivateRanges
+    And an auditor with loki output to the local Loki receiver with AllowPrivateRanges
     When I audit a uniquely marked "user_create" event
     Then the local Loki receiver should have at least 1 push within 10 seconds
 
   Scenario: Redirect is rejected and not followed
     Given a local Loki receiver configured to redirect
     And mock loki metrics are configured
-    And a logger with loki output to the redirecting Loki receiver with metrics
+    And an auditor with loki output to the redirecting Loki receiver with metrics
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the loki metrics should have recorded at least 1 drop within 5 seconds
 
   # --- Metrics (httptest.Server) ---
@@ -301,7 +301,7 @@ Feature: Loki Output
   Scenario: Successful delivery records flush metric
     Given a local Loki receiver accepting pushes
     And mock loki metrics are configured
-    And a logger with loki output to the local Loki receiver with metrics
+    And an auditor with loki output to the local Loki receiver with metrics
     When I audit a uniquely marked "user_create" event
     Then the local Loki receiver should have at least 1 push within 10 seconds
     And the loki metrics should have recorded at least 1 flush
@@ -309,14 +309,14 @@ Feature: Loki Output
 
   Scenario: Nil loki metrics does not panic
     Given a local Loki receiver accepting pushes
-    And a logger with loki output to the local Loki receiver with AllowPrivateRanges
+    And an auditor with loki output to the local Loki receiver with AllowPrivateRanges
     When I audit a uniquely marked "user_create" event
     Then the local Loki receiver should have at least 1 push within 10 seconds
 
   Scenario: Delivery failure records RecordError metric
     Given a local Loki receiver returning status 400
     And mock loki metrics are configured
-    And a logger with loki output to the local Loki receiver with metrics and max retries 0
+    And an auditor with loki output to the local Loki receiver with metrics and max retries 0
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the loki metrics should have recorded at least 1 error within 5 seconds

--- a/tests/bdd/features/loki_uncategorised_events.feature
+++ b/tests/bdd/features/loki_uncategorised_events.feature
@@ -62,10 +62,10 @@ Feature: Loki streams for uncategorised events
   # ---------------------------------------------------------------------------
 
   Scenario: Categorised events carry event_category in both stream label and JSON payload
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "cat_write"
     And I audit an "auth_failure" event with marker "cat_sec"
-    And I close the logger
+    And I close the auditor
     Then querying Loki by label "event_category" = "write" should return an event with:
       | field          | value       |
       | event_type     | user_create |
@@ -91,7 +91,7 @@ Feature: Loki streams for uncategorised events
     # The health_check event is in the taxonomy but belongs to no category.
     # Its Loki stream must not carry the event_category label — querying by
     # {event_category="anything"} will never find it.
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "health_check" event
     Then the loki server should contain the marker within 15 seconds
     And the loki stream should not have label "event_category"
@@ -100,7 +100,7 @@ Feature: Loki streams for uncategorised events
     # The JSON log line for health_check must not include the event_category
     # key. The framework only appends event_category when the event has a
     # non-empty category — uncategorised events have none.
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "health_check" event
     Then the loki server should contain the marker within 15 seconds
     And the loki event payload for the marker should not contain field "event_category"
@@ -109,10 +109,10 @@ Feature: Loki streams for uncategorised events
     # Push one categorised and one uncategorised event with distinct markers.
     # The category label selector must find only its own event — proving the
     # streams are genuinely separate.
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "mixed_write"
     And I audit a "health_check" event with marker "mixed_uncat"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the named marker "mixed_write" within 15 seconds
     And the loki server should contain the named marker "mixed_uncat" within 15 seconds
     And querying Loki by label "event_category" = "write" should not return named marker "mixed_uncat" within 3 seconds
@@ -125,10 +125,10 @@ Feature: Loki streams for uncategorised events
     # Both user_create (write category) and health_check (uncategorised)
     # carry actor_id in their JSON payload. A LogQL JSON filter searching
     # by actor_id must find both, proving uncategorised events are not lost.
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "actor_write"
     And I audit a "health_check" event with marker "actor_uncat"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the named marker "actor_write" within 15 seconds
     And the loki server should contain the named marker "actor_uncat" within 15 seconds
 
@@ -136,11 +136,11 @@ Feature: Loki streams for uncategorised events
     # Emit one event per category and one uncategorised. A line filter
     # that matches the shared test suite label finds all three — proving
     # event_category does not gate queryability.
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "all_write"
     And I audit an "auth_failure" event with marker "all_sec"
     And I audit a "health_check" event with marker "all_uncat"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the named marker "all_write" within 15 seconds
     And the loki server should contain the named marker "all_sec" within 15 seconds
     And the loki server should contain the named marker "all_uncat" within 15 seconds
@@ -154,11 +154,11 @@ Feature: Loki streams for uncategorised events
     # match only streams that have no event_category label — i.e., only
     # uncategorised events. This is the correct pattern for "show me
     # everything that has not been classified yet."
-    Given a logger with loki output with batch size 10
+    Given an auditor with loki output with batch size 10
     When I audit a "user_create" event with marker "neg_write"
     And I audit an "auth_failure" event with marker "neg_sec"
     And I audit a "health_check" event with marker "neg_uncat"
-    And I close the logger
+    And I close the auditor
     Then querying Loki excluding event_category labels "write,security" should return the named marker "neg_uncat" within 15 seconds
     And querying Loki excluding event_category labels "write,security" should not return the named marker "neg_write" within 3 seconds
     And querying Loki excluding event_category labels "write,security" should not return the named marker "neg_sec" within 3 seconds
@@ -170,7 +170,7 @@ Feature: Loki streams for uncategorised events
   Scenario: Uncategorised event payload is complete apart from the absent event_category field
     # Verify every field that SHOULD be present, then explicitly verify
     # that event_category is absent. This documents the full contract.
-    Given a logger with loki output
+    Given an auditor with loki output
     When I audit a uniquely marked "health_check" event
     Then the loki server should contain the marker within 15 seconds
     And the loki event payload should contain:

--- a/tests/bdd/features/metadata_writer.feature
+++ b/tests/bdd/features/metadata_writer.feature
@@ -10,7 +10,7 @@ Feature: MetadataWriter Interface
     Given a standard test taxonomy
 
   Scenario: MetadataWriter output receives correct event_type
-    Given a logger with a MetadataWriter output
+    Given an auditor with a MetadataWriter output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -18,7 +18,7 @@ Feature: MetadataWriter Interface
     Then the MetadataWriter should have received event_type "user_create"
 
   Scenario: MetadataWriter output receives correct severity
-    Given a logger with a MetadataWriter output
+    Given an auditor with a MetadataWriter output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -26,7 +26,7 @@ Feature: MetadataWriter Interface
     Then the MetadataWriter should have received severity 5
 
   Scenario: MetadataWriter output receives delivery-specific category
-    Given a logger with a MetadataWriter output
+    Given an auditor with a MetadataWriter output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -34,7 +34,7 @@ Feature: MetadataWriter Interface
     Then the MetadataWriter should have received category "write"
 
   Scenario: Non-MetadataWriter output still receives events
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |

--- a/tests/bdd/features/metrics.feature
+++ b/tests/bdd/features/metrics.feature
@@ -1,6 +1,6 @@
 @core @metrics
 Feature: Metrics Interface
-  As a library consumer, I want the logger to record metrics for all
+  As a library consumer, I want the auditor to record metrics for all
   pipeline events so that I can monitor audit health via my observability
   stack.
 
@@ -14,20 +14,20 @@ Feature: Metrics Interface
     And mock metrics are configured
 
   Scenario: Successful event delivery records success metric
-    Given a logger with stdout output and metrics
+    Given an auditor with stdout output and metrics
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the metrics should have recorded event "success" for output "stdout"
 
   Scenario: Validation error records validation metric
-    Given a logger with stdout output and metrics
+    Given an auditor with stdout output and metrics
     When I audit event "nonexistent_event" with fields:
       | field   | value   |
       | outcome | success |
     Then the metrics should have recorded a validation error
 
   Scenario: Missing required field records validation metric
-    Given a logger with stdout output and metrics
+    Given an auditor with stdout output and metrics
     When I audit event "user_create" with fields:
       | field   | value   |
       | outcome | success |
@@ -35,47 +35,47 @@ Feature: Metrics Interface
 
   Scenario: Filtered event records filter metric
     Given a standard test taxonomy
-    And a logger with stdout output and metrics
+    And an auditor with stdout output and metrics
     And I disable category "security"
     When I audit event "auth_failure" with required fields
     Then the metrics should have recorded a filtered event "auth_failure"
 
   Scenario: Nil metrics does not cause panic
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the event should be delivered successfully
 
   Scenario: Multiple outputs record success metric for non-DeliveryReporter outputs
-    Given a logger with file and stdout outputs and metrics
+    Given an auditor with file and stdout outputs and metrics
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the metrics should have recorded at least 1 success events
 
   Scenario: Unknown field in strict mode records validation error
-    Given a logger with stdout output and metrics in strict mode
+    Given an auditor with stdout output and metrics in strict mode
     When I audit event "user_create" with required fields and an unknown field "extra"
     Then the metrics should have recorded a validation error
 
   Scenario: Unknown field in warn mode does not record validation error
-    Given a logger with stdout output and metrics in warn mode
+    Given an auditor with stdout output and metrics in warn mode
     When I audit event "user_create" with required fields and an unknown field "extra"
     Then the metrics should not have recorded a validation error
 
   Scenario: Buffer drop metric recorded when buffer full
-    Given a logger with stdout output and metrics and buffer size 1
-    When I fill the logger buffer beyond capacity
+    Given an auditor with stdout output and metrics and buffer size 1
+    When I fill the auditor buffer beyond capacity
     Then the metrics should have recorded at least 1 buffer drop
 
   Scenario: Per-output route filter records output filtered metric
     Given a routing taxonomy with write, read, and security categories
-    And a logger with routed outputs and metrics where webhook excludes "write"
+    And an auditor with routed outputs and metrics where webhook excludes "write"
     When I audit a "user_create" event in category "write" with marker "m_filt"
-    And I close the logger
+    And I close the auditor
     Then the metrics should have recorded an output filtered event
 
   Scenario: Nil metrics with validation error does not panic
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "nonexistent_event" with fields:
       | field   | value   |
       | outcome | success |
@@ -86,30 +86,30 @@ Feature: Metrics Interface
 
   Scenario: Serialization error records serialization metric
     Given mock metrics are configured
-    And a logger with error-returning formatter and metrics
+    And an auditor with error-returning formatter and metrics
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the metrics should have recorded a serialization error
 
   @docker @webhook
   Scenario: DeliveryReporter output does not double-record in core metrics
     Given mock metrics are configured
-    And a logger with webhook output and metrics
+    And an auditor with webhook output and metrics
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the metrics should not have recorded a success event for webhook output
 
   Scenario: Output write failure records output error metric
     Given mock metrics are configured
-    And a logger with error output and metrics
+    And an auditor with error output and metrics
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the metrics should have recorded an output error for "error-output"
 
   Scenario: Nil metrics with filtered event does not panic
     Given a standard test taxonomy
-    And a logger with stdout output
+    And an auditor with stdout output
     And I disable category "security"
     When I audit event "auth_failure" with required fields
     Then the audit call should return no error

--- a/tests/bdd/features/multi_category_events.feature
+++ b/tests/bdd/features/multi_category_events.feature
@@ -18,7 +18,7 @@ Feature: Multi-category event delivery and severity
   # ---------------------------------------------------------------------------
 
   Scenario: Event in two enabled categories is delivered twice to unrouted output
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -27,7 +27,7 @@ Feature: Multi-category event delivery and severity
     And all delivered events should have event_type "auth_failure"
 
   Scenario: Event in two categories with include route for one category delivers once
-    Given a logger with stdout output routed to include only "security"
+    Given an auditor with stdout output routed to include only "security"
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -36,7 +36,7 @@ Feature: Multi-category event delivery and severity
     And all delivered events should have event_type "auth_failure"
 
   Scenario: Event in two categories with exclude route for one category delivers once
-    Given a logger with stdout output routed to exclude "compliance"
+    Given an auditor with stdout output routed to exclude "compliance"
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -45,7 +45,7 @@ Feature: Multi-category event delivery and severity
     And all delivered events should have event_type "auth_failure"
 
   Scenario: Uncategorised event delivered exactly once to unrouted output
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "data_export" with fields:
       | field   | value   |
       | outcome | success |
@@ -53,14 +53,14 @@ Feature: Multi-category event delivery and severity
     And all delivered events should have event_type "data_export"
 
   Scenario: Uncategorised event not delivered to category-routed include output
-    Given a logger with stdout output routed to include only "security"
+    Given an auditor with stdout output routed to include only "security"
     When I audit event "data_export" with fields:
       | field   | value   |
       | outcome | success |
     Then the output should contain exactly 0 events
 
   Scenario: Uncategorised event delivered via event-type include route
-    Given a logger with stdout output routed to include event type "data_export"
+    Given an auditor with stdout output routed to include event type "data_export"
     When I audit event "data_export" with fields:
       | field   | value   |
       | outcome | success |
@@ -72,7 +72,7 @@ Feature: Multi-category event delivery and severity
   # ---------------------------------------------------------------------------
 
   Scenario: Disabling one of two categories reduces delivery count to 1
-    Given a logger with stdout output
+    Given an auditor with stdout output
     And I disable category "compliance"
     When I audit event "auth_failure" with fields:
       | field    | value   |
@@ -82,7 +82,7 @@ Feature: Multi-category event delivery and severity
     And all delivered events should have event_type "auth_failure"
 
   Scenario: Disabling both categories produces 0 deliveries
-    Given a logger with stdout output
+    Given an auditor with stdout output
     And I disable category "security"
     And I disable category "compliance"
     When I audit event "auth_failure" with fields:
@@ -92,7 +92,7 @@ Feature: Multi-category event delivery and severity
     Then the output should contain exactly 0 events
 
   Scenario: DisableEvent overrides both enabled categories and delivers 0 times
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I disable event "auth_failure"
     And I audit event "auth_failure" with fields:
       | field    | value   |
@@ -101,7 +101,7 @@ Feature: Multi-category event delivery and severity
     Then the output should contain exactly 0 events
 
   Scenario: EnableEvent overrides both disabled categories and delivers on all category passes
-    Given a logger with stdout output
+    Given an auditor with stdout output
     And I disable category "security"
     And I disable category "compliance"
     When I enable event "auth_failure"
@@ -113,7 +113,7 @@ Feature: Multi-category event delivery and severity
     And all delivered events should have event_type "auth_failure"
 
   Scenario: EnableEvent with one category enabled and one disabled delivers on all passes
-    Given a logger with stdout output
+    Given an auditor with stdout output
     And I disable category "compliance"
     When I enable event "auth_failure"
     And I audit event "auth_failure" with fields:
@@ -129,7 +129,7 @@ Feature: Multi-category event delivery and severity
 
   Scenario: Category severity appears in JSON output for an event with no event-level severity
     Given a multi-category severity taxonomy
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -139,7 +139,7 @@ Feature: Multi-category event delivery and severity
 
   Scenario: Event-level severity overrides category severity in JSON output
     Given a taxonomy where auth_failure has event severity 10 in category with severity 3
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -159,7 +159,7 @@ Feature: Multi-category event delivery and severity
           fields:
             outcome: {required: true}
       """
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "ping" with fields:
       | field   | value   |
       | outcome | success |
@@ -179,7 +179,7 @@ Feature: Multi-category event delivery and severity
           fields:
             outcome: {required: true}
       """
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "audit_event" with fields:
       | field   | value   |
       | outcome | success |
@@ -188,7 +188,7 @@ Feature: Multi-category event delivery and severity
 
   Scenario: CEF header contains correct taxonomy severity
     Given a multi-category severity taxonomy
-    And a logger with stdout output using CEF formatter
+    And an auditor with stdout output using CEF formatter
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -210,7 +210,7 @@ Feature: Multi-category event delivery and severity
           fields:
             outcome: {required: true}
       """
-    And a logger with stdout output
+    And an auditor with stdout output
     When I audit event "auth_failure" with fields:
       | field   | value   |
       | outcome | failure |
@@ -222,7 +222,7 @@ Feature: Multi-category event delivery and severity
   # ---------------------------------------------------------------------------
 
   Scenario: Same event audited twice produces double deliveries
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "auth_failure" with fields:
       | field    | value    |
       | outcome  | failure  |

--- a/tests/bdd/features/multi_output_fanout.feature
+++ b/tests/bdd/features/multi_output_fanout.feature
@@ -10,34 +10,34 @@ Feature: Multi-Output Fan-Out
   # --- Delivery ---
 
   Scenario: Event delivered to file and webhook simultaneously
-    Given a logger with file and webhook outputs
+    Given an auditor with file and webhook outputs
     When I audit a uniquely marked "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain the marker
 
   Scenario: Event delivered to file and syslog simultaneously
-    Given a logger with file and syslog outputs
+    Given an auditor with file and syslog outputs
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the file should contain the marker
     And the syslog server should contain the marker within 10 seconds
 
   Scenario: Event delivered to all three outputs simultaneously
-    Given a logger with file, syslog, and webhook outputs
+    Given an auditor with file, syslog, and webhook outputs
     When I audit a uniquely marked "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain the marker
     And the syslog server should contain the marker within 10 seconds
 
   Scenario: Multiple events delivered to all outputs
-    Given a logger with file and webhook outputs
+    Given an auditor with file and webhook outputs
     When I audit a "user_create" event in category "write" with marker "multi_all_1"
     And I audit a "user_create" event in category "write" with marker "multi_all_2"
     And I audit a "user_create" event in category "write" with marker "multi_all_3"
     Then the webhook receiver should have at least 3 events within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "multi_all_1"
     And the file should contain "multi_all_2"
     And the file should contain "multi_all_3"
@@ -46,40 +46,40 @@ Feature: Multi-Output Fan-Out
 
   Scenario: Webhook failure does not block file delivery
     Given the webhook receiver is configured to return status 503
-    And a logger with file and webhook outputs
+    And an auditor with file and webhook outputs
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the file should contain the marker
 
   # --- Formatters ---
 
   Scenario: Shared formatter delivers identical content to both outputs
-    Given a logger with two file outputs sharing the same formatter
+    Given an auditor with two file outputs sharing the same formatter
     When I audit a "user_create" event in category "write" with marker "shared_fmt"
-    And I close the logger
+    And I close the auditor
     Then both files should contain identical content
 
   Scenario: Mixed formatters per output
-    Given a logger with file output using JSON and webhook output using CEF
+    Given an auditor with file output using JSON and webhook output using CEF
     When I audit a uniquely marked "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain JSON format with "event_type"
 
   # --- Construction validation ---
 
   Scenario: Duplicate output name rejected
-    When I try to create a logger with duplicate output names
-    Then the logger construction should fail with an error containing "duplicate output name"
+    When I try to create an auditor with duplicate output names
+    Then the auditor construction should fail with an error containing "duplicate output name"
 
   Scenario: Duplicate file destination rejected
-    When I try to create a logger with two file outputs to the same path
-    Then the logger construction should fail with an error containing "duplicate"
+    When I try to create an auditor with two file outputs to the same path
+    Then the auditor construction should fail with an error containing "duplicate"
 
   # --- Complete payload ---
 
   Scenario: All fields present in both file and webhook output
-    Given a logger with file and webhook outputs configured for batch size 1
+    Given an auditor with file and webhook outputs configured for batch size 1
     When I audit event "user_create" with fields:
       | field     | value       |
       | outcome   | success     |
@@ -87,7 +87,7 @@ Feature: Multi-Output Fan-Out
       | marker    | fanout_all  |
       | target_id | user-42     |
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain an event matching:
       | field       | value       |
       | event_type  | user_create |
@@ -104,47 +104,47 @@ Feature: Multi-Output Fan-Out
     And the webhook event body should contain field "timestamp"
 
   Scenario: Duplicate syslog destination rejected
-    When I try to create a logger with two syslog outputs to the same address
-    Then the logger construction should fail with an error containing "duplicate"
+    When I try to create an auditor with two syslog outputs to the same address
+    Then the auditor construction should fail with an error containing "duplicate"
 
   # --- Panic recovery ---
 
   Scenario: Output write error logged but other outputs continue
-    Given a logger with file output and an error-returning output
+    Given an auditor with file output and an error-returning output
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the file should contain the marker
 
   Scenario: Panic in per-output formatter does not crash logger
-    Given a logger with file output and a panicking formatter on a second output
+    Given an auditor with file output and a panicking formatter on a second output
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the file should contain the marker
 
   Scenario: Panic in output Write does not crash logger
-    Given a logger with file output and a panicking output
+    Given an auditor with file output and a panicking output
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the file should contain the marker
 
   # --- Routing diversity ---
 
   Scenario: Different events routed to different file outputs
-    Given a logger with two file outputs where security goes to file-a and write goes to file-b
+    Given an auditor with two file outputs where security goes to file-a and write goes to file-b
     When I audit a "user_create" event in category "write" with marker "div_w"
     And I audit an "auth_failure" event in category "security" with marker "div_s"
-    And I close the logger
+    And I close the auditor
     Then file "security" should contain "div_s"
     And file "security" should not contain "div_w"
     And file "write" should contain "div_w"
     And file "write" should not contain "div_s"
 
   Scenario: Three outputs with different routes verify distribution
-    Given a logger with file getting all, syslog getting security, and webhook getting write
+    Given an auditor with file getting all, syslog getting security, and webhook getting write
     When I audit a "user_create" event in category "write" with marker "dist_w"
     And I audit an "auth_failure" event in category "security" with marker "dist_s"
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "dist_w"
     And the file should contain "dist_s"
     And the syslog server should contain "dist_s" within 10 seconds

--- a/tests/bdd/features/multi_output_with_loki.feature
+++ b/tests/bdd/features/multi_output_with_loki.feature
@@ -39,9 +39,9 @@ Feature: Multi-Output Fan-Out with Loki
       """
 
   Scenario: Event delivered to file and Loki simultaneously
-    Given a logger with file and loki outputs
+    Given an auditor with file and loki outputs
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the file should contain the marker
     And the loki event payload should contain:
@@ -54,18 +54,18 @@ Feature: Multi-Output Fan-Out with Loki
       | event_category | write        |
 
   Scenario: Different routes per output with Loki receiving only security
-    Given a logger with file receiving all events and loki receiving only "security"
+    Given an auditor with file receiving all events and loki receiving only "security"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success" named "write_event"
     And I audit a uniquely marked "auth_failure" event with actor "mallory" and outcome "failure" and field "reason" = "invalid_password" named "security_event"
-    And I close the logger
+    And I close the auditor
     Then the file should contain both markers
     And querying Loki by label event_type = "auth_failure" should return the security_event marker within 10 seconds
     And the loki server should not contain marker "write_event" within 5 seconds
 
   Scenario: HMAC present on both file and Loki with same salt
-    Given a logger with file and loki outputs both HMAC-enabled with salt "fanout-hmac-salt-16!" version "v1"
+    Given an auditor with file and loki outputs both HMAC-enabled with salt "fanout-hmac-salt-16!" version "v1"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the file should contain the marker
     And the file event should contain "_hmac" field
@@ -93,9 +93,9 @@ Feature: Multi-Output Fan-Out with Loki
             email:
               labels: [pii]
       """
-    And a logger with file output keeping all fields and loki output excluding label "pii"
+    And an auditor with file output keeping all fields and loki output excluding label "pii"
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success" and field "email" = "alice@example.com"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the file should contain "alice@example.com"
     And the loki event payload should not contain field "email"
@@ -109,15 +109,15 @@ Feature: Multi-Output Fan-Out with Loki
       | event_category | write        |
 
   Scenario: Loki failure does not block file delivery
-    Given a logger with file output and loki output to unreachable server
+    Given an auditor with file output and loki output to unreachable server
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the file should contain the marker
 
   Scenario: Complete payload present in both file and Loki
-    Given a logger with file and loki outputs
+    Given an auditor with file and loki outputs
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the file should contain the marker
     And the file event should contain:
@@ -138,8 +138,8 @@ Feature: Multi-Output Fan-Out with Loki
       | event_category | write        |
 
   Scenario: Multiple events delivered to file and Loki
-    Given a logger with file and loki outputs
+    Given an auditor with file and loki outputs
     When I audit 3 uniquely marked "user_create" events with actor "alice" and outcome "success"
-    And I close the logger
+    And I close the auditor
     Then the loki fanout server should have at least 3 events within 10 seconds
     And the file should contain all 3 markers

--- a/tests/bdd/features/output_isolation.feature
+++ b/tests/bdd/features/output_isolation.feature
@@ -14,28 +14,28 @@ Feature: Output Isolation
     Given a standard test taxonomy
 
   Scenario: Events delivered to all outputs after close
-    Given a logger with stdout and a recording mock output
+    Given an auditor with stdout and a recording mock output
     When I audit 5 events rapidly
-    And I close the logger
+    And I close the auditor
     Then stdout should have received all 5 events
     And the recording output should have received all 5 events
 
   Scenario: Stdout remains synchronous
-    Given a logger with stdout output only
+    Given an auditor with stdout output only
     When I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then stdout should have received the event before close returned
 
   Scenario: Multiple recording outputs each receive all events
-    Given a logger with two recording mock outputs
+    Given an auditor with two recording mock outputs
     When I audit 5 events rapidly
-    And I close the logger
+    And I close the auditor
     Then both recording outputs should have received all 5 events
 
   @docker @syslog
   Scenario: Unreachable syslog does not block file delivery
-    Given a logger with file and syslog outputs
+    Given an auditor with file and syslog outputs
     When I stop the syslog-ng process
     And I audit 5 uniquely marked events after syslog down
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 5 events

--- a/tests/bdd/features/output_metrics_factory.feature
+++ b/tests/bdd/features/output_metrics_factory.feature
@@ -140,9 +140,9 @@ Feature: OutputMetrics Factory
     When I load the outputs config with the output metrics factory
     Then the config should load successfully
     And the output metrics factory should have been called with type "file" and name "audit_log"
-    When I create a logger from the loaded config
+    When I create an auditor from the loaded config
     And I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the output metrics for "file:audit_log" should have recorded at least 1 flush
     And the output metrics for "file:audit_log" should have recorded 0 errors
     And the output metrics for "file:audit_log" should have recorded 0 drops
@@ -161,7 +161,7 @@ Feature: OutputMetrics Factory
       """
     When I load the outputs config with a nil-returning output metrics factory
     Then the config should load successfully
-    When I create a logger from the loaded config
+    When I create an auditor from the loaded config
     And I audit event "user_create" with required fields
-    And I close the logger
+    And I close the auditor
     Then the event should be delivered successfully

--- a/tests/bdd/features/per_output_buffer_config.feature
+++ b/tests/bdd/features/per_output_buffer_config.feature
@@ -45,9 +45,9 @@ Feature: Per-Output Buffer Configuration
     Then the config load should fail with an error containing "buffer_size"
 
   Scenario: File output defaults buffer_size when omitted
-    Given a logger with file output at a temporary path
+    Given an auditor with file output at a temporary path
     When I audit 50 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the file should contain exactly 50 events
 
   Scenario: Syslog output buffer_size exceeding maximum is rejected

--- a/tests/bdd/features/per_output_buffer_drops.feature
+++ b/tests/bdd/features/per_output_buffer_drops.feature
@@ -14,56 +14,56 @@ Feature: Per-Output Buffer Drops
 
   Scenario: File output drops events when internal buffer is full
     Given a file output with buffer_size 1 and mock output metrics
-    And a logger with that file output and queue_size 10000
+    And an auditor with that file output and queue_size 10000
     When I audit 100 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the output metrics should have recorded at least 1 drop
 
   Scenario: Per-output drop does not cause core output error
     Given a file output with buffer_size 1 and mock output metrics
     And mock metrics are configured
-    And a logger with that file output and pipeline metrics and queue_size 10000
+    And an auditor with that file output and pipeline metrics and queue_size 10000
     When I audit 100 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the output metrics should have recorded at least 1 drop
     And the pipeline metrics should not have recorded an output error for file
 
   Scenario: Core queue drops and per-output drops are independent
     Given a file output with buffer_size 1 and mock output metrics
     And mock metrics are configured
-    And a logger with that file output and pipeline metrics and queue_size 5
-    When I fill the logger buffer beyond capacity
-    And I close the logger
+    And an auditor with that file output and pipeline metrics and queue_size 5
+    When I fill the auditor buffer beyond capacity
+    And I close the auditor
     Then the metrics should have recorded at least 1 buffer drop
     And the output metrics should have recorded at least 1 drop
 
   Scenario: Multiple outputs with different buffer sizes drop independently
     Given a file output with buffer_size 1 and mock output metrics
-    And a logger with that file output and a stdout output
+    And an auditor with that file output and a stdout output
     When I audit 50 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the output metrics should have recorded at least 1 drop
 
   @docker @syslog
   Scenario: Syslog output drops events when internal buffer is full
     Given a syslog output with buffer_size 1 and mock output metrics
-    And a logger with those outputs and queue_size 10000
+    And an auditor with those outputs and queue_size 10000
     When I audit 100 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the output metrics should have recorded at least 1 drop
 
   @docker @webhook
   Scenario: Webhook output drops events when internal buffer is full
     Given a webhook output with buffer_size 1 and mock output metrics
-    And a logger with those outputs and queue_size 10000
+    And an auditor with those outputs and queue_size 10000
     When I audit 200 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the output metrics should have recorded at least 1 drop
 
   @docker @loki
   Scenario: Loki output drops events when internal buffer is full
     Given a loki output with buffer_size 100 and mock output metrics
-    And a logger with those outputs and queue_size 10000
+    And an auditor with those outputs and queue_size 10000
     When I audit 500 events rapidly
-    And I close the logger
+    And I close the auditor
     Then the output metrics should have recorded at least 1 drop

--- a/tests/bdd/features/per_output_routing.feature
+++ b/tests/bdd/features/per_output_routing.feature
@@ -13,32 +13,32 @@ Feature: Per-Output Event Routing
   # --- Include mode ---
 
   Scenario: Include categories restricts output to matching events
-    Given a logger with file receiving all events and webhook receiving only "security"
+    Given an auditor with file receiving all events and webhook receiving only "security"
     When I audit a "user_create" event in category "write" with marker "route_inc_w"
     And I audit an "auth_failure" event in category "security" with marker "route_inc_s"
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "route_inc_w"
     And the file should contain "route_inc_s"
     And the webhook event body should contain field "event_type" with value "auth_failure"
     And the webhook should not contain event_type "user_create"
 
   Scenario: Include event types restricts output to specific events
-    Given a logger with file receiving all events and webhook including event types "auth_failure"
+    Given an auditor with file receiving all events and webhook including event types "auth_failure"
     When I audit a "user_create" event in category "write" with marker "route_evt_w"
     And I audit an "auth_failure" event in category "security" with marker "route_evt_s"
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "route_evt_w"
     And the file should contain "route_evt_s"
 
   Scenario: Include multiple event types delivers union
-    Given a logger with file receiving all events and webhook including event types "auth_failure,permission_denied"
+    Given an auditor with file receiving all events and webhook including event types "auth_failure,permission_denied"
     When I audit a "user_create" event in category "write" with marker "multi_evt_w"
     And I audit an "auth_failure" event in category "security" with marker "multi_evt_af"
     And I audit a "permission_denied" event in category "security" with marker "multi_evt_pd"
     Then the webhook receiver should have at least 2 events within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "multi_evt_w"
     And the file should contain "multi_evt_af"
     And the file should contain "multi_evt_pd"
@@ -46,11 +46,11 @@ Feature: Per-Output Event Routing
   # --- Exclude mode ---
 
   Scenario: Exclude categories removes matching events from output
-    Given a logger with file receiving all events and webhook excluding categories "write"
+    Given an auditor with file receiving all events and webhook excluding categories "write"
     When I audit a "user_create" event in category "write" with marker "route_exc_w"
     And I audit an "auth_failure" event in category "security" with marker "route_exc_s"
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "route_exc_w"
     And the file should contain "route_exc_s"
     And the webhook should not contain event_type "user_create"
@@ -58,26 +58,26 @@ Feature: Per-Output Event Routing
   # --- Validation ---
 
   Scenario: Mixed include and exclude on same route is rejected
-    When I try to create a logger with mixed include and exclude route
-    Then the logger construction should fail with an error containing "EventRoute must use either include or exclude, not both"
+    When I try to create an auditor with mixed include and exclude route
+    Then the auditor construction should fail with an error containing "EventRoute must use either include or exclude, not both"
 
   Scenario: Route referencing unknown category is rejected
-    When I try to create a logger with route referencing unknown category
-    Then the logger construction should fail with an error
+    When I try to create an auditor with route referencing unknown category
+    Then the auditor construction should fail with an error
 
   Scenario: Route referencing unknown event type is rejected
-    When I try to create a logger with route referencing unknown event type
-    Then the logger construction should fail with an error
+    When I try to create an auditor with route referencing unknown event type
+    Then the auditor construction should fail with an error
 
   # --- Include union ---
 
   Scenario: Include categories and event types form union
-    Given a logger with file receiving all events and webhook including categories "write" and event types "auth_failure"
+    Given an auditor with file receiving all events and webhook including categories "write" and event types "auth_failure"
     When I audit a "user_create" event in category "write" with marker "union_w"
     And I audit an "auth_failure" event in category "security" with marker "union_s"
     And I audit a "permission_denied" event in category "security" with marker "union_p"
     Then the webhook receiver should have at least 2 events within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "union_w"
     And the file should contain "union_s"
     And the file should contain "union_p"
@@ -85,98 +85,98 @@ Feature: Per-Output Event Routing
   # --- Exclude event types ---
 
   Scenario: Exclude single event type removes only that event
-    Given a logger with file receiving all events and webhook excluding event types "user_create"
+    Given an auditor with file receiving all events and webhook excluding event types "user_create"
     When I audit a "user_create" event in category "write" with marker "exc_single_w"
     And I audit a "config_update" event in category "write" with marker "exc_single_c"
     And I audit an "auth_failure" event in category "security" with marker "exc_single_s"
     Then the webhook receiver should have at least 2 events within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "exc_single_w"
     And the file should contain "exc_single_c"
     And the file should contain "exc_single_s"
 
   Scenario: Exclude event types removes specific events
-    Given a logger with file receiving all events and webhook excluding event types "user_create"
+    Given an auditor with file receiving all events and webhook excluding event types "user_create"
     When I audit a "user_create" event in category "write" with marker "excevt_w"
     And I audit an "auth_failure" event in category "security" with marker "excevt_s"
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "excevt_w"
     And the file should contain "excevt_s"
 
   # --- Empty route ---
 
   Scenario: Exclude multiple categories delivers union of exclusions
-    Given a logger with file receiving all events and webhook excluding categories "write" and "read"
+    Given an auditor with file receiving all events and webhook excluding categories "write" and "read"
     When I audit a "user_create" event in category "write" with marker "exc_multi_w"
     And I audit a "user_get" event in category "read" with marker "exc_multi_r"
     And I audit an "auth_failure" event in category "security" with marker "exc_multi_s"
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "exc_multi_w"
     And the file should contain "exc_multi_r"
     And the file should contain "exc_multi_s"
 
   Scenario: Empty route delivers all globally enabled events
-    Given a logger with file and webhook both receiving all events
+    Given an auditor with file and webhook both receiving all events
     When I audit a "user_create" event in category "write" with marker "empty_w"
     And I audit an "auth_failure" event in category "security" with marker "empty_s"
     Then the webhook receiver should have at least 2 events within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "empty_w"
     And the file should contain "empty_s"
 
   # --- Runtime changes ---
 
   Scenario: SetOutputRoute changes routing at runtime
-    Given a logger with file and webhook both receiving all events
+    Given an auditor with file and webhook both receiving all events
     When I audit a "user_create" event in category "write" with marker "pre_route"
     And the webhook receiver should have at least 1 event within 5 seconds
     And I set the webhook output route to include only "security"
     And I audit an "auth_failure" event in category "security" with marker "post_route_s"
     And I audit a "user_create" event in category "write" with marker "post_route_w"
     Then the webhook receiver should have at least 2 events within 5 seconds
-    And I close the logger
+    And I close the auditor
 
   Scenario: Exclude event types and categories form union
-    Given a logger with file receiving all events and webhook excluding categories "read" and event types "config_update"
+    Given an auditor with file receiving all events and webhook excluding categories "read" and event types "config_update"
     When I audit a "user_create" event in category "write" with marker "exc_union_w"
     And I audit a "config_update" event in category "write" with marker "exc_union_cu"
     And I audit a "user_get" event in category "read" with marker "exc_union_r"
     And I audit an "auth_failure" event in category "security" with marker "exc_union_s"
     Then the webhook receiver should have at least 2 events within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "exc_union_w"
     And the file should contain "exc_union_cu"
     And the file should contain "exc_union_r"
     And the file should contain "exc_union_s"
 
   Scenario: ClearOutputRoute resets to all events
-    Given a logger with file receiving all events and webhook receiving only "security"
+    Given an auditor with file receiving all events and webhook receiving only "security"
     When I clear the webhook output route
     And I audit a "user_create" event in category "write" with marker "clear_w"
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "clear_w"
 
   Scenario: Include multiple categories delivers union
-    Given a logger with file receiving all events and webhook including categories "write" and "security"
+    Given an auditor with file receiving all events and webhook including categories "write" and "security"
     When I audit a "user_create" event in category "write" with marker "multi_inc_w"
     And I audit an "auth_failure" event in category "security" with marker "multi_inc_s"
     And I audit a "user_get" event in category "read" with marker "multi_inc_r"
     Then the webhook receiver should have at least 2 events within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the file should contain "multi_inc_w"
     And the file should contain "multi_inc_s"
     And the file should contain "multi_inc_r"
 
   Scenario: OutputRoute returns current route
-    Given a logger with file receiving all events and webhook receiving only "security"
+    Given an auditor with file receiving all events and webhook receiving only "security"
     When I query the webhook output route
     Then the route should include category "security"
 
   Scenario: Unknown output name in SetOutputRoute returns error
-    Given a logger with file receiving all events and webhook receiving only "security"
+    Given an auditor with file receiving all events and webhook receiving only "security"
     When I try to set route for unknown output "nonexistent"
     Then the operation should return an error matching:
       """
@@ -186,8 +186,8 @@ Feature: Per-Output Event Routing
   # --- Global filter precedence ---
 
   Scenario: Global filter takes precedence over per-output route
-    Given a logger with file receiving all events and webhook receiving only "security"
+    Given an auditor with file receiving all events and webhook receiving only "security"
     When I disable category "security"
     And I audit an "auth_failure" event in category "security" with marker "global_sec"
-    And I close the logger
+    And I close the auditor
     Then the file should not contain "global_sec"

--- a/tests/bdd/features/queue_size_config.feature
+++ b/tests/bdd/features/queue_size_config.feature
@@ -1,23 +1,23 @@
 @core @config
 Feature: Queue Size YAML Configuration
   As a library consumer, I want to configure the core intake queue
-  via queue_size in the YAML logger section so that I can control
+  via queue_size in the YAML auditor section so that I can control
   back-pressure behaviour.
 
-  The logger-level queue was renamed from buffer_size to queue_size
+  The auditor-level queue was renamed from buffer_size to queue_size
   to avoid confusion with per-output buffer_size. The old field name
   is rejected as an unknown field.
 
   Background:
     Given a standard test taxonomy
 
-  Scenario: queue_size accepted in logger section
+  Scenario: queue_size accepted in auditor section
     Given the following outputs YAML:
       """
       version: 1
       app_name: bdd-test
       host: bdd-host
-      logger:
+      auditor:
         queue_size: 500
       outputs:
         console:
@@ -33,7 +33,7 @@ Feature: Queue Size YAML Configuration
       version: 1
       app_name: bdd-test
       host: bdd-host
-      logger:
+      auditor:
         queue_size: 2000000
       outputs:
         console:
@@ -56,13 +56,13 @@ Feature: Queue Size YAML Configuration
     Then the config should load successfully
     And the loaded config queue_size should be 0
 
-  Scenario: Old buffer_size under logger section is rejected
+  Scenario: Old buffer_size under auditor section is rejected
     Given the following outputs YAML:
       """
       version: 1
       app_name: bdd-test
       host: bdd-host
-      logger:
+      auditor:
         buffer_size: 1000
       outputs:
         console:

--- a/tests/bdd/features/sensitivity_labels.feature
+++ b/tests/bdd/features/sensitivity_labels.feature
@@ -25,7 +25,7 @@ Feature: Field-Level Sensitivity Labels
             actor_id: {required: true}
             email: {}
       """
-    And a logger with stdout output and no exclusions
+    And an auditor with stdout output and no exclusions
     When I audit event "user_create" with fields:
       | field    | value         |
       | outcome  | success       |
@@ -391,7 +391,7 @@ Feature: Field-Level Sensitivity Labels
             actor_id: {required: true}
             email: {}
       """
-    And a logger with stdout output excluding labels "pii"
+    And an auditor with stdout output excluding labels "pii"
     When I audit event "user_create" with fields:
       | field    | value             |
       | outcome  | success           |
@@ -419,7 +419,7 @@ Feature: Field-Level Sensitivity Labels
             outcome: {required: true}
             email: {}
       """
-    And a logger with stdout output excluding labels "pii"
+    And an auditor with stdout output excluding labels "pii"
     When I audit event "user_create" with fields:
       | field   | value             |
       | outcome | success           |
@@ -443,7 +443,7 @@ Feature: Field-Level Sensitivity Labels
             outcome: {required: true}
             email: {}
       """
-    And a logger with stdout output and no exclusions
+    And an auditor with stdout output and no exclusions
     When I audit event "user_create" with fields:
       | field   | value             |
       | outcome | success           |
@@ -467,7 +467,7 @@ Feature: Field-Level Sensitivity Labels
             outcome: {required: true}
             actor_id: {required: true}
       """
-    And a logger with stdout output excluding labels "pii"
+    And an auditor with stdout output excluding labels "pii"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -494,7 +494,7 @@ Feature: Field-Level Sensitivity Labels
             actor_id: {required: true}
             email: {}
       """
-    And a logger with stdout output excluding labels "pii"
+    And an auditor with stdout output excluding labels "pii"
     When I audit event "user_create" with fields:
       | field    | value             |
       | outcome  | success           |
@@ -505,7 +505,7 @@ Feature: Field-Level Sensitivity Labels
     And the output should not contain field "actor_id"
     And the output should not contain field "email"
 
-  Scenario: Undefined label in exclude_labels → logger construction error
+  Scenario: Undefined label in exclude_labels → auditor construction error
     Given a taxonomy with sensitivity labels:
       """
       version: 1
@@ -521,10 +521,10 @@ Feature: Field-Level Sensitivity Labels
           fields:
             outcome: {required: true}
       """
-    When I try to create a logger with stdout output excluding labels "nonexistent"
+    When I try to create an auditor with stdout output excluding labels "nonexistent"
     Then logger creation should fail with an error containing "undefined sensitivity label"
 
-  Scenario: Exclude_labels on output but no sensitivity config → logger construction error
+  Scenario: Exclude_labels on output but no sensitivity config → auditor construction error
     Given a taxonomy without sensitivity labels:
       """
       version: 1
@@ -536,7 +536,7 @@ Feature: Field-Level Sensitivity Labels
           fields:
             outcome: {required: true}
       """
-    When I try to create a logger with stdout output excluding labels "pii"
+    When I try to create an auditor with stdout output excluding labels "pii"
     Then logger creation should fail with an error containing "no sensitivity config"
 
   Scenario: No fields match any labels plus exclude_labels present → no stripping
@@ -556,7 +556,7 @@ Feature: Field-Level Sensitivity Labels
             outcome: {required: true}
             email: {}
       """
-    And a logger with stdout output excluding labels "pii"
+    And an auditor with stdout output excluding labels "pii"
     When I audit event "user_create" with fields:
       | field   | value             |
       | outcome | success           |
@@ -588,7 +588,7 @@ Feature: Field-Level Sensitivity Labels
             card_number: {}
             merchant: {}
       """
-    And a logger with stdout output excluding labels "pii,financial"
+    And an auditor with stdout output excluding labels "pii,financial"
     When I audit event "payment" with fields:
       | field       | value             |
       | outcome     | success           |
@@ -616,7 +616,7 @@ Feature: Field-Level Sensitivity Labels
             outcome: {required: true}
             actor_id: {required: true}
       """
-    And a logger with stdout output excluding labels "pii"
+    And an auditor with stdout output excluding labels "pii"
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |

--- a/tests/bdd/features/severity_routing.feature
+++ b/tests/bdd/features/severity_routing.feature
@@ -16,7 +16,7 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: MinSeverity filters out events below threshold
-    Given a logger with stdout output routed with min_severity 7
+    Given an auditor with stdout output routed with min_severity 7
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -31,7 +31,7 @@ Feature: Severity-based event routing
     And all delivered events should have event_type "auth_failure"
 
   Scenario: MinSeverity equal to event severity delivers the event
-    Given a logger with stdout output routed with min_severity 8
+    Given an auditor with stdout output routed with min_severity 8
     When I audit event "auth_failure" with fields:
       | field    | value       |
       | outcome  | failure     |
@@ -44,7 +44,7 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: MaxSeverity filters out events above threshold
-    Given a logger with stdout output routed with max_severity 5
+    Given an auditor with stdout output routed with max_severity 5
     When I audit event "user_create" with fields:
       | field    | value     |
       | outcome  | success   |
@@ -59,7 +59,7 @@ Feature: Severity-based event routing
     And all delivered events should have event_type "user_create"
 
   Scenario: MaxSeverity equal to event severity delivers the event
-    Given a logger with stdout output routed with max_severity 4
+    Given an auditor with stdout output routed with max_severity 4
     When I audit event "user_create" with fields:
       | field    | value     |
       | outcome  | success   |
@@ -72,7 +72,7 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: Severity range delivers only events within the band
-    Given a logger with stdout output routed with min_severity 3 and max_severity 7
+    Given an auditor with stdout output routed with min_severity 3 and max_severity 7
     When I audit event "health_check" with fields:
       | field   | value   |
       | outcome | success |
@@ -95,7 +95,7 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: Severity-only route with no category or event type filters
-    Given a logger with stdout output routed with min_severity 9
+    Given an auditor with stdout output routed with min_severity 9
     When I audit event "health_check" with fields:
       | field   | value   |
       | outcome | success |
@@ -123,7 +123,7 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: Category include AND severity must both match
-    Given a logger with stdout output routed to include only "security" with min_severity 9
+    Given an auditor with stdout output routed to include only "security" with min_severity 9
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -132,7 +132,7 @@ Feature: Severity-based event routing
     Then the output should contain exactly 0 events
 
   Scenario: Category include AND severity both satisfied delivers
-    Given a logger with stdout output routed to include only "security" with min_severity 7
+    Given an auditor with stdout output routed to include only "security" with min_severity 7
     When I audit event "auth_failure" with fields:
       | field    | value      |
       | outcome  | failure    |
@@ -141,7 +141,7 @@ Feature: Severity-based event routing
     Then the output should contain exactly 1 event
 
   Scenario: Category exclude with severity filter
-    Given a logger with stdout output routed to exclude "read" with min_severity 3
+    Given an auditor with stdout output routed to exclude "read" with min_severity 3
     When I audit event "user_get" with fields:
       | field   | value   |
       | outcome | success |
@@ -163,21 +163,21 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: MinSeverity 0 acts as no-op floor — all events pass
-    Given a logger with stdout output routed with min_severity 0
+    Given an auditor with stdout output routed with min_severity 0
     When I audit event "health_check" with fields:
       | field   | value   |
       | outcome | success |
     Then the output should contain exactly 1 event
 
   Scenario: MaxSeverity 0 filters everything except severity 0
-    Given a logger with stdout output routed with max_severity 0
+    Given an auditor with stdout output routed with max_severity 0
     When I audit event "health_check" with fields:
       | field   | value   |
       | outcome | success |
     Then the output should contain exactly 0 events
 
   Scenario: MinSeverity 10 delivers only severity 10 events
-    Given a logger with stdout output routed with min_severity 10
+    Given an auditor with stdout output routed with min_severity 10
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -190,7 +190,7 @@ Feature: Severity-based event routing
     And all delivered events should have event_type "system_breach"
 
   Scenario: MaxSeverity 10 acts as no-op ceiling — all events pass
-    Given a logger with stdout output routed with max_severity 10
+    Given an auditor with stdout output routed with max_severity 10
     When I audit event "system_breach" with fields:
       | field    | value    |
       | outcome  | failure  |
@@ -202,7 +202,7 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: Nil severity filters deliver all events unchanged
-    Given a logger with stdout output routed to include only "security"
+    Given an auditor with stdout output routed to include only "security"
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |
@@ -215,7 +215,7 @@ Feature: Severity-based event routing
 
   # custom_event has event-level severity 6 in the taxonomy (below min 7).
   Scenario: Severity filter applies to uncategorised events
-    Given a logger with stdout output routed with min_severity 7
+    Given an auditor with stdout output routed with min_severity 7
     When I audit event "custom_event" with fields:
       | field   | value   |
       | outcome | success |
@@ -226,7 +226,7 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: SetOutputRoute changes severity threshold at runtime
-    Given a logger with named stdout output "alerts" receiving all events
+    Given an auditor with named stdout output "alerts" receiving all events
     When I audit event "user_create" with fields:
       | field    | value         |
       | outcome  | success       |
@@ -250,20 +250,20 @@ Feature: Severity-based event routing
   # ---------------------------------------------------------------------------
 
   Scenario: MinSeverity out of range is rejected
-    When I try to create a logger with route min_severity 11
-    Then the logger creation should fail with error containing "min_severity 11 out of range 0-10"
+    When I try to create an auditor with route min_severity 11
+    Then the auditor creation should fail with error containing "min_severity 11 out of range 0-10"
 
   Scenario: MaxSeverity out of range is rejected
-    When I try to create a logger with route max_severity -1
-    Then the logger creation should fail with error containing "max_severity -1 out of range 0-10"
+    When I try to create an auditor with route max_severity -1
+    Then the auditor creation should fail with error containing "max_severity -1 out of range 0-10"
 
   Scenario: MinSeverity greater than MaxSeverity is rejected
-    When I try to create a logger with route min_severity 8 and max_severity 3
-    Then the logger creation should fail with error containing "min_severity 8 exceeds max_severity 3"
+    When I try to create an auditor with route min_severity 8 and max_severity 3
+    Then the auditor creation should fail with error containing "min_severity 8 exceeds max_severity 3"
 
   Scenario: MinSeverity 0 is valid and accepted
-    Given a logger with stdout output routed with min_severity 0
-    Then the logger should be created successfully
+    Given an auditor with stdout output routed with min_severity 0
+    Then the auditor should be created successfully
 
   # ---------------------------------------------------------------------------
   # Multi-category interaction
@@ -275,7 +275,7 @@ Feature: Severity-based event routing
   # → rejected on ALL category passes.
   Scenario: Multi-category event uses single resolved severity for routing
     Given a multi-category severity taxonomy
-    And a logger with stdout output routed with min_severity 5
+    And an auditor with stdout output routed with min_severity 5
     When I audit event "auth_failure" with fields:
       | field    | value   |
       | outcome  | failure |

--- a/tests/bdd/features/syslog_output.feature
+++ b/tests/bdd/features/syslog_output.feature
@@ -15,48 +15,48 @@ Feature: Syslog Output
   # --- Transport variants ---
 
   Scenario: Deliver event over TCP plain
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
   Scenario: Deliver event over UDP
-    Given a logger with syslog output on "udp" to "127.0.0.1:5515"
+    Given an auditor with syslog output on "udp" to "127.0.0.1:5515"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
   Scenario: Deliver event over TLS with CA certificate
-    Given a logger with syslog TLS output to "localhost:6514" with CA cert
+    Given an auditor with syslog TLS output to "localhost:6514" with CA cert
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
   Scenario: Deliver event over mTLS with client certificate
-    Given a logger with syslog mTLS output to "localhost:6515"
+    Given an auditor with syslog mTLS output to "localhost:6515"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
   Scenario: Multiple events delivered over TCP
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit 5 uniquely marked events
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain all 5 markers within 10 seconds
 
   # --- RFC 5424 format ---
 
   Scenario: Syslog message contains app name
-    Given a logger with syslog output on "tcp" to "localhost:5514" with app name "bdd-audit"
+    Given an auditor with syslog output on "tcp" to "localhost:5514" with app name "bdd-audit"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
     And the syslog line with the marker should contain "bdd-audit"
 
   Scenario: Syslog message contains timestamp
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
     And the syslog line with the marker should contain the current year
 
@@ -108,16 +108,16 @@ Feature: Syslog Output
   # --- Hostname configuration (#237) ---
 
   Scenario: Syslog hostname from Config appears in RFC 5424 header
-    Given a logger with syslog output on "tcp" to "localhost:5514" with hostname "bdd-custom-host"
+    Given an auditor with syslog output on "tcp" to "localhost:5514" with hostname "bdd-custom-host"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
     And the syslog line with the marker should contain "bdd-custom-host"
 
   Scenario: Syslog hostname defaults to os.Hostname when not configured
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
   Scenario: Syslog invalid hostname with space is rejected
@@ -129,16 +129,16 @@ Feature: Syslog Output
     Then the syslog construction should fail with an error containing "exceeds RFC 5424 maximum"
 
   Scenario: Default app name is "audit"
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
     And the syslog line with the marker should contain "audit"
 
   Scenario Outline: Valid facility names are accepted
-    Given a logger with syslog output on "tcp" to "localhost:5514" with facility "<facility>"
+    Given an auditor with syslog output on "tcp" to "localhost:5514" with facility "<facility>"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
     Examples:
@@ -152,34 +152,34 @@ Feature: Syslog Output
   # --- UDP edge cases ---
 
   Scenario: UDP large payload accepted without panic
-    Given a logger with syslog output on "udp" to "127.0.0.1:5515"
+    Given an auditor with syslog output on "udp" to "127.0.0.1:5515"
     When I audit an event with a 4096-byte payload
     Then the audit call should return no error
 
   Scenario: UDP does not use octet-count framing
-    Given a logger with syslog output on "udp" to "127.0.0.1:5515"
+    Given an auditor with syslog output on "udp" to "127.0.0.1:5515"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
   # --- Lifecycle ---
 
   Scenario: Write after close returns error
-    Given a logger with syslog output on "tcp" to "localhost:5514"
-    When I close the logger
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
+    When I close the auditor
     And I try to audit event "user_create" with required fields
     Then the audit call should return an error wrapping "ErrClosed"
 
   # --- Reconnection ---
 
   Scenario: Syslog reconnects after server process restart
-    Given a logger with syslog output on "tcp" to "localhost:5514" with max retries 10
+    Given an auditor with syslog output on "tcp" to "localhost:5514" with max retries 10
     When I audit a uniquely marked "user_create" event
     Then the syslog server should contain the marker within 10 seconds
     When I restart the syslog-ng process
     And I wait for syslog-ng to be ready
     And I audit a second uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the second marker within 15 seconds
 
   Scenario: Max retries exceeded returns error
@@ -189,36 +189,36 @@ Feature: Syslog Output
   # --- Syslog-specific metrics ---
 
   Scenario: Nil syslog metrics does not panic during delivery
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
   Scenario: Syslog metrics configured during delivery does not panic
     Given mock syslog metrics are configured
-    And a logger with syslog output on "tcp" to "localhost:5514" with metrics and max retries 10
+    And an auditor with syslog output on "tcp" to "localhost:5514" with metrics and max retries 10
     When I audit a uniquely marked "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
 
   Scenario: Close is idempotent
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit a uniquely marked "user_create" event
-    And I close the logger
-    And I close the logger again
+    And I close the auditor
+    And I close the auditor again
     Then the second close should return no error
 
   # --- Complete payload verification ---
 
   Scenario: All event fields present in syslog output
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit event "user_create" with fields:
       | field     | value      |
       | outcome   | success    |
       | actor_id  | alice      |
       | marker    | syslog_all |
       | target_id | user-42    |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain "syslog_all" within 10 seconds
     And the syslog line with "syslog_all" should contain "user_create"
     And the syslog line with "syslog_all" should contain "alice"

--- a/tests/bdd/features/syslog_severity.feature
+++ b/tests/bdd/features/syslog_severity.feature
@@ -20,9 +20,9 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
   # --- PRI verification per severity band (including boundaries) ---
 
   Scenario Outline: Audit severity <audit_sev> produces syslog PRI <expected_pri>
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit a uniquely marked "<event_type>" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
     And the syslog line with the marker should contain PRI "<expected_pri>"
 
@@ -40,7 +40,7 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
       | sev0_event  | 0         | 135          |
 
   Scenario: Different events produce different syslog PRIs
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit event "sev8_event" with fields and marker "pri_high":
       | field    | value   |
       | outcome  | success |
@@ -49,7 +49,7 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
       | field    | value   |
       | outcome  | success |
       | actor_id | bob     |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "pri_high" within 10 seconds
     And the syslog server should contain marker "pri_low" within 10 seconds
     And the syslog line with marker "pri_high" should contain PRI "131"
@@ -58,9 +58,9 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
   # --- RFC 5424 message structure ---
 
   Scenario: Syslog message has valid RFC 5424 structure
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit a uniquely marked "sev5_event" event
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
     And the syslog line with the marker should contain PRI "133"
 
@@ -68,12 +68,12 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
 
   Scenario: Framework fields present in syslog JSON payload
     Given framework fields app_name "bdd-syslog" host "bdd-host" timezone "UTC"
-    And a logger with syslog output on "tcp" to "localhost:5514"
+    And an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit event "sev5_event" with fields and marker "fw_fields":
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "fw_fields" within 10 seconds
     And the syslog line with marker "fw_fields" should contain "bdd-syslog"
     And the syslog line with marker "fw_fields" should contain "bdd-host"
@@ -81,12 +81,12 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
   # --- event_category verification ---
 
   Scenario: event_category present in syslog output for categorised events
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit event "sev5_event" with fields and marker "cat_check":
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "cat_check" within 10 seconds
     And the syslog line with marker "cat_check" should contain "event_category"
     And the syslog line with marker "cat_check" should contain "write"
@@ -94,12 +94,12 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
   # --- CEF formatter with syslog ---
 
   Scenario: Syslog with CEF formatter produces CEF in MSG body
-    Given a logger with syslog output on "tcp" to "localhost:5514" using CEF formatter
+    Given an auditor with syslog output on "tcp" to "localhost:5514" using CEF formatter
     When I audit event "sev8_event" with fields and marker "cef_syslog":
       | field    | value   |
       | outcome  | failure |
       | actor_id | mallory |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "cef_syslog" within 10 seconds
     And the syslog line with marker "cef_syslog" should contain "CEF:0|"
     And the syslog line with marker "cef_syslog" should contain "BDDTest"
@@ -110,7 +110,7 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
 
   Scenario: Syslog output does not contain events excluded by include route
     Given a routing taxonomy
-    And a logger with syslog output on "tcp" to "localhost:5514" routed to include only "security"
+    And an auditor with syslog output on "tcp" to "localhost:5514" routed to include only "security"
     When I audit event "user_create" with fields and marker "inc_excluded":
       | field    | value   |
       | outcome  | success |
@@ -119,7 +119,7 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
       | field    | value   |
       | outcome  | failure |
       | actor_id | mallory |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "inc_included" within 10 seconds
     And the syslog server should not contain marker "inc_excluded" within 5 seconds
 
@@ -127,7 +127,7 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
 
   Scenario: Syslog output excludes events matching exclude route
     Given a routing taxonomy
-    And a logger with syslog output on "tcp" to "localhost:5514" routed to exclude "write"
+    And an auditor with syslog output on "tcp" to "localhost:5514" routed to exclude "write"
     When I audit event "user_create" with fields and marker "exc_excluded":
       | field    | value   |
       | outcome  | success |
@@ -136,41 +136,41 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
       | field    | value   |
       | outcome  | failure |
       | actor_id | mallory |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "exc_included" within 10 seconds
     And the syslog server should not contain marker "exc_excluded" within 5 seconds
 
   # --- HMAC integrity with syslog ---
 
   Scenario: HMAC fields present in syslog output when enabled
-    Given a logger with syslog output on "tcp" to "localhost:5514" and HMAC enabled with salt "syslog-hmac-salt16!" version "v1" hash "HMAC-SHA-256"
+    Given an auditor with syslog output on "tcp" to "localhost:5514" and HMAC enabled with salt "syslog-hmac-salt16!" version "v1" hash "HMAC-SHA-256"
     When I audit event "sev5_event" with fields and marker "hmac_present":
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "hmac_present" within 10 seconds
     And the syslog line with marker "hmac_present" should contain "_hmac"
     And the syslog line with marker "hmac_present" should contain "_hmac_v"
     And the syslog line with marker "hmac_present" should contain "v1"
 
   Scenario: HMAC fields absent in syslog output when not configured
-    Given a logger with syslog output on "tcp" to "localhost:5514"
+    Given an auditor with syslog output on "tcp" to "localhost:5514"
     When I audit event "sev5_event" with fields and marker "hmac_absent":
       | field    | value   |
       | outcome  | success |
       | actor_id | alice   |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "hmac_absent" within 10 seconds
     And the syslog line with marker "hmac_absent" should not contain "_hmac"
 
   Scenario: HMAC-enabled syslog output preserves all event fields
-    Given a logger with syslog output on "tcp" to "localhost:5514" and HMAC enabled with salt "syslog-hmac-full16!" version "v1" hash "HMAC-SHA-256"
+    Given an auditor with syslog output on "tcp" to "localhost:5514" and HMAC enabled with salt "syslog-hmac-full16!" version "v1" hash "HMAC-SHA-256"
     When I audit event "sev8_event" with fields and marker "hmac_full":
       | field    | value   |
       | outcome  | failure |
       | actor_id | mallory |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "hmac_full" within 10 seconds
     And the syslog line with marker "hmac_full" should contain "sev8_event"
     And the syslog line with marker "hmac_full" should contain "failure"
@@ -182,26 +182,26 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
 
   Scenario: PII field stripped from syslog output when label excluded
     Given a sensitivity test taxonomy
-    And a logger with syslog output on "tcp" to "localhost:5514" excluding labels "pii"
+    And an auditor with syslog output on "tcp" to "localhost:5514" excluding labels "pii"
     When I audit event "user_create" with fields and marker "strip_pii":
       | field    | value             |
       | outcome  | success           |
       | actor_id | alice             |
       | email    | alice@example.com |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "strip_pii" within 10 seconds
     And the syslog line with marker "strip_pii" should contain "alice"
     And the syslog line with marker "strip_pii" should not contain "alice@example.com"
 
   Scenario: Non-excluded fields preserved when PII stripped from syslog
     Given a sensitivity test taxonomy
-    And a logger with syslog output on "tcp" to "localhost:5514" excluding labels "pii"
+    And an auditor with syslog output on "tcp" to "localhost:5514" excluding labels "pii"
     When I audit event "user_create" with fields and marker "keep_fields":
       | field    | value            |
       | outcome  | success          |
       | actor_id | bob              |
       | email    | bob@example.com  |
-    And I close the logger
+    And I close the auditor
     Then the syslog server should contain marker "keep_fields" within 10 seconds
     And the syslog line with marker "keep_fields" should contain "user_create"
     And the syslog line with marker "keep_fields" should contain "bob"

--- a/tests/bdd/features/taxonomy_validation.feature
+++ b/tests/bdd/features/taxonomy_validation.feature
@@ -1,6 +1,6 @@
 @core @taxonomy
 Feature: Taxonomy Validation
-  As a library consumer, I want the logger to validate my YAML taxonomy
+  As a library consumer, I want the auditor to validate my YAML taxonomy
   and reject malformed or inconsistent definitions so that only well-formed
   audit events can be emitted.
 
@@ -37,7 +37,7 @@ Feature: Taxonomy Validation
     And the taxonomy should contain event type "auth_failure"
     And the taxonomy event "user_create" should require field "outcome"
     And the taxonomy event "user_create" should require field "actor_id"
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -64,7 +64,7 @@ Feature: Taxonomy Validation
     Then the taxonomy should contain category "ops"
     And the taxonomy should contain event type "health_check"
     And the taxonomy event "health_check" should require field "outcome"
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit event "health_check" with fields:
       | field   | value   |
       | outcome | success |
@@ -257,7 +257,7 @@ Feature: Taxonomy Validation
 
   Scenario: Unknown fields rejected in strict mode
     Given a standard test taxonomy
-    And a logger with stdout output and validation mode "strict"
+    And an auditor with stdout output and validation mode "strict"
     When I audit event "user_create" with fields:
       | field      | value   |
       | outcome    | success |
@@ -270,7 +270,7 @@ Feature: Taxonomy Validation
 
   Scenario: Unknown fields accepted with warning in warn mode
     Given a standard test taxonomy
-    And a logger with stdout output and validation mode "warn"
+    And an auditor with stdout output and validation mode "warn"
     When I audit event "user_create" with fields:
       | field      | value   |
       | outcome    | success |
@@ -280,7 +280,7 @@ Feature: Taxonomy Validation
 
   Scenario: Unknown fields silently accepted in permissive mode
     Given a standard test taxonomy
-    And a logger with stdout output and validation mode "permissive"
+    And an auditor with stdout output and validation mode "permissive"
     When I audit event "user_create" with fields:
       | field      | value   |
       | outcome    | success |
@@ -291,7 +291,7 @@ Feature: Taxonomy Validation
 
   Scenario Outline: Missing required field fails in all validation modes
     Given a standard test taxonomy
-    And a logger with stdout output and validation mode "<mode>"
+    And an auditor with stdout output and validation mode "<mode>"
     When I audit event "user_create" with fields:
       | field   | value   |
       | outcome | success |
@@ -390,7 +390,7 @@ Feature: Taxonomy Validation
           fields:
             outcome: {required: true}
       """
-    And a logger with stdout output and validation mode "strict"
+    And an auditor with stdout output and validation mode "strict"
     When I audit event "user_create" with fields:
       | field     | value    |
       | outcome   | success  |
@@ -416,7 +416,7 @@ Feature: Taxonomy Validation
             source_ip:
               labels: [pii]
       """
-    And a logger with stdout output excluding labels "pii"
+    And an auditor with stdout output excluding labels "pii"
     When I audit event "user_create" with fields:
       | field     | value    |
       | outcome   | success  |
@@ -492,7 +492,7 @@ Feature: Taxonomy Validation
           fields:
             outcome: {required: true}
       """
-    And a logger with stdout output and validation mode "permissive"
+    And an auditor with stdout output and validation mode "permissive"
     When I audit event "user_create" with fields:
       | field     | value    |
       | outcome   | success  |
@@ -512,7 +512,7 @@ Feature: Taxonomy Validation
           fields:
             outcome: {required: true}
       """
-    And a logger with stdout output and validation mode "warn"
+    And an auditor with stdout output and validation mode "warn"
     When I audit event "user_create" with fields:
       | field     | value    |
       | outcome   | success  |

--- a/tests/bdd/features/typed_builders.feature
+++ b/tests/bdd/features/typed_builders.feature
@@ -12,7 +12,7 @@ Feature: Typed Event Builders
     Given a standard test taxonomy
 
   Scenario: AuditEvent delivers event to output
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit via NewEvent "user_create" with fields:
       | field    | value   |
       | outcome  | success |
@@ -21,26 +21,26 @@ Feature: Typed Event Builders
     And the stdout output should contain field "actor_id" with value "alice"
 
   Scenario: AuditEvent with nil event returns error
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit a nil event
     Then the last error should contain "event must not be nil"
 
   Scenario: NewEvent with missing required field returns error
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit via NewEvent "user_create" with fields:
       | field   | value   |
       | outcome | success |
     Then the last error should contain "missing required"
 
   Scenario: NewEvent with unknown event type returns error
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit via NewEvent "nonexistent_event" with fields:
       | field   | value   |
       | outcome | success |
     Then the last error should contain "unknown event type"
 
   Scenario: AuditEvent with optional fields delivered correctly
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit via NewEvent "user_create" with fields:
       | field    | value       |
       | outcome  | success     |
@@ -49,7 +49,7 @@ Feature: Typed Event Builders
     Then the stdout output should contain field "marker" with value "test-marker"
 
   Scenario: Multiple AuditEvent calls deliver multiple events
-    Given a logger with stdout output
+    Given an auditor with stdout output
     When I audit via NewEvent "user_create" with fields:
       | field    | value   |
       | outcome  | success |

--- a/tests/bdd/features/webhook_output.feature
+++ b/tests/bdd/features/webhook_output.feature
@@ -12,22 +12,22 @@ Feature: Webhook Output
   # --- Batch delivery ---
 
   Scenario: Batch delivery sends events in batches
-    Given a logger with webhook output configured for batch size 5
+    Given an auditor with webhook output configured for batch size 5
     When I audit 12 uniquely marked webhook events
     Then the webhook receiver should have at least 3 requests within 10 seconds
 
   Scenario: Single event with batch size 1 delivered immediately
-    Given a logger with webhook output configured for batch size 1
+    Given an auditor with webhook output configured for batch size 1
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
 
   Scenario: Flush interval triggers delivery before batch full
-    Given a logger with webhook output configured for batch size 100 and flush interval 200ms
+    Given an auditor with webhook output configured for batch size 100 and flush interval 200ms
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
 
   Scenario: Timer resets after batch flush
-    Given a logger with webhook output configured for batch size 2 and flush interval 300ms
+    Given an auditor with webhook output configured for batch size 2 and flush interval 300ms
     When I audit a uniquely marked webhook "user_create" event "timer1"
     And I audit a uniquely marked webhook "user_create" event "timer2"
     Then the webhook receiver should have at least 1 event within 5 seconds
@@ -39,28 +39,28 @@ Feature: Webhook Output
 
   Scenario: Retry on 503 response with eventual delivery
     Given the webhook receiver is configured to return status 503
-    And a logger with webhook output configured for batch size 1 and max retries 3
+    And an auditor with webhook output configured for batch size 1 and max retries 3
     When I audit a uniquely marked webhook "user_create" event
     And the webhook receiver is reconfigured to return status 200
     Then the webhook receiver should have at least 1 event within 10 seconds
 
   Scenario: Retry on 429 rate limit response
     Given the webhook receiver is configured to return status 429
-    And a logger with webhook output configured for batch size 1 and max retries 3
+    And an auditor with webhook output configured for batch size 1 and max retries 3
     When I audit a uniquely marked webhook "user_create" event
     And the webhook receiver is reconfigured to return status 200
     Then the webhook receiver should have at least 1 event within 10 seconds
 
   Scenario: Retry on 504 gateway timeout
     Given the webhook receiver is configured to return status 504
-    And a logger with webhook output configured for batch size 1 and max retries 3
+    And an auditor with webhook output configured for batch size 1 and max retries 3
     When I audit a uniquely marked webhook "user_create" event
     And the webhook receiver is reconfigured to return status 200
     Then the webhook receiver should have at least 1 event within 10 seconds
 
   Scenario: No retry on 400 bad request
     Given the webhook receiver is configured to return status 400
-    And a logger with webhook output configured for batch size 1 and max retries 5
+    And an auditor with webhook output configured for batch size 1 and max retries 5
     When I audit a uniquely marked webhook "user_create" event "first"
     And the webhook receiver is reconfigured to return status 200
     And I audit a uniquely marked webhook "user_create" event "sentinel"
@@ -68,7 +68,7 @@ Feature: Webhook Output
 
   Scenario: No retry on 401 unauthorized
     Given the webhook receiver is configured to return status 401
-    And a logger with webhook output configured for batch size 1 and max retries 5
+    And an auditor with webhook output configured for batch size 1 and max retries 5
     When I audit a uniquely marked webhook "user_create" event "no_retry_401"
     And the webhook receiver is reconfigured to return status 200
     And I audit a uniquely marked webhook "user_create" event "sentinel_401"
@@ -76,7 +76,7 @@ Feature: Webhook Output
 
   Scenario: No retry on 403 forbidden
     Given the webhook receiver is configured to return status 403
-    And a logger with webhook output configured for batch size 1 and max retries 5
+    And an auditor with webhook output configured for batch size 1 and max retries 5
     When I audit a uniquely marked webhook "user_create" event "no_retry_403"
     And the webhook receiver is reconfigured to return status 200
     And I audit a uniquely marked webhook "user_create" event "sentinel_403"
@@ -85,19 +85,19 @@ Feature: Webhook Output
   # --- Custom headers ---
 
   Scenario: Custom headers delivered with events
-    Given a logger with webhook output with custom header "X-Audit-Source" = "bdd-test"
+    Given an auditor with webhook output with custom header "X-Audit-Source" = "bdd-test"
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
     And the received webhook event should have header "X-Audit-Source" with value "bdd-test"
 
   Scenario: Authorization header delivered to receiver
-    Given a logger with webhook output with custom header "Authorization" = "Bearer test-token-123"
+    Given an auditor with webhook output with custom header "Authorization" = "Bearer test-token-123"
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
     And the received webhook event should have header "Authorization" with value "Bearer test-token-123"
 
   Scenario: Content-Type is application/x-ndjson
-    Given a logger with webhook output configured for batch size 1
+    Given an auditor with webhook output configured for batch size 1
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
     And the received webhook event should have header "Content-Type" with value "application/x-ndjson"
@@ -105,9 +105,9 @@ Feature: Webhook Output
   # --- Shutdown flush ---
 
   Scenario: Pending events flushed on shutdown
-    Given a logger with webhook output configured for batch size 100 and flush interval 60s
+    Given an auditor with webhook output configured for batch size 100 and flush interval 60s
     When I audit 3 uniquely marked webhook events
-    And I close the logger
+    And I close the auditor
     Then the webhook receiver should have at least 1 event within 5 seconds
 
   # --- SSRF protection ---
@@ -120,30 +120,30 @@ Feature: Webhook Output
       """
 
   Scenario: AllowInsecureHTTP permits http URLs
-    Given a logger with webhook output to "http://localhost:8080/events" with AllowInsecureHTTP
+    Given an auditor with webhook output to "http://localhost:8080/events" with AllowInsecureHTTP
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
 
   Scenario: Private range blocked by default drops events
     Given a local HTTP webhook receiver
     And mock webhook metrics are configured
-    And a logger with webhook output to the local receiver without AllowPrivateRanges
+    And an auditor with webhook output to the local receiver without AllowPrivateRanges
     When I audit a uniquely marked webhook "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the webhook metrics should have recorded at least 1 drop within 5 seconds
 
   Scenario: AllowPrivateRanges permits private addresses
     Given a local HTTP webhook receiver
-    And a logger with webhook output to the local receiver with AllowPrivateRanges
+    And an auditor with webhook output to the local receiver with AllowPrivateRanges
     When I audit a uniquely marked webhook "user_create" event
     Then the local webhook receiver should have at least 1 event within 5 seconds
 
   Scenario: Redirect is rejected and not followed
     Given a local HTTP webhook receiver configured to redirect
     And mock webhook metrics are configured
-    And a logger with webhook output to the redirecting receiver with metrics
+    And an auditor with webhook output to the redirecting receiver with metrics
     When I audit a uniquely marked webhook "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the webhook metrics should have recorded at least 1 drop within 5 seconds
 
   Scenario: Embedded credentials in URL rejected with exact error
@@ -193,7 +193,7 @@ Feature: Webhook Output
   # --- Complete payload verification ---
 
   Scenario: All event fields present in webhook delivery
-    Given a logger with webhook output configured for batch size 1
+    Given an auditor with webhook output configured for batch size 1
     When I audit event "user_create" with fields:
       | field     | value         |
       | outcome   | success       |
@@ -212,21 +212,21 @@ Feature: Webhook Output
 
   Scenario: Retry on 500 internal server error
     Given the webhook receiver is configured to return status 500
-    And a logger with webhook output configured for batch size 1 and max retries 3
+    And an auditor with webhook output configured for batch size 1 and max retries 3
     When I audit a uniquely marked webhook "user_create" event
     And the webhook receiver is reconfigured to return status 200
     Then the webhook receiver should have at least 1 event within 10 seconds
 
   Scenario: Retry on 502 bad gateway
     Given the webhook receiver is configured to return status 502
-    And a logger with webhook output configured for batch size 1 and max retries 3
+    And an auditor with webhook output configured for batch size 1 and max retries 3
     When I audit a uniquely marked webhook "user_create" event
     And the webhook receiver is reconfigured to return status 200
     Then the webhook receiver should have at least 1 event within 10 seconds
 
   Scenario: No retry on 404 not found
     Given the webhook receiver is configured to return status 404
-    And a logger with webhook output configured for batch size 1 and max retries 5
+    And an auditor with webhook output configured for batch size 1 and max retries 5
     When I audit a uniquely marked webhook "user_create" event "no_retry_404"
     And the webhook receiver is reconfigured to return status 200
     And I audit a uniquely marked webhook "user_create" event "sentinel_404"
@@ -234,7 +234,7 @@ Feature: Webhook Output
 
   Scenario: Retries exhausted drops batch and continues
     Given the webhook receiver is configured to return status 503
-    And a logger with webhook output configured for batch size 1 and max retries 1
+    And an auditor with webhook output configured for batch size 1 and max retries 1
     When I audit a uniquely marked webhook "user_create" event "exhausted"
     And I wait 3 seconds for retries to exhaust
     And the webhook receiver is reconfigured to return status 200
@@ -244,40 +244,40 @@ Feature: Webhook Output
   # --- Buffer management ---
 
   Scenario: Buffer overflow is non-blocking
-    Given a logger with webhook output configured for batch size 100 and flush interval 60s
+    Given an auditor with webhook output configured for batch size 100 and flush interval 60s
     When I rapidly audit 200 webhook events measuring time
     Then all 200 audit calls should complete within 2 seconds
 
   Scenario: Buffer overflow records per-output RecordDrop metric
     Given a local HTTP webhook receiver
     And mock webhook metrics are configured
-    And a logger with webhook to local receiver with buffer size 1 and metrics
+    And an auditor with webhook to local receiver with buffer size 1 and metrics
     When I rapidly audit 200 webhook events measuring time
-    And I close the logger
+    And I close the auditor
     Then the webhook metrics should have recorded at least 1 drop within 5 seconds
 
   # --- Close idempotent ---
 
   Scenario: Close is idempotent
-    Given a logger with webhook output configured for batch size 1
-    When I close the logger
-    And I close the logger again
+    Given an auditor with webhook output configured for batch size 1
+    When I close the auditor
+    And I close the auditor again
     Then the second close should return no error
 
   # --- HTTPS / TLS ---
 
   Scenario: Webhook over HTTPS with custom CA validates server
     Given a local HTTPS webhook receiver
-    And a logger with webhook output to the HTTPS receiver with custom CA
+    And an auditor with webhook output to the HTTPS receiver with custom CA
     When I audit a uniquely marked webhook "user_create" event
     Then the HTTPS webhook receiver should have at least 1 event within 5 seconds
 
   Scenario: Webhook HTTPS with wrong CA drops events
     Given a local HTTPS webhook receiver
     And mock webhook metrics are configured
-    And a logger with webhook output to the HTTPS receiver with wrong CA and metrics
+    And an auditor with webhook output to the HTTPS receiver with wrong CA and metrics
     When I audit a uniquely marked webhook "user_create" event
-    And I close the logger
+    And I close the auditor
     Then the webhook metrics should have recorded at least 1 drop within 5 seconds
     And the HTTPS webhook receiver should have received 0 events
 
@@ -285,21 +285,21 @@ Feature: Webhook Output
 
   Scenario: Webhook flush records RecordWebhookFlush metric
     Given mock webhook metrics are configured
-    And a logger with webhook output and webhook metrics configured for batch size 1
+    And an auditor with webhook output and webhook metrics configured for batch size 1
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
-    And I close the logger
+    And I close the auditor
     And the webhook metrics should have recorded at least 1 flush
 
   Scenario: Nil webhook metrics does not panic
-    Given a logger with webhook output configured for batch size 1
+    Given an auditor with webhook output configured for batch size 1
     When I audit a uniquely marked webhook "user_create" event
     Then the webhook receiver should have at least 1 event within 5 seconds
 
   # --- Lifecycle ---
 
   Scenario: Write after close returns error
-    Given a logger with webhook output configured for batch size 1
-    When I close the logger
+    Given an auditor with webhook output configured for batch size 1
+    When I close the auditor
     And I try to audit event "user_create" with required fields
     Then the audit call should return an error wrapping "ErrClosed"

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -91,23 +91,23 @@ func registerAuditGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 		return nil
 	})
 
-	ctx.Step(`^a logger with stdout output$`, func() error {
-		return createStdoutLogger(tc)
+	ctx.Step(`^an auditor with stdout output$`, func() error {
+		return createStdoutAuditor(tc)
 	})
 
-	ctx.Step(`^a logger with stdout output and validation mode "([^"]*)"$`, func(mode string) error {
-		return createStdoutLogger(tc, audit.WithValidationMode(audit.ValidationMode(mode)))
+	ctx.Step(`^an auditor with stdout output and validation mode "([^"]*)"$`, func(mode string) error {
+		return createStdoutAuditor(tc, audit.WithValidationMode(audit.ValidationMode(mode)))
 	})
 
-	ctx.Step(`^a logger with stdout output and OmitEmpty "([^"]*)"$`, func(val string) error {
+	ctx.Step(`^an auditor with stdout output and OmitEmpty "([^"]*)"$`, func(val string) error {
 		if val == "true" {
-			return createStdoutLogger(tc, audit.WithOmitEmpty())
+			return createStdoutAuditor(tc, audit.WithOmitEmpty())
 		}
-		return createStdoutLogger(tc)
+		return createStdoutAuditor(tc)
 	})
 
-	ctx.Step(`^a disabled logger$`, func() error {
-		return createStdoutLogger(tc, audit.WithDisabled())
+	ctx.Step(`^a disabled auditor$`, func() error {
+		return createStdoutAuditor(tc, audit.WithDisabled())
 	})
 
 	ctx.Step(`^framework fields app_name "([^"]*)" host "([^"]*)" timezone "([^"]*)"$`, func(appName, host, tz string) error {
@@ -137,61 +137,61 @@ func registerAuditWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 func registerAuditWhenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^I audit event "([^"]*)" with fields:$`, func(eventType string, table *godog.Table) error {
 		fields := tableToFields(table)
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with required fields$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with required fields and an unknown field "([^"]*)"$`, func(eventType, extraField string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields[extraField] = "extra_value"
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit a uniquely marked "([^"]*)" event$`, func(eventType string) error {
-		if tc.Logger == nil {
-			return fmt.Errorf("logger is nil (construction may have failed: %w)", tc.LastErr)
+		if tc.Auditor == nil {
+			return fmt.Errorf("auditor is nil (construction may have failed: %w)", tc.LastErr)
 		}
 		m := marker("BDD")
 		tc.Markers["default"] = m
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = m
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with empty fields$`, func(eventType string) error {
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, audit.Fields{}))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, audit.Fields{}))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with nil fields$`, func(eventType string) error {
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, nil))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, nil))
 		return nil
 	})
 
-	ctx.Step(`^I close the logger$`, func() error {
-		if tc.Logger == nil {
+	ctx.Step(`^I close the auditor$`, func() error {
+		if tc.Auditor == nil {
 			return nil
 		}
-		tc.LastErr = tc.Logger.Close()
+		tc.LastErr = tc.Auditor.Close()
 		return nil
 	})
 
 	ctx.Step(`^I try to audit event "([^"]*)" with required fields$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I get a handle for event type "([^"]*)"$`, func(eventType string) error {
-		h, err := tc.Logger.Handle(eventType)
+		h, err := tc.Auditor.Handle(eventType)
 		if err != nil {
 			tc.LastErr = err
 			return nil //nolint:nilerr // scenario may assert on error
@@ -201,7 +201,7 @@ func registerAuditWhenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 	})
 
 	ctx.Step(`^I try to get a handle for event type "([^"]*)"$`, func(eventType string) error {
-		_, err := tc.Logger.Handle(eventType)
+		_, err := tc.Auditor.Handle(eventType)
 		tc.LastErr = err
 		return nil
 	})
@@ -215,7 +215,7 @@ func registerAuditWhenHandleSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 				tc.LastErr = fmt.Errorf("%v", r)
 			}
 		}()
-		h := tc.Logger.MustHandle(eventType)
+		h := tc.Auditor.MustHandle(eventType)
 		tc.EventHandle = h
 		return nil
 	})
@@ -228,11 +228,11 @@ func registerAuditWhenHandleSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 	})
 
 	ctx.Step(`^I fill the buffer and audit one more event$`, func() error {
-		// The logger has buffer size 1. The drain goroutine processes
+		// The auditor has buffer size 1. The drain goroutine processes
 		// events async, so we need to fill the buffer faster than drain.
 		// Send events in a tight loop until we get ErrQueueFull.
 		for range 1000 {
-			err := tc.Logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+			err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 				"outcome":  "success",
 				"actor_id": "overflow",
 			}))
@@ -244,8 +244,8 @@ func registerAuditWhenHandleSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 		return fmt.Errorf("never got ErrQueueFull after 1000 attempts")
 	})
 
-	ctx.Step(`^a logger with stdout output and buffer size (\d+)$`, func(bufSize int) error {
-		return createStdoutLogger(tc, audit.WithQueueSize(bufSize))
+	ctx.Step(`^an auditor with stdout output and buffer size (\d+)$`, func(bufSize int) error {
+		return createStdoutAuditor(tc, audit.WithQueueSize(bufSize))
 	})
 
 	ctx.Step(`^I audit via handle with fields:$`, func(table *godog.Table) error {
@@ -436,8 +436,8 @@ func registerAuditThenOutputSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 }
 
 func assertNoEvents(tc *AuditTestContext) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	if tc.StdoutBuf != nil {
 		events, _ := parseJSONLines(tc.StdoutBuf.Bytes())
@@ -584,8 +584,8 @@ func assertNotSentinelError(tc *AuditTestContext, sentinel string) error {
 
 // --- Internal helpers ---
 
-// createStdoutLogger creates a logger with an in-memory stdout output.
-func createStdoutLogger(tc *AuditTestContext, extraOpts ...audit.Option) error {
+// createStdoutAuditor creates an auditor with an in-memory stdout output.
+func createStdoutAuditor(tc *AuditTestContext, extraOpts ...audit.Option) error {
 	buf := &bytes.Buffer{}
 	tc.StdoutBuf = buf
 
@@ -604,34 +604,34 @@ func createStdoutLogger(tc *AuditTestContext, extraOpts ...audit.Option) error {
 	opts = append(opts, tc.Options...)
 	opts = append(opts, extraOpts...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
 		// Store the error for scenarios that expect construction failure.
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-// createStdoutLoggerWithOpts is an alias for createStdoutLogger for
+// createStdoutAuditorWithOpts is an alias for createStdoutAuditor for
 // callers that pass additional options.
-func createStdoutLoggerWithOpts(tc *AuditTestContext, opts ...audit.Option) error {
-	return createStdoutLogger(tc, opts...)
+func createStdoutAuditorWithOpts(tc *AuditTestContext, opts ...audit.Option) error {
+	return createStdoutAuditor(tc, opts...)
 }
 
-// getStdoutEvents closes the logger (to flush the drain) and parses
-// JSON events from the stdout buffer. The logger must be closed before
+// getStdoutEvents closes the auditor (to flush the drain) and parses
+// JSON events from the stdout buffer. The auditor must be closed before
 // reading the buffer to avoid a data race with the drain goroutine.
 func getStdoutEvents(tc *AuditTestContext) ([]map[string]any, error) {
 	if tc.StdoutBuf == nil {
 		return nil, fmt.Errorf("no stdout buffer configured")
 	}
-	// Close the logger to flush all pending events. Close is
+	// Close the auditor to flush all pending events. Close is
 	// idempotent, so calling it multiple times is safe.
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	return parseJSONLines(tc.StdoutBuf.Bytes())
 }

--- a/tests/bdd/steps/builder_steps.go
+++ b/tests/bdd/steps/builder_steps.go
@@ -28,12 +28,12 @@ func registerBuilderSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^I audit via NewEvent "([^"]*)" with fields:$`,
 		func(eventType string, table *godog.Table) error {
 			fields := tableToFields(table)
-			tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 			return nil
 		})
 
 	ctx.Step(`^I audit a nil event$`, func() error {
-		tc.LastErr = tc.Logger.AuditEvent(nil)
+		tc.LastErr = tc.Auditor.AuditEvent(nil)
 		return nil
 	})
 
@@ -60,9 +60,9 @@ func registerBuilderSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 }
 
 func assertStdoutContainsField(tc *AuditTestContext, field, value string) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
-		tc.Logger = nil
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
+		tc.Auditor = nil
 	}
 	if tc.StdoutBuf == nil {
 		return fmt.Errorf("no stdout buffer configured")

--- a/tests/bdd/steps/config_steps.go
+++ b/tests/bdd/steps/config_steps.go
@@ -32,81 +32,81 @@ func registerConfigSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 }
 
 func registerConfigWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^I try to create a logger$`, func() error {
-		return tryCreateLogger(tc)
+	ctx.Step(`^I try to create an auditor$`, func() error {
+		return tryCreateAuditor(tc)
 	})
 
-	ctx.Step(`^I create a logger$`, func() error {
-		return tryCreateLogger(tc)
+	ctx.Step(`^I create an auditor$`, func() error {
+		return tryCreateAuditor(tc)
 	})
 
-	ctx.Step(`^I create a logger with buffer size (\d+)$`, func(bufSize int) error {
-		return tryCreateLogger(tc, audit.WithQueueSize(bufSize))
+	ctx.Step(`^I create an auditor with buffer size (\d+)$`, func(bufSize int) error {
+		return tryCreateAuditor(tc, audit.WithQueueSize(bufSize))
 	})
 
-	ctx.Step(`^I try to create a logger with buffer size (\d+)$`, func(bufSize int) error {
-		return tryCreateLogger(tc, audit.WithQueueSize(bufSize))
+	ctx.Step(`^I try to create an auditor with buffer size (\d+)$`, func(bufSize int) error {
+		return tryCreateAuditor(tc, audit.WithQueueSize(bufSize))
 	})
 
-	ctx.Step(`^I create a logger with drain timeout (\d+)$`, func(timeout int) error {
-		return tryCreateLogger(tc, audit.WithDrainTimeout(time.Duration(timeout)))
+	ctx.Step(`^I create an auditor with drain timeout (\d+)$`, func(timeout int) error {
+		return tryCreateAuditor(tc, audit.WithShutdownTimeout(time.Duration(timeout)))
 	})
 
-	ctx.Step(`^I try to create a logger with drain timeout (\d+)s$`, func(secs int) error {
-		return tryCreateLogger(tc, audit.WithDrainTimeout(time.Duration(secs)*time.Second))
+	ctx.Step(`^I try to create an auditor with drain timeout (\d+)s$`, func(secs int) error {
+		return tryCreateAuditor(tc, audit.WithShutdownTimeout(time.Duration(secs)*time.Second))
 	})
 
-	ctx.Step(`^I create a disabled logger$`, func() error {
-		return tryCreateLogger(tc, audit.WithDisabled())
+	ctx.Step(`^I create a disabled auditor$`, func() error {
+		return tryCreateAuditor(tc, audit.WithDisabled())
 	})
 
 }
 
 func registerConfigThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^the logger construction should fail with an error matching:$`, func(doc *godog.DocString) error {
+	ctx.Step(`^the auditor construction should fail with an error matching:$`, func(doc *godog.DocString) error {
 		return assertConstructionExactError(tc, strings.TrimSpace(doc.Content))
 	})
-	ctx.Step(`^the logger construction should fail wrapping "([^"]*)"$`, func(s string) error {
+	ctx.Step(`^the auditor construction should fail wrapping "([^"]*)"$`, func(s string) error {
 		return assertConstructionSentinel(tc, s)
 	})
-	ctx.Step(`^the logger construction should fail with an error$`, func() error {
+	ctx.Step(`^the auditor construction should fail with an error$`, func() error {
 		return assertConstructionFailed(tc)
 	})
-	ctx.Step(`^the logger construction should fail with an error containing "([^"]*)"$`, func(s string) error {
+	ctx.Step(`^the auditor construction should fail with an error containing "([^"]*)"$`, func(s string) error {
 		return assertConstructionErrorContaining(tc, s)
 	})
 
-	ctx.Step(`^the logger should be created successfully$`, func() error {
+	ctx.Step(`^the auditor should be created successfully$`, func() error {
 		if tc.LastErr != nil {
 			return fmt.Errorf("expected successful creation, got: %w", tc.LastErr)
 		}
-		if tc.Logger == nil {
-			return fmt.Errorf("logger is nil after successful creation")
+		if tc.Auditor == nil {
+			return fmt.Errorf("auditor is nil after successful creation")
 		}
 		return nil
 	})
 
-	ctx.Step(`^the logger should handle audit calls without error$`, func() error {
-		// Disabled logger returns nil from Audit without delivering.
-		if tc.Logger == nil {
-			// No-op logger (Enabled=false) returns nil from NewLogger.
+	ctx.Step(`^the auditor should handle audit calls without error$`, func() error {
+		// Disabled auditor returns nil from Audit without delivering.
+		if tc.Auditor == nil {
+			// No-op auditor (Enabled=false) returns nil from audit.New.
 			return nil
 		}
-		err := tc.Logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 			"outcome":  "success",
 			"actor_id": "test",
 		}))
 		if err != nil {
-			return fmt.Errorf("expected no error from disabled logger, got: %w", err)
+			return fmt.Errorf("expected no error from disabled auditor, got: %w", err)
 		}
 		return nil
 	})
 }
 
-// tryCreateLogger creates a logger with the given options and stores it
+// tryCreateAuditor creates an auditor with the given options and stores it
 // in the test context. If creation fails, the error is stored in tc.LastErr
 // without failing the step (the scenario may assert on the error).
-func tryCreateLogger(tc *AuditTestContext, extraOpts ...audit.Option) error {
+func tryCreateAuditor(tc *AuditTestContext, extraOpts ...audit.Option) error {
 	buf := &bytes.Buffer{}
 	tc.StdoutBuf = buf
 
@@ -121,13 +121,13 @@ func tryCreateLogger(tc *AuditTestContext, extraOpts ...audit.Option) error {
 	}
 	opts = append(opts, extraOpts...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -36,8 +36,8 @@ import (
 // AuditTestContext holds all mutable state for a single BDD scenario.
 // A fresh context is created for every scenario in BeforeScenario.
 type AuditTestContext struct { //nolint:govet // fieldalignment: readability preferred over packing
-	// Logger state.
-	Logger      *audit.Logger
+	// Auditor state.
+	Auditor     *audit.Auditor
 	EventHandle *audit.EventHandle
 	LastErr     error
 	Taxonomy    *audit.Taxonomy
@@ -108,7 +108,7 @@ func (tc *AuditTestContext) Cleanup() {
 
 // Reset prepares the context for a new scenario.
 func (tc *AuditTestContext) Reset() {
-	tc.Logger = nil
+	tc.Auditor = nil
 	tc.EventHandle = nil
 	tc.LastErr = nil
 	tc.Taxonomy = nil
@@ -165,9 +165,9 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	})
 
 	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
-		// Close logger if not already closed.
-		if tc.Logger != nil {
-			_ = tc.Logger.Close()
+		// Close auditor if not already closed.
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
 		}
 		tc.Cleanup()
 		return ctx, nil

--- a/tests/bdd/steps/event_metrics_steps.go
+++ b/tests/bdd/steps/event_metrics_steps.go
@@ -37,7 +37,7 @@ func registerEventMetricsSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 }
 
 func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { //nolint:gocognit // BDD step registration
-	ctx.Step(`^a logger with file output and pipeline metrics$`, func() error {
+	ctx.Step(`^an auditor with file output and pipeline metrics$`, func() error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -57,12 +57,12 @@ func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 			audit.WithNamedOutput(fileOut),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
@@ -88,23 +88,23 @@ func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 		return nil
 	})
 
-	ctx.Step(`^a logger with that file output and queue_size (\d+)$`, func(queueSize int) error {
+	ctx.Step(`^an auditor with that file output and queue_size (\d+)$`, func(queueSize int) error {
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithQueueSize(queueSize),
 		}
 		opts = append(opts, tc.Options...)
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
-	ctx.Step(`^a logger with that file output and pipeline metrics and queue_size (\d+)$`, func(queueSize int) error {
+	ctx.Step(`^an auditor with that file output and pipeline metrics and queue_size (\d+)$`, func(queueSize int) error {
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithMetrics(tc.MockMetrics),
@@ -112,16 +112,16 @@ func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 		}
 		opts = append(opts, tc.Options...)
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
-	ctx.Step(`^a logger with that file output and a stdout output$`, func() error {
+	ctx.Step(`^an auditor with that file output and a stdout output$`, func() error {
 		stdoutBuf := &bytes.Buffer{}
 		tc.StdoutBuf = stdoutBuf
 
@@ -136,20 +136,20 @@ func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 		}
 		opts = append(opts, tc.Options...)
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
 
 func registerEventMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { //nolint:gocognit,gocyclo,cyclop // BDD step registration
 	ctx.Step(`^RecordSubmitted should have been called (\d+) times?$`, func(n int) error {
-		if tc.Logger != nil {
-			_ = tc.Logger.Close()
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
 		}
 		got := tc.MockMetrics.SubmittedCount()
 		if got != n {
@@ -159,8 +159,8 @@ func registerEventMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 	})
 
 	ctx.Step(`^RecordQueueDepth should have been called at least (\d+) times?$`, func(n int) error {
-		if tc.Logger != nil {
-			_ = tc.Logger.Close()
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
 		}
 		got := tc.MockMetrics.QueueDepthCallCount()
 		if got < n {
@@ -170,8 +170,8 @@ func registerEventMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 	})
 
 	ctx.Step(`^the pipeline metrics should not have recorded a success event for file output$`, func() error {
-		if tc.Logger != nil {
-			_ = tc.Logger.Close()
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
 		}
 		if tc.MockMetrics.HasSuccessEventFor("file:") {
 			return fmt.Errorf("expected no core success metrics for file, but found success events")
@@ -180,8 +180,8 @@ func registerEventMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 	})
 
 	ctx.Step(`^the output metrics should have recorded at least (\d+) drops?$`, func(n int) error {
-		if tc.Logger != nil {
-			_ = tc.Logger.Close()
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
 		}
 		if tc.OutputMetricsMock == nil {
 			return fmt.Errorf("no output metrics configured")
@@ -193,8 +193,8 @@ func registerEventMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 	})
 
 	ctx.Step(`^the pipeline metrics should not have recorded an output error for file$`, func() error {
-		if tc.Logger != nil {
-			_ = tc.Logger.Close()
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
 		}
 		if tc.MockMetrics.HasOutputErrorFor("file:") {
 			return fmt.Errorf("expected no output errors for file, but found output errors")
@@ -268,19 +268,19 @@ func registerEventMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 		return nil
 	})
 
-	ctx.Step(`^a logger with those outputs and queue_size (\d+)$`, func(queueSize int) error {
+	ctx.Step(`^an auditor with those outputs and queue_size (\d+)$`, func(queueSize int) error {
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithQueueSize(queueSize),
 		}
 		opts = append(opts, tc.Options...)
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }

--- a/tests/bdd/steps/fanout_steps.go
+++ b/tests/bdd/steps/fanout_steps.go
@@ -87,30 +87,30 @@ func registerFanoutGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) 
 }
 
 func registerFanoutGivenOutputSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file and webhook outputs$`, func() error {
-		return createFanoutLogger(tc, true, false, true, nil, nil)
+	ctx.Step(`^an auditor with file and webhook outputs$`, func() error {
+		return createFanoutAuditor(tc, true, false, true, nil, nil)
 	})
-	ctx.Step(`^a logger with file and webhook outputs configured for batch size (\d+)$`, func(bs int) error {
-		return createFanoutLogger(tc, true, false, true, nil, &bs)
+	ctx.Step(`^an auditor with file and webhook outputs configured for batch size (\d+)$`, func(bs int) error {
+		return createFanoutAuditor(tc, true, false, true, nil, &bs)
 	})
-	ctx.Step(`^a logger with file and syslog outputs$`, func() error {
-		return createFanoutLogger(tc, true, true, false, nil, nil)
+	ctx.Step(`^an auditor with file and syslog outputs$`, func() error {
+		return createFanoutAuditor(tc, true, true, false, nil, nil)
 	})
-	ctx.Step(`^a logger with file, syslog, and webhook outputs$`, func() error {
-		return createFanoutLogger(tc, true, true, true, nil, nil)
+	ctx.Step(`^an auditor with file, syslog, and webhook outputs$`, func() error {
+		return createFanoutAuditor(tc, true, true, true, nil, nil)
 	})
-	ctx.Step(`^a logger with file output and an error-returning output$`, func() error {
-		return createErrorOutputLogger(tc)
+	ctx.Step(`^an auditor with file output and an error-returning output$`, func() error {
+		return createErrorOutputAuditor(tc)
 	})
-	ctx.Step(`^a logger with file output and a panicking output$`, func() error {
-		return createPanicOutputLogger(tc)
+	ctx.Step(`^an auditor with file output and a panicking output$`, func() error {
+		return createPanicOutputAuditor(tc)
 	})
-	ctx.Step(`^a logger with file output and a panicking formatter on a second output$`, func() error {
-		return createPanicFormatterLogger(tc)
+	ctx.Step(`^an auditor with file output and a panicking formatter on a second output$`, func() error {
+		return createPanicFormatterAuditor(tc)
 	})
-	ctx.Step(`^a logger with file output using JSON and webhook output using CEF$`, func() error {
+	ctx.Step(`^an auditor with file output using JSON and webhook output using CEF$`, func() error {
 		cefFmt := &audit.CEFFormatter{Vendor: "Test", Product: "BDD", Version: "1.0"}
-		return createFanoutLogger(tc, true, false, true, cefFmt, nil)
+		return createFanoutAuditor(tc, true, false, true, cefFmt, nil)
 	})
 }
 
@@ -123,48 +123,48 @@ func registerFanoutGivenRoutingSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 		tc.Taxonomy = tax
 		return nil
 	})
-	ctx.Step(`^a logger with file receiving all events and webhook receiving only "([^"]*)"$`, func(cat string) error {
-		return createRoutedLogger(tc, &audit.EventRoute{IncludeCategories: []string{cat}})
+	ctx.Step(`^an auditor with file receiving all events and webhook receiving only "([^"]*)"$`, func(cat string) error {
+		return createRoutedAuditor(tc, &audit.EventRoute{IncludeCategories: []string{cat}})
 	})
-	ctx.Step(`^a logger with file receiving all events and webhook including event types "([^"]*)"$`, func(types string) error {
-		return createRoutedLogger(tc, &audit.EventRoute{IncludeEventTypes: strings.Split(types, ",")})
+	ctx.Step(`^an auditor with file receiving all events and webhook including event types "([^"]*)"$`, func(types string) error {
+		return createRoutedAuditor(tc, &audit.EventRoute{IncludeEventTypes: strings.Split(types, ",")})
 	})
-	ctx.Step(`^a logger with file receiving all events and webhook excluding categories "([^"]*)"$`, func(cat string) error {
-		return createRoutedLogger(tc, &audit.EventRoute{ExcludeCategories: []string{cat}})
+	ctx.Step(`^an auditor with file receiving all events and webhook excluding categories "([^"]*)"$`, func(cat string) error {
+		return createRoutedAuditor(tc, &audit.EventRoute{ExcludeCategories: []string{cat}})
 	})
-	ctx.Step(`^a logger with file receiving all events and webhook including categories "([^"]*)" and "([^"]*)"$`, func(cat1, cat2 string) error {
-		return createRoutedLogger(tc, &audit.EventRoute{IncludeCategories: []string{cat1, cat2}})
+	ctx.Step(`^an auditor with file receiving all events and webhook including categories "([^"]*)" and "([^"]*)"$`, func(cat1, cat2 string) error {
+		return createRoutedAuditor(tc, &audit.EventRoute{IncludeCategories: []string{cat1, cat2}})
 	})
-	ctx.Step(`^a logger with file receiving all events and webhook including categories "([^"]*)" and event types "([^"]*)"$`, func(cats, types string) error {
-		return createRoutedLogger(tc, &audit.EventRoute{
+	ctx.Step(`^an auditor with file receiving all events and webhook including categories "([^"]*)" and event types "([^"]*)"$`, func(cats, types string) error {
+		return createRoutedAuditor(tc, &audit.EventRoute{
 			IncludeCategories: strings.Split(cats, ","),
 			IncludeEventTypes: strings.Split(types, ","),
 		})
 	})
-	ctx.Step(`^a logger with file receiving all events and webhook excluding categories "([^"]*)" and "([^"]*)"$`, func(cat1, cat2 string) error {
-		return createRoutedLogger(tc, &audit.EventRoute{ExcludeCategories: []string{cat1, cat2}})
+	ctx.Step(`^an auditor with file receiving all events and webhook excluding categories "([^"]*)" and "([^"]*)"$`, func(cat1, cat2 string) error {
+		return createRoutedAuditor(tc, &audit.EventRoute{ExcludeCategories: []string{cat1, cat2}})
 	})
-	ctx.Step(`^a logger with file receiving all events and webhook excluding categories "([^"]*)" and event types "([^"]*)"$`, func(cat, types string) error {
-		return createRoutedLogger(tc, &audit.EventRoute{
+	ctx.Step(`^an auditor with file receiving all events and webhook excluding categories "([^"]*)" and event types "([^"]*)"$`, func(cat, types string) error {
+		return createRoutedAuditor(tc, &audit.EventRoute{
 			ExcludeCategories: []string{cat},
 			ExcludeEventTypes: strings.Split(types, ","),
 		})
 	})
-	ctx.Step(`^a logger with file receiving all events and webhook excluding event types "([^"]*)"$`, func(types string) error {
-		return createRoutedLogger(tc, &audit.EventRoute{ExcludeEventTypes: strings.Split(types, ",")})
+	ctx.Step(`^an auditor with file receiving all events and webhook excluding event types "([^"]*)"$`, func(types string) error {
+		return createRoutedAuditor(tc, &audit.EventRoute{ExcludeEventTypes: strings.Split(types, ",")})
 	})
 }
 
 func registerFanoutGivenRuntimeSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file and webhook both receiving all events$`, func() error {
-		return createRoutedLogger(tc, nil) // nil route = all events
+	ctx.Step(`^an auditor with file and webhook both receiving all events$`, func() error {
+		return createRoutedAuditor(tc, nil) // nil route = all events
 	})
 	ctx.Step(`^I set the webhook output route to include only "([^"]*)"$`, func(cat string) error {
 		// Webhook output name is "webhook:<host:port>" (from url.Parse).
 		// tc.WebhookURL is "http://localhost:8080", so name is "webhook:localhost:8080".
 		u := strings.TrimPrefix(tc.WebhookURL, "http://")
 		u = strings.TrimPrefix(u, "https://")
-		return tc.Logger.SetOutputRoute(
+		return tc.Auditor.SetOutputRoute(
 			"webhook:"+u,
 			&audit.EventRoute{IncludeCategories: []string{cat}},
 		)
@@ -172,15 +172,15 @@ func registerFanoutGivenRuntimeSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 }
 
 func registerFanoutGivenSharedFmtSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with two file outputs sharing the same formatter$`, func() error {
-		return createSharedFormatterLogger(tc)
+	ctx.Step(`^an auditor with two file outputs sharing the same formatter$`, func() error {
+		return createSharedFormatterAuditor(tc)
 	})
 	ctx.Step(`^both files should contain identical content$`, func() error {
 		return assertFilesIdentical(tc, "file-a", "file-b")
 	})
 }
 
-func createSharedFormatterLogger(tc *AuditTestContext) error {
+func createSharedFormatterAuditor(tc *AuditTestContext) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -201,19 +201,19 @@ func createSharedFormatterLogger(tc *AuditTestContext) error {
 	}
 	tc.AddCleanup(func() { _ = fB.Close() })
 
-	// Both outputs share the default JSON formatter (nil = logger default).
+	// Both outputs share the default JSON formatter (nil = auditor default).
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(fA),
 		audit.WithNamedOutput(fB),
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
@@ -234,18 +234,18 @@ func assertFilesIdentical(tc *AuditTestContext, nameA, nameB string) error {
 }
 
 func registerFanoutGivenMultiOutputSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with two file outputs where security goes to file-a and write goes to file-b$`, func() error { return createDualFileRoutedLogger(tc) })
-	ctx.Step(`^a logger with file getting all, syslog getting security, and webhook getting write$`, func() error { return createTripleRoutedLogger(tc) })
+	ctx.Step(`^an auditor with two file outputs where security goes to file-a and write goes to file-b$`, func() error { return createDualFileRoutedAuditor(tc) })
+	ctx.Step(`^an auditor with file getting all, syslog getting security, and webhook getting write$`, func() error { return createTripleRoutedAuditor(tc) })
 	ctx.Step(`^I query the webhook output route$`, func() error { return queryWebhookRoute(tc) })
 	ctx.Step(`^the route should include category "([^"]*)"$`, func(cat string) error { return assertRouteIncludesCategory(tc, cat) })
 	ctx.Step(`^I try to set route for unknown output "([^"]*)"$`, func(name string) error {
-		tc.LastErr = tc.Logger.SetOutputRoute(name, &audit.EventRoute{IncludeCategories: []string{"write"}})
+		tc.LastErr = tc.Auditor.SetOutputRoute(name, &audit.EventRoute{IncludeCategories: []string{"write"}})
 		return nil
 	})
 	ctx.Step(`^I clear the webhook output route$`, func() error {
 		u := strings.TrimPrefix(tc.WebhookURL, "http://")
 		u = strings.TrimPrefix(u, "https://")
-		return tc.Logger.ClearOutputRoute("webhook:" + u)
+		return tc.Auditor.ClearOutputRoute("webhook:" + u)
 	})
 	// Note: "I disable category" step is registered in filter_steps.go
 	ctx.Step(`^file "([^"]*)" should contain "([^"]*)"$`, func(name, text string) error {
@@ -277,22 +277,22 @@ func registerFanoutWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^I audit (?:a|an) "([^"]*)" event in category "[^"]*" with marker "([^"]*)"$`, func(eventType, m string) error {
 		return auditEventWithMarker(tc, eventType, m)
 	})
-	ctx.Step(`^I try to create a logger with two syslog outputs to the same address$`, func() error {
+	ctx.Step(`^I try to create an auditor with two syslog outputs to the same address$`, func() error {
 		return tryDuplicateSyslogAddress(tc)
 	})
-	ctx.Step(`^I try to create a logger with duplicate output names$`, func() error {
+	ctx.Step(`^I try to create an auditor with duplicate output names$`, func() error {
 		return tryDuplicateOutputNames(tc)
 	})
-	ctx.Step(`^I try to create a logger with two file outputs to the same path$`, func() error {
+	ctx.Step(`^I try to create an auditor with two file outputs to the same path$`, func() error {
 		return tryDuplicateFilePath(tc)
 	})
-	ctx.Step(`^I try to create a logger with mixed include and exclude route$`, func() error {
+	ctx.Step(`^I try to create an auditor with mixed include and exclude route$`, func() error {
 		return tryMixedRoute(tc)
 	})
-	ctx.Step(`^I try to create a logger with route referencing unknown category$`, func() error {
+	ctx.Step(`^I try to create an auditor with route referencing unknown category$`, func() error {
 		return tryUnknownCategoryRoute(tc)
 	})
-	ctx.Step(`^I try to create a logger with route referencing unknown event type$`, func() error {
+	ctx.Step(`^I try to create an auditor with route referencing unknown event type$`, func() error {
 		return tryUnknownEventTypeRoute(tc)
 	})
 }
@@ -326,13 +326,13 @@ func registerFanoutThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 // --- Extracted when-step helpers ---
 
 func auditEventWithMarker(tc *AuditTestContext, eventType, m string) error {
-	if tc.Logger == nil {
-		return fmt.Errorf("logger is nil")
+	if tc.Auditor == nil {
+		return fmt.Errorf("auditor is nil")
 	}
 	tc.Markers[m] = m
 	fields := defaultRequiredFields(tc.Taxonomy, eventType)
 	fields["marker"] = m
-	tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+	tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 	return nil
 }
 
@@ -346,7 +346,7 @@ func tryDuplicateOutputNames(tc *AuditTestContext) error {
 		return fmt.Errorf("create file a: %w", err)
 	}
 	tc.AddCleanup(func() { _ = f1.Close() })
-	_, err = audit.NewLogger(
+	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(f1, f1), // same output = duplicate name
 	)
@@ -370,7 +370,7 @@ func tryDuplicateFilePath(tc *AuditTestContext) error {
 		return fmt.Errorf("create file 2: %w", err)
 	}
 	tc.AddCleanup(func() { _ = f2.Close() })
-	_, err = audit.NewLogger(
+	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(f1, f2),
 	)
@@ -388,7 +388,7 @@ func tryMixedRoute(tc *AuditTestContext) error {
 		return fmt.Errorf("create file: %w", err)
 	}
 	tc.AddCleanup(func() { _ = f.Close() })
-	_, err = audit.NewLogger(
+	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
@@ -409,7 +409,7 @@ func tryUnknownCategoryRoute(tc *AuditTestContext) error {
 		return fmt.Errorf("create file: %w", err)
 	}
 	tc.AddCleanup(func() { _ = f.Close() })
-	_, err = audit.NewLogger(
+	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
@@ -422,7 +422,7 @@ func tryUnknownCategoryRoute(tc *AuditTestContext) error {
 func queryWebhookRoute(tc *AuditTestContext) error {
 	u := strings.TrimPrefix(tc.WebhookURL, "http://")
 	u = strings.TrimPrefix(u, "https://")
-	route, err := tc.Logger.OutputRoute("webhook:" + u)
+	route, err := tc.Auditor.OutputRoute("webhook:" + u)
 	if err != nil {
 		return fmt.Errorf("OutputRoute: %w", err)
 	}
@@ -453,7 +453,7 @@ func tryDuplicateSyslogAddress(tc *AuditTestContext) error {
 		return fmt.Errorf("create syslog 2: %w", err)
 	}
 	tc.AddCleanup(func() { _ = s2.Close() })
-	_, err = audit.NewLogger(
+	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(s1, s2),
 	)
@@ -471,7 +471,7 @@ func tryUnknownEventTypeRoute(tc *AuditTestContext) error {
 		return fmt.Errorf("create file: %w", err)
 	}
 	tc.AddCleanup(func() { _ = f.Close() })
-	_, err = audit.NewLogger(
+	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
 			IncludeEventTypes: []string{"nonexistent_event"},
@@ -494,7 +494,7 @@ func assertFileContainsText(tc *AuditTestContext, name, text string) error {
 	return nil
 }
 
-func createFanoutLogger(tc *AuditTestContext, useFile, useSyslog, useWebhook bool, webhookFmt audit.Formatter, batchSize *int) error {
+func createFanoutAuditor(tc *AuditTestContext, useFile, useSyslog, useWebhook bool, webhookFmt audit.Formatter, batchSize *int) error {
 	var opts []audit.Option
 	opts = append(opts, audit.WithTaxonomy(tc.Taxonomy))
 
@@ -542,13 +542,13 @@ func createFanoutLogger(tc *AuditTestContext, useFile, useSyslog, useWebhook boo
 		opts = append(opts, audit.WithNamedOutput(w, audit.OutputFormatter(webhookFmt)))
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
@@ -559,7 +559,7 @@ func (e *errorOutput) Write(_ []byte) error { return fmt.Errorf("intentional wri
 func (e *errorOutput) Close() error         { return nil }
 func (e *errorOutput) Name() string         { return "error-output" }
 
-func createErrorOutputLogger(tc *AuditTestContext) error {
+func createErrorOutputAuditor(tc *AuditTestContext) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -579,12 +579,12 @@ func createErrorOutputLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(&errorOutput{}),
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
@@ -595,7 +595,7 @@ func (p *panicOutput) Write(_ []byte) error { panic("intentional panic in output
 func (p *panicOutput) Close() error         { return nil }
 func (p *panicOutput) Name() string         { return "panic-output" }
 
-func createPanicOutputLogger(tc *AuditTestContext) error {
+func createPanicOutputAuditor(tc *AuditTestContext) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -615,12 +615,12 @@ func createPanicOutputLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(&panicOutput{}),
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
@@ -645,7 +645,7 @@ func (d *devNullOutput) Write(_ []byte) error { return nil }
 func (d *devNullOutput) Close() error         { return nil }
 func (d *devNullOutput) Name() string         { return "devnull" }
 
-func createPanicFormatterLogger(tc *AuditTestContext) error {
+func createPanicFormatterAuditor(tc *AuditTestContext) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -665,16 +665,16 @@ func createPanicFormatterLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(&devNullOutput{}, audit.OutputFormatter(&panicFormatter{})), // panicking formatter
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-func createDualFileRoutedLogger(tc *AuditTestContext) error {
+func createDualFileRoutedAuditor(tc *AuditTestContext) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -701,16 +701,16 @@ func createDualFileRoutedLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(writeOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-func createTripleRoutedLogger(tc *AuditTestContext) error {
+func createTripleRoutedAuditor(tc *AuditTestContext) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -748,16 +748,16 @@ func createTripleRoutedLogger(tc *AuditTestContext) error {
 		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),   // write only
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-func createRoutedLogger(tc *AuditTestContext, webhookRoute *audit.EventRoute) error {
+func createRoutedAuditor(tc *AuditTestContext, webhookRoute *audit.EventRoute) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -786,12 +786,12 @@ func createRoutedLogger(tc *AuditTestContext, webhookRoute *audit.EventRoute) er
 		audit.WithNamedOutput(w, audit.OutputRoute(webhookRoute)),
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }

--- a/tests/bdd/steps/file_steps.go
+++ b/tests/bdd/steps/file_steps.go
@@ -36,29 +36,29 @@ func registerFileSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 }
 
 func registerFileGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file output at a temporary path$`, func() error {
-		return createFileLogger(tc, file.Config{})
+	ctx.Step(`^an auditor with file output at a temporary path$`, func() error {
+		return createFileAuditor(tc, file.Config{})
 	})
-	ctx.Step(`^a logger with file output with permissions "([^"]*)"$`, func(perms string) error {
-		return createFileLogger(tc, file.Config{Permissions: perms})
+	ctx.Step(`^an auditor with file output with permissions "([^"]*)"$`, func(perms string) error {
+		return createFileAuditor(tc, file.Config{Permissions: perms})
 	})
-	ctx.Step(`^a logger with file output configured for (\d+) MB max size$`, func(mb int) error {
-		return createFileLogger(tc, file.Config{MaxSizeMB: mb})
+	ctx.Step(`^an auditor with file output configured for (\d+) MB max size$`, func(mb int) error {
+		return createFileAuditor(tc, file.Config{MaxSizeMB: mb})
 	})
-	ctx.Step(`^a logger with file output configured for (\d+) MB max size with compression$`, func(mb int) error {
+	ctx.Step(`^an auditor with file output configured for (\d+) MB max size with compression$`, func(mb int) error {
 		compress := true
-		return createFileLogger(tc, file.Config{MaxSizeMB: mb, Compress: &compress})
+		return createFileAuditor(tc, file.Config{MaxSizeMB: mb, Compress: &compress})
 	})
-	ctx.Step(`^a logger with file output configured for (\d+) MB max size without compression$`, func(mb int) error {
+	ctx.Step(`^an auditor with file output configured for (\d+) MB max size without compression$`, func(mb int) error {
 		compress := false
-		return createFileLogger(tc, file.Config{MaxSizeMB: mb, Compress: &compress})
+		return createFileAuditor(tc, file.Config{MaxSizeMB: mb, Compress: &compress})
 	})
-	ctx.Step(`^a logger with file output configured for (\d+) MB max size and max backups (\d+)$`, func(mb, backups int) error {
-		return createFileLogger(tc, file.Config{MaxSizeMB: mb, MaxBackups: backups})
+	ctx.Step(`^an auditor with file output configured for (\d+) MB max size and max backups (\d+)$`, func(mb, backups int) error {
+		return createFileAuditor(tc, file.Config{MaxSizeMB: mb, MaxBackups: backups})
 	})
 	ctx.Step(`^at most (\d+) files should exist in the output directory$`, func(maxFiles int) error {
-		if tc.Logger != nil {
-			_ = tc.Logger.Close()
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
 		}
 		dir := tc.FileDir
 		entries, err := os.ReadDir(dir)
@@ -77,23 +77,23 @@ func registerFileGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 		return nil
 	})
 
-	ctx.Step(`^a logger with file output configured for (\d+) MB max size with file metrics$`, func(mb int) error {
+	ctx.Step(`^an auditor with file output configured for (\d+) MB max size with file metrics$`, func(mb int) error {
 		tc.FileMetrics = &MockFileMetrics{}
-		return createFileLoggerWithMetrics(tc, file.Config{MaxSizeMB: mb}, tc.FileMetrics)
+		return createFileAuditorWithMetrics(tc, file.Config{MaxSizeMB: mb}, tc.FileMetrics)
 	})
 	ctx.Step(`^mock file metrics are configured$`, func() error {
 		tc.FileMetrics = &MockFileMetrics{}
 		return nil
 	})
-	ctx.Step(`^a logger with file output at a temporary path and short drain timeout$`, func() error {
-		return createFileLoggerWithExtraOpts(tc, file.Config{}, audit.WithDrainTimeout(100*time.Millisecond))
+	ctx.Step(`^an auditor with file output at a temporary path and short drain timeout$`, func() error {
+		return createFileAuditorWithExtraOpts(tc, file.Config{}, audit.WithShutdownTimeout(100*time.Millisecond))
 	})
-	ctx.Step(`^closing the logger should complete within (\d+) seconds$`, func(maxSecs int) error {
-		if tc.Logger == nil {
-			return fmt.Errorf("no logger to close")
+	ctx.Step(`^closing the auditor should complete within (\d+) seconds$`, func(maxSecs int) error {
+		if tc.Auditor == nil {
+			return fmt.Errorf("no auditor to close")
 		}
 		done := make(chan error, 1)
-		go func() { done <- tc.Logger.Close() }()
+		go func() { done <- tc.Auditor.Close() }()
 		select {
 		case <-done:
 			return nil
@@ -101,7 +101,7 @@ func registerFileGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 			return fmt.Errorf("Close() did not return within %d seconds", maxSecs)
 		}
 	})
-	ctx.Step(`^a logger with no outputs$`, func() error { return createNoOutputLogger(tc) })
+	ctx.Step(`^an auditor with no outputs$`, func() error { return createNoOutputAuditor(tc) })
 
 }
 
@@ -155,16 +155,16 @@ func registerFileThenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 	ctx.Step(`^the file should contain an event with event_type "([^"]*)"$`, func(et string) error { return assertFileHasEventType(tc, et) })
 	ctx.Step(`^every event in the file should be valid JSON$`, func() error { return assertFileAllValidJSON(tc) })
 	ctx.Step(`^the file should contain events$`, func() error { return assertFileHasAnyEvents(tc) })
-	ctx.Step(`^I close the logger again$`, func() error { return closeLoggerAgain(tc) })
+	ctx.Step(`^I close the auditor again$`, func() error { return closeLoggerAgain(tc) })
 	ctx.Step(`^the second close should return no error$`, func() error { return assertLastErrNil(tc) })
 	ctx.Step(`^the file should have permissions "([^"]*)"$`, func(perms string) error { return assertFilePermissions(tc, perms) })
-	ctx.Step(`^I close the logger from (\d+) goroutines concurrently$`, func(count int) error {
+	ctx.Step(`^I close the auditor from (\d+) goroutines concurrently$`, func(count int) error {
 		var wg sync.WaitGroup
 		for range count {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_ = tc.Logger.Close()
+				_ = tc.Auditor.Close()
 			}()
 		}
 		wg.Wait()
@@ -176,8 +176,8 @@ func registerFileThenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 	})
 
 	ctx.Step(`^a backup file with a timestamp pattern should exist in the output directory$`, func() error {
-		if tc.Logger != nil {
-			_ = tc.Logger.Close()
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
 		}
 		entries, readErr := os.ReadDir(tc.FileDir)
 		if readErr != nil {
@@ -224,15 +224,15 @@ func registerFileThenValidationSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 
 // --- Extracted step implementations ---
 
-func createNoOutputLogger(tc *AuditTestContext) error {
+func createNoOutputAuditor(tc *AuditTestContext) error {
 	opts := []audit.Option{audit.WithTaxonomy(tc.Taxonomy)}
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
@@ -240,7 +240,7 @@ func auditNEvents(tc *AuditTestContext, count int) error {
 	for i := range count {
 		fields := defaultRequiredFields(tc.Taxonomy, "user_create")
 		fields["marker"] = fmt.Sprintf("rapid_%d", i)
-		if err := tc.Logger.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
+		if err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
 			return fmt.Errorf("audit event %d: %w", i, err)
 		}
 	}
@@ -258,7 +258,7 @@ func auditConcurrent(tc *AuditTestContext, total, goroutines int) error {
 			for i := range perGoroutine {
 				fields := defaultRequiredFields(tc.Taxonomy, "user_create")
 				fields["marker"] = fmt.Sprintf("g%d_e%d", gID, i)
-				if err := tc.Logger.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
+				if err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
 					errCh <- fmt.Errorf("goroutine %d event %d: %w", gID, i, err)
 				}
 			}
@@ -281,7 +281,7 @@ func writeEventsExceeding(tc *AuditTestContext, mb int) error {
 	for i := range count {
 		fields := defaultRequiredFields(tc.Taxonomy, "user_create")
 		fields["marker"] = fmt.Sprintf("rot_%d_padding_data_for_size", i)
-		err := tc.Logger.AuditEvent(audit.NewEvent("user_create", fields))
+		err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", fields))
 		if err != nil && !errors.Is(err, audit.ErrQueueFull) {
 			return fmt.Errorf("write event %d: %w", i, err)
 		}
@@ -369,8 +369,8 @@ func assertFileHasAnyEvents(tc *AuditTestContext) error {
 }
 
 func closeLoggerAgain(tc *AuditTestContext) error {
-	if tc.Logger != nil {
-		tc.LastErr = tc.Logger.Close()
+	if tc.Auditor != nil {
+		tc.LastErr = tc.Auditor.Close()
 	}
 	return nil
 }
@@ -383,8 +383,8 @@ func assertLastErrNil(tc *AuditTestContext) error {
 }
 
 func assertFilePermissions(tc *AuditTestContext, expected string) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	path := tc.FilePaths["default"]
 	info, err := os.Stat(path)
@@ -470,21 +470,21 @@ func assertFileRotationCount(tc *AuditTestContext, minCount int) error {
 	return nil
 }
 
-// --- Logger construction helpers ---
+// --- Auditor construction helpers ---
 
-func createFileLogger(tc *AuditTestContext, fileCfg file.Config) error {
-	return createFileLoggerImpl(tc, fileCfg, nil)
+func createFileAuditor(tc *AuditTestContext, fileCfg file.Config) error {
+	return createFileAuditorImpl(tc, fileCfg, nil)
 }
 
-func createFileLoggerWithMetrics(tc *AuditTestContext, fileCfg file.Config, fileMetrics file.Metrics) error {
-	return createFileLoggerImpl(tc, fileCfg, fileMetrics)
+func createFileAuditorWithMetrics(tc *AuditTestContext, fileCfg file.Config, fileMetrics file.Metrics) error {
+	return createFileAuditorImpl(tc, fileCfg, fileMetrics)
 }
 
-func createFileLoggerWithExtraOpts(tc *AuditTestContext, fileCfg file.Config, extraOpts ...audit.Option) error {
-	return createFileLoggerImpl(tc, fileCfg, nil, extraOpts...)
+func createFileAuditorWithExtraOpts(tc *AuditTestContext, fileCfg file.Config, extraOpts ...audit.Option) error {
+	return createFileAuditorImpl(tc, fileCfg, nil, extraOpts...)
 }
 
-func createFileLoggerImpl(tc *AuditTestContext, fileCfg file.Config, fileMetrics file.Metrics, extraOpts ...audit.Option) error {
+func createFileAuditorImpl(tc *AuditTestContext, fileCfg file.Config, fileMetrics file.Metrics, extraOpts ...audit.Option) error {
 	dir, err := tc.EnsureFileDir()
 	if err != nil {
 		return err
@@ -511,20 +511,20 @@ func createFileLoggerImpl(tc *AuditTestContext, fileCfg file.Config, fileMetrics
 	opts = append(opts, tc.Options...)
 	opts = append(opts, extraOpts...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err
 		return nil //nolint:nilerr // scenario may assert on tc.LastErr
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
 // readFileEvents reads and parses JSON events from a named file output.
 func readFileEvents(tc *AuditTestContext, name string) ([]map[string]any, error) {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	path, ok := tc.FilePaths[name]
 	if !ok {

--- a/tests/bdd/steps/filter_steps.go
+++ b/tests/bdd/steps/filter_steps.go
@@ -77,44 +77,44 @@ func registerFilterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) 
 	})
 
 	ctx.Step(`^I enable category "([^"]*)"$`, func(category string) error {
-		tc.LastErr = tc.Logger.EnableCategory(category)
+		tc.LastErr = tc.Auditor.EnableCategory(category)
 		return nil
 	})
 
 	ctx.Step(`^I disable category "([^"]*)"$`, func(category string) error {
-		tc.LastErr = tc.Logger.DisableCategory(category)
+		tc.LastErr = tc.Auditor.DisableCategory(category)
 		return nil
 	})
 
 	ctx.Step(`^I enable event "([^"]*)"$`, func(eventType string) error {
-		tc.LastErr = tc.Logger.EnableEvent(eventType)
+		tc.LastErr = tc.Auditor.EnableEvent(eventType)
 		return nil
 	})
 
 	ctx.Step(`^I disable event "([^"]*)"$`, func(eventType string) error {
-		tc.LastErr = tc.Logger.DisableEvent(eventType)
+		tc.LastErr = tc.Auditor.DisableEvent(eventType)
 		return nil
 	})
 }
 
 func registerFilterWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^I try to enable category "([^"]*)"$`, func(category string) error {
-		tc.LastErr = tc.Logger.EnableCategory(category)
+		tc.LastErr = tc.Auditor.EnableCategory(category)
 		return nil
 	})
 
 	ctx.Step(`^I try to disable category "([^"]*)"$`, func(category string) error {
-		tc.LastErr = tc.Logger.DisableCategory(category)
+		tc.LastErr = tc.Auditor.DisableCategory(category)
 		return nil
 	})
 
 	ctx.Step(`^I try to enable event "([^"]*)"$`, func(eventType string) error {
-		tc.LastErr = tc.Logger.EnableEvent(eventType)
+		tc.LastErr = tc.Auditor.EnableEvent(eventType)
 		return nil
 	})
 
 	ctx.Step(`^I try to disable event "([^"]*)"$`, func(eventType string) error {
-		tc.LastErr = tc.Logger.DisableEvent(eventType)
+		tc.LastErr = tc.Auditor.DisableEvent(eventType)
 		return nil
 	})
 }

--- a/tests/bdd/steps/formatter_steps.go
+++ b/tests/bdd/steps/formatter_steps.go
@@ -44,11 +44,11 @@ func registerFormatterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 }
 
 func registerFormatterGivenJSONSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file output using JSON formatter$`, func() error {
-		return createFileLogger(tc, file.Config{})
+	ctx.Step(`^an auditor with file output using JSON formatter$`, func() error {
+		return createFileAuditor(tc, file.Config{})
 	})
 
-	ctx.Step(`^a logger with file output using JSON formatter with unix millis timestamps$`, func() error {
+	ctx.Step(`^an auditor with file output using JSON formatter with unix millis timestamps$`, func() error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -68,26 +68,26 @@ func registerFormatterGivenJSONSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 			audit.WithOutputs(fileOut),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
-	ctx.Step(`^a logger with file output using JSON formatter and OmitEmpty (true|false)$`, func(val string) error {
+	ctx.Step(`^an auditor with file output using JSON formatter and OmitEmpty (true|false)$`, func(val string) error {
 		if val == "true" {
 			tc.Options = append(tc.Options, audit.WithOmitEmpty())
 		}
-		return createFileLogger(tc, file.Config{})
+		return createFileAuditor(tc, file.Config{})
 	})
 
 }
 
 func registerFormatterGivenCEFSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file output using CEF formatter with vendor "([^"]*)" product "([^"]*)" version "([^"]*)"$`, func(vendor, product, version string) error {
+	ctx.Step(`^an auditor with file output using CEF formatter with vendor "([^"]*)" product "([^"]*)" version "([^"]*)"$`, func(vendor, product, version string) error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -113,19 +113,19 @@ func registerFormatterGivenCEFSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 		}
 		opts = append(opts, tc.Options...)
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
 }
 
 func registerFormatterGivenMultiSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with two file outputs using JSON and CEF formatters$`, func() error {
+	ctx.Step(`^an auditor with two file outputs using JSON and CEF formatters$`, func() error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -155,18 +155,18 @@ func registerFormatterGivenMultiSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithNamedOutput(cefOut, audit.OutputFormatter(cefFmt)), // CEF
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
 
 func registerFormatterGivenCustomSeveritySteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file output using CEF formatter with custom severity function$`, func() error {
+	ctx.Step(`^an auditor with file output using CEF formatter with custom severity function$`, func() error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -195,18 +195,18 @@ func registerFormatterGivenCustomSeveritySteps(ctx *godog.ScenarioContext, tc *A
 			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
 
 func registerFormatterGivenInvalidKeySteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file output using CEF formatter with invalid field mapping$`, func() error {
+	ctx.Step(`^an auditor with file output using CEF formatter with invalid field mapping$`, func() error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -232,18 +232,18 @@ func registerFormatterGivenInvalidKeySteps(ctx *godog.ScenarioContext, tc *Audit
 			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
 
 func registerFormatterGivenSeveritySteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file output using CEF formatter with severity below (\d+)$`, func(_ int) error {
+	ctx.Step(`^an auditor with file output using CEF formatter with severity below (\d+)$`, func(_ int) error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -267,18 +267,18 @@ func registerFormatterGivenSeveritySteps(ctx *godog.ScenarioContext, tc *AuditTe
 			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
 
 func registerFormatterGivenExtraSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file output using CEF formatter with severity above (\d+)$`, func(above int) error {
+	ctx.Step(`^an auditor with file output using CEF formatter with severity above (\d+)$`, func(above int) error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -306,12 +306,12 @@ func registerFormatterGivenExtraSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
@@ -320,63 +320,63 @@ func registerFormatterWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 	ctx.Step(`^I audit event "([^"]*)" with a duration field$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["duration_ms"] = 150 * time.Millisecond
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with a field containing a tab character$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = "before\ttab\tafter"
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with a (\d+)-character field value$`, func(eventType string, length int) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = strings.Repeat("a", length)
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with a field containing control characters$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = "before\x01\x02\x03after"
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with a field containing invalid UTF-8$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = "bad\xfe\xffbyte"
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with a field containing null bytes$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = "before\x00after"
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with a field containing U\+2028$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = "before\u2028after"
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with a field containing U\+2029$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = "before\u2029after"
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
 	ctx.Step(`^I audit event "([^"]*)" with a field containing a newline$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
 		fields["marker"] = "before\n{\"injected\":true}"
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 }
@@ -654,9 +654,9 @@ func readFirstLine(tc *AuditTestContext, name string) (string, error) {
 
 // readRawFile reads the raw content of a named file output.
 func readRawFile(tc *AuditTestContext, name string) (string, error) {
-	// Close logger to flush pending events.
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	// Close auditor to flush pending events.
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 
 	path, ok := tc.FilePaths[name]

--- a/tests/bdd/steps/hmac_steps.go
+++ b/tests/bdd/steps/hmac_steps.go
@@ -34,12 +34,12 @@ func registerHMACSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 }
 
 func registerHMACGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with stdout output and HMAC enabled using salt "([^"]*)" version "([^"]*)" and hash "([^"]*)"$`,
+	ctx.Step(`^an auditor with stdout output and HMAC enabled using salt "([^"]*)" version "([^"]*)" and hash "([^"]*)"$`,
 		func(salt, version, hash string) error {
 			out := newCaptureOutput("stdout")
 			tc.CaptureOutput = out
 
-			logger, err := audit.NewLogger(
+			auditor, err := audit.New(
 				audit.WithTaxonomy(tc.Taxonomy),
 				audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 					Enabled:     true,
@@ -49,19 +49,19 @@ func registerHMACGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 				})),
 			)
 			if err != nil {
-				return fmt.Errorf("create logger with HMAC: %w", err)
+				return fmt.Errorf("create auditor with HMAC: %w", err)
 			}
-			tc.Logger = logger
+			tc.Auditor = auditor
 			return nil
 		})
 }
 
 func registerHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^I try to create a logger with HMAC salt "([^"]*)" version "([^"]*)" and hash "([^"]*)"$`,
+	ctx.Step(`^I try to create an auditor with HMAC salt "([^"]*)" version "([^"]*)" and hash "([^"]*)"$`,
 		func(salt, version, hash string) error {
 			out := newCaptureOutput("stdout")
 
-			_, err := audit.NewLogger(
+			_, err := audit.New(
 				audit.WithTaxonomy(tc.Taxonomy),
 				audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
 					Enabled:     true,
@@ -154,7 +154,7 @@ func registerHMACVerificationSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 			return nil
 		})
 
-	ctx.Step(`^logger creation should fail with an error containing "([^"]*)"$`, func(substr string) error {
+	ctx.Step(`^auditor creation should fail with an error containing "([^"]*)"$`, func(substr string) error {
 		if tc.LastErr == nil {
 			return fmt.Errorf("expected error containing %q, got nil", substr)
 		}
@@ -305,7 +305,7 @@ func registerHMACLabelSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	})
 	ctx.Step(`^two HMAC-enabled outputs where "([^"]*)" excludes label "([^"]*)" using salts "([^"]*)" and "([^"]*)"$`,
 		func(strippedName, label, fullSalt, strippedSalt string) error {
-			return createDualHMACLogger(tc, strippedName, label, fullSalt, strippedSalt)
+			return createDualHMACAuditor(tc, strippedName, label, fullSalt, strippedSalt)
 		})
 	ctx.Step(`^output "([^"]*)" should contain field "([^"]*)" with value "([^"]*)"$`,
 		func(outputName, field, want string) error {
@@ -324,7 +324,7 @@ func registerHMACLabelSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 		})
 }
 
-func createDualHMACLogger(tc *AuditTestContext, strippedName, label, fullSalt, strippedSalt string) error {
+func createDualHMACAuditor(tc *AuditTestContext, strippedName, label, fullSalt, strippedSalt string) error {
 	fullOut := newCaptureOutput("full")
 	strippedOut := newCaptureOutput(strippedName)
 	tc.CaptureOutputs = map[string]*captureOutput{
@@ -347,15 +347,15 @@ func createDualHMACLogger(tc *AuditTestContext, strippedName, label, fullSalt, s
 		Algorithm:   "HMAC-SHA-256",
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(fullOut, audit.OutputHMAC(fullHMACCfg)),
 		audit.WithNamedOutput(strippedOut, audit.OutputExcludeLabels(label), audit.OutputHMAC(strippedHMACCfg)),
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
+	tc.Auditor = auditor
 	return nil
 }
 

--- a/tests/bdd/steps/isolation_steps.go
+++ b/tests/bdd/steps/isolation_steps.go
@@ -58,14 +58,14 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		recOut1, recOut2 *recordingMockOutput
 	)
 
-	ctx.Step(`^a logger with stdout and a recording mock output$`, func() error {
+	ctx.Step(`^an auditor with stdout and a recording mock output$`, func() error {
 		stdoutBuf = &bytes.Buffer{}
 		stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: stdoutBuf})
 		if err != nil {
 			return fmt.Errorf("create stdout: %w", err)
 		}
 		recOut1 = &recordingMockOutput{name: "recording-1"}
-		tc.Logger, err = audit.NewLogger(
+		tc.Auditor, err = audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(stdout, recOut1),
 			audit.WithQueueSize(1000),
@@ -73,13 +73,13 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		return err //nolint:wrapcheck // BDD step
 	})
 
-	ctx.Step(`^a logger with stdout output only$`, func() error {
+	ctx.Step(`^an auditor with stdout output only$`, func() error {
 		stdoutBuf = &bytes.Buffer{}
 		stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: stdoutBuf})
 		if err != nil {
 			return fmt.Errorf("create stdout: %w", err)
 		}
-		tc.Logger, err = audit.NewLogger(
+		tc.Auditor, err = audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(stdout),
 			audit.WithQueueSize(1000),
@@ -87,11 +87,11 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		return err //nolint:wrapcheck // BDD step
 	})
 
-	ctx.Step(`^a logger with two recording mock outputs$`, func() error {
+	ctx.Step(`^an auditor with two recording mock outputs$`, func() error {
 		recOut1 = &recordingMockOutput{name: "recording-1"}
 		recOut2 = &recordingMockOutput{name: "recording-2"}
 		var err error
-		tc.Logger, err = audit.NewLogger(
+		tc.Auditor, err = audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(recOut1, recOut2),
 			audit.WithQueueSize(1000),

--- a/tests/bdd/steps/loki_fanout_steps.go
+++ b/tests/bdd/steps/loki_fanout_steps.go
@@ -36,18 +36,18 @@ func registerLokiFanoutSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 func registerLokiFanoutGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
-	ctx.Step(`^a logger with file and loki outputs$`,
+	ctx.Step(`^an auditor with file and loki outputs$`,
 		func() error {
-			return createFileAndLokiLogger(tc, nil, nil)
+			return createFileAndLokiAuditor(tc, nil, nil)
 		})
 
-	ctx.Step(`^a logger with file receiving all events and loki receiving only "([^"]*)"$`,
+	ctx.Step(`^an auditor with file receiving all events and loki receiving only "([^"]*)"$`,
 		func(category string) error {
 			lokiRoute := &audit.EventRoute{IncludeCategories: []string{category}}
-			return createFileAndLokiLogger(tc, nil, lokiRoute)
+			return createFileAndLokiAuditor(tc, nil, lokiRoute)
 		})
 
-	ctx.Step(`^a logger with file and loki outputs both HMAC-enabled with salt "([^"]*)" version "([^"]*)"$`,
+	ctx.Step(`^an auditor with file and loki outputs both HMAC-enabled with salt "([^"]*)" version "([^"]*)"$`,
 		func(salt, version string) error {
 			hmacCfg := &audit.HMACConfig{
 				Enabled:     true,
@@ -55,17 +55,17 @@ func registerLokiFanoutGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 				SaltValue:   []byte(salt),
 				Algorithm:   "HMAC-SHA-256",
 			}
-			return createFileAndLokiLogger(tc, hmacCfg, nil)
+			return createFileAndLokiAuditor(tc, hmacCfg, nil)
 		})
 
-	ctx.Step(`^a logger with file output keeping all fields and loki output excluding label "([^"]*)"$`,
+	ctx.Step(`^an auditor with file output keeping all fields and loki output excluding label "([^"]*)"$`,
 		func(label string) error {
-			return createFileAndLokiLoggerWithExclusion(tc, label)
+			return createFileAndLokiAuditorWithExclusion(tc, label)
 		})
 
-	ctx.Step(`^a logger with file output and loki output to unreachable server$`,
+	ctx.Step(`^an auditor with file output and loki output to unreachable server$`,
 		func() error {
-			return createFileAndLokiLoggerUnreachable(tc)
+			return createFileAndLokiAuditorUnreachable(tc)
 		})
 
 }
@@ -188,7 +188,7 @@ func registerLokiFanoutCountSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 					"outcome":  outcome,
 					"marker":   m,
 				}
-				if err := tc.Logger.AuditEvent(audit.NewEvent(eventType, fields)); err != nil {
+				if err := tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields)); err != nil {
 					return fmt.Errorf("audit event %d: %w", i, err)
 				}
 			}
@@ -197,10 +197,10 @@ func registerLokiFanoutCountSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 }
 
 // ---------------------------------------------------------------------------
-// Logger construction helpers
+// Auditor construction helpers
 // ---------------------------------------------------------------------------
 
-func createFileAndLokiLogger(tc *AuditTestContext, hmacCfg *audit.HMACConfig, lokiRoute *audit.EventRoute) error {
+func createFileAndLokiAuditor(tc *AuditTestContext, hmacCfg *audit.HMACConfig, lokiRoute *audit.EventRoute) error {
 	// Create temp file for file output.
 	tmpFile, err := os.CreateTemp(tc.FileDir, "fanout-*.log")
 	if err != nil {
@@ -245,16 +245,16 @@ func createFileAndLokiLogger(tc *AuditTestContext, hmacCfg *audit.HMACConfig, lo
 		audit.WithNamedOutput(lokiOut, lokiOpts...),
 	)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-func createFileAndLokiLoggerWithExclusion(tc *AuditTestContext, excludeLabel string) error {
+func createFileAndLokiAuditorWithExclusion(tc *AuditTestContext, excludeLabel string) error {
 	tmpFile, err := os.CreateTemp(tc.FileDir, "fanout-pii-*.log")
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
@@ -281,7 +281,7 @@ func createFileAndLokiLoggerWithExclusion(tc *AuditTestContext, excludeLabel str
 	tc.AddCleanup(func() { _ = lokiOut.Close() })
 	tc.LokiOutputName = lokiOut.Name()
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
@@ -289,14 +289,14 @@ func createFileAndLokiLoggerWithExclusion(tc *AuditTestContext, excludeLabel str
 		audit.WithNamedOutput(lokiOut, audit.OutputExcludeLabels(excludeLabel)), // strip PII
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-func createFileAndLokiLoggerUnreachable(tc *AuditTestContext) error {
+func createFileAndLokiAuditorUnreachable(tc *AuditTestContext) error {
 	tmpFile, err := os.CreateTemp(tc.FileDir, "fanout-unreachable-*.log")
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
@@ -333,7 +333,7 @@ func createFileAndLokiLoggerUnreachable(tc *AuditTestContext) error {
 	}
 	tc.AddCleanup(func() { _ = lokiOut.Close() })
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
@@ -341,10 +341,10 @@ func createFileAndLokiLoggerUnreachable(tc *AuditTestContext) error {
 		audit.WithNamedOutput(lokiOut),
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 

--- a/tests/bdd/steps/loki_hmac_steps.go
+++ b/tests/bdd/steps/loki_hmac_steps.go
@@ -35,29 +35,29 @@ func registerLokiHMACSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 func registerLokiHMACGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
-	ctx.Step(`^a logger with loki output and HMAC enabled using salt "([^"]*)" version "([^"]*)" and hash "([^"]*)"$`,
+	ctx.Step(`^an auditor with loki output and HMAC enabled using salt "([^"]*)" version "([^"]*)" and hash "([^"]*)"$`,
 		func(salt, version, hash string) error {
-			return createLokiLoggerWithHMAC(tc, salt, version, hash, nil)
+			return createLokiAuditorWithHMAC(tc, salt, version, hash, nil)
 		})
 
-	ctx.Step(`^a logger with loki output using HMAC salt "([^"]*)" version "([^"]*)"$`,
+	ctx.Step(`^an auditor with loki output using HMAC salt "([^"]*)" version "([^"]*)"$`,
 		func(salt, version string) error {
-			return createLokiLoggerWithHMACAndCapture(tc, salt, version)
+			return createLokiAuditorWithHMACAndCapture(tc, salt, version)
 		})
 
 	ctx.Step(`^a capture output with HMAC salt "([^"]*)" version "([^"]*)"$`,
 		func(salt, version string) error {
-			// This step is called AFTER the loki logger is already set up
-			// with a capture output added alongside. The loki logger setup
-			// with capture is handled by createLokiLoggerWithHMACAndCapture.
+			// This step is called AFTER the loki auditor is already set up
+			// with a capture output added alongside. The loki auditor setup
+			// with capture is handled by createLokiAuditorWithHMACAndCapture.
 			// This step is a no-op marker for readability.
 			return nil
 		})
 
-	ctx.Step(`^a logger with loki output excluding label "([^"]*)" with HMAC salt "([^"]*)" version "([^"]*)"$`,
+	ctx.Step(`^an auditor with loki output excluding label "([^"]*)" with HMAC salt "([^"]*)" version "([^"]*)"$`,
 		func(label, salt, version string) error {
 			excludeLabels := []string{label}
-			return createLokiLoggerWithHMAC(tc, salt, version, "HMAC-SHA-256", excludeLabels)
+			return createLokiAuditorWithHMAC(tc, salt, version, "HMAC-SHA-256", excludeLabels)
 		})
 
 	ctx.Step(`^a capture output with no exclusions and HMAC salt "([^"]*)" version "([^"]*)"$`,
@@ -72,8 +72,8 @@ func registerLokiHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 
 	ctx.Step(`^I audit a uniquely marked "([^"]*)" event with actor "([^"]*)" and outcome "([^"]*)"$`,
 		func(eventType, actor, outcome string) error {
-			if tc.Logger == nil {
-				return fmt.Errorf("logger is nil")
+			if tc.Auditor == nil {
+				return fmt.Errorf("auditor is nil")
 			}
 			m := marker("BDD")
 			tc.Markers["default"] = m
@@ -82,13 +82,13 @@ func registerLokiHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 				"outcome":  outcome,
 				"marker":   m,
 			}
-			return tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			return tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		})
 
 	ctx.Step(`^I audit a uniquely marked "([^"]*)" event with actor "([^"]*)" and outcome "([^"]*)" and field "([^"]*)" = "([^"]*)"$`,
 		func(eventType, actor, outcome, field, value string) error {
-			if tc.Logger == nil {
-				return fmt.Errorf("logger is nil")
+			if tc.Auditor == nil {
+				return fmt.Errorf("auditor is nil")
 			}
 			m := marker("BDD")
 			tc.Markers["default"] = m
@@ -98,13 +98,13 @@ func registerLokiHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 				"marker":   m,
 				field:      value,
 			}
-			return tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			return tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		})
 
 	ctx.Step(`^I audit a uniquely marked "([^"]*)" event with actor "([^"]*)" and outcome "([^"]*)" named "([^"]*)"$`,
 		func(eventType, actor, outcome, name string) error {
-			if tc.Logger == nil {
-				return fmt.Errorf("logger is nil")
+			if tc.Auditor == nil {
+				return fmt.Errorf("auditor is nil")
 			}
 			m := marker("BDD")
 			tc.Markers[name] = m
@@ -113,13 +113,13 @@ func registerLokiHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 				"outcome":  outcome,
 				"marker":   m,
 			}
-			return tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			return tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		})
 
 	ctx.Step(`^I audit a uniquely marked "([^"]*)" event with actor "([^"]*)" and outcome "([^"]*)" and field "([^"]*)" = "([^"]*)" named "([^"]*)"$`,
 		func(eventType, actor, outcome, field, value, name string) error {
-			if tc.Logger == nil {
-				return fmt.Errorf("logger is nil")
+			if tc.Auditor == nil {
+				return fmt.Errorf("auditor is nil")
 			}
 			m := marker("BDD")
 			tc.Markers[name] = m
@@ -129,7 +129,7 @@ func registerLokiHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 				"marker":   m,
 				field:      value,
 			}
-			return tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			return tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		})
 
 }
@@ -234,11 +234,11 @@ func registerLokiHMACVerificationSteps(ctx *godog.ScenarioContext, tc *AuditTest
 		})
 }
 
-// createLokiLoggerWithHMAC creates a Loki output + logger with HMAC
+// createLokiAuditorWithHMAC creates a Loki output + auditor with HMAC
 // enabled. If excludeLabels is non-nil, sensitivity label stripping
 // is applied to the Loki output. A captureOutput is also added for
 // cross-output comparison when excludeLabels is set.
-func createLokiLoggerWithHMAC(tc *AuditTestContext, salt, version, hash string, excludeLabels []string) error {
+func createLokiAuditorWithHMAC(tc *AuditTestContext, salt, version, hash string, excludeLabels []string) error {
 	cfg := defaultLokiTestConfig(tc)
 
 	out, err := loki.New(cfg, nil)
@@ -276,18 +276,18 @@ func createLokiLoggerWithHMAC(tc *AuditTestContext, salt, version, hash string, 
 	}
 	opts = append(opts, audit.WithNamedOutput(out, lokiOpts...))
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-// createLokiLoggerWithHMACAndCapture creates a Loki+capture logger
+// createLokiAuditorWithHMACAndCapture creates a Loki+capture auditor
 // for cross-output HMAC comparison (different salts).
-func createLokiLoggerWithHMACAndCapture(tc *AuditTestContext, lokiSalt, lokiVersion string) error {
+func createLokiAuditorWithHMACAndCapture(tc *AuditTestContext, lokiSalt, lokiVersion string) error {
 	cfg := defaultLokiTestConfig(tc)
 
 	out, err := loki.New(cfg, nil)
@@ -300,7 +300,7 @@ func createLokiLoggerWithHMACAndCapture(tc *AuditTestContext, lokiSalt, lokiVers
 	capture := newCaptureOutput("capture-compare")
 	tc.CaptureOutput = capture
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
@@ -318,10 +318,10 @@ func createLokiLoggerWithHMACAndCapture(tc *AuditTestContext, lokiSalt, lokiVers
 		})),
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 

--- a/tests/bdd/steps/loki_receiver_steps.go
+++ b/tests/bdd/steps/loki_receiver_steps.go
@@ -116,19 +116,19 @@ func registerLokiReceiverLoggerSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 }
 
 func registerLokiReceiverLoggerRetrySteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with loki output to the local receiver with max retries (\d+)$`, func(retries int) error {
+	ctx.Step(`^an auditor with loki output to the local receiver with max retries (\d+)$`, func(retries int) error {
 		r, ok := tc.LocalReceiver.(*localLokiReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local Loki receiver configured")
 		}
-		return createLokiLoggerWithReceiver(tc, r, &loki.Config{
+		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			MaxRetries: retries,
 			BatchSize:  1,
 			Compress:   true,
 		})
 	})
 
-	ctx.Step(`^a logger with loki output to the local Loki receiver with metrics and max retries (\d+)$`, func(retries int) error {
+	ctx.Step(`^an auditor with loki output to the local Loki receiver with metrics and max retries (\d+)$`, func(retries int) error {
 		r, ok := tc.LocalReceiver.(*localLokiReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local Loki receiver configured")
@@ -156,17 +156,17 @@ func registerLokiReceiverLoggerRetrySteps(ctx *godog.ScenarioContext, tc *AuditT
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(out),
 		}
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
+		tc.Auditor = auditor
 		tc.LokiOutputName = out.Name()
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
-	ctx.Step(`^a logger with loki output to unreachable server with metrics$`, func() error {
+	ctx.Step(`^an auditor with loki output to unreachable server with metrics$`, func() error {
 		cfg := &loki.Config{
 			URL:                "http://127.0.0.1:19999/loki/api/v1/push", // nothing listening
 			AllowInsecureHTTP:  true,
@@ -175,12 +175,12 @@ func registerLokiReceiverLoggerRetrySteps(ctx *godog.ScenarioContext, tc *AuditT
 			MaxRetries:         1,
 			Compress:           true,
 		}
-		return createLokiLoggerFromConfig(tc, cfg)
+		return createLokiAuditorFromConfig(tc, cfg)
 	})
 }
 
 func registerLokiReceiverLoggerSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with loki output to the local Loki receiver without AllowPrivateRanges$`, func() error {
+	ctx.Step(`^an auditor with loki output to the local Loki receiver without AllowPrivateRanges$`, func() error {
 		r, ok := tc.LocalReceiver.(*localLokiReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local Loki receiver configured")
@@ -196,37 +196,37 @@ func registerLokiReceiverLoggerSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTe
 			BufferSize:         100,
 			Compress:           true,
 		}
-		return createLokiLoggerFromConfig(tc, cfg)
+		return createLokiAuditorFromConfig(tc, cfg)
 	})
 
-	ctx.Step(`^a logger with loki output to the local Loki receiver with AllowPrivateRanges$`, func() error {
+	ctx.Step(`^an auditor with loki output to the local Loki receiver with AllowPrivateRanges$`, func() error {
 		r, ok := tc.LocalReceiver.(*localLokiReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local Loki receiver configured")
 		}
-		return createLokiLoggerWithReceiver(tc, r, &loki.Config{
+		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			BatchSize: 1,
 			Compress:  true,
 		})
 	})
 
-	ctx.Step(`^a logger with loki output to the local Loki receiver with metrics$`, func() error {
+	ctx.Step(`^an auditor with loki output to the local Loki receiver with metrics$`, func() error {
 		r, ok := tc.LocalReceiver.(*localLokiReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local Loki receiver configured")
 		}
-		return createLokiLoggerWithReceiver(tc, r, &loki.Config{
+		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			BatchSize: 1,
 			Compress:  true,
 		})
 	})
 
-	ctx.Step(`^a logger with loki output to the redirecting Loki receiver with metrics$`, func() error {
+	ctx.Step(`^an auditor with loki output to the redirecting Loki receiver with metrics$`, func() error {
 		r, ok := tc.LocalReceiver.(*localLokiReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local Loki receiver configured")
 		}
-		return createLokiLoggerWithReceiver(tc, r, &loki.Config{
+		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			BatchSize:  1,
 			MaxRetries: 1,
 			Compress:   true,
@@ -366,16 +366,16 @@ func assertZeroDrops(tc *AuditTestContext) error {
 	return nil
 }
 
-// createLokiLoggerWithReceiver creates a Loki output pointing at the local receiver.
-func createLokiLoggerWithReceiver(tc *AuditTestContext, r *localLokiReceiver, cfg *loki.Config) error {
+// createLokiAuditorWithReceiver creates a Loki output pointing at the local receiver.
+func createLokiAuditorWithReceiver(tc *AuditTestContext, r *localLokiReceiver, cfg *loki.Config) error {
 	cfg.URL = r.server.URL + "/loki/api/v1/push"
 	cfg.AllowInsecureHTTP = true
 	cfg.AllowPrivateRanges = true
-	return createLokiLoggerFromConfig(tc, cfg)
+	return createLokiAuditorFromConfig(tc, cfg)
 }
 
-// createLokiLoggerFromConfig creates a Loki output from the exact config.
-func createLokiLoggerFromConfig(tc *AuditTestContext, cfg *loki.Config) error {
+// createLokiAuditorFromConfig creates a Loki output from the exact config.
+func createLokiAuditorFromConfig(tc *AuditTestContext, cfg *loki.Config) error {
 	if cfg.FlushInterval == 0 {
 		cfg.FlushInterval = 200 * time.Millisecond
 	}
@@ -397,16 +397,16 @@ func createLokiLoggerFromConfig(tc *AuditTestContext, cfg *loki.Config) error {
 		out.SetOutputMetrics(tc.LokiMetrics)
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }

--- a/tests/bdd/steps/loki_steps.go
+++ b/tests/bdd/steps/loki_steps.go
@@ -54,42 +54,42 @@ func registerLokiGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 func registerLokiGivenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
-	ctx.Step(`^a logger with loki output$`, func() error {
-		return createLokiLogger(tc, &loki.Config{Compress: true})
+	ctx.Step(`^an auditor with loki output$`, func() error {
+		return createLokiAuditor(tc, &loki.Config{Compress: true})
 	})
 
-	ctx.Step(`^a logger with loki output to tenant "([^"]*)"$`, func(tenant string) error {
-		return createLokiLogger(tc, &loki.Config{TenantID: tenant, Compress: true})
+	ctx.Step(`^an auditor with loki output to tenant "([^"]*)"$`, func(tenant string) error {
+		return createLokiAuditor(tc, &loki.Config{TenantID: tenant, Compress: true})
 	})
 
-	ctx.Step(`^a logger with loki output with static label "([^"]*)" = "([^"]*)"$`, func(name, value string) error {
-		return createLokiLogger(tc, &loki.Config{
+	ctx.Step(`^an auditor with loki output with static label "([^"]*)" = "([^"]*)"$`, func(name, value string) error {
+		return createLokiAuditor(tc, &loki.Config{
 			Compress: true,
 			Labels:   loki.LabelConfig{Static: map[string]string{name: value}},
 		})
 	})
 
-	ctx.Step(`^a logger with loki output with batch size (\d+)$`, func(size int) error {
-		return createLokiLogger(tc, &loki.Config{BatchSize: size, Compress: true})
+	ctx.Step(`^an auditor with loki output with batch size (\d+)$`, func(size int) error {
+		return createLokiAuditor(tc, &loki.Config{BatchSize: size, Compress: true})
 	})
 
-	ctx.Step(`^a logger with loki output with batch size (\d+) and flush interval (\d+)ms$`, func(size, ms int) error {
-		return createLokiLogger(tc, &loki.Config{
+	ctx.Step(`^an auditor with loki output with batch size (\d+) and flush interval (\d+)ms$`, func(size, ms int) error {
+		return createLokiAuditor(tc, &loki.Config{
 			BatchSize:     size,
 			FlushInterval: time.Duration(ms) * time.Millisecond,
 			Compress:      true,
 		})
 	})
 
-	ctx.Step(`^a logger with loki output with batch size (\d+) and flush interval (\d+)s$`, func(size, s int) error {
-		return createLokiLogger(tc, &loki.Config{
+	ctx.Step(`^an auditor with loki output with batch size (\d+) and flush interval (\d+)s$`, func(size, s int) error {
+		return createLokiAuditor(tc, &loki.Config{
 			BatchSize:     size,
 			FlushInterval: time.Duration(s) * time.Second,
 			Compress:      true,
 		})
 	})
 
-	ctx.Step(`^a logger with loki output excluding dynamic label "([^"]*)"$`, func(label string) error {
+	ctx.Step(`^an auditor with loki output excluding dynamic label "([^"]*)"$`, func(label string) error {
 		cfg := &loki.Config{Compress: true}
 		switch label {
 		case "severity":
@@ -107,17 +107,17 @@ func registerLokiGivenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditTes
 		default:
 			return fmt.Errorf("unknown dynamic label: %s", label)
 		}
-		return createLokiLogger(tc, cfg)
+		return createLokiAuditor(tc, cfg)
 	})
 
-	ctx.Step(`^a logger with loki output with gzip enabled$`, func() error {
-		return createLokiLogger(tc, &loki.Config{Compress: true})
+	ctx.Step(`^an auditor with loki output with gzip enabled$`, func() error {
+		return createLokiAuditor(tc, &loki.Config{Compress: true})
 	})
 
-	ctx.Step(`^a logger with loki output with gzip disabled$`, func() error {
+	ctx.Step(`^an auditor with loki output with gzip disabled$`, func() error {
 		cfg := &loki.Config{}
 		cfg.Compress = false
-		return createLokiLogger(tc, cfg)
+		return createLokiAuditor(tc, cfg)
 	})
 }
 
@@ -265,7 +265,7 @@ func registerLokiWhenAuditSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 			fields := defaultRequiredFields(tc.Taxonomy, eventType)
 			fields["marker"] = m
 			fields[field] = value
-			return tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			return tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		})
 
 	ctx.Step(`^I audit (\d+) loki events with a shared marker$`, func(count int) error {
@@ -274,7 +274,7 @@ func registerLokiWhenAuditSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 		for i := range count {
 			fields := defaultRequiredFields(tc.Taxonomy, "user_create")
 			fields["marker"] = m
-			if err := tc.Logger.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
+			if err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
 				return fmt.Errorf("audit event %d: %w", i, err)
 			}
 		}
@@ -291,7 +291,7 @@ func registerLokiWhenAuditSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 			}
 			fields := defaultRequiredFields(tc.Taxonomy, eventType)
 			fields["marker"] = m
-			return tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			return tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		})
 
 	ctx.Step(`^I audit (\d+) uniquely marked events with the same timestamp$`,
@@ -304,7 +304,7 @@ func registerLokiWhenAuditSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 				}
 				fields := defaultRequiredFields(tc.Taxonomy, "user_create")
 				fields["marker"] = m
-				if err := tc.Logger.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
+				if err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
 					return fmt.Errorf("audit event %d: %w", i, err)
 				}
 			}
@@ -316,7 +316,7 @@ func registerLokiWhenAuditSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 func registerLokiWhenLifecycleSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^I try to audit a "([^"]*)" event$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
@@ -454,7 +454,7 @@ func applyLokiTestDefaults(tc *AuditTestContext, cfg *loki.Config) {
 	cfg.Labels.Static["test_suite"] = "bdd"
 }
 
-func createLokiLogger(tc *AuditTestContext, cfg *loki.Config) error {
+func createLokiAuditor(tc *AuditTestContext, cfg *loki.Config) error {
 	applyLokiTestDefaults(tc, cfg)
 
 	out, err := loki.New(cfg, nil)
@@ -463,17 +463,17 @@ func createLokiLogger(tc *AuditTestContext, cfg *loki.Config) error {
 	}
 	tc.AddCleanup(func() { _ = out.Close() })
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 

--- a/tests/bdd/steps/metadata_writer_steps.go
+++ b/tests/bdd/steps/metadata_writer_steps.go
@@ -79,7 +79,7 @@ func registerMetadataWriterSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 }
 
 func registerMetadataWriterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with a MetadataWriter output$`, func() error {
+	ctx.Step(`^an auditor with a MetadataWriter output$`, func() error {
 		mock := &MetadataWriterMock{name: "bdd-metadata-writer"}
 		tc.MetadataMock = mock
 
@@ -89,21 +89,21 @@ func registerMetadataWriterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 		}
 		opts = append(opts, tc.Options...)
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
 }
 
-// flushAndGetMeta closes the logger and returns the captured metadata.
+// flushAndGetMeta closes the auditor and returns the captured metadata.
 func flushAndGetMeta(tc *AuditTestContext) (audit.EventMetadata, error) {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	meta, called := tc.MetadataMock.getMeta()
 	if !called {

--- a/tests/bdd/steps/metrics_steps.go
+++ b/tests/bdd/steps/metrics_steps.go
@@ -47,30 +47,30 @@ func registerMetricsGivenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 		return nil
 	})
 
-	ctx.Step(`^a logger with stdout output and metrics$`, func() error {
+	ctx.Step(`^an auditor with stdout output and metrics$`, func() error {
 		tc.Options = append(tc.Options, audit.WithMetrics(tc.MockMetrics))
-		return createStdoutLogger(tc)
+		return createStdoutAuditor(tc)
 	})
 
-	ctx.Step(`^a logger with stdout output and metrics in strict mode$`, func() error {
+	ctx.Step(`^an auditor with stdout output and metrics in strict mode$`, func() error {
 		tc.Options = append(tc.Options, audit.WithMetrics(tc.MockMetrics))
-		return createStdoutLogger(tc)
+		return createStdoutAuditor(tc)
 	})
 
-	ctx.Step(`^a logger with stdout output and metrics in warn mode$`, func() error {
+	ctx.Step(`^an auditor with stdout output and metrics in warn mode$`, func() error {
 		tc.Options = append(tc.Options, audit.WithMetrics(tc.MockMetrics))
-		return createStdoutLoggerWithOpts(tc, audit.WithValidationMode(audit.ValidationWarn))
+		return createStdoutAuditorWithOpts(tc, audit.WithValidationMode(audit.ValidationWarn))
 	})
 
-	ctx.Step(`^a logger with stdout output and metrics and buffer size (\d+)$`, func(bufSize int) error {
+	ctx.Step(`^an auditor with stdout output and metrics and buffer size (\d+)$`, func(bufSize int) error {
 		tc.Options = append(tc.Options, audit.WithMetrics(tc.MockMetrics))
-		return createStdoutLoggerWithOpts(tc, audit.WithQueueSize(bufSize))
+		return createStdoutAuditorWithOpts(tc, audit.WithQueueSize(bufSize))
 	})
 
 }
 
 func registerMetricsGivenAdvancedSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with file and stdout outputs and metrics$`, func() error {
+	ctx.Step(`^an auditor with file and stdout outputs and metrics$`, func() error {
 		buf := &bytes.Buffer{}
 		tc.StdoutBuf = buf
 
@@ -99,21 +99,21 @@ func registerMetricsGivenAdvancedSteps(ctx *godog.ScenarioContext, tc *AuditTest
 			audit.WithNamedOutput(fileOut),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
 }
 
 func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with webhook output and metrics$`, func() error {
+	ctx.Step(`^an auditor with webhook output and metrics$`, func() error {
 		// Pass nil for core metrics to the webhook output — it self-reports
-		// delivery via DeliveryReporter. The core logger's global metrics
+		// delivery via DeliveryReporter. The core auditor's global metrics
 		// (tc.MockMetrics) should NOT record for webhook because
 		// ReportsDelivery() returns true.
 		w, err := webhook.New(&webhook.Config{
@@ -132,16 +132,16 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithOutputs(w),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
-	ctx.Step(`^a logger with panicking formatter and metrics$`, func() error {
+	ctx.Step(`^an auditor with panicking formatter and metrics$`, func() error {
 		buf := &bytes.Buffer{}
 		tc.StdoutBuf = buf
 
@@ -157,16 +157,16 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithOutputs(stdoutOut),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
-	ctx.Step(`^a logger with error-returning formatter and metrics$`, func() error {
+	ctx.Step(`^an auditor with error-returning formatter and metrics$`, func() error {
 		buf := &bytes.Buffer{}
 		tc.StdoutBuf = buf
 
@@ -182,34 +182,34 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 			audit.WithOutputs(stdoutOut),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
-	ctx.Step(`^a logger with error output and metrics$`, func() error {
+	ctx.Step(`^an auditor with error output and metrics$`, func() error {
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithNamedOutput(&errorOutput{}),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
 
 func registerMetricsGivenFilterSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with routed outputs and metrics where webhook excludes "([^"]*)"$`, func(excludeCat string) error {
+	ctx.Step(`^an auditor with routed outputs and metrics where webhook excludes "([^"]*)"$`, func(excludeCat string) error {
 		dir, err := tc.EnsureFileDir()
 		if err != nil {
 			return err
@@ -239,21 +239,21 @@ func registerMetricsGivenFilterSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 			audit.WithNamedOutput(whOut, audit.OutputRoute(&audit.EventRoute{ExcludeCategories: []string{excludeCat}})),
 		}
 
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
 
 func registerMetricsWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^I fill the logger buffer beyond capacity$`, func() error {
+	ctx.Step(`^I fill the auditor buffer beyond capacity$`, func() error {
 		// Send more events than buffer can hold. Some will be dropped.
 		for range 100 {
-			_ = tc.Logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+			_ = tc.Auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 				"outcome":  "success",
 				"actor_id": "overflow",
 			}))
@@ -298,8 +298,8 @@ func registerMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) 
 // --- Metrics assertion helpers ---
 
 func assertMetricsEvent(tc *AuditTestContext, output, status string) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()
@@ -311,8 +311,8 @@ func assertMetricsEvent(tc *AuditTestContext, output, status string) error {
 }
 
 func assertMetricsTotalSuccessEvents(tc *AuditTestContext, minCount int) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()
@@ -345,8 +345,8 @@ func assertMetricsValidationError(tc *AuditTestContext, expectPresent bool) erro
 }
 
 func assertMetricsFiltered(tc *AuditTestContext, eventType string) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()
@@ -357,8 +357,8 @@ func assertMetricsFiltered(tc *AuditTestContext, eventType string) error {
 }
 
 func assertMetricsBufferDrops(tc *AuditTestContext, minCount int) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()
@@ -369,8 +369,8 @@ func assertMetricsBufferDrops(tc *AuditTestContext, minCount int) error {
 }
 
 func assertMetricsSerializationError(tc *AuditTestContext) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()
@@ -385,8 +385,8 @@ func assertMetricsSerializationError(tc *AuditTestContext) error {
 }
 
 func assertMetricsNoWebhookCoreSuccess(tc *AuditTestContext) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()
@@ -402,8 +402,8 @@ func assertMetricsNoWebhookCoreSuccess(tc *AuditTestContext) error {
 }
 
 func assertMetricsOutputFiltered(tc *AuditTestContext) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()
@@ -418,8 +418,8 @@ func assertMetricsOutputFiltered(tc *AuditTestContext) error {
 }
 
 func assertMetricsOutputError(tc *AuditTestContext, output string) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()

--- a/tests/bdd/steps/middleware_steps.go
+++ b/tests/bdd/steps/middleware_steps.go
@@ -113,7 +113,7 @@ func registerMiddlewareGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 		return createTestServer(tc, 0, false, false) // 0 = don't call WriteHeader
 	})
 
-	ctx.Step(`^an HTTP test server with nil logger middleware$`, func() error {
+	ctx.Step(`^an HTTP test server with nil auditor middleware$`, func() error {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
@@ -333,7 +333,7 @@ func createPanicBuilderServer(tc *AuditTestContext) error {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(tc.Logger, panicBuilder)
+	mw := audit.Middleware(tc.Auditor, panicBuilder)
 	tc.TestServer = httptest.NewServer(mw(handler))
 	tc.AddCleanup(func() { tc.TestServer.Close() })
 	return nil
@@ -359,7 +359,7 @@ func createTLSTestServer(tc *AuditTestContext, status int) error {
 		}
 	})
 
-	mw := audit.Middleware(tc.Logger, builder)
+	mw := audit.Middleware(tc.Auditor, builder)
 	tc.TestServer = httptest.NewTLSServer(mw(handler))
 	tc.AddCleanup(func() { tc.TestServer.Close() })
 	return nil
@@ -398,7 +398,7 @@ func createPanicHandlerServer(tc *AuditTestContext) error {
 		panic("intentional handler panic")
 	})
 
-	mw := audit.Middleware(tc.Logger, builder)
+	mw := audit.Middleware(tc.Auditor, builder)
 	tc.TestServer = httptest.NewServer(mw(handler))
 	tc.AddCleanup(func() { tc.TestServer.Close() })
 	return nil
@@ -430,7 +430,7 @@ func createTestServerWithExtra(tc *AuditTestContext) error {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := audit.Middleware(tc.Logger, builder)
+	mw := audit.Middleware(tc.Auditor, builder)
 	tc.TestServer = httptest.NewServer(mw(handler))
 	tc.AddCleanup(func() { tc.TestServer.Close() })
 	return nil
@@ -488,7 +488,7 @@ func createTestServer(tc *AuditTestContext, status int, setActorID, skipGET bool
 		// status=0 means don't call WriteHeader (default 200)
 	})
 
-	mw := audit.Middleware(tc.Logger, builder)
+	mw := audit.Middleware(tc.Auditor, builder)
 	tc.TestServer = httptest.NewServer(mw(handler))
 	tc.AddCleanup(func() { tc.TestServer.Close() })
 	return nil

--- a/tests/bdd/steps/multicat_steps.go
+++ b/tests/bdd/steps/multicat_steps.go
@@ -104,42 +104,42 @@ events:
 }
 
 func registerMultiCatLoggerSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with stdout output routed to include only "([^"]*)"$`, func(category string) error {
-		return createMultiCatLogger(tc, &audit.EventRoute{IncludeCategories: []string{category}}, nil)
+	ctx.Step(`^an auditor with stdout output routed to include only "([^"]*)"$`, func(category string) error {
+		return createMultiCatAuditor(tc, &audit.EventRoute{IncludeCategories: []string{category}}, nil)
 	})
 
-	ctx.Step(`^a logger with stdout output routed to exclude "([^"]*)"$`, func(category string) error {
-		return createMultiCatLogger(tc, &audit.EventRoute{ExcludeCategories: []string{category}}, nil)
+	ctx.Step(`^an auditor with stdout output routed to exclude "([^"]*)"$`, func(category string) error {
+		return createMultiCatAuditor(tc, &audit.EventRoute{ExcludeCategories: []string{category}}, nil)
 	})
 
-	ctx.Step(`^a logger with stdout output routed to include event type "([^"]*)"$`, func(eventType string) error {
-		return createMultiCatLogger(tc, &audit.EventRoute{IncludeEventTypes: []string{eventType}}, nil)
+	ctx.Step(`^an auditor with stdout output routed to include event type "([^"]*)"$`, func(eventType string) error {
+		return createMultiCatAuditor(tc, &audit.EventRoute{IncludeEventTypes: []string{eventType}}, nil)
 	})
 
-	ctx.Step(`^a logger with stdout output using CEF formatter$`, func() error {
+	ctx.Step(`^an auditor with stdout output using CEF formatter$`, func() error {
 		cefFmt := &audit.CEFFormatter{
 			Vendor:  "Test",
 			Product: "BDD",
 			Version: "1.0",
 		}
-		return createMultiCatLogger(tc, nil, cefFmt)
+		return createMultiCatAuditor(tc, nil, cefFmt)
 	})
 }
 
-func createMultiCatLogger(tc *AuditTestContext, route *audit.EventRoute, formatter audit.Formatter) error {
+func createMultiCatAuditor(tc *AuditTestContext, route *audit.EventRoute, formatter audit.Formatter) error {
 	tc.StdoutBuf = &bytes.Buffer{}
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: tc.StdoutBuf})
 	if err != nil {
 		return fmt.Errorf("create stdout: %w", err)
 	}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(stdout, audit.OutputRoute(route), audit.OutputFormatter(formatter)),
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
+	tc.Auditor = auditor
 	return nil
 }
 
@@ -151,7 +151,7 @@ func registerMultiCatAssertionSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 
 func registerMultiCatCountSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^the output should contain exactly (\d+) events?$`, func(expected int) error {
-		if err := flushLogger(tc); err != nil {
+		if err := flushAuditor(tc); err != nil {
 			return err
 		}
 		lines := nonEmptyLines(tc.StdoutBuf.String())
@@ -164,14 +164,14 @@ func registerMultiCatCountSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 
 func registerMultiCatContentSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^all delivered events should have event_type "([^"]*)"$`, func(et string) error {
-		if err := flushLogger(tc); err != nil {
+		if err := flushAuditor(tc); err != nil {
 			return err
 		}
 		return assertAllEventsHaveField(tc, "event_type", et)
 	})
 
 	ctx.Step(`^all delivered events should have JSON field "([^"]*)" equal to (\d+)$`, func(field string, expected int) error {
-		if err := flushLogger(tc); err != nil {
+		if err := flushAuditor(tc); err != nil {
 			return err
 		}
 		return assertAllEventsHaveNumericField(tc, field, expected)
@@ -180,21 +180,21 @@ func registerMultiCatContentSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 
 func registerMultiCatCEFSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^the CEF output severity should be (\d+)$`, func(expected int) error {
-		if err := flushLogger(tc); err != nil {
+		if err := flushAuditor(tc); err != nil {
 			return err
 		}
 		return assertMultiCatCEFSeverity(tc, expected)
 	})
 }
 
-// flushLogger closes the logger to flush buffered events. Safe to
+// flushAuditor closes the auditor to flush buffered events. Safe to
 // call multiple times — subsequent calls are no-ops.
-func flushLogger(tc *AuditTestContext) error {
-	if tc.Logger != nil {
-		if err := tc.Logger.Close(); err != nil {
-			return fmt.Errorf("close logger: %w", err)
+func flushAuditor(tc *AuditTestContext) error {
+	if tc.Auditor != nil {
+		if err := tc.Auditor.Close(); err != nil {
+			return fmt.Errorf("close auditor: %w", err)
 		}
-		tc.Logger = nil
+		tc.Auditor = nil
 	}
 	return nil
 }

--- a/tests/bdd/steps/outputconfig_steps.go
+++ b/tests/bdd/steps/outputconfig_steps.go
@@ -94,17 +94,17 @@ func registerOutputConfigSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 		return nil
 	})
 
-	ctx.Step(`^I create a logger from the loaded config$`, func() error {
+	ctx.Step(`^I create an auditor from the loaded config$`, func() error {
 		if loadResult == nil {
 			return fmt.Errorf("no load result available — load the outputs config first")
 		}
 		opts := append([]audit.Option{audit.WithTaxonomy(tc.Taxonomy)}, loadResult.Options...)
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("failed to create logger from loaded config: %w", err)
+			return fmt.Errorf("failed to create auditor from loaded config: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 

--- a/tests/bdd/steps/sensitivity_steps.go
+++ b/tests/bdd/steps/sensitivity_steps.go
@@ -41,22 +41,22 @@ func registerSensitivityGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 }
 
 func registerSensitivityWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with stdout output and no exclusions$`, func() error {
-		return createSensitivityLogger(tc, nil)
+	ctx.Step(`^an auditor with stdout output and no exclusions$`, func() error {
+		return createSensitivityAuditor(tc, nil)
 	})
-	ctx.Step(`^a logger with stdout output excluding labels "([^"]*)"$`, func(labels string) error {
+	ctx.Step(`^an auditor with stdout output excluding labels "([^"]*)"$`, func(labels string) error {
 		excludeLabels := strings.Split(labels, ",")
 		for i := range excludeLabels {
 			excludeLabels[i] = strings.TrimSpace(excludeLabels[i])
 		}
-		return createSensitivityLogger(tc, excludeLabels)
+		return createSensitivityAuditor(tc, excludeLabels)
 	})
-	ctx.Step(`^I try to create a logger with stdout output excluding labels "([^"]*)"$`, func(labels string) error {
+	ctx.Step(`^I try to create an auditor with stdout output excluding labels "([^"]*)"$`, func(labels string) error {
 		excludeLabels := strings.Split(labels, ",")
 		for i := range excludeLabels {
 			excludeLabels[i] = strings.TrimSpace(excludeLabels[i])
 		}
-		err := createSensitivityLogger(tc, excludeLabels)
+		err := createSensitivityAuditor(tc, excludeLabels)
 		if err != nil {
 			tc.LastErr = err
 		}
@@ -64,21 +64,21 @@ func registerSensitivityWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 	})
 }
 
-func createSensitivityLogger(tc *AuditTestContext, excludeLabels []string) error {
+func createSensitivityAuditor(tc *AuditTestContext, excludeLabels []string) error {
 	tc.StdoutBuf = &bytes.Buffer{}
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: tc.StdoutBuf})
 	if err != nil {
 		return fmt.Errorf("create stdout output: %w", err)
 	}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels(excludeLabels...)),
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
@@ -97,7 +97,7 @@ func registerSensitivityThenSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 		})
 	// Note: "the output should not contain field" is registered in audit_steps.go.
 	// Note: "the output should contain an event with field" is registered in audit_steps.go.
-	// Note: "logger creation should fail with an error containing" is registered in hmac_steps.go.
+	// Note: "auditor creation should fail with an error containing" is registered in hmac_steps.go.
 	// Do not duplicate any of these here.
 }
 
@@ -136,9 +136,9 @@ func assertFieldLabeled(tc *AuditTestContext, eventType, field, label string) er
 }
 
 func assertOutputContainsFieldValue(tc *AuditTestContext, field, value string) error {
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
-		tc.Logger = nil
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
+		tc.Auditor = nil
 	}
 	if tc.StdoutBuf == nil {
 		return fmt.Errorf("no stdout buffer configured")

--- a/tests/bdd/steps/severity_routing_steps.go
+++ b/tests/bdd/steps/severity_routing_steps.go
@@ -101,51 +101,51 @@ events:
 }
 
 func registerSeverityLoggerSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with stdout output routed with min_severity (\d+)$`, func(minSev int) error {
-		return createSeverityRoutedLogger(tc, &minSev, nil, nil, nil)
+	ctx.Step(`^an auditor with stdout output routed with min_severity (\d+)$`, func(minSev int) error {
+		return createSeverityRoutedAuditor(tc, &minSev, nil, nil, nil)
 	})
 
-	ctx.Step(`^a logger with stdout output routed with max_severity (\d+)$`, func(maxSev int) error {
-		return createSeverityRoutedLogger(tc, nil, &maxSev, nil, nil)
+	ctx.Step(`^an auditor with stdout output routed with max_severity (\d+)$`, func(maxSev int) error {
+		return createSeverityRoutedAuditor(tc, nil, &maxSev, nil, nil)
 	})
 
-	ctx.Step(`^a logger with stdout output routed with min_severity (\d+) and max_severity (\d+)$`, func(minSev, maxSev int) error {
-		return createSeverityRoutedLogger(tc, &minSev, &maxSev, nil, nil)
+	ctx.Step(`^an auditor with stdout output routed with min_severity (\d+) and max_severity (\d+)$`, func(minSev, maxSev int) error {
+		return createSeverityRoutedAuditor(tc, &minSev, &maxSev, nil, nil)
 	})
 
-	ctx.Step(`^a logger with stdout output routed to include only "([^"]*)" with min_severity (\d+)$`, func(cat string, minSev int) error {
+	ctx.Step(`^an auditor with stdout output routed to include only "([^"]*)" with min_severity (\d+)$`, func(cat string, minSev int) error {
 		include := []string{cat}
-		return createSeverityRoutedLogger(tc, &minSev, nil, include, nil)
+		return createSeverityRoutedAuditor(tc, &minSev, nil, include, nil)
 	})
 
-	ctx.Step(`^a logger with stdout output routed to exclude "([^"]*)" with min_severity (\d+)$`, func(cat string, minSev int) error {
+	ctx.Step(`^an auditor with stdout output routed to exclude "([^"]*)" with min_severity (\d+)$`, func(cat string, minSev int) error {
 		exclude := []string{cat}
-		return createSeverityRoutedLogger(tc, &minSev, nil, nil, exclude)
+		return createSeverityRoutedAuditor(tc, &minSev, nil, nil, exclude)
 	})
 
-	ctx.Step(`^a logger with named stdout output "([^"]*)" receiving all events$`, func(name string) error {
+	ctx.Step(`^an auditor with named stdout output "([^"]*)" receiving all events$`, func(name string) error {
 		tc.StdoutBuf = &bytes.Buffer{}
 		stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: tc.StdoutBuf})
 		if err != nil {
 			return fmt.Errorf("create stdout: %w", err)
 		}
-		logger, err := audit.NewLogger(
+		auditor, err := audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithNamedOutput(audit.WrapOutput(stdout, name)),
 			audit.WithSynchronousDelivery(),
 		)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
+		tc.Auditor = auditor
 		return nil
 	})
 
-	// Note: "the logger should be created successfully" is registered
+	// Note: "the auditor should be created successfully" is registered
 	// in config_steps.go. Do not duplicate here.
 }
 
-func createSeverityRoutedLogger(tc *AuditTestContext, minSev, maxSev *int, includeCats, excludeCats []string) error {
+func createSeverityRoutedAuditor(tc *AuditTestContext, minSev, maxSev *int, includeCats, excludeCats []string) error {
 	tc.StdoutBuf = &bytes.Buffer{}
 	stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: tc.StdoutBuf})
 	if err != nil {
@@ -157,31 +157,31 @@ func createSeverityRoutedLogger(tc *AuditTestContext, minSev, maxSev *int, inclu
 		IncludeCategories: includeCats,
 		ExcludeCategories: excludeCats,
 	}
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(stdout, audit.OutputRoute(route)),
 	)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
+	tc.Auditor = auditor
 	return nil
 }
 
 func registerSeverityValidationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^I try to create a logger with route min_severity (\-?\d+)$`, func(minSev int) error {
+	ctx.Step(`^I try to create an auditor with route min_severity (\-?\d+)$`, func(minSev int) error {
 		return trySeverityLoggerCreation(tc, &minSev, nil)
 	})
 
-	ctx.Step(`^I try to create a logger with route max_severity (\-?\d+)$`, func(maxSev int) error {
+	ctx.Step(`^I try to create an auditor with route max_severity (\-?\d+)$`, func(maxSev int) error {
 		return trySeverityLoggerCreation(tc, nil, &maxSev)
 	})
 
-	ctx.Step(`^I try to create a logger with route min_severity (\d+) and max_severity (\d+)$`, func(minSev, maxSev int) error {
+	ctx.Step(`^I try to create an auditor with route min_severity (\d+) and max_severity (\d+)$`, func(minSev, maxSev int) error {
 		return trySeverityLoggerCreation(tc, &minSev, &maxSev)
 	})
 
-	ctx.Step(`^the logger creation should fail with error containing "([^"]*)"$`, func(expected string) error {
+	ctx.Step(`^the auditor creation should fail with error containing "([^"]*)"$`, func(expected string) error {
 		if tc.LastErr == nil {
 			return fmt.Errorf("expected error containing %q, got nil", expected)
 		}
@@ -202,23 +202,23 @@ func trySeverityLoggerCreation(tc *AuditTestContext, minSev, maxSev *int) error 
 		MinSeverity: minSev,
 		MaxSeverity: maxSev,
 	}
-	logger, lErr := audit.NewLogger(
+	auditor, lErr := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(stdout, audit.OutputRoute(route)),
 	)
 	tc.LastErr = lErr
-	if logger != nil {
-		tc.Logger = logger
+	if auditor != nil {
+		tc.Auditor = auditor
 	}
 	return nil
 }
 
 func registerSeverityRuntimeSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^I set output "([^"]*)" route to min_severity (\d+)$`, func(name string, minSev int) error {
-		if tc.Logger == nil {
-			return fmt.Errorf("logger not created")
+		if tc.Auditor == nil {
+			return fmt.Errorf("auditor not created")
 		}
 		route := &audit.EventRoute{MinSeverity: &minSev}
-		return tc.Logger.SetOutputRoute(name, route)
+		return tc.Auditor.SetOutputRoute(name, route)
 	})
 }

--- a/tests/bdd/steps/shutdown_steps.go
+++ b/tests/bdd/steps/shutdown_steps.go
@@ -25,7 +25,7 @@ import (
 
 // blockingMockOutput is a synchronous output whose Write blocks forever.
 // Used to verify that the drain timeout mechanism works correctly when
-// an output hangs. Close returns immediately so the logger can shut down.
+// an output hangs. Close returns immediately so the auditor can shut down.
 type blockingMockOutput struct {
 	blockCh chan struct{} // closed on cleanup to unblock Write
 }
@@ -42,25 +42,25 @@ func (b *blockingMockOutput) Close() error { return nil }
 // registerShutdownSteps registers step definitions for shutdown scenarios.
 func registerShutdownSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	// Most shutdown scenarios use steps from audit_steps.go and file_steps.go:
-	// - "I close the logger" (audit_steps)
-	// - "I close the logger again" (file_steps)
+	// - "I close the auditor" (audit_steps)
+	// - "I close the auditor again" (file_steps)
 	// - "the second close should return no error" (file_steps)
 	// - "the file should contain exactly N events" (file_steps)
-	// - "closing the logger should complete within N seconds" (file_steps)
+	// - "closing the auditor should complete within N seconds" (file_steps)
 
-	ctx.Step(`^a logger with a blocking output and drain timeout (\d+)s$`, func(timeoutSecs int) error {
+	ctx.Step(`^an auditor with a blocking output and drain timeout (\d+)s$`, func(timeoutSecs int) error {
 		blocking := &blockingMockOutput{blockCh: make(chan struct{})}
 		tc.AddCleanup(func() { close(blocking.blockCh) })
 
-		logger, err := audit.NewLogger(
+		auditor, err := audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(blocking),
-			audit.WithDrainTimeout(time.Duration(timeoutSecs)*time.Second),
+			audit.WithShutdownTimeout(time.Duration(timeoutSecs)*time.Second),
 		)
 		if err != nil {
-			return fmt.Errorf("create logger with blocking output: %w", err)
+			return fmt.Errorf("create auditor with blocking output: %w", err)
 		}
-		tc.Logger = logger
+		tc.Auditor = auditor
 		return nil
 	})
 }

--- a/tests/bdd/steps/syslog_severity_steps.go
+++ b/tests/bdd/steps/syslog_severity_steps.go
@@ -169,45 +169,45 @@ func registerSyslogSeverityGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 		return nil
 	})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" and HMAC enabled with salt "([^"]*)" version "([^"]*)" hash "([^"]*)"$`,
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" and HMAC enabled with salt "([^"]*)" version "([^"]*)" hash "([^"]*)"$`,
 		func(network, address, salt, version, hash string) error {
-			return createSyslogLoggerWithHMAC(tc, &syslog.Config{
+			return createSyslogAuditorWithHMAC(tc, &syslog.Config{
 				Network: network, Address: address,
 			}, salt, version, hash)
 		})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" excluding labels "([^"]*)"$`,
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" excluding labels "([^"]*)"$`,
 		func(network, address, labels string) error {
 			excludeLabels := strings.Split(labels, ",")
 			for i := range excludeLabels {
 				excludeLabels[i] = strings.TrimSpace(excludeLabels[i])
 			}
-			return createSyslogLoggerWithExcludeLabels(tc, &syslog.Config{
+			return createSyslogAuditorWithExcludeLabels(tc, &syslog.Config{
 				Network: network, Address: address,
 			}, excludeLabels)
 		})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" routed to exclude "([^"]*)"$`,
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" routed to exclude "([^"]*)"$`,
 		func(network, address, category string) error {
-			return createSyslogLoggerWithRoute(tc, &syslog.Config{
+			return createSyslogAuditorWithRoute(tc, &syslog.Config{
 				Network: network, Address: address,
 			}, &audit.EventRoute{
 				ExcludeCategories: []string{category},
 			})
 		})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" using CEF formatter$`,
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" using CEF formatter$`,
 		func(network, address string) error {
-			return createSyslogLoggerWithFormatter(tc, &syslog.Config{
+			return createSyslogAuditorWithFormatter(tc, &syslog.Config{
 				Network: network, Address: address,
 			}, &audit.CEFFormatter{
 				Vendor: "BDDTest", Product: "Audit", Version: "1.0",
 			})
 		})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" routed to include only "([^"]*)"$`,
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" routed to include only "([^"]*)"$`,
 		func(network, address, category string) error {
-			return createSyslogLoggerWithRoute(tc, &syslog.Config{
+			return createSyslogAuditorWithRoute(tc, &syslog.Config{
 				Network: network, Address: address,
 			}, &audit.EventRoute{
 				IncludeCategories: []string{category},
@@ -225,7 +225,7 @@ func registerSyslogSeverityWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 			m := marker("BDD")
 			tc.Markers[markerName] = m
 			fields["marker"] = m
-			return tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			return tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		})
 }
 
@@ -330,9 +330,9 @@ func assertSyslogNotContains(text string, timeout time.Duration) error {
 	return nil
 }
 
-// createSyslogLoggerWithFormatter creates a syslog logger with a
+// createSyslogAuditorWithFormatter creates a syslog auditor with a
 // per-output formatter (e.g., CEF).
-func createSyslogLoggerWithFormatter(tc *AuditTestContext, cfg *syslog.Config, formatter audit.Formatter) error {
+func createSyslogAuditorWithFormatter(tc *AuditTestContext, cfg *syslog.Config, formatter audit.Formatter) error {
 	if cfg.Facility == "" {
 		cfg.Facility = "local0"
 	}
@@ -349,18 +349,18 @@ func createSyslogLoggerWithFormatter(tc *AuditTestContext, cfg *syslog.Config, f
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-// createSyslogLoggerWithHMAC creates a syslog logger with per-output
+// createSyslogAuditorWithHMAC creates a syslog auditor with per-output
 // HMAC integrity enabled.
-func createSyslogLoggerWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt, version, hash string) error {
+func createSyslogAuditorWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt, version, hash string) error {
 	if cfg.Facility == "" {
 		cfg.Facility = "local0"
 	}
@@ -382,18 +382,18 @@ func createSyslogLoggerWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt, 
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-// createSyslogLoggerWithExcludeLabels creates a syslog logger with
+// createSyslogAuditorWithExcludeLabels creates a syslog auditor with
 // sensitivity label exclusions.
-func createSyslogLoggerWithExcludeLabels(tc *AuditTestContext, cfg *syslog.Config, excludeLabels []string) error {
+func createSyslogAuditorWithExcludeLabels(tc *AuditTestContext, cfg *syslog.Config, excludeLabels []string) error {
 	if cfg.Facility == "" {
 		cfg.Facility = "local0"
 	}
@@ -410,12 +410,12 @@ func createSyslogLoggerWithExcludeLabels(tc *AuditTestContext, cfg *syslog.Confi
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
@@ -434,9 +434,9 @@ func assertSyslogMarkerLineNotContains(searchMarker, text string) error {
 	return fmt.Errorf("no syslog line found with marker %q", searchMarker)
 }
 
-// createSyslogLoggerWithRoute creates a syslog logger with a per-output
+// createSyslogAuditorWithRoute creates a syslog auditor with a per-output
 // event route.
-func createSyslogLoggerWithRoute(tc *AuditTestContext, cfg *syslog.Config, route *audit.EventRoute) error {
+func createSyslogAuditorWithRoute(tc *AuditTestContext, cfg *syslog.Config, route *audit.EventRoute) error {
 	if cfg.Facility == "" {
 		cfg.Facility = "local0"
 	}
@@ -453,11 +453,11 @@ func createSyslogLoggerWithRoute(tc *AuditTestContext, cfg *syslog.Config, route
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }

--- a/tests/bdd/steps/syslog_steps.go
+++ b/tests/bdd/steps/syslog_steps.go
@@ -49,32 +49,32 @@ func registerSyslogSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 }
 
 func registerSyslogGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)"$`, func(network, address string) error {
-		return createSyslogLogger(tc, &syslog.Config{Network: network, Address: address})
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)"$`, func(network, address string) error {
+		return createSyslogAuditor(tc, &syslog.Config{Network: network, Address: address})
 	})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" with app name "([^"]*)"$`, func(network, address, appName string) error {
-		return createSyslogLogger(tc, &syslog.Config{Network: network, Address: address, AppName: appName})
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" with app name "([^"]*)"$`, func(network, address, appName string) error {
+		return createSyslogAuditor(tc, &syslog.Config{Network: network, Address: address, AppName: appName})
 	})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" with facility "([^"]*)"$`, func(network, address, facility string) error {
-		return createSyslogLogger(tc, &syslog.Config{Network: network, Address: address, Facility: facility})
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" with facility "([^"]*)"$`, func(network, address, facility string) error {
+		return createSyslogAuditor(tc, &syslog.Config{Network: network, Address: address, Facility: facility})
 	})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" with hostname "([^"]*)"$`, func(network, address, hostname string) error {
-		return createSyslogLogger(tc, &syslog.Config{Network: network, Address: address, Hostname: hostname})
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" with hostname "([^"]*)"$`, func(network, address, hostname string) error {
+		return createSyslogAuditor(tc, &syslog.Config{Network: network, Address: address, Hostname: hostname})
 	})
 
 	ctx.Step(`^I try to create a syslog output on "([^"]*)" to "([^"]*)" with hostname "([^"]*)"$`, func(network, address, hostname string) error {
-		err := createSyslogLogger(tc, &syslog.Config{Network: network, Address: address, Hostname: hostname})
+		err := createSyslogAuditor(tc, &syslog.Config{Network: network, Address: address, Hostname: hostname})
 		if err != nil {
 			tc.LastErr = err
 		}
 		return nil
 	})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" with max retries (\d+)$`, func(network, address string, retries int) error {
-		return createSyslogLogger(tc, &syslog.Config{Network: network, Address: address, MaxRetries: retries})
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" with max retries (\d+)$`, func(network, address string, retries int) error {
+		return createSyslogAuditor(tc, &syslog.Config{Network: network, Address: address, MaxRetries: retries})
 	})
 
 	ctx.Step(`^mock syslog metrics are configured$`, func() error {
@@ -82,24 +82,24 @@ func registerSyslogGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) 
 		return nil
 	})
 
-	ctx.Step(`^a logger with syslog output on "([^"]*)" to "([^"]*)" with metrics and max retries (\d+)$`, func(network, address string, retries int) error {
-		return createSyslogLoggerWithMetrics(tc, &syslog.Config{
+	ctx.Step(`^an auditor with syslog output on "([^"]*)" to "([^"]*)" with metrics and max retries (\d+)$`, func(network, address string, retries int) error {
+		return createSyslogAuditorWithMetrics(tc, &syslog.Config{
 			Network: network, Address: address, MaxRetries: retries,
 		})
 	})
 
-	ctx.Step(`^a logger with syslog TLS output to "([^"]*)" with CA cert$`, func(address string) error {
+	ctx.Step(`^an auditor with syslog TLS output to "([^"]*)" with CA cert$`, func(address string) error {
 		certs := certDir()
-		return createSyslogLogger(tc, &syslog.Config{
+		return createSyslogAuditor(tc, &syslog.Config{
 			Network: "tcp+tls",
 			Address: address,
 			TLSCA:   filepath.Join(certs, "ca.crt"),
 		})
 	})
 
-	ctx.Step(`^a logger with syslog mTLS output to "([^"]*)"$`, func(address string) error {
+	ctx.Step(`^an auditor with syslog mTLS output to "([^"]*)"$`, func(address string) error {
 		certs := certDir()
-		return createSyslogLogger(tc, &syslog.Config{
+		return createSyslogAuditor(tc, &syslog.Config{
 			Network: "tcp+tls",
 			Address: address,
 			TLSCA:   filepath.Join(certs, "ca.crt"),
@@ -122,7 +122,7 @@ func registerSyslogWhenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 			tc.Markers[fmt.Sprintf("multi_%d", i)] = m
 			fields := defaultRequiredFields(tc.Taxonomy, "user_create")
 			fields["marker"] = m
-			if err := tc.Logger.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
+			if err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", fields)); err != nil {
 				return fmt.Errorf("audit event %d: %w", i, err)
 			}
 		}
@@ -132,7 +132,7 @@ func registerSyslogWhenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 	ctx.Step(`^I audit an event with a (\d+)-byte payload$`, func(size int) error {
 		fields := defaultRequiredFields(tc.Taxonomy, "user_create")
 		fields["marker"] = strings.Repeat("x", size)
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent("user_create", fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent("user_create", fields))
 		return nil
 	})
 
@@ -201,7 +201,7 @@ func registerSyslogWhenReconnectSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 				"outcome": "success",
 				"reason":  marker,
 			})
-			_ = tc.Logger.AuditEvent(ev) // may return error (syslog dead), that's expected
+			_ = tc.Auditor.AuditEvent(ev) // may return error (syslog dead), that's expected
 		}
 		return nil
 	})
@@ -240,13 +240,13 @@ func registerSyslogWhenReconnectSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 		// The first write after restart may fail and trigger reconnect.
 		// Retry a few times to allow reconnection.
 		for range 10 {
-			err := tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+			err := tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 			if err == nil {
 				return nil
 			}
 			time.Sleep(500 * time.Millisecond)
 		}
-		tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 		return nil
 	})
 
@@ -392,8 +392,8 @@ func assertSyslogConstructionError(tc *AuditTestContext, substr string) error {
 
 // --- Internal helpers ---
 
-// createSyslogLogger creates a logger with a syslog output.
-func createSyslogLogger(tc *AuditTestContext, cfg *syslog.Config) error {
+// createSyslogAuditor creates an auditor with a syslog output.
+func createSyslogAuditor(tc *AuditTestContext, cfg *syslog.Config) error {
 	if cfg.Facility == "" {
 		cfg.Facility = "local0"
 	}
@@ -410,17 +410,17 @@ func createSyslogLogger(tc *AuditTestContext, cfg *syslog.Config) error {
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-// createSyslogLoggerWithMetrics creates a logger with syslog output and metrics.
-func createSyslogLoggerWithMetrics(tc *AuditTestContext, cfg *syslog.Config) error {
+// createSyslogAuditorWithMetrics creates an auditor with syslog output and metrics.
+func createSyslogAuditorWithMetrics(tc *AuditTestContext, cfg *syslog.Config) error {
 	if cfg.Facility == "" {
 		cfg.Facility = "local0"
 	}
@@ -441,12 +441,12 @@ func createSyslogLoggerWithMetrics(tc *AuditTestContext, cfg *syslog.Config) err
 	}
 	opts = append(opts, tc.Options...)
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 

--- a/tests/bdd/steps/webhook_steps.go
+++ b/tests/bdd/steps/webhook_steps.go
@@ -146,45 +146,45 @@ func (r *localWebhookReceiver) close() {
 }
 
 func registerWebhookGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
-	ctx.Step(`^a logger with webhook output configured for batch size (\d+)$`, func(batchSize int) error {
-		return createWebhookLogger(tc, &webhook.Config{
+	ctx.Step(`^an auditor with webhook output configured for batch size (\d+)$`, func(batchSize int) error {
+		return createWebhookAuditor(tc, &webhook.Config{
 			BatchSize:     batchSize,
 			FlushInterval: 100 * time.Millisecond,
 		})
 	})
 
-	ctx.Step(`^a logger with webhook output configured for batch size (\d+) and flush interval (\d+)ms$`, func(batchSize, flushMS int) error {
-		return createWebhookLogger(tc, &webhook.Config{
+	ctx.Step(`^an auditor with webhook output configured for batch size (\d+) and flush interval (\d+)ms$`, func(batchSize, flushMS int) error {
+		return createWebhookAuditor(tc, &webhook.Config{
 			BatchSize:     batchSize,
 			FlushInterval: time.Duration(flushMS) * time.Millisecond,
 		})
 	})
 
-	ctx.Step(`^a logger with webhook output configured for batch size (\d+) and flush interval (\d+)s$`, func(batchSize, flushS int) error {
-		return createWebhookLogger(tc, &webhook.Config{
+	ctx.Step(`^an auditor with webhook output configured for batch size (\d+) and flush interval (\d+)s$`, func(batchSize, flushS int) error {
+		return createWebhookAuditor(tc, &webhook.Config{
 			BatchSize:     batchSize,
 			FlushInterval: time.Duration(flushS) * time.Second,
 		})
 	})
 
-	ctx.Step(`^a logger with webhook output configured for batch size (\d+) and max retries (\d+)$`, func(batchSize, maxRetries int) error {
-		return createWebhookLogger(tc, &webhook.Config{
+	ctx.Step(`^an auditor with webhook output configured for batch size (\d+) and max retries (\d+)$`, func(batchSize, maxRetries int) error {
+		return createWebhookAuditor(tc, &webhook.Config{
 			BatchSize:     batchSize,
 			FlushInterval: 100 * time.Millisecond,
 			MaxRetries:    maxRetries,
 		})
 	})
 
-	ctx.Step(`^a logger with webhook output with custom header "([^"]*)" = "([^"]*)"$`, func(name, value string) error {
-		return createWebhookLogger(tc, &webhook.Config{
+	ctx.Step(`^an auditor with webhook output with custom header "([^"]*)" = "([^"]*)"$`, func(name, value string) error {
+		return createWebhookAuditor(tc, &webhook.Config{
 			BatchSize:     1,
 			FlushInterval: 100 * time.Millisecond,
 			Headers:       map[string]string{name: value},
 		})
 	})
 
-	ctx.Step(`^a logger with webhook output to "([^"]*)" with AllowInsecureHTTP$`, func(url string) error {
-		return createWebhookLoggerWithURL(tc, url, &webhook.Config{
+	ctx.Step(`^an auditor with webhook output to "([^"]*)" with AllowInsecureHTTP$`, func(url string) error {
+		return createWebhookAuditorWithURL(tc, url, &webhook.Config{
 			BatchSize:     1,
 			FlushInterval: 100 * time.Millisecond,
 		})
@@ -195,8 +195,8 @@ func registerWebhookGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 		return nil
 	})
 
-	ctx.Step(`^a logger with webhook output and webhook metrics configured for batch size (\d+)$`, func(batchSize int) error {
-		return createWebhookLoggerWithWebhookMetrics(tc, batchSize)
+	ctx.Step(`^an auditor with webhook output and webhook metrics configured for batch size (\d+)$`, func(batchSize int) error {
+		return createWebhookAuditorWithWebhookMetrics(tc, batchSize)
 	})
 
 	ctx.Step(`^the webhook receiver is configured to return status (\d+)$`, func(status int) error {
@@ -214,7 +214,7 @@ func registerWebhookGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 		return nil
 	})
 
-	ctx.Step(`^a logger with webhook output to the HTTPS receiver with custom CA$`, func() error {
+	ctx.Step(`^an auditor with webhook output to the HTTPS receiver with custom CA$`, func() error {
 		r, ok := tc.TLSReceiver.(*tlsWebhookReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no TLS webhook receiver configured")
@@ -243,12 +243,12 @@ func registerWebhookGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(out),
 		}
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
@@ -270,23 +270,23 @@ func registerWebhookGivenSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 		return nil
 	})
 
-	ctx.Step(`^a logger with webhook output to the local receiver without AllowPrivateRanges$`, func() error {
+	ctx.Step(`^an auditor with webhook output to the local receiver without AllowPrivateRanges$`, func() error {
 		r, ok := tc.LocalReceiver.(*localWebhookReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local webhook receiver configured")
 		}
-		return createWebhookLoggerSSRF(tc, r.server.URL+"/events", false)
+		return createWebhookAuditorSSRF(tc, r.server.URL+"/events", false)
 	})
 
-	ctx.Step(`^a logger with webhook output to the local receiver with AllowPrivateRanges$`, func() error {
+	ctx.Step(`^an auditor with webhook output to the local receiver with AllowPrivateRanges$`, func() error {
 		r, ok := tc.LocalReceiver.(*localWebhookReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local webhook receiver configured")
 		}
-		return createWebhookLoggerSSRF(tc, r.server.URL+"/events", true)
+		return createWebhookAuditorSSRF(tc, r.server.URL+"/events", true)
 	})
 
-	ctx.Step(`^a logger with webhook output to the redirecting receiver with metrics$`, func() error {
+	ctx.Step(`^an auditor with webhook output to the redirecting receiver with metrics$`, func() error {
 		r, ok := tc.LocalReceiver.(*localWebhookReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local webhook receiver configured")
@@ -312,16 +312,16 @@ func registerWebhookGivenSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(out),
 		}
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 
-	ctx.Step(`^a logger with webhook to local receiver with buffer size (\d+) and metrics$`, func(bufSize int) error {
+	ctx.Step(`^an auditor with webhook to local receiver with buffer size (\d+) and metrics$`, func(bufSize int) error {
 		r, ok := tc.LocalReceiver.(*localWebhookReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no local webhook receiver configured")
@@ -347,12 +347,12 @@ func registerWebhookGivenSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(out),
 		}
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
@@ -389,7 +389,7 @@ func registerWebhookWhenAuditSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 	ctx.Step(`^I rapidly audit (\d+) webhook events measuring time$`, func(count int) error {
 		start := time.Now()
 		for i := range count {
-			_ = tc.Logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+			_ = tc.Auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 				"outcome":  "success",
 				"actor_id": fmt.Sprintf("rapid_%d", i),
 			}))
@@ -494,7 +494,7 @@ func registerWebhookWhenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditT
 		return nil
 	})
 
-	ctx.Step(`^a logger with webhook output to the HTTPS receiver with wrong CA and metrics$`, func() error {
+	ctx.Step(`^an auditor with webhook output to the HTTPS receiver with wrong CA and metrics$`, func() error {
 		r, ok := tc.TLSReceiver.(*tlsWebhookReceiver)
 		if !ok || r == nil {
 			return fmt.Errorf("no TLS webhook receiver configured")
@@ -522,12 +522,12 @@ func registerWebhookWhenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditT
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithOutputs(out),
 		}
-		logger, err := audit.NewLogger(opts...)
+		auditor, err := audit.New(opts...)
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
+			return fmt.Errorf("create auditor: %w", err)
 		}
-		tc.Logger = logger
-		tc.AddCleanup(func() { _ = logger.Close() })
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
 		return nil
 	})
 }
@@ -631,15 +631,15 @@ func registerWebhookThenMetricsAndErrorSteps(ctx *godog.ScenarioContext, tc *Aud
 
 // --- Internal helpers ---
 
-func createWebhookLogger(tc *AuditTestContext, cfg *webhook.Config) error {
+func createWebhookAuditor(tc *AuditTestContext, cfg *webhook.Config) error {
 	cfg.URL = tc.WebhookURL + "/events"
 	cfg.AllowInsecureHTTP = true
 	cfg.AllowPrivateRanges = true
 	cfg.Timeout = 5 * time.Second
-	return createWebhookLoggerFromConfig(tc, cfg)
+	return createWebhookAuditorFromConfig(tc, cfg)
 }
 
-func createWebhookLoggerWithWebhookMetrics(tc *AuditTestContext, batchSize int) error {
+func createWebhookAuditorWithWebhookMetrics(tc *AuditTestContext, batchSize int) error {
 	cfg := &webhook.Config{
 		URL:                tc.WebhookURL + "/events",
 		AllowInsecureHTTP:  true,
@@ -666,24 +666,24 @@ func createWebhookLoggerWithWebhookMetrics(tc *AuditTestContext, batchSize int) 
 		audit.WithOutputs(out),
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
-func createWebhookLoggerWithURL(tc *AuditTestContext, url string, cfg *webhook.Config) error {
+func createWebhookAuditorWithURL(tc *AuditTestContext, url string, cfg *webhook.Config) error {
 	cfg.URL = url
 	cfg.AllowInsecureHTTP = true
 	cfg.AllowPrivateRanges = true
 	cfg.Timeout = 5 * time.Second
-	return createWebhookLoggerFromConfig(tc, cfg)
+	return createWebhookAuditorFromConfig(tc, cfg)
 }
 
-func createWebhookLoggerFromConfig(tc *AuditTestContext, cfg *webhook.Config) error {
+func createWebhookAuditorFromConfig(tc *AuditTestContext, cfg *webhook.Config) error {
 	out, err := webhook.New(cfg, nil)
 	if err != nil {
 		tc.LastErr = err
@@ -696,24 +696,24 @@ func createWebhookLoggerFromConfig(tc *AuditTestContext, cfg *webhook.Config) er
 		audit.WithOutputs(out),
 	}
 
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }
 
 func auditMarkedWebhookEvent(tc *AuditTestContext, eventType, name string) error {
-	if tc.Logger == nil {
-		return fmt.Errorf("logger is nil (construction may have failed: %w)", tc.LastErr)
+	if tc.Auditor == nil {
+		return fmt.Errorf("auditor is nil (construction may have failed: %w)", tc.LastErr)
 	}
 	m := marker("WH")
 	tc.Markers[name] = m
 	fields := defaultRequiredFields(tc.Taxonomy, eventType)
 	fields["marker"] = m
-	tc.LastErr = tc.Logger.AuditEvent(audit.NewEvent(eventType, fields))
+	tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
 	return nil
 }
 
@@ -768,8 +768,8 @@ func assertWebhookFlushCount(tc *AuditTestContext, minFlush int) error {
 	if tc.WebhookMetrics == nil {
 		return fmt.Errorf("no webhook metrics configured")
 	}
-	if tc.Logger != nil {
-		_ = tc.Logger.Close()
+	if tc.Auditor != nil {
+		_ = tc.Auditor.Close()
 	}
 	if tc.WebhookMetrics.FlushCount() < minFlush {
 		return fmt.Errorf("expected >= %d webhook flushes, got %d", minFlush, tc.WebhookMetrics.FlushCount())
@@ -921,7 +921,7 @@ func pollReceiverCount(label string, countFn func() int, minCount, timeoutSecs i
 	return fmt.Errorf("wanted >= %d %s webhook events, got %d after %ds", minCount, label, countFn(), timeoutSecs)
 }
 
-func createWebhookLoggerSSRF(tc *AuditTestContext, url string, allowPrivate bool) error {
+func createWebhookAuditorSSRF(tc *AuditTestContext, url string, allowPrivate bool) error {
 	cfg := &webhook.Config{
 		URL:                url,
 		AllowInsecureHTTP:  true,
@@ -944,11 +944,11 @@ func createWebhookLoggerSSRF(tc *AuditTestContext, url string, allowPrivate bool
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithOutputs(out),
 	}
-	logger, err := audit.NewLogger(opts...)
+	auditor, err := audit.New(opts...)
 	if err != nil {
-		return fmt.Errorf("create logger: %w", err)
+		return fmt.Errorf("create auditor: %w", err)
 	}
-	tc.Logger = logger
-	tc.AddCleanup(func() { _ = logger.Close() })
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
 	return nil
 }

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -176,18 +176,18 @@ func TestFanOut_AllOutputs(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	// Create logger with all three outputs.
-	logger, err := audit.NewLogger(
+	// Create auditor with all three outputs.
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(syslogOut),
 		audit.WithNamedOutput(webhookOut),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// Send an event.
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"marker":   m,
@@ -200,7 +200,7 @@ func TestFanOut_AllOutputs(t *testing.T) {
 		"webhook should receive event before close")
 
 	// Close flushes remaining outputs.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// Verify file output.
 	data, err := os.ReadFile(filePath)
@@ -236,7 +236,7 @@ func TestFanOut_EventRouting(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut), // all events
 		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{
@@ -247,7 +247,7 @@ func TestFanOut_EventRouting(t *testing.T) {
 
 	// Send a write event (should go to file, NOT webhook).
 	writeMarker := marker(t)
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"marker":   writeMarker,
@@ -256,7 +256,7 @@ func TestFanOut_EventRouting(t *testing.T) {
 
 	// Send a security event (should go to BOTH).
 	secMarker := marker(t)
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
 		"actor_id": "bob",
 		"marker":   secMarker,
@@ -265,7 +265,7 @@ func TestFanOut_EventRouting(t *testing.T) {
 
 	// Wait for webhook delivery before closing.
 	assert.True(t, waitForWebhookEvents(t, 1, 10*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// File should have both events.
 	data, err := os.ReadFile(filePath)
@@ -323,7 +323,7 @@ func TestFanOut_PartialFailure(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(syslogOut),
@@ -332,7 +332,7 @@ func TestFanOut_PartialFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Send event while webhook is failing.
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"marker":   m,
@@ -340,7 +340,7 @@ func TestFanOut_PartialFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Close flushes file and syslog despite webhook failure.
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	data, err := os.ReadFile(filePath)
 	require.NoError(t, err)
@@ -376,7 +376,7 @@ func TestFanOut_MixedFormatters(t *testing.T) {
 		Version: "1.0",
 	}
 
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut),                                   // JSON (default)
 		audit.WithNamedOutput(webhookOut, audit.OutputFormatter(cefFmt)), // CEF
@@ -384,7 +384,7 @@ func TestFanOut_MixedFormatters(t *testing.T) {
 	require.NoError(t, err)
 
 	m := marker(t)
-	err = logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
 		"marker":   m,
@@ -393,7 +393,7 @@ func TestFanOut_MixedFormatters(t *testing.T) {
 
 	// Wait for webhook delivery before closing.
 	assert.True(t, waitForWebhookEvents(t, 1, 10*time.Second))
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
 	// File should have JSON format.
 	data, err := os.ReadFile(filePath)

--- a/validate_fields.go
+++ b/validate_fields.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 )
 
-func (l *Logger) validateFields(eventType string, def *EventDef, fields Fields) error {
+func (a *Auditor) validateFields(eventType string, def *EventDef, fields Fields) error {
 	if err := checkRequiredFields(eventType, def, fields); err != nil {
 		return err
 	}
-	return l.checkUnknownFields(eventType, def, fields)
+	return a.checkUnknownFields(eventType, def, fields)
 }
 
 // checkRequiredFields returns an error listing any missing required fields.
@@ -43,8 +43,8 @@ func checkRequiredFields(eventType string, def *EventDef, fields Fields) error {
 }
 
 // checkUnknownFields validates unknown fields per the validation mode.
-func (l *Logger) checkUnknownFields(eventType string, def *EventDef, fields Fields) error {
-	if l.cfg.ValidationMode == ValidationPermissive {
+func (a *Auditor) checkUnknownFields(eventType string, def *EventDef, fields Fields) error {
+	if a.cfg.ValidationMode == ValidationPermissive {
 		return nil
 	}
 
@@ -61,12 +61,12 @@ func (l *Logger) checkUnknownFields(eventType string, def *EventDef, fields Fiel
 
 	slices.Sort(unknown)
 
-	switch l.cfg.ValidationMode {
+	switch a.cfg.ValidationMode {
 	case ValidationStrict:
 		return newValidationError(ErrUnknownField, "audit: event %q has unknown fields: [%s]",
 			eventType, strings.Join(unknown, ", "))
 	case ValidationWarn:
-		l.logger.Warn("audit: event has unknown fields",
+		a.logger.Warn("audit: event has unknown fields",
 			"event_type", eventType,
 			"unknown_fields", unknown)
 	case ValidationPermissive:

--- a/validation_error_test.go
+++ b/validation_error_test.go
@@ -32,12 +32,12 @@ import (
 func TestAuditEvent_AllValidationErrors_WrapErrValidation(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	tests := []struct { //nolint:govet // fieldalignment: test readability
 		name      string
@@ -63,7 +63,7 @@ func TestAuditEvent_AllValidationErrors_WrapErrValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := logger.AuditEvent(audit.NewEvent(tt.eventType, tt.fields))
+			err := auditor.AuditEvent(audit.NewEvent(tt.eventType, tt.fields))
 			require.Error(t, err)
 			assert.ErrorIs(t, err, audit.ErrValidation, "all validation errors must wrap ErrValidation")
 		})
@@ -77,14 +77,14 @@ func TestAuditEvent_AllValidationErrors_WrapErrValidation(t *testing.T) {
 func TestAuditEvent_UnknownEventType_WrapsErrUnknownEventType(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	err = auditor.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrUnknownEventType)
 	assert.ErrorIs(t, err, audit.ErrValidation)
@@ -96,14 +96,14 @@ func TestAuditEvent_UnknownEventType_WrapsErrUnknownEventType(t *testing.T) {
 func TestAuditEvent_MissingRequired_WrapsErrMissingRequiredField(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
 	assert.ErrorIs(t, err, audit.ErrValidation)
@@ -115,14 +115,14 @@ func TestAuditEvent_MissingRequired_WrapsErrMissingRequiredField(t *testing.T) {
 func TestAuditEvent_UnknownFieldStrict_WrapsErrUnknownField(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "fail",
 		"actor_id": "bob",
 		"bogus":    "val",
@@ -158,14 +158,14 @@ func TestErrClosed_NotErrValidation(t *testing.T) {
 func TestValidationError_ErrorsAs(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	err = auditor.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
 	require.Error(t, err)
 
 	var ve *audit.ValidationError
@@ -180,20 +180,20 @@ func TestValidationError_ErrorsAs(t *testing.T) {
 func TestValidationError_MessageTextUnchanged(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// Unknown event type — exact text check.
-	err = logger.AuditEvent(audit.NewEvent("bogus", audit.Fields{}))
+	err = auditor.AuditEvent(audit.NewEvent("bogus", audit.Fields{}))
 	require.Error(t, err)
 	assert.Equal(t, `audit: unknown event type "bogus"`, err.Error())
 
 	// Missing required — text starts with expected prefix.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `audit: event "auth_failure" missing required fields:`)
 }
@@ -205,14 +205,14 @@ func TestValidationError_MessageTextUnchanged(t *testing.T) {
 func TestValidationError_ConsumerWrapping_PreservesErrorsIs(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	inner := logger.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
+	inner := auditor.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
 	require.Error(t, inner)
 
 	// Consumer wraps the error with additional context.
@@ -228,15 +228,15 @@ func TestValidationError_ConsumerWrapping_PreservesErrorsIs(t *testing.T) {
 func TestAuditEvent_WarnMode_NoSentinelLeak(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationWarn),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "fail",
 		"actor_id": "bob",
 		"bogus":    "val",
@@ -247,15 +247,15 @@ func TestAuditEvent_WarnMode_NoSentinelLeak(t *testing.T) {
 func TestAuditEvent_PermissiveMode_NoSentinelLeak(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "fail",
 		"actor_id": "bob",
 		"bogus":    "val",
@@ -270,15 +270,15 @@ func TestAuditEvent_PermissiveMode_NoSentinelLeak(t *testing.T) {
 func TestAuditEvent_ReservedStandardField_NotErrUnknownField(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
 	// actor_id is a reserved standard field — should not trigger unknown field.
-	err = logger.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":   "fail",
 		"actor_id":  "bob",
 		"source_ip": "10.0.0.1", // reserved standard field
@@ -293,14 +293,14 @@ func TestAuditEvent_ReservedStandardField_NotErrUnknownField(t *testing.T) {
 func TestAuditEvent_EmptyEventType_WrapsErrUnknownEventType(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
+	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = logger.Close() })
+	t.Cleanup(func() { _ = auditor.Close() })
 
-	err = logger.AuditEvent(audit.NewEvent("", audit.Fields{}))
+	err = auditor.AuditEvent(audit.NewEvent("", audit.Fields{}))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrUnknownEventType)
 	assert.ErrorIs(t, err, audit.ErrValidation)

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -16,13 +16,13 @@ package webhook
 
 // The webhook output uses a two-buffer architecture:
 //
-//	Logger drain goroutine
+//	Auditor drain goroutine
 //	  → Output.Write(data) — non-blocking copy+enqueue
 //	    → batch goroutine reads from channel
 //	      → accumulates events, flushes on size/timer/close
 //	      → HTTP POST as NDJSON with retry
 //
-// The internal channel decouples the Logger's drain loop from HTTP
+// The internal channel decouples the Auditor's drain loop from HTTP
 // latency. If the channel is full, events are dropped (non-blocking)
 // and [audit.OutputMetrics.RecordDrop] is recorded.
 
@@ -105,8 +105,8 @@ type Output struct {
 	closed        atomic.Bool
 }
 
-// SetLogger receives the library's diagnostic logger.
-func (w *Output) SetLogger(l *slog.Logger) {
+// SetDiagnosticLogger receives the library's diagnostic logger.
+func (w *Output) SetDiagnosticLogger(l *slog.Logger) {
 	w.logger = l
 }
 

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1330,8 +1330,8 @@ func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
 	}, metrics)
 	require.NoError(t, err)
 
-	// Create a logger with the webhook output and metrics.
-	logger, err := audit.NewLogger(
+	// Create an auditor with the webhook output and metrics.
+	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{})),
@@ -1339,7 +1339,7 @@ func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, logger.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
 
 	// Wait for the batch goroutine to finish delivery and record the
 	// success metric. Polling the metric is the correct synchronisation
@@ -1351,7 +1351,7 @@ func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond,
 		"webhook should report delivery success from batch goroutine")
 
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
 // ---------------------------------------------------------------------------

--- a/with_diagnostic_logger_test.go
+++ b/with_diagnostic_logger_test.go
@@ -25,39 +25,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithLogger_CustomLogger_ReceivesMessages(t *testing.T) {
+func TestWithDiagnosticLogger_CustomLogger_ReceivesMessages(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	customLogger := slog.New(slog.NewTextHandler(&buf, nil))
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
-		audit.WithLogger(customLogger),
+	auditor, err := audit.New(
+		audit.WithDiagnosticLogger(customLogger),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
-	// The "logger created" and "shutdown" messages should appear in buf.
-	assert.Contains(t, buf.String(), "logger created")
+	// The "auditor created" and "shutdown" messages should appear in buf.
+	assert.Contains(t, buf.String(), "auditor created")
 	assert.Contains(t, buf.String(), "shutdown")
 }
 
-func TestWithLogger_NilLogger_UsesDefault(t *testing.T) {
+func TestWithDiagnosticLogger_NilLogger_UsesDefault(t *testing.T) {
 	t.Parallel()
 	out := testhelper.NewMockOutput("test")
-	// nil logger should not panic — falls back to slog.Default().
-	logger, err := audit.NewLogger(
-		audit.WithLogger(nil),
+	// nil auditor should not panic — falls back to slog.Default().
+	auditor, err := audit.New(
+		audit.WithDiagnosticLogger(nil),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 }
 
-func TestWithLogger_DiscardLogger_SilencesOutput(t *testing.T) {
+func TestWithDiagnosticLogger_DiscardLogger_SilencesOutput(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	discardLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
@@ -65,13 +65,13 @@ func TestWithLogger_DiscardLogger_SilencesOutput(t *testing.T) {
 	}))
 
 	out := testhelper.NewMockOutput("test")
-	logger, err := audit.NewLogger(
-		audit.WithLogger(discardLogger),
+	auditor, err := audit.New(
+		audit.WithDiagnosticLogger(discardLogger),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
-	require.NoError(t, logger.Close())
+	require.NoError(t, auditor.Close())
 
-	assert.Empty(t, buf.String(), "discard logger should produce no output")
+	assert.Empty(t, buf.String(), "discard auditor should produce no output")
 }


### PR DESCRIPTION
## Summary

Renames the primary type from `audit.Logger` to `audit.Auditor` to eliminate confusion with application logging libraries (slog, zap, zerolog). Combined with `drain_timeout` → `shutdown_timeout` rename.

**Key renames:**
- `audit.Logger` → `audit.Auditor`, `audit.NewLogger()` → `audit.New()`
- `outputconfig.NewLogger()` → `outputconfig.New()`
- `WithLogger()` → `WithDiagnosticLogger()`, `LoggerReceiver` → `DiagnosticLoggerReceiver`
- `Config.DrainTimeout` → `Config.ShutdownTimeout`, YAML `drain_timeout` → `shutdown_timeout`
- YAML `logger:` section → `auditor:` section
- Migration errors for old YAML keys with "renamed to" guidance
- All variables, receivers, docs, examples, and BDD tests updated

170 files changed, purely mechanical rename with no behavioral changes.

## Test plan

- [x] `make check` passes (full quality gate)
- [x] `go build ./...` clean
- [x] All unit tests pass across all modules
- [x] `make test-examples` passes
- [x] `make lint` clean

Closes #457
Closes #456