### PR TITLE
chore: review and update audittest package (#458)

### DIFF
--- a/audittest/audittest.go
+++ b/audittest/audittest.go
@@ -15,6 +15,8 @@
 package audittest
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/axonops/audit"
@@ -26,6 +28,7 @@ type Option func(*config)
 type config struct {
 	extraOpts []audit.Option
 	async     bool // opt out of default synchronous delivery
+	verbose   bool // re-enable diagnostic logs (silenced by default)
 }
 
 // WithConfig applies a [audit.Config] struct to the test auditor.
@@ -64,6 +67,22 @@ func WithAsync() Option {
 	return func(c *config) { c.async = true }
 }
 
+// WithAuditOption passes an arbitrary [audit.Option] through to the
+// underlying [audit.New] call. Use for options not covered by the
+// audittest.With* helpers (e.g., WithNamedOutput, WithFormatter,
+// WithAppName, WithHost).
+func WithAuditOption(opt audit.Option) Option {
+	return func(c *config) { c.extraOpts = append(c.extraOpts, opt) }
+}
+
+// WithVerbose re-enables diagnostic log output from the auditor. By
+// default, test auditors silence diagnostic logs (lifecycle messages,
+// shutdown notices) to keep test output clean. Use this option when
+// debugging auditor behaviour in tests.
+func WithVerbose() Option {
+	return func(c *config) { c.verbose = true }
+}
+
 // New creates a test auditor with an in-memory [Recorder]
 // and [MetricsRecorder]. The taxonomy is parsed from YAML bytes.
 //
@@ -91,7 +110,7 @@ func New(tb testing.TB, taxonomyYAML []byte, opts ...Option) (*audit.Auditor, *R
 // are available in the Recorder immediately without calling Close.
 func NewQuick(tb testing.TB, eventTypes ...string) (*audit.Auditor, *Recorder, *MetricsRecorder) {
 	tb.Helper()
-	return newTestLogger(tb, QuickTaxonomy(eventTypes...), WithValidationMode(audit.ValidationPermissive), WithSync())
+	return newTestLogger(tb, QuickTaxonomy(eventTypes...), WithValidationMode(audit.ValidationPermissive))
 }
 
 // QuickTaxonomy builds a minimal [*audit.Taxonomy] where every listed
@@ -129,6 +148,11 @@ func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.A
 		audit.WithTaxonomy(tax),
 		audit.WithOutputs(rec),
 		audit.WithMetrics(met),
+	}
+	if !c.verbose {
+		auditOpts = append(auditOpts, audit.WithDiagnosticLogger(
+			slog.New(slog.NewTextHandler(io.Discard, nil)),
+		))
 	}
 	if !c.async {
 		auditOpts = append(auditOpts, audit.WithSynchronousDelivery())

--- a/audittest/audittest_test.go
+++ b/audittest/audittest_test.go
@@ -16,7 +16,6 @@ package audittest_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -133,8 +132,8 @@ func TestNew_TableDriven_WithReset(t *testing.T) {
 			events.Reset()
 			err := auditor.AuditEvent(audit.NewEvent(tc.eventType, tc.fields))
 			require.NoError(t, err)
-			// Wait for drain to process — auditor stays open across sub-tests.
-			require.Eventually(t, func() bool { return events.Count() == 1 }, 2*time.Second, 10*time.Millisecond)
+			// Synchronous delivery — events available immediately.
+			require.Equal(t, 1, events.Count())
 			assert.Equal(t, tc.eventType, events.Events()[0].EventType)
 		})
 	}
@@ -147,4 +146,57 @@ func TestQuickTaxonomy(t *testing.T) {
 	assert.Contains(t, tax.Events, "user_create")
 	assert.Contains(t, tax.Events, "user_delete")
 	assert.Contains(t, tax.Categories, "test")
+}
+
+func TestNew_WithConfig(t *testing.T) {
+	t.Parallel()
+	auditor, events, _ := audittest.New(t, testTaxonomyYAML,
+		audittest.WithConfig(audit.Config{QueueSize: 50}),
+	)
+
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, 1, events.Count())
+	assert.Equal(t, "user_create", events.Events()[0].EventType)
+}
+
+func TestNew_WithAsync(t *testing.T) {
+	t.Parallel()
+	auditor, events, _ := audittest.New(t, testTaxonomyYAML,
+		audittest.WithAsync(),
+	)
+
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	}))
+	require.NoError(t, err)
+
+	// Async delivery — must Close before assertions.
+	require.NoError(t, auditor.Close())
+
+	require.Equal(t, 1, events.Count())
+	assert.Equal(t, "user_create", events.Events()[0].EventType)
+}
+
+func TestNew_WithAuditOption(t *testing.T) {
+	t.Parallel()
+	auditor, events, _ := audittest.New(t, testTaxonomyYAML,
+		audittest.WithAuditOption(audit.WithAppName("test-app")),
+	)
+
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, 1, events.Count())
+	evt := events.Events()[0]
+	assert.Equal(t, "user_create", evt.EventType)
+	assert.Equal(t, "test-app", evt.StringField("app_name"))
 }

--- a/audittest/example_test.go
+++ b/audittest/example_test.go
@@ -44,7 +44,6 @@ func ExampleNew() {
 		"outcome":  "success",
 		"actor_id": "alice",
 	}))
-	_ = auditor.Close()
 
 	fmt.Println("count:", events.Count())
 	fmt.Println("type:", events.Events()[0].EventType)
@@ -63,7 +62,6 @@ func ExampleNewQuick() {
 	_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"any_field": "any_value",
 	}))
-	_ = auditor.Close()
 
 	fmt.Println("count:", events.Count())
 	fmt.Println("type:", events.Events()[0].EventType)
@@ -80,7 +78,6 @@ func ExampleRecorder_FindByType() {
 	_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"actor_id": "alice"}))
 	_ = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{"actor_id": "bob"}))
 	_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"actor_id": "charlie"}))
-	_ = auditor.Close()
 
 	creates := events.FindByType("user_create")
 	fmt.Println("user_create count:", len(creates))

--- a/audittest/metrics_interface_test.go
+++ b/audittest/metrics_interface_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audittest_test
+
+import (
+	"github.com/axonops/audit/audittest"
+	"github.com/axonops/audit/file"
+	"github.com/axonops/audit/syslog"
+)
+
+// Compile-time assertions: MetricsRecorder satisfies output extension interfaces.
+var (
+	_ file.Metrics   = (*audittest.MetricsRecorder)(nil)
+	_ syslog.Metrics = (*audittest.MetricsRecorder)(nil)
+)

--- a/audittest/metrics_test.go
+++ b/audittest/metrics_test.go
@@ -15,6 +15,7 @@
 package audittest_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,4 +110,71 @@ func TestMetricsRecorder_Reset(t *testing.T) {
 	// Per-output extension zeroed.
 	assert.Equal(t, 0, m.FileRotations("/path"))
 	assert.Equal(t, 0, m.SyslogReconnects("addr", true))
+}
+
+func TestMetricsRecorder_SubmittedCount(t *testing.T) {
+	t.Parallel()
+	m := audittest.NewMetricsRecorder()
+
+	assert.Equal(t, 0, m.SubmittedCount())
+	m.RecordSubmitted()
+	m.RecordSubmitted()
+	m.RecordSubmitted()
+	assert.Equal(t, 3, m.SubmittedCount())
+}
+
+func TestMetricsRecorder_Reset_AllFields(t *testing.T) {
+	t.Parallel()
+	m := audittest.NewMetricsRecorder()
+
+	// Populate all 10 metric fields.
+	m.RecordSubmitted()
+	m.RecordEvent("out", "success")
+	m.RecordOutputError("out")
+	m.RecordOutputFiltered("out")
+	m.RecordValidationError("evt")
+	m.RecordFiltered("evt")
+	m.RecordSerializationError("evt")
+	m.RecordBufferDrop()
+	m.RecordFileRotation("/path")
+	m.RecordSyslogReconnect("addr", true)
+
+	m.Reset()
+
+	assert.Equal(t, 0, m.SubmittedCount())
+	assert.Equal(t, 0, m.EventDeliveries("out", "success"))
+	assert.Equal(t, 0, m.OutputErrors("out"))
+	assert.Equal(t, 0, m.OutputFiltered("out"))
+	assert.Equal(t, 0, m.ValidationErrors("evt"))
+	assert.Equal(t, 0, m.FilteredCount("evt"))
+	assert.Equal(t, 0, m.SerializationErrors("evt"))
+	assert.Equal(t, 0, m.BufferDrops())
+	assert.Equal(t, 0, m.FileRotations("/path"))
+	assert.Equal(t, 0, m.SyslogReconnects("addr", true))
+}
+
+func TestMetricsRecorder_Concurrent(t *testing.T) {
+	t.Parallel()
+	m := audittest.NewMetricsRecorder()
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.RecordSubmitted()
+			m.RecordEvent("out", "success")
+			m.RecordOutputError("out")
+			m.RecordBufferDrop()
+			_ = m.SubmittedCount()
+			_ = m.EventDeliveries("out", "success")
+			_ = m.BufferDrops()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 100, m.SubmittedCount())
+	assert.Equal(t, 100, m.EventDeliveries("out", "success"))
+	assert.Equal(t, 100, m.OutputErrors("out"))
+	assert.Equal(t, 100, m.BufferDrops())
 }

--- a/audittest/output_metrics.go
+++ b/audittest/output_metrics.go
@@ -1,0 +1,101 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audittest
+
+import (
+	"sync"
+	"time"
+
+	"github.com/axonops/audit"
+)
+
+var _ audit.OutputMetrics = (*OutputMetricsRecorder)(nil)
+
+// OutputMetricsRecorder implements [audit.OutputMetrics] and captures
+// all per-output metric calls for assertion. Use with
+// [audit.OutputMetricsReceiver.SetOutputMetrics] when testing custom
+// outputs. It is safe for concurrent use.
+type OutputMetricsRecorder struct { //nolint:govet // fieldalignment: readability preferred
+	mu       sync.Mutex
+	drops    int
+	flushes  int
+	errors   int
+	retries  int
+	flushDur []time.Duration
+}
+
+// NewOutputMetricsRecorder creates an OutputMetricsRecorder.
+func NewOutputMetricsRecorder() *OutputMetricsRecorder {
+	return &OutputMetricsRecorder{}
+}
+
+// RecordDrop implements [audit.OutputMetrics].
+func (m *OutputMetricsRecorder) RecordDrop() { m.mu.Lock(); m.drops++; m.mu.Unlock() }
+
+// RecordFlush implements [audit.OutputMetrics].
+func (m *OutputMetricsRecorder) RecordFlush(_ int, d time.Duration) {
+	m.mu.Lock()
+	m.flushes++
+	m.flushDur = append(m.flushDur, d)
+	m.mu.Unlock()
+}
+
+// RecordError implements [audit.OutputMetrics].
+func (m *OutputMetricsRecorder) RecordError() { m.mu.Lock(); m.errors++; m.mu.Unlock() }
+
+// RecordRetry implements [audit.OutputMetrics].
+func (m *OutputMetricsRecorder) RecordRetry(_ int) { m.mu.Lock(); m.retries++; m.mu.Unlock() }
+
+// RecordQueueDepth implements [audit.OutputMetrics].
+func (m *OutputMetricsRecorder) RecordQueueDepth(_, _ int) {}
+
+// DropCount returns the number of recorded drops.
+func (m *OutputMetricsRecorder) DropCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.drops
+}
+
+// FlushCount returns the number of recorded flushes.
+func (m *OutputMetricsRecorder) FlushCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.flushes
+}
+
+// ErrorCount returns the number of recorded errors.
+func (m *OutputMetricsRecorder) ErrorCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.errors
+}
+
+// RetryCount returns the number of recorded retries.
+func (m *OutputMetricsRecorder) RetryCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.retries
+}
+
+// Reset clears all recorded output metrics.
+func (m *OutputMetricsRecorder) Reset() {
+	m.mu.Lock()
+	m.drops = 0
+	m.flushes = 0
+	m.errors = 0
+	m.retries = 0
+	m.flushDur = nil
+	m.mu.Unlock()
+}

--- a/audittest/output_metrics_test.go
+++ b/audittest/output_metrics_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audittest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/audittest"
+)
+
+func TestOutputMetricsRecorder_Implements(t *testing.T) {
+	t.Parallel()
+	var _ audit.OutputMetrics = (*audittest.OutputMetricsRecorder)(nil)
+}
+
+func TestOutputMetricsRecorder_AllMethods(t *testing.T) {
+	t.Parallel()
+	m := audittest.NewOutputMetricsRecorder()
+
+	m.RecordDrop()
+	m.RecordDrop()
+	m.RecordFlush(10, 5*time.Millisecond)
+	m.RecordError()
+	m.RecordRetry(1)
+	m.RecordRetry(2)
+	m.RecordQueueDepth(5, 100) // no-op, should not panic
+
+	assert.Equal(t, 2, m.DropCount())
+	assert.Equal(t, 1, m.FlushCount())
+	assert.Equal(t, 1, m.ErrorCount())
+	assert.Equal(t, 2, m.RetryCount())
+}
+
+func TestOutputMetricsRecorder_Reset(t *testing.T) {
+	t.Parallel()
+	m := audittest.NewOutputMetricsRecorder()
+
+	m.RecordDrop()
+	m.RecordFlush(5, time.Millisecond)
+	m.RecordError()
+	m.RecordRetry(1)
+
+	m.Reset()
+
+	assert.Equal(t, 0, m.DropCount())
+	assert.Equal(t, 0, m.FlushCount())
+	assert.Equal(t, 0, m.ErrorCount())
+	assert.Equal(t, 0, m.RetryCount())
+}

--- a/audittest/recorder.go
+++ b/audittest/recorder.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/axonops/audit"
@@ -88,6 +89,13 @@ func (e RecordedEvent) FloatField(key string) float64 { //nolint:gocritic // val
 	return v
 }
 
+// BoolField returns the value of the named field as a bool.
+// Returns false if the key is missing or the value is not a bool.
+func (e RecordedEvent) BoolField(key string) bool { //nolint:gocritic // value receiver for consistency
+	v, _ := e.Fields[key].(bool)
+	return v
+}
+
 // UserFields returns a copy of the event's fields with framework
 // fields removed (event_category, app_name, host, timezone, pid,
 // duration_ms, _hmac, _hmac_v). This is useful for count assertions
@@ -123,16 +131,28 @@ func (e RecordedEvent) GoString() string { //nolint:gocritic // value receiver r
 // Recorder implements [audit.Output] and captures events in memory
 // for assertion. It is safe for concurrent use by the drain goroutine
 // (writing) and the test goroutine (reading).
+//
+// The Recorder only parses JSON-formatted events. Events formatted
+// with CEFFormatter will have ParseErr set and structured fields will
+// be zero-valued.
 type Recorder struct {
+	name   string
 	events []RecordedEvent
 	mu     sync.Mutex
 }
 
-// NewRecorder creates a Recorder. Use it with [audit.WithOutputs] or
-// [audit.WithNamedOutput] when composing an auditor manually. For the
-// common case, use [New] or [NewQuick] instead.
+// NewRecorder creates a Recorder with the default name "recorder".
+// Use it with [audit.WithOutputs] or [audit.WithNamedOutput] when
+// composing an auditor manually. For the common case, use [New] or
+// [NewQuick] instead.
 func NewRecorder() *Recorder {
-	return &Recorder{}
+	return &Recorder{name: "recorder"}
+}
+
+// NewNamedRecorder creates a Recorder with a custom name. The name is
+// returned by [Recorder.Name] and appears in metrics keys.
+func NewNamedRecorder(name string) *Recorder {
+	return &Recorder{name: name}
 }
 
 // Write implements [audit.Output]. It parses the serialised JSON event
@@ -146,14 +166,16 @@ func (r *Recorder) Write(data []byte) error {
 }
 
 // Name implements [audit.Output].
-func (r *Recorder) Name() string { return "recorder" }
+func (r *Recorder) Name() string { return r.name }
 
 // Close implements [audit.Output]. It is a no-op — the Recorder does
 // not own any resources.
 func (r *Recorder) Close() error { return nil }
 
 // Events returns a snapshot of all recorded events in drain order.
-// The returned slice is a copy; later Reset calls do not affect it.
+// The returned slice is a shallow copy of the event list. Later Reset
+// calls do not affect the slice, but the Fields maps within events
+// share references with the Recorder's internal state.
 // Call after [audit.Auditor.Close] to ensure all events have been processed.
 func (r *Recorder) Events() []RecordedEvent {
 	r.mu.Lock()
@@ -183,12 +205,105 @@ func (r *Recorder) Count() int {
 	return len(r.events)
 }
 
+// Last returns the most recently recorded event, or false if the
+// Recorder is empty.
+func (r *Recorder) Last() (RecordedEvent, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.events) == 0 {
+		return RecordedEvent{}, false
+	}
+	return r.events[len(r.events)-1], true
+}
+
+// First returns the earliest recorded event, or false if the Recorder
+// is empty.
+func (r *Recorder) First() (RecordedEvent, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.events) == 0 {
+		return RecordedEvent{}, false
+	}
+	return r.events[0], true
+}
+
+// FindByField returns all recorded events where the given field
+// matches val (compared with [reflect.DeepEqual]).
+func (r *Recorder) FindByField(key string, val any) []RecordedEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var result []RecordedEvent
+	for _, e := range r.events {
+		if reflect.DeepEqual(e.Fields[key], val) {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// RequireEvent asserts that exactly one event of the given type was
+// recorded and returns it. It calls tb.Fatal if the count is not 1.
+func (r *Recorder) RequireEvent(tb testing.TB, eventType string) RecordedEvent {
+	tb.Helper()
+	found := r.FindByType(eventType)
+	if len(found) != 1 {
+		tb.Fatalf("audittest: expected 1 %q event, got %d\n%s", eventType, len(found), r.GoString())
+	}
+	return found[0]
+}
+
+// RequireEvents asserts that exactly n events were recorded and
+// returns them. It calls tb.Fatal if the count does not match.
+func (r *Recorder) RequireEvents(tb testing.TB, n int) []RecordedEvent {
+	tb.Helper()
+	events := r.Events()
+	if len(events) != n {
+		tb.Fatalf("audittest: expected %d events, got %d\n%s", n, len(events), r.GoString())
+	}
+	return events
+}
+
+// RequireEmpty asserts that no events have been recorded. It calls
+// tb.Fatal if any events are present.
+func (r *Recorder) RequireEmpty(tb testing.TB) {
+	tb.Helper()
+	if c := r.Count(); c != 0 {
+		tb.Fatalf("audittest: expected 0 events, got %d\n%s", c, r.GoString())
+	}
+}
+
+// AssertContains asserts that at least one event of the given type
+// was recorded with fields matching every key-value pair in fields.
+// It calls tb.Error (not Fatal) on failure, allowing further
+// assertions to run.
+func (r *Recorder) AssertContains(tb testing.TB, eventType string, fields audit.Fields) {
+	tb.Helper()
+	found := r.FindByType(eventType)
+	if len(found) == 0 {
+		tb.Errorf("audittest: no %q events recorded\n%s", eventType, r.GoString())
+		return
+	}
+	for _, evt := range found {
+		match := true
+		for k, v := range fields {
+			if !evt.HasField(k, v) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return
+		}
+	}
+	tb.Errorf("audittest: no %q event matches fields %v\n%s", eventType, fields, r.GoString())
+}
+
 // Reset clears all recorded events. The underlying auditor remains
 // open and functional. Use Reset between sub-tests to isolate
 // assertions without creating a new auditor.
 func (r *Recorder) Reset() {
 	r.mu.Lock()
-	r.events = r.events[:0]
+	r.events = nil
 	r.mu.Unlock()
 }
 

--- a/audittest/recorder_test.go
+++ b/audittest/recorder_test.go
@@ -206,3 +206,165 @@ func TestRecordedEvent_FloatField(t *testing.T) {
 	assert.Equal(t, float64(0), evt.FloatField("name"), "non-float returns 0")
 	assert.Equal(t, float64(0), evt.FloatField("missing"), "missing returns 0")
 }
+
+func TestRecordedEvent_UserFields(t *testing.T) {
+	t.Parallel()
+	evt := audittest.RecordedEvent{
+		Fields: map[string]any{
+			"actor_id":       "alice",
+			"outcome":        "success",
+			"event_category": "write",
+			"app_name":       "my-app",
+			"host":           "localhost",
+			"timezone":       "UTC",
+			"pid":            float64(1234),
+			"duration_ms":    float64(10),
+			"_hmac":          "abc",
+			"_hmac_v":        float64(1),
+		},
+	}
+	userFields := evt.UserFields()
+	assert.Equal(t, 2, len(userFields), "only user fields remain")
+	assert.Equal(t, "alice", userFields["actor_id"])
+	assert.Equal(t, "success", userFields["outcome"])
+	// Framework fields excluded.
+	assert.NotContains(t, userFields, "event_category")
+	assert.NotContains(t, userFields, "app_name")
+	assert.NotContains(t, userFields, "host")
+	assert.NotContains(t, userFields, "timezone")
+	assert.NotContains(t, userFields, "pid")
+	assert.NotContains(t, userFields, "duration_ms")
+	assert.NotContains(t, userFields, "_hmac")
+	assert.NotContains(t, userFields, "_hmac_v")
+}
+
+func TestRecordedEvent_BoolField(t *testing.T) {
+	t.Parallel()
+	evt := audittest.RecordedEvent{
+		Fields: map[string]any{
+			"active":  true,
+			"deleted": false,
+			"name":    "alice",
+		},
+	}
+	assert.True(t, evt.BoolField("active"))
+	assert.False(t, evt.BoolField("deleted"))
+	assert.False(t, evt.BoolField("name"), "non-bool returns false")
+	assert.False(t, evt.BoolField("missing"), "missing returns false")
+}
+
+func TestRecorder_Write_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	err := rec.Write([]byte("this is not json\n"))
+	require.NoError(t, err)
+
+	events := rec.Events()
+	require.Len(t, events, 1)
+	assert.Error(t, events[0].ParseErr, "ParseErr set for invalid JSON")
+	assert.Empty(t, events[0].EventType, "EventType zero-valued")
+	assert.Equal(t, 0, events[0].Severity, "Severity zero-valued")
+	assert.True(t, events[0].Timestamp.IsZero(), "Timestamp zero-valued")
+}
+
+func TestRecorder_Timestamp_RFC3339(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	_ = rec.Write([]byte(`{"event_type":"test","timestamp":"2026-03-15T10:30:00Z"}` + "\n"))
+
+	events := rec.Events()
+	require.Len(t, events, 1)
+	assert.False(t, events[0].Timestamp.IsZero(), "timestamp parsed from RFC3339")
+	assert.Equal(t, 2026, events[0].Timestamp.Year())
+	assert.Equal(t, 3, int(events[0].Timestamp.Month()))
+	assert.Equal(t, 15, events[0].Timestamp.Day())
+}
+
+func TestRecorder_Timestamp_Float64(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	// 1710000000000 ms = some date in 2024
+	_ = rec.Write([]byte(`{"event_type":"test","timestamp":1710000000000}` + "\n"))
+
+	events := rec.Events()
+	require.Len(t, events, 1)
+	assert.False(t, events[0].Timestamp.IsZero(), "timestamp parsed from float64 millis")
+}
+
+func TestRecorder_Last_Empty(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	_, ok := rec.Last()
+	assert.False(t, ok, "Last on empty recorder returns false")
+}
+
+func TestRecorder_First(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	_ = rec.Write([]byte(`{"event_type":"first","severity":1}` + "\n"))
+	_ = rec.Write([]byte(`{"event_type":"second","severity":2}` + "\n"))
+
+	evt, ok := rec.First()
+	assert.True(t, ok)
+	assert.Equal(t, "first", evt.EventType)
+
+	last, ok := rec.Last()
+	assert.True(t, ok)
+	assert.Equal(t, "second", last.EventType)
+}
+
+func TestRecorder_FindByField(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	_ = rec.Write([]byte(`{"event_type":"test","severity":5,"actor_id":"alice"}` + "\n"))
+	_ = rec.Write([]byte(`{"event_type":"test","severity":5,"actor_id":"bob"}` + "\n"))
+	_ = rec.Write([]byte(`{"event_type":"test","severity":5,"actor_id":"alice"}` + "\n"))
+
+	found := rec.FindByField("actor_id", "alice")
+	assert.Len(t, found, 2)
+
+	found = rec.FindByField("actor_id", "bob")
+	assert.Len(t, found, 1)
+
+	found = rec.FindByField("actor_id", "nonexistent")
+	assert.Empty(t, found)
+}
+
+func TestRecorder_RequireEvent(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	_ = rec.Write([]byte(`{"event_type":"user_create","severity":5}` + "\n"))
+
+	evt := rec.RequireEvent(t, "user_create")
+	assert.Equal(t, "user_create", evt.EventType)
+}
+
+func TestRecorder_RequireEmpty(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	rec.RequireEmpty(t) // should not fail
+}
+
+func TestRecorder_AssertContains(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewRecorder()
+	_ = rec.Write([]byte(`{"event_type":"user_create","severity":5,"actor_id":"alice","outcome":"success"}` + "\n"))
+	_ = rec.Write([]byte(`{"event_type":"user_create","severity":5,"actor_id":"bob","outcome":"failure"}` + "\n"))
+
+	// Match on alice's event.
+	rec.AssertContains(t, "user_create", audit.Fields{
+		"actor_id": "alice",
+		"outcome":  "success",
+	})
+
+	// Match on bob's event.
+	rec.AssertContains(t, "user_create", audit.Fields{
+		"actor_id": "bob",
+	})
+}
+
+func TestRecorder_NewNamedRecorder(t *testing.T) {
+	t.Parallel()
+	rec := audittest.NewNamedRecorder("custom-output")
+	assert.Equal(t, "custom-output", rec.Name())
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,16 +8,19 @@
 - [Dependency Injection](#dependency-injection)
 - [Two Constructor Patterns](#two-constructor-patterns)
 - [Recorded Event API](#recorded-event-api)
+- [Assertion Helpers](#assertion-helpers)
 - [Metrics Assertions](#metrics-assertions)
+- [OutputMetricsRecorder](#outputmetricsrecorder)
 - [Table-Driven Tests](#table-driven-tests)
+- [Common Gotchas](#common-gotchas)
 
-## 🔍 What Is audittest?
+## What Is audittest?
 
 The `audittest` package provides an in-memory audit logger for your
 unit and integration tests. It captures events and metrics in memory for
-assertion, with the same validation and async pipeline as production.
+assertion, with the same validation and pipeline as production.
 
-## ❓ Why a Test Package?
+## Why a Test Package?
 
 Testing audit logging without `audittest` requires ~25 lines of
 boilerplate per test: implementing `audit.Output`, creating a full
@@ -30,7 +33,7 @@ asserting on `map[string]interface{}`.
 auditor, events, metrics := audittest.New(t, taxonomyYAML)
 ```
 
-## 🚀 Quick Start
+## Quick Start
 
 ```go
 func TestCreateUser(t *testing.T) {
@@ -57,14 +60,20 @@ returns. No `Close()` call is needed before assertions.
 after the test completes. Use `WithAsync()` to opt into asynchronous
 delivery for tests that exercise drain timeout or buffer backpressure.
 
-## 💉 Dependency Injection
+### Silent Diagnostics (Default)
+
+Test auditors silence diagnostic logs (lifecycle messages, shutdown
+notices) by default. Use `WithVerbose()` to re-enable diagnostic
+output when debugging auditor behaviour in tests.
+
+## Dependency Injection
 
 The Quick Start above uses `NewUserService(auditor)` — this is the
 correct pattern. Your service takes a `*audit.Auditor` as a constructor
 parameter, not from a package-level global:
 
 ```go
-// ✅ Correct: inject the auditor
+// Correct: inject the auditor
 type UserService struct {
     audit *audit.Auditor
 }
@@ -75,7 +84,7 @@ func NewUserService(auditor *audit.Auditor) *UserService {
 ```
 
 ```go
-// ❌ Wrong: package-level global logger
+// Wrong: package-level global logger
 var auditor *audit.Auditor // data races in parallel tests
 
 type UserService struct{}
@@ -92,7 +101,7 @@ Why this matters for testing:
 Structure your code with constructor injection from the start — it is
 the only pattern that makes audit testing reliable.
 
-## 🔧 Two Constructor Patterns
+## Two Constructor Patterns
 
 ### New — full integration test
 
@@ -112,14 +121,32 @@ enforcement:
 auditor, events, _ := audittest.NewQuick(t, "user_create", "auth_failure")
 ```
 
-## 📋 Recorded Event API
+### WithAuditOption — pass-through for advanced options
+
+For options not covered by the `audittest.With*` helpers, use
+`WithAuditOption` to pass an arbitrary `audit.Option` through:
+
+```go
+auditor, events, _ := audittest.New(t, taxonomyYAML,
+    audittest.WithAuditOption(audit.WithAppName("my-service")),
+    audittest.WithAuditOption(audit.WithHost("test-host")),
+)
+```
+
+## Recorded Event API
 
 | Method | Returns | Purpose |
 |--------|---------|---------|
 | `evt.EventType` | `string` | Event type name |
 | `evt.Severity` | `int` | Resolved severity (0-10) |
+| `evt.Timestamp` | `time.Time` | When the event was processed |
 | `evt.Fields` | `map[string]any` | Non-framework field values |
 | `evt.Field(key)` | `any` | Single field value (nil if absent) |
+| `evt.StringField(key)` | `string` | String value (empty if missing or wrong type) |
+| `evt.IntField(key)` | `int` | Int value with float64 coercion (0 if missing) |
+| `evt.FloatField(key)` | `float64` | Float value (0 if missing or wrong type) |
+| `evt.BoolField(key)` | `bool` | Bool value (false if missing or wrong type) |
+| `evt.UserFields()` | `map[string]any` | Fields with framework fields removed |
 | `evt.HasField(key, val)` | `bool` | Deep-equal check |
 | `evt.RawJSON` | `[]byte` | Original serialised bytes |
 | `evt.ParseErr` | `error` | Non-nil if JSON deserialisation failed; assert nil before inspecting other fields |
@@ -128,31 +155,115 @@ auditor, events, _ := audittest.NewQuick(t, "user_create", "auth_failure")
 > other fields. A non-nil `ParseErr` means the formatter produced
 > invalid JSON; other fields are zero-valued in that case.
 
-## 📊 Metrics Assertions
+## Assertion Helpers
+
+The `Recorder` provides assertion helpers that accept `testing.TB`,
+producing clear failure messages including a dump of all recorded events:
 
 ```go
-metrics.EventDeliveries("recorder", "success") // successful deliveries
-metrics.ValidationErrors("user_create")        // validation rejections
-metrics.BufferDrops()                          // buffer-full drops
-metrics.OutputErrors("recorder")               // output write errors
+// Require exactly 1 event of the given type (Fatal on mismatch).
+evt := events.RequireEvent(t, "user_create")
+
+// Require exactly N events total (Fatal on mismatch).
+all := events.RequireEvents(t, 3)
+
+// Require no events recorded (Fatal if any).
+events.RequireEmpty(t)
+
+// Assert that at least one event of the type has matching fields (Error on failure).
+events.AssertContains(t, "user_create", audit.Fields{
+    "actor_id": "alice",
+    "outcome":  "success",
+})
 ```
 
-## 📊 Table-Driven Tests
+### Recorder utility methods
 
-Use `events.Reset()` to clear captured events between sub-tests
-without creating a new auditor:
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `events.First()` | `(RecordedEvent, bool)` | Earliest event, or false if empty |
+| `events.Last()` | `(RecordedEvent, bool)` | Most recent event, or false if empty |
+| `events.FindByType(t)` | `[]RecordedEvent` | All events matching the type |
+| `events.FindByField(k, v)` | `[]RecordedEvent` | All events where field k == v |
+| `events.Count()` | `int` | Total recorded events |
+| `events.Reset()` | — | Clear all events |
+
+## Metrics Assertions
+
+The `MetricsRecorder` captures all metric calls:
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `metrics.SubmittedCount()` | `int` | Events submitted via AuditEvent |
+| `metrics.EventDeliveries(output, status)` | `int` | Delivery attempts per output/status |
+| `metrics.ValidationErrors(eventType)` | `int` | Validation rejections |
+| `metrics.FilteredCount(eventType)` | `int` | Globally filtered events |
+| `metrics.BufferDrops()` | `int` | Buffer-full drops |
+| `metrics.OutputErrors(output)` | `int` | Output write errors |
+| `metrics.OutputFiltered(output)` | `int` | Per-output route-filtered events |
+| `metrics.SerializationErrors(eventType)` | `int` | Serialisation errors |
+| `metrics.FileRotations(path)` | `int` | File rotation count |
+| `metrics.SyslogReconnects(addr, success)` | `int` | Syslog reconnection count |
+
+## OutputMetricsRecorder
+
+For testing custom outputs that use `audit.OutputMetrics`, use
+`OutputMetricsRecorder`:
+
+```go
+om := audittest.NewOutputMetricsRecorder()
+// Pass om to your output via SetOutputMetrics.
+
+om.DropCount()   // recorded drops
+om.FlushCount()  // recorded flushes
+om.ErrorCount()  // recorded errors
+om.RetryCount()  // recorded retries
+om.Reset()       // clear all counters
+```
+
+## Table-Driven Tests
+
+Use `events.Reset()` and `metrics.Reset()` to clear captured state
+between sub-tests without creating a new auditor:
 
 ```go
 for _, tc := range tests {
     t.Run(tc.name, func(t *testing.T) {
         events.Reset()
+        metrics.Reset()
         svc.Do(tc.action)
-        // assert on events for this sub-test only
+        // assert on events and metrics for this sub-test only
     })
 }
 ```
 
-## 📚 Further Reading
+## Common Gotchas
+
+### JSON float64 coercion
+
+JSON round-tripping stores all numbers as `float64`. When asserting
+on numeric fields, use `evt.IntField("count")` instead of comparing
+`evt.Field("count")` to an `int` literal — the latter will fail
+because the underlying value is `float64(42)`, not `int(42)`.
+
+### Close not needed with synchronous delivery
+
+Both `New` and `NewQuick` default to synchronous delivery.
+Events are available immediately after `AuditEvent()` returns. You
+do NOT need to call `auditor.Close()` before assertions. The
+`t.Cleanup(auditor.Close)` registered by `New` handles resource
+cleanup automatically.
+
+Only call `Close()` before assertions when using `WithAsync()`.
+
+### CEF formatter limitation
+
+The `Recorder` only parses JSON-formatted events. If you use
+`audit.WithFormatter(audit.CEFFormatter{})`, captured events will
+have `ParseErr` set and structured fields will be zero-valued.
+Use `evt.RawJSON` for format-level assertions with non-JSON formatters.
+
+## Further Reading
 
 - [Progressive Example: Testing](../examples/04-testing/) — three testing patterns
 - [API Reference: audittest](https://pkg.go.dev/github.com/axonops/audit/audittest)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -185,7 +185,7 @@ goroutine will cause test failures.
 |-------|-----|
 | **`auditor.Close()` not called** | The drain goroutine runs until `Close()` is called. Always call `Close()` in tests. |
 | **`Close()` called too late** | `goleak` checks at test end. If `Close()` is deferred but another deferred function runs first, the goroutine may still be active. Put `Close()` as the first defer or use `t.Cleanup()`. |
-| **Using `audittest.New`** | The `audittest` constructors register `t.Cleanup(auditor.Close)` automatically — but you MUST call `auditor.Close()` explicitly before assertions. The cleanup is a safety net, not a substitute. See [Testing](testing.md#️-close-before-assert--critical). |
+| **Using `audittest.New`** | The `audittest` constructors default to synchronous delivery and register `t.Cleanup(auditor.Close)` automatically. With the default synchronous mode, no explicit `Close()` is needed before assertions. If you use `WithAsync()`, call `auditor.Close()` before assertions to drain the buffer. See [Testing](testing.md). |
 
 ---
 

--- a/examples/04-testing/README.md
+++ b/examples/04-testing/README.md
@@ -32,7 +32,7 @@ an in-memory test logger that captures events and metrics for assertion.
 
 ## Key Concepts
 
-The patterns below address the core challenge of testing async audit
+The patterns below address the core challenge of testing audit
 pipelines. Each pattern maps to a distinct testing need.
 
 ### The Testing Problem
@@ -47,8 +47,9 @@ untyped maps. That's ~25 lines of boilerplate per test.
 
 The `audittest` package gives you an in-memory audit logger that
 works exactly like production — same validation, same taxonomy
-enforcement, same async pipeline — but events land in a `Recorder`
-instead of being written anywhere.
+enforcement — but events land in a `Recorder` instead of being
+written anywhere. By default, delivery is synchronous, so events
+are available immediately after `AuditEvent()` returns.
 
 ### Pattern 1: Full Integration Test
 
@@ -58,14 +59,13 @@ taxonomy.
 
 ```go
 func TestCreateUser(t *testing.T) {
-    logger, events, metrics := audittest.New(t, taxonomyYAML)
+    auditor, events, metrics := audittest.New(t, taxonomyYAML)
 
-    svc := NewUserService(logger)
+    svc := NewUserService(auditor)
     err := svc.CreateUser("alice", "alice@example.com")
     require.NoError(t, err)
 
-    auditor.Close() // drain async buffer
-
+    // Synchronous delivery — assert immediately, no Close needed.
     require.Equal(t, 1, events.Count())
     evt := events.Events()[0]
     assert.Equal(t, EventUserCreate, evt.EventType)
@@ -81,12 +81,12 @@ about field validation:
 
 ```go
 func TestAuditHappens(t *testing.T) {
-    logger, events, _ := audittest.NewQuick(t, "user_create")
+    auditor, events, _ := audittest.NewQuick(t, "user_create")
 
-    svc := NewUserService(logger)
+    svc := NewUserService(auditor)
     _ = svc.CreateUser("alice", "alice@example.com")
 
-    auditor.Close()
+    // Synchronous delivery — assert immediately.
     assert.Equal(t, 1, events.Count())
 }
 ```
@@ -101,7 +101,7 @@ buffer drops, delivery counts:
 
 ```go
 func TestValidationError(t *testing.T) {
-    logger, _, metrics := audittest.New(t, taxonomyYAML)
+    auditor, _, metrics := audittest.New(t, taxonomyYAML)
 
     // Emit event missing required field "actor_id"
     err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
@@ -111,36 +111,37 @@ func TestValidationError(t *testing.T) {
     require.Error(t, err)
     assert.Contains(t, err.Error(), "missing required")
 
-    auditor.Close()
     assert.Equal(t, 1, metrics.ValidationErrors("user_create"))
 }
 ```
 
-### Close Before Assert
+### Synchronous Delivery (Default)
 
-The audit logger delivers events asynchronously. Call
-`auditor.Close()` before making assertions to drain the buffer.
-`New` registers `t.Cleanup(auditor.Close)` as a safety net
-against goroutine leaks, but your assertions need the explicit
-Close to see events.
+Both `New` and `NewQuick` default to synchronous delivery — events
+are available in the `Recorder` immediately after `AuditEvent()`
+returns. No `Close()` call is needed before assertions. `New`
+registers `t.Cleanup(auditor.Close)` to clean up resources after
+the test completes.
+
+Use `WithAsync()` only when testing async-specific behaviour such
+as drain timeout or buffer backpressure. With `WithAsync()`, you
+MUST call `auditor.Close()` before assertions.
 
 ### Table-Driven Tests with Reset
 
-Use `events.Reset()` to clear captured events between sub-tests
-without creating a new logger:
+Use `events.Reset()` and `metrics.Reset()` to clear captured state
+between sub-tests without creating a new auditor:
 
 ```go
 for _, tc := range tests {
     t.Run(tc.name, func(t *testing.T) {
         events.Reset()
+        metrics.Reset()
         svc.Do(tc.action)
         // assert on events for this sub-test only
     })
 }
 ```
-
-When sharing an auditor across sub-tests without calling Close(), use
-`require.Eventually` to wait for the async drain.
 
 ### RecordedEvent API
 
@@ -153,6 +154,11 @@ Each captured event provides structured access:
 | `evt.Timestamp` | `time.Time` | When the event was processed |
 | `evt.Fields` | `map[string]any` | Non-framework field values |
 | `evt.Field(key)` | `any` | Single field value (nil if absent) |
+| `evt.StringField(key)` | `string` | String value (empty if missing or wrong type) |
+| `evt.IntField(key)` | `int` | Int value with float64 coercion (0 if missing) |
+| `evt.FloatField(key)` | `float64` | Float value (0 if missing or wrong type) |
+| `evt.BoolField(key)` | `bool` | Bool value (false if missing or wrong type) |
+| `evt.UserFields()` | `map[string]any` | Fields with framework fields removed |
 | `evt.HasField(key, val)` | `bool` | Deep-equal check on field value |
 | `evt.RawJSON` | `[]byte` | Original serialised bytes |
 | `evt.ParseErr` | `error` | JSON deserialisation error (nil on success) |
@@ -165,11 +171,11 @@ pass a real logger, in tests you pass the audittest logger:
 
 ```go
 type UserService struct {
-    logger *audit.Auditor
+    auditor *audit.Auditor
 }
 
-func NewUserService(logger *audit.Auditor) *UserService {
-    return &UserService{logger: logger}
+func NewUserService(auditor *audit.Auditor) *UserService {
+    return &UserService{auditor: auditor}
 }
 ```
 
@@ -196,11 +202,8 @@ PASS
 ```
 
 All five tests pass, each demonstrating a different testing pattern.
-You will also see `INFO audit:` lifecycle messages from logger creation
-and shutdown — these are normal.
 
 ## Further Reading
 
 - [Testing](../../docs/testing.md) — full audittest reference and testing patterns
 - [Troubleshooting](../../docs/troubleshooting.md) — common issues and solutions
-

--- a/examples/04-testing/main_test.go
+++ b/examples/04-testing/main_test.go
@@ -34,17 +34,11 @@ func TestCreateUser_EmitsAuditEvent(t *testing.T) {
 	err := svc.CreateUser("alice", "alice@example.com")
 	require.NoError(t, err)
 
-	// Close drains the async buffer — events are now in the recorder.
-	_ = auditor.Close()
-
-	// Assert on captured events.
-	require.Equal(t, 1, events.Count())
-	evt := events.Events()[0]
-	assert.Equal(t, EventUserCreate, evt.EventType)
-	assert.True(t, evt.HasField(FieldActorID, "alice"))
-	assert.True(t, evt.HasField(FieldEmail, "alice@example.com"))
-
-	// Assert on metrics.
+	// Synchronous delivery — events are immediately available.
+	// No Close() needed before assertions.
+	evt := events.RequireEvent(t, EventUserCreate)
+	assert.Equal(t, "alice", evt.StringField(FieldActorID))
+	assert.Equal(t, "alice@example.com", evt.StringField(FieldEmail))
 	assert.Equal(t, 1, metrics.EventDeliveries("recorder", "success"))
 }
 
@@ -55,13 +49,9 @@ func TestLogin_Failure_EmitsAuthEvent(t *testing.T) {
 	err := svc.Login("bob", "wrong-password")
 	require.NoError(t, err) // AuditEvent itself shouldn't error
 
-	_ = auditor.Close()
-
-	require.Equal(t, 1, events.Count())
-	evt := events.Events()[0]
-	assert.Equal(t, EventAuthFailure, evt.EventType)
-	assert.True(t, evt.HasField(FieldActorID, "bob"))
-	assert.True(t, evt.HasField(FieldReason, "invalid password"))
+	evt := events.RequireEvent(t, EventAuthFailure)
+	assert.Equal(t, "bob", evt.StringField(FieldActorID))
+	assert.Equal(t, "invalid password", evt.StringField(FieldReason))
 }
 
 func TestLogin_Success_NoAuditEvent(t *testing.T) {
@@ -71,10 +61,8 @@ func TestLogin_Success_NoAuditEvent(t *testing.T) {
 	err := svc.Login("alice", "correct")
 	require.NoError(t, err)
 
-	_ = auditor.Close()
-
 	// Successful login does not emit an audit event.
-	assert.Equal(t, 0, events.Count())
+	events.RequireEmpty(t)
 }
 
 // --- Pattern 2: Quick smoke test (permissive taxonomy, any fields accepted) ---
@@ -86,17 +74,29 @@ func TestAuditEventEmitted_Quick(t *testing.T) {
 	svc := NewUserService(auditor)
 	_ = svc.CreateUser("charlie", "charlie@example.com")
 
-	_ = auditor.Close()
-
 	// Just verify the event was emitted — no field validation.
-	assert.Equal(t, 1, events.Count())
-	assert.Equal(t, "user_create", events.Events()[0].EventType)
+	events.RequireEvent(t, "user_create")
 }
 
-// --- Pattern 3: Validation error testing ---
+// --- Pattern 3: One-liner field assertion ---
+
+func TestCreateUser_AssertContains(t *testing.T) {
+	auditor, events, _ := audittest.New(t, taxonomyYAML)
+
+	svc := NewUserService(auditor)
+	_ = svc.CreateUser("alice", "alice@example.com")
+
+	// One-liner: assert event type + specific fields.
+	events.AssertContains(t, EventUserCreate, audit.Fields{
+		FieldActorID: "alice",
+		FieldEmail:   "alice@example.com",
+	})
+}
+
+// --- Pattern 4: Validation error testing ---
 
 func TestValidationError_MissingRequiredField(t *testing.T) {
-	auditor, _, metrics := audittest.New(t, taxonomyYAML)
+	auditor, events, metrics := audittest.New(t, taxonomyYAML)
 
 	// Emit event missing required field "actor_id" using NewEvent directly.
 	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
@@ -104,9 +104,9 @@ func TestValidationError_MissingRequiredField(t *testing.T) {
 		// actor_id missing — validation error
 	}))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required")
+	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
 
-	_ = auditor.Close()
-
+	// Event was rejected — nothing in the recorder.
+	events.RequireEmpty(t)
 	assert.Equal(t, 1, metrics.ValidationErrors("user_create"))
 }

--- a/examples/17-capstone/main_test.go
+++ b/examples/17-capstone/main_test.go
@@ -16,7 +16,7 @@
 //
 // These tests demonstrate how to verify audit events in a realistic
 // HTTP application using audittest.New and the full middleware
-// stack. The audit auditor is wired with the production middleware,
+// stack. The auditor is wired with the production middleware,
 // so events flow through buildAuditEvent → collectFields → Auditor
 // exactly as they do in the running application.
 package main
@@ -44,7 +44,7 @@ type testEnv struct {
 	auditor interface{ Close() error }
 }
 
-// Flush stops the HTTP server and closes the audit auditor so all
+// Flush stops the HTTP server and closes the auditor so all
 // buffered events are visible in the recorder. Call this before
 // any assertions on the recorder. Safe to call multiple times.
 func (e *testEnv) Flush(t *testing.T) {
@@ -132,9 +132,9 @@ func TestAuthFailure_InvalidAPIKey(t *testing.T) {
 	evt := events[0]
 	require.Nil(t, evt.ParseErr)
 	// The auth middleware truncates the key to 4 chars + "..."
-	assert.Equal(t, "bad-...", evt.Field(FieldActorID))
-	assert.Equal(t, "failure", evt.Field(FieldOutcome))
-	assert.Equal(t, "invalid credentials", evt.Field(FieldReason))
+	assert.Equal(t, "bad-...", evt.StringField(FieldActorID))
+	assert.Equal(t, "failure", evt.StringField(FieldOutcome))
+	assert.Equal(t, "invalid credentials", evt.StringField(FieldReason))
 }
 
 func TestAuthFailure_NoCredentials(t *testing.T) {
@@ -147,7 +147,7 @@ func TestAuthFailure_NoCredentials(t *testing.T) {
 
 	events := env.rec.FindByType(EventAuthFailure)
 	require.Len(t, events, 1)
-	assert.Equal(t, "anonymous", events[0].Field(FieldActorID))
+	assert.Equal(t, "anonymous", events[0].StringField(FieldActorID))
 }
 
 // --- Admin authorization tests (no DB needed) ---
@@ -165,9 +165,9 @@ func TestAdminSettings_NonAdmin_Forbidden(t *testing.T) {
 
 	evt := events[0]
 	require.Nil(t, evt.ParseErr)
-	assert.Equal(t, "alice", evt.Field(FieldActorID))
-	assert.Equal(t, "failure", evt.Field(FieldOutcome))
-	assert.Equal(t, "admin access required", evt.Field(FieldReason))
+	assert.Equal(t, "alice", evt.StringField(FieldActorID))
+	assert.Equal(t, "failure", evt.StringField(FieldOutcome))
+	assert.Equal(t, "admin access required", evt.StringField(FieldReason))
 }
 
 func TestAdminSettings_AdminAllowed(t *testing.T) {
@@ -205,11 +205,11 @@ func TestConfigChange_EmitsEventWithOldNewValues(t *testing.T) {
 
 	evt := events[0]
 	require.Nil(t, evt.ParseErr)
-	assert.Equal(t, "admin", evt.Field(FieldActorID))
-	assert.Equal(t, "success", evt.Field(FieldOutcome))
-	assert.Equal(t, "maintenance_mode", evt.Field(FieldSettingKey))
-	assert.Equal(t, "false", evt.Field(FieldOldValue))
-	assert.Equal(t, "true", evt.Field(FieldNewValue))
+	assert.Equal(t, "admin", evt.StringField(FieldActorID))
+	assert.Equal(t, "success", evt.StringField(FieldOutcome))
+	assert.Equal(t, "maintenance_mode", evt.StringField(FieldSettingKey))
+	assert.Equal(t, "false", evt.StringField(FieldOldValue))
+	assert.Equal(t, "true", evt.StringField(FieldNewValue))
 }
 
 // --- Item CRUD test (requires sqlmock) ---
@@ -235,9 +235,9 @@ func TestCreateItem_EmitsItemCreateEvent(t *testing.T) {
 
 	evt := events[0]
 	require.Nil(t, evt.ParseErr)
-	assert.Equal(t, "alice", evt.Field(FieldActorID))
-	assert.Equal(t, "success", evt.Field(FieldOutcome))
-	assert.NotEmpty(t, evt.Field(FieldTargetID))
+	assert.Equal(t, "alice", evt.StringField(FieldActorID))
+	assert.Equal(t, "success", evt.StringField(FieldOutcome))
+	assert.NotEmpty(t, evt.StringField(FieldTargetID))
 }
 
 // --- User create with PII fields ---
@@ -263,13 +263,13 @@ func TestCreateUser_EmitsPIIFields(t *testing.T) {
 
 	evt := events[0]
 	require.Nil(t, evt.ParseErr)
-	assert.Equal(t, "alice", evt.Field(FieldActorID))
-	assert.Equal(t, "success", evt.Field(FieldOutcome))
+	assert.Equal(t, "alice", evt.StringField(FieldActorID))
+	assert.Equal(t, "success", evt.StringField(FieldOutcome))
 	// PII fields should be present in the recorder (they are only
 	// stripped by the Loki output's exclude_labels, not by the
 	// recorder which captures all fields).
-	assert.Equal(t, "test@example.com", evt.Field(FieldEmail))
-	assert.Equal(t, "+1555000", evt.Field(FieldPhone))
+	assert.Equal(t, "test@example.com", evt.StringField(FieldEmail))
+	assert.Equal(t, "+1555000", evt.StringField(FieldPhone))
 }
 
 // --- Login/Logout tests (direct audit events, no middleware) ---
@@ -285,8 +285,8 @@ func TestLogin_Success_EmitsAuthSuccess(t *testing.T) {
 
 	events := env.rec.FindByType(EventAuthSuccess)
 	require.Len(t, events, 1, "expected one auth_success event")
-	assert.Equal(t, "alice", events[0].Field(FieldActorID))
-	assert.Equal(t, "success", events[0].Field(FieldOutcome))
+	assert.Equal(t, "alice", events[0].StringField(FieldActorID))
+	assert.Equal(t, "success", events[0].StringField(FieldOutcome))
 }
 
 func TestLogin_BadPassword_EmitsAuthFailure(t *testing.T) {
@@ -300,6 +300,6 @@ func TestLogin_BadPassword_EmitsAuthFailure(t *testing.T) {
 
 	events := env.rec.FindByType(EventAuthFailure)
 	require.Len(t, events, 1, "expected one auth_failure event")
-	assert.Equal(t, "alice", events[0].Field(FieldActorID))
-	assert.Equal(t, "invalid credentials", events[0].Field(FieldReason))
+	assert.Equal(t, "alice", events[0].StringField(FieldActorID))
+	assert.Equal(t, "invalid credentials", events[0].StringField(FieldReason))
 }


### PR DESCRIPTION
## Summary

Comprehensive review and update of the `audittest` package based on findings from 5 review agents (api-ergonomics, test-analyst, code-reviewer, user-guide-reviewer, api-ergonomics-usage).

### New assertion helpers (the headline feature)
```go
// Before (4-5 lines):
require.Equal(t, 1, events.Count())
evt := events.Events()[0]
assert.Equal(t, "user_create", evt.EventType)
assert.True(t, evt.HasField("actor_id", "alice"))

// After (1-2 lines):
evt := events.RequireEvent(t, "user_create")
assert.Equal(t, "alice", evt.StringField("actor_id"))

// Or one-liner:
events.AssertContains(t, "user_create", audit.Fields{"actor_id": "alice"})
```

### Changes
- **Assertion helpers**: `RequireEvent`, `RequireEvents`, `RequireEmpty`, `AssertContains`
- **`WithAuditOption`**: pass any `audit.Option` through to the auditor
- **`NewNamedRecorder`**: enable multi-output routing tests
- **`OutputMetricsRecorder`**: public mock for `audit.OutputMetrics`
- **`BoolField`, `Last`, `First`, `FindByField`**: convenience methods
- **Silent diagnostics**: no more INFO noise in test output (add `WithVerbose()` to re-enable)
- **20+ new tests**: UserFields, SubmittedCount, ParseErr, Timestamp, WithConfig, WithAsync, concurrency
- **Example 04 updated**: showcases new helpers, no Close-before-assert
- **docs/testing.md**: complete API reference tables, fixed contradictory guidance

## Test plan
- [x] `make check` passes
- [x] Coverage: audittest 93.9% (up from 90.1%)
- [x] All examples compile

Closes #458