### PR TITLE
feat: include valid field names in unknown YAML field errors (#447)

### DIFF
--- a/file/register.go
+++ b/file/register.go
@@ -83,7 +83,7 @@ func buildOutput(name string, rawConfig []byte, fileMetrics Metrics) (audit.Outp
 	var yc yamlFileConfig
 	dec := yaml.NewDecoder(bytes.NewReader(rawConfig), yaml.DisallowUnknownField())
 	if err := dec.Decode(&yc); err != nil {
-		return nil, fmt.Errorf("audit: file output %q: %w", name, err)
+		return nil, fmt.Errorf("audit: file output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
 	}
 
 	cfg := Config{

--- a/loki/register.go
+++ b/loki/register.go
@@ -113,7 +113,7 @@ func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics) (audi
 	var yc yamlLokiConfig
 	dec := yaml.NewDecoder(bytes.NewReader(rawConfig), yaml.DisallowUnknownField())
 	if err := dec.Decode(&yc); err != nil {
-		return nil, fmt.Errorf("audit: loki output %q: %w", name, err)
+		return nil, fmt.Errorf("audit: loki output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
 	}
 
 	cfg := &Config{

--- a/outputconfig/auditor_config.go
+++ b/outputconfig/auditor_config.go
@@ -97,7 +97,7 @@ func parseAuditorConfig(raw any) (auditorConfigResult, error) { //nolint:gocyclo
 		case "drain_timeout":
 			return result, fmt.Errorf("unknown field %q (renamed to %q in this version)", "drain_timeout", "shutdown_timeout")
 		default:
-			return result, fmt.Errorf("unknown field %q", key)
+			return result, fmt.Errorf("unknown field %q (valid: enabled, omit_empty, queue_size, shutdown_timeout, validation_mode)", key)
 		}
 	}
 	return result, nil

--- a/outputconfig/formatter.go
+++ b/outputconfig/formatter.go
@@ -73,7 +73,7 @@ func buildFormatter(raw any) (audit.Formatter, error) {
 	}
 	var cfg yamlFormatterConfig
 	if err := yaml.UnmarshalWithOptions(fmtBytes, &cfg, yaml.DisallowUnknownField()); err != nil {
-		return nil, fmt.Errorf("formatter: %w", err)
+		return nil, fmt.Errorf("formatter: %w", audit.WrapUnknownFieldError(err, cfg))
 	}
 
 	switch cfg.Type {

--- a/outputconfig/hmac.go
+++ b/outputconfig/hmac.go
@@ -89,7 +89,7 @@ func buildHMACConfig(ctx context.Context, name string, raw any, r *resolver) (*a
 	}
 	var yc yamlHMACConfig
 	if uErr := yaml.UnmarshalWithOptions(hmacBytes, &yc, yaml.DisallowUnknownField()); uErr != nil {
-		return nil, fmt.Errorf("output %q: hmac: %w", name, uErr)
+		return nil, fmt.Errorf("output %q: hmac: %w", name, audit.WrapUnknownFieldError(uErr, yc))
 	}
 
 	cfg := &audit.HMACConfig{

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -547,7 +547,7 @@ func parseTopLevel(ctx context.Context, doc, orderedOutputs yaml.MapSlice, order
 		}
 		var validated yamlTLSPolicy
 		if uErr := yaml.UnmarshalWithOptions(tlsBytes, &validated, yaml.DisallowUnknownField()); uErr != nil {
-			return nil, fmt.Errorf("%w: tls_policy: %w", ErrOutputConfigInvalid, uErr)
+			return nil, fmt.Errorf("%w: tls_policy: %w", ErrOutputConfigInvalid, audit.WrapUnknownFieldError(uErr, validated))
 		}
 	}
 

--- a/outputconfig/provider_config.go
+++ b/outputconfig/provider_config.go
@@ -230,7 +230,7 @@ func unmarshalProviderConfig(raw any, providerName string) (*yamlProviderConfig,
 
 	var cfg yamlProviderConfig
 	if uErr := yaml.UnmarshalWithOptions(b, &cfg, yaml.DisallowUnknownField()); uErr != nil {
-		return nil, fmt.Errorf("%w: secrets.%s: %w", ErrOutputConfigInvalid, providerName, uErr)
+		return nil, fmt.Errorf("%w: secrets.%s: %w", ErrOutputConfigInvalid, providerName, audit.WrapUnknownFieldError(uErr, cfg))
 	}
 
 	return &cfg, nil

--- a/outputconfig/route.go
+++ b/outputconfig/route.go
@@ -46,7 +46,7 @@ func buildRoute(name string, raw any, taxonomy *audit.Taxonomy) (*audit.EventRou
 	}
 	var yr yamlRoute
 	if uErr := yaml.UnmarshalWithOptions(routeBytes, &yr, yaml.DisallowUnknownField()); uErr != nil {
-		return nil, fmt.Errorf("output %q route: %w", name, uErr)
+		return nil, fmt.Errorf("output %q route: %w", name, audit.WrapUnknownFieldError(uErr, yr))
 	}
 	route := &audit.EventRoute{
 		IncludeCategories: yr.IncludeCategories,

--- a/syslog/register.go
+++ b/syslog/register.go
@@ -92,7 +92,7 @@ func buildOutput(name string, rawConfig []byte, syslogMetrics Metrics) (audit.Ou
 	var yc yamlSyslogConfig
 	dec := yaml.NewDecoder(bytes.NewReader(rawConfig), yaml.DisallowUnknownField())
 	if err := dec.Decode(&yc); err != nil {
-		return nil, fmt.Errorf("audit: syslog output %q: %w", name, err)
+		return nil, fmt.Errorf("audit: syslog output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
 	}
 
 	cfg := &Config{

--- a/taxonomy_yaml.go
+++ b/taxonomy_yaml.go
@@ -232,7 +232,7 @@ func ParseTaxonomyYAML(data []byte) (*Taxonomy, error) {
 
 	var yt yamlTaxonomy
 	if err := dec.Decode(&yt); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidInput, err) //nolint:errorlint // intentionally not wrapping yaml.v3 error to avoid leaking third-party types into the public error chain
+		return nil, fmt.Errorf("%w: %v", ErrInvalidInput, WrapUnknownFieldError(err, yamlTaxonomy{})) //nolint:errorlint // intentionally not wrapping yaml.v3 error to avoid leaking third-party types into the public error chain
 	}
 
 	// Reject multi-document YAML and trailing content.

--- a/webhook/register.go
+++ b/webhook/register.go
@@ -100,7 +100,7 @@ func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics) (audi
 	var yc yamlWebhookConfig
 	dec := yaml.NewDecoder(bytes.NewReader(rawConfig), yaml.DisallowUnknownField())
 	if err := dec.Decode(&yc); err != nil {
-		return nil, fmt.Errorf("audit: webhook output %q: %w", name, err)
+		return nil, fmt.Errorf("audit: webhook output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
 	}
 
 	cfg := &Config{

--- a/yaml_errors.go
+++ b/yaml_errors.go
@@ -1,0 +1,80 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// WrapUnknownFieldError checks if err contains "unknown field" (the
+// error text from goccy/go-yaml's DisallowUnknownField option) and,
+// if so, appends a "(valid: ...)" suffix listing the sorted YAML
+// field names from the target struct. Returns err unchanged if it
+// does not contain "unknown field".
+//
+// target must be a struct or pointer to struct. The function extracts
+// YAML tag names via reflection — no manual field lists needed.
+func WrapUnknownFieldError(err error, target any) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unknown field") {
+		return err
+	}
+	names := yamlFieldNames(target)
+	if len(names) == 0 {
+		return err
+	}
+	return fmt.Errorf("%w (valid: %s)", err, strings.Join(names, ", "))
+}
+
+// yamlFieldNames returns sorted YAML tag names from a struct's fields.
+// It handles both struct values and pointers to structs. Fields with
+// tag "-" or no yaml tag are skipped. Tag options after a comma (e.g.
+// "name,omitempty") are stripped — only the field name is returned.
+func yamlFieldNames(v any) []string {
+	t := reflect.TypeOf(v)
+	if t == nil {
+		return nil
+	}
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+	names := make([]string, 0, t.NumField())
+	for i := range t.NumField() {
+		f := t.Field(i)
+		tag := f.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		// Strip options like ",omitempty"
+		if idx := strings.IndexByte(tag, ','); idx != -1 {
+			tag = tag[:idx]
+		}
+		if tag == "" {
+			continue
+		}
+		names = append(names, tag)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/yaml_errors_test.go
+++ b/yaml_errors_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/axonops/audit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type flatStruct struct {
+	Name    string `yaml:"name"`
+	Address string `yaml:"address"`
+	Port    int    `yaml:"port"`
+}
+
+type structWithDash struct {
+	Name    string `yaml:"name"`
+	Ignored string `yaml:"-"`
+	Port    int    `yaml:"port"`
+}
+
+type structWithOmitempty struct {
+	Name string `yaml:"name,omitempty"`
+	Port int    `yaml:"port"`
+}
+
+type structNoTags struct {
+	Name string
+	Port int
+}
+
+func TestWrapUnknownFieldError_AddsValidFields(t *testing.T) {
+	err := errors.New(`[1:1] unknown field "typo"`)
+	wrapped := audit.WrapUnknownFieldError(err, flatStruct{})
+	assert.Contains(t, wrapped.Error(), "(valid: address, name, port)")
+}
+
+func TestWrapUnknownFieldError_SkipsDashTags(t *testing.T) {
+	err := errors.New(`[1:1] unknown field "typo"`)
+	wrapped := audit.WrapUnknownFieldError(err, structWithDash{})
+	assert.Contains(t, wrapped.Error(), "(valid: name, port)")
+	assert.NotContains(t, wrapped.Error(), "Ignored")
+}
+
+func TestWrapUnknownFieldError_HandlesOmitempty(t *testing.T) {
+	err := errors.New(`[1:1] unknown field "typo"`)
+	wrapped := audit.WrapUnknownFieldError(err, structWithOmitempty{})
+	assert.Contains(t, wrapped.Error(), "(valid: name, port)")
+}
+
+func TestWrapUnknownFieldError_SortedAlphabetically(t *testing.T) {
+	err := errors.New(`[1:1] unknown field "typo"`)
+	wrapped := audit.WrapUnknownFieldError(err, flatStruct{})
+	// address < name < port
+	assert.Contains(t, wrapped.Error(), "(valid: address, name, port)")
+}
+
+func TestWrapUnknownFieldError_AcceptsPointer(t *testing.T) {
+	err := errors.New(`[1:1] unknown field "typo"`)
+	wrapped := audit.WrapUnknownFieldError(err, &flatStruct{})
+	assert.Contains(t, wrapped.Error(), "(valid: address, name, port)")
+}
+
+func TestWrapUnknownFieldError_NonUnknownFieldError_PassesThrough(t *testing.T) {
+	err := errors.New("some other yaml error")
+	wrapped := audit.WrapUnknownFieldError(err, flatStruct{})
+	assert.Equal(t, err, wrapped)
+}
+
+func TestWrapUnknownFieldError_NilError_ReturnsNil(t *testing.T) {
+	assert.Nil(t, audit.WrapUnknownFieldError(nil, flatStruct{}))
+}
+
+func TestWrapUnknownFieldError_NoTags_PassesThrough(t *testing.T) {
+	err := errors.New(`[1:1] unknown field "typo"`)
+	wrapped := audit.WrapUnknownFieldError(err, structNoTags{})
+	// No yaml tags → no valid field list → error unchanged
+	assert.Equal(t, err, wrapped)
+}
+
+func TestWrapUnknownFieldError_PreservesWrapping(t *testing.T) {
+	inner := errors.New(`[1:1] unknown field "typo"`)
+	wrapped := audit.WrapUnknownFieldError(inner, flatStruct{})
+	require.ErrorIs(t, wrapped, inner)
+}


### PR DESCRIPTION
## Summary

When a user makes a typo in YAML config, the error now lists valid fields:

**Before:** `unknown field "allow_insecure"`
**After:** `unknown field "allow_insecure" (valid: address, allow_insecure_http, allow_private_ranges, ...)`

### Implementation
- `WrapUnknownFieldError(err, target)` helper uses `reflect` to extract sorted YAML tag names from config structs — no manual lists that can drift
- Applied to all 10 `DisallowUnknownField` locations across core, file, syslog, webhook, loki, and outputconfig
- Updated manual switch validator in auditor_config.go
- 9 unit tests for the helper + existing integration tests verify the enhanced errors

13 files changed, 192 insertions.

## Test plan
- [x] `make lint` clean
- [x] All module tests pass (core, file, syslog, webhook, loki, outputconfig)
- [x] 9 unit tests for WrapUnknownFieldError

Closes #447