### PR TITLE
refactor: thread diagnostic logger through output construction (#490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `audit-gen` generates typed parameters (string/int) instead of `any` for standard field setters and constructors (#394)
 - HMAC wire-format: `_hmac_v` now appears BEFORE `_hmac` on the wire and is inside the HMAC-authenticated bytes. External verifiers must strip only the `_hmac` field from the received line (keeping `_hmac_v` in place) to recompute the HMAC. See [`docs/hmac-integrity.md`](docs/hmac-integrity.md#canonicalisation-rule-for-verifiers) for the full canonicalisation contract (#473)
 - HMAC `SaltVersion` character set restricted to `[A-Za-z0-9._:-]` (length 1–64) at config-time validation — values containing spaces, control characters, CEF/JSON metacharacters, or other ambiguous bytes are rejected (#473)
+- `OutputFactory` signature grew a `*slog.Logger` parameter: `func(name string, rawConfig []byte, coreMetrics Metrics, logger *slog.Logger) (Output, error)`. Custom factories must add the parameter (nil is valid; treated as `slog.Default`). The logger is plumbed from `outputconfig.WithDiagnosticLogger` / `audit.WithDiagnosticLogger` so construction-time warnings reach the consumer's handler (#490)
 
 ### Security
 
@@ -40,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `RecordedEvent.StringField()`, `IntField()`, `FloatField()` accessors with JSON float64 coercion (#397)
 - `NoOpMetrics` base struct for composable Metrics implementations (#401)
 - `WithFactory` LoadOption for per-call factory overrides (#399)
+- `webhook.WithDiagnosticLogger`, `syslog.WithDiagnosticLogger`, `loki.WithDiagnosticLogger`, `file.WithDiagnosticLogger` functional options on each output module's `New()` — route construction-time TLS and permission warnings to a caller-supplied logger rather than `slog.Default` (#490)
+- `outputconfig.WithDiagnosticLogger` LoadOption — threads the auditor's diagnostic logger through every output constructed by `outputconfig.Load`. Pair with `audit.WithDiagnosticLogger` on the `Auditor` for consistent routing of both construction-time and runtime warnings (#490)
 - Runtime introspection methods: `BufferLen()`, `BufferCap()`, `OutputNames()`, `IsCategoryEnabled()`, `IsEventEnabled()`, `IsDisabled()`, `IsSynchronous()` (#404)
 - `docs/writing-custom-outputs.md` — interface hierarchy and decision tree (#397)
 - `docs/migrating-from-application-logging.md` — side-by-side coexistence guide (#397)

--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -195,6 +195,41 @@ auditor:
   enabled: ${AUDIT_ENABLED:-true}
 ```
 
+## 🪵 Diagnostic Logger Propagation
+
+The `auditor:` section has no YAML field for the diagnostic logger — a
+`*slog.Logger` is a runtime value, not a YAML construct. Configure it
+programmatically when loading the output configuration:
+
+```go
+logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+result, err := outputconfig.Load(
+    ctx,
+    data,
+    taxonomy,
+    outputconfig.WithDiagnosticLogger(logger), // construction-time warnings
+)
+
+auditor, err := audit.New(
+    audit.WithTaxonomy(taxonomy),
+    audit.WithDiagnosticLogger(logger),         // runtime warnings
+    audit.WithOutputs(result.Outputs...),
+)
+```
+
+Pass the same logger to both `outputconfig.WithDiagnosticLogger` and
+`audit.WithDiagnosticLogger`. The first routes warnings emitted during
+output construction (TLS policy, file permission mode). The second
+routes warnings emitted at runtime (connection retries, buffer-full
+drops). Using the same logger ensures all library diagnostics reach
+one handler.
+
+Supplying only `audit.WithDiagnosticLogger` leaves construction-time
+warnings routed through `slog.Default` — a subtle inconsistency if
+your application uses a non-default handler. Both options accept nil
+(equivalent to `slog.Default`).
+
 ## 🔒 Global TLS Policy
 
 The optional `tls_policy:` section sets the default TLS version and

--- a/docs/writing-custom-outputs.md
+++ b/docs/writing-custom-outputs.md
@@ -74,10 +74,17 @@ Register it via a factory:
 
 ```go
 func init() {
-    audit.RegisterOutputFactory("my-output", func(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
+    audit.RegisterOutputFactory("my-output", func(name string, rawConfig []byte, coreMetrics audit.Metrics, logger *slog.Logger) (audit.Output, error) {
         // coreMetrics is the pipeline-level Metrics instance (may be nil).
         // Per-output metrics are injected separately via SetOutputMetrics —
         // see "Receiving Per-Output Metrics" below.
+        //
+        // logger is the auditor's diagnostic logger, threaded through
+        // outputconfig.WithDiagnosticLogger / audit.WithDiagnosticLogger.
+        // Route construction-time warnings here (TLS policy, permission
+        // mode) so they reach the consumer's configured handler rather
+        // than slog.Default. A nil logger is valid; treat it as
+        // slog.Default.
         return audit.WrapOutput(&MyOutput{name: name}, name), nil
     })
 }
@@ -465,7 +472,7 @@ forwarding for all optional interfaces:
 
 ```go
 func init() {
-    audit.RegisterOutputFactory("my-output", func(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
+    audit.RegisterOutputFactory("my-output", func(name string, rawConfig []byte, coreMetrics audit.Metrics, logger *slog.Logger) (audit.Output, error) {
         inner := &MyAsyncOutput{/* ... */}
         return audit.WrapOutput(inner, name), nil
     })

--- a/file/file.go
+++ b/file/file.go
@@ -182,7 +182,10 @@ func resolvePath(path string) (string, error) {
 // has no pointer fields (except Compress), so the value copy prevents
 // caller mutation without requiring an explicit defensive copy inside
 // New.
-func New(cfg Config, fileMetrics Metrics) (*Output, error) { //nolint:gocyclo,cyclop // constructor with validation
+func New(cfg Config, fileMetrics Metrics, opts ...Option) (*Output, error) { //nolint:gocyclo,cyclop // constructor with validation
+	o := resolveOptions(opts)
+	logger := o.logger
+
 	if cfg.Path == "" {
 		return nil, fmt.Errorf("audit: file output path must not be empty")
 	}
@@ -203,9 +206,6 @@ func New(cfg Config, fileMetrics Metrics) (*Output, error) { //nolint:gocyclo,cy
 	if err != nil {
 		return nil, fmt.Errorf("audit: file output permissions %q: %w", cfg.Permissions, err)
 	}
-
-	// Default logger — replaced by SetDiagnosticLogger when the core calls it.
-	logger := slog.Default()
 
 	// Warn if permissions grant group or world access to audit data.
 	if perm&0o077 != 0 {

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -16,6 +16,7 @@ package file_test
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -858,4 +859,53 @@ func BenchmarkFileOutput_Write_Parallel(b *testing.B) {
 			_ = out.Write(event)
 		}
 	})
+}
+
+// TestFile_ConstructionWarningsRoutedToInjectedLogger verifies that
+// the permission-mode warning emitted during New() routes through
+// the WithDiagnosticLogger-supplied logger rather than slog.Default.
+// Closes #490.
+func TestFile_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
+	var buf strings.Builder
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	injected := slog.New(handler)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perm-warning.log")
+
+	// Permission 0o644 grants group read + world read → triggers the
+	// "grants group/world access" warning in file.New.
+	out, err := file.New(file.Config{
+		Path:        path,
+		Permissions: "0644",
+	}, nil, file.WithDiagnosticLogger(injected))
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	logged := buf.String()
+	assert.Contains(t, logged, "permissions grant group/world access",
+		"expected permission warning on injected logger, got: %q", logged)
+}
+
+// TestFile_NilDiagnosticLoggerFallsBackToDefault verifies
+// WithDiagnosticLogger(nil) does not nil-deref and falls back to
+// slog.Default for warning emission.
+func TestFile_NilDiagnosticLoggerFallsBackToDefault(t *testing.T) {
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perm-warning-nil.log")
+
+	out, err := file.New(file.Config{
+		Path:        path,
+		Permissions: "0644",
+	}, nil, file.WithDiagnosticLogger(nil))
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	assert.Contains(t, buf.String(), "permissions grant group/world access",
+		"WithDiagnosticLogger(nil) should fall back to slog.Default")
 }

--- a/file/options.go
+++ b/file/options.go
@@ -1,0 +1,60 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import "log/slog"
+
+// Option configures a file [Output] at construction time. Options
+// are passed as variadic arguments to [New] and applied in order
+// before any configuration validation or warning emission.
+type Option func(*options)
+
+// options holds resolved construction-time settings. Zero value is
+// valid — all fields receive sensible defaults inside [New].
+type options struct {
+	logger *slog.Logger
+}
+
+// WithDiagnosticLogger routes construction-time and runtime warnings
+// (permission-mode warnings, rotation notices, delivery failures) to
+// the given logger. When nil or not supplied, warnings go to
+// [slog.Default].
+//
+// Consumers normally do not call this directly when using
+// [github.com/axonops/audit/outputconfig.Load] — outputconfig plumbs
+// the auditor's diagnostic logger into every output it constructs.
+// Use this option when constructing a file output programmatically
+// and you want its warnings to match your application's log handler.
+//
+// The option mirrors [github.com/axonops/audit.WithDiagnosticLogger]
+// at the auditor level; the same logger may be passed to both for
+// consistent routing.
+func WithDiagnosticLogger(l *slog.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// resolveOptions applies the given options over a defaulted value.
+// A nil logger (either absent or explicitly WithDiagnosticLogger(nil))
+// falls back to [slog.Default].
+func resolveOptions(opts []Option) options {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.logger == nil {
+		o.logger = slog.Default()
+	}
+	return o
+}

--- a/file/register.go
+++ b/file/register.go
@@ -17,6 +17,7 @@ package file
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 
 	"github.com/axonops/audit"
 	"github.com/goccy/go-yaml"
@@ -28,20 +29,22 @@ func init() {
 
 // defaultFactory creates a file output from YAML config. Per-output
 // metrics are auto-detected via type assertion on coreMetrics.
-func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
+// The logger is plumbed through to construction-time permission-mode
+// warnings.
+func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics, logger *slog.Logger) (audit.Output, error) {
 	var fileMetrics Metrics
 	if fm, ok := coreMetrics.(Metrics); ok {
 		fileMetrics = fm
 	}
-	return buildOutput(name, rawConfig, fileMetrics)
+	return buildOutput(name, rawConfig, fileMetrics, logger)
 }
 
 // NewFactory returns an [audit.OutputFactory] that creates file outputs
 // from YAML configuration with the provided file-specific metrics
 // captured in the closure. Pass nil to disable file metrics.
 func NewFactory(fileMetrics Metrics) audit.OutputFactory {
-	return func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
-		return buildOutput(name, rawConfig, fileMetrics)
+	return func(name string, rawConfig []byte, _ audit.Metrics, logger *slog.Logger) (audit.Output, error) {
+		return buildOutput(name, rawConfig, fileMetrics, logger)
 	}
 }
 
@@ -75,7 +78,7 @@ func intPtrOrDefault(p *int, def int) int {
 	return *p
 }
 
-func buildOutput(name string, rawConfig []byte, fileMetrics Metrics) (audit.Output, error) {
+func buildOutput(name string, rawConfig []byte, fileMetrics Metrics, logger *slog.Logger) (audit.Output, error) {
 	if len(rawConfig) == 0 {
 		return nil, fmt.Errorf("audit: file output %q: config is required", name)
 	}
@@ -96,7 +99,7 @@ func buildOutput(name string, rawConfig []byte, fileMetrics Metrics) (audit.Outp
 		BufferSize:  intPtrOrDefault(yc.BufferSize, DefaultBufferSize),
 	}
 
-	out, err := New(cfg, fileMetrics)
+	out, err := New(cfg, fileMetrics, WithDiagnosticLogger(logger))
 	if err != nil {
 		return nil, fmt.Errorf("audit: file output %q: %w", name, err)
 	}

--- a/file/register_test.go
+++ b/file/register_test.go
@@ -38,7 +38,7 @@ func TestFileFactory_ValidConfig(t *testing.T) {
 	factory := audit.LookupOutputFactory("file")
 	require.NotNil(t, factory)
 
-	out, err := factory("compliance_file", yaml, nil)
+	out, err := factory("compliance_file", yaml, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 
@@ -52,7 +52,7 @@ func TestFileFactory_InvalidConfig_ReturnsError(t *testing.T) {
 	factory := audit.LookupOutputFactory("file")
 	require.NotNil(t, factory)
 
-	_, err := factory("bad_file", yaml, nil)
+	_, err := factory("bad_file", yaml, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "bad_file")
 }
@@ -63,7 +63,7 @@ func TestFileFactory_UnknownYAMLField_Rejected(t *testing.T) {
 	factory := audit.LookupOutputFactory("file")
 	require.NotNil(t, factory)
 
-	_, err := factory("test", yaml, nil)
+	_, err := factory("test", yaml, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown_field")
 }
@@ -72,7 +72,7 @@ func TestFileFactory_EmptyConfig_ReturnsError(t *testing.T) {
 	factory := audit.LookupOutputFactory("file")
 	require.NotNil(t, factory)
 
-	_, err := factory("empty", nil, nil)
+	_, err := factory("empty", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "config is required")
 }
@@ -85,7 +85,7 @@ func TestFileNewFactory_WithMetrics(t *testing.T) {
 	metrics := &mockFileMetrics{}
 	factory := file.NewFactory(metrics)
 
-	out, err := factory("with_metrics", yaml, nil)
+	out, err := factory("with_metrics", yaml, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 
@@ -99,7 +99,7 @@ func TestFileNewFactory_NilMetrics(t *testing.T) {
 
 	factory := file.NewFactory(nil)
 
-	out, err := factory("nil_metrics", yaml, nil)
+	out, err := factory("nil_metrics", yaml, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 

--- a/loki/config_test.go
+++ b/loki/config_test.go
@@ -17,6 +17,7 @@ package loki_test
 import (
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -787,4 +788,57 @@ func TestBuildLokiTLSConfig(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no valid pem blocks")
 	})
+}
+
+// TestLoki_ConstructionWarningsRoutedToInjectedLogger verifies that
+// TLS-policy warnings emitted during New() route through the
+// WithDiagnosticLogger-supplied logger rather than slog.Default().
+// Closes #490.
+func TestLoki_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
+	var buf strings.Builder
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	injected := slog.New(handler)
+
+	out, err := loki.New(&loki.Config{
+		URL:                "https://loki.example.com/loki/api/v1/push",
+		TLSPolicy:          &audit.TLSPolicy{AllowTLS12: true, AllowWeakCiphers: true},
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      100 * time.Millisecond,
+		Timeout:            1 * time.Second,
+		BufferSize:         1000,
+	}, nil, loki.WithDiagnosticLogger(injected))
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	logged := buf.String()
+	assert.Contains(t, logged, "weak ciphers",
+		"expected weak-ciphers warning on injected logger, got: %q", logged)
+	assert.Contains(t, logged, "output=loki",
+		"warning should carry output=loki attribute: %q", logged)
+}
+
+// TestLoki_NilDiagnosticLoggerFallsBackToDefault verifies
+// WithDiagnosticLogger(nil) does not nil-deref and falls back to
+// slog.Default for warning emission.
+func TestLoki_NilDiagnosticLoggerFallsBackToDefault(t *testing.T) {
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	out, err := loki.New(&loki.Config{
+		URL:                "https://loki.example.com/loki/api/v1/push",
+		TLSPolicy:          &audit.TLSPolicy{AllowTLS12: true, AllowWeakCiphers: true},
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      100 * time.Millisecond,
+		Timeout:            1 * time.Second,
+		BufferSize:         1000,
+	}, nil, loki.WithDiagnosticLogger(nil))
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	assert.Contains(t, buf.String(), "weak ciphers",
+		"WithDiagnosticLogger(nil) should fall back to slog.Default")
 }

--- a/loki/loki.go
+++ b/loki/loki.go
@@ -106,10 +106,17 @@ type Output struct { //nolint:govet // fieldalignment: readability preferred
 // background batch goroutine. The metrics parameter is optional
 // (may be nil). Per-output metrics are injected via
 // [audit.OutputMetricsReceiver.SetOutputMetrics] after construction.
-func New(cfg *Config, metrics audit.Metrics) (*Output, error) {
+//
+// Optional [Option] arguments tune construction-time behaviour. Pass
+// [WithDiagnosticLogger] to route TLS-policy warnings (emitted before
+// the auditor's diagnostic logger is propagated post-construction) to
+// a custom logger.
+func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 	// Copy config so validation/defaults don't mutate the caller's struct.
 	cfgCopy := *cfg
 	cfg = &cfgCopy
+
+	resolved := resolveOptions(opts)
 
 	if err := validateLokiConfig(cfg); err != nil {
 		return nil, err
@@ -119,11 +126,12 @@ func New(cfg *Config, metrics audit.Metrics) (*Output, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Log TLS policy warnings via slog (consistent with webhook/syslog).
+	// Log TLS policy warnings via the injected logger (falls back to
+	// slog.Default when no option supplied).
 	u, _ := url.Parse(cfg.URL) // already validated
 	host := u.Scheme + "://" + u.Host
 	for _, w := range warnings {
-		slog.Warn(w, "url", host)
+		resolved.logger.Warn(w, "output", "loki", "url", host)
 	}
 
 	var ssrfOpts []audit.SSRFOption
@@ -162,7 +170,7 @@ func New(cfg *Config, metrics audit.Metrics) (*Output, error) {
 	o := &Output{
 		cfg:     cfg,
 		metrics: metrics,
-		logger:  slog.Default(),
+		logger:  resolved.logger,
 		ch:      make(chan lokiEntry, cfg.BufferSize),
 		closeCh: make(chan struct{}),
 		cancel:  cancel,

--- a/loki/options.go
+++ b/loki/options.go
@@ -1,0 +1,59 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki
+
+import "log/slog"
+
+// Option configures a Loki [Output] at construction time. Options
+// are passed as variadic arguments to [New] and applied in order
+// before any configuration validation, TLS setup, or warning emission.
+type Option func(*options)
+
+// options holds resolved construction-time settings. Zero value is
+// valid — all fields receive sensible defaults inside [New].
+type options struct {
+	logger *slog.Logger
+}
+
+// WithDiagnosticLogger routes construction-time and runtime warnings
+// (TLS policy, retry, buffer-full drops) to the given logger. When
+// nil or not supplied, warnings go to [slog.Default].
+//
+// Consumers normally do not call this directly when using
+// [github.com/axonops/audit/outputconfig.Load] — outputconfig plumbs
+// the auditor's diagnostic logger into every output it constructs.
+// Use this option when constructing a Loki output programmatically
+// and you want its warnings to match your application's log handler.
+//
+// The option mirrors [github.com/axonops/audit.WithDiagnosticLogger]
+// at the auditor level; the same logger may be passed to both for
+// consistent routing.
+func WithDiagnosticLogger(l *slog.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// resolveOptions applies the given options over a defaulted value.
+// A nil logger (either absent or explicitly WithDiagnosticLogger(nil))
+// falls back to [slog.Default].
+func resolveOptions(opts []Option) options {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.logger == nil {
+		o.logger = slog.Default()
+	}
+	return o
+}

--- a/loki/register.go
+++ b/loki/register.go
@@ -17,6 +17,7 @@ package loki
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/axonops/audit"
@@ -30,8 +31,9 @@ func init() {
 // defaultFactory creates a Loki output from YAML config. Core metrics
 // are forwarded for delivery reporting. Per-output metrics are
 // injected via OutputMetricsReceiver after construction.
-func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
-	return buildOutput(name, rawConfig, coreMetrics)
+// The logger is plumbed through to construction-time TLS warnings.
+func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics, logger *slog.Logger) (audit.Output, error) {
+	return buildOutput(name, rawConfig, coreMetrics, logger)
 }
 
 // yamlLokiConfig is the YAML-specific representation of Loki output
@@ -105,7 +107,7 @@ func intPtrOrDefault(p *int, def int) int {
 	return *p
 }
 
-func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
+func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics, logger *slog.Logger) (audit.Output, error) {
 	if len(rawConfig) == 0 {
 		return nil, fmt.Errorf("audit: loki output %q: config is required", name)
 	}
@@ -167,7 +169,7 @@ func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics) (audi
 		}
 	}
 
-	output, err := New(cfg, coreMetrics)
+	output, err := New(cfg, coreMetrics, WithDiagnosticLogger(logger))
 	if err != nil {
 		return nil, fmt.Errorf("audit: loki output %q: %w", name, err)
 	}

--- a/loki/register_test.go
+++ b/loki/register_test.go
@@ -50,7 +50,7 @@ func TestLokiFactory_EmptyConfig(t *testing.T) {
 	factory := audit.LookupOutputFactory("loki")
 	require.NotNil(t, factory)
 
-	_, err := factory("my_loki", nil, nil)
+	_, err := factory("my_loki", nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "config is required",
 		"empty config should produce 'config is required' error, got: %q", err.Error())
@@ -66,7 +66,7 @@ func TestLokiFactory_UnknownField(t *testing.T) {
 	require.NotNil(t, factory)
 
 	rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\nunknown_field: oops\n")
-	_, err := factory("strict_loki", rawYAML, nil)
+	_, err := factory("strict_loki", rawYAML, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown_field",
 		"strict YAML decode should name the unexpected field, got: %q", err.Error())
@@ -129,7 +129,7 @@ func TestLokiFactory_DurationParsing(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := factory("dur_test", []byte(tt.yaml), nil)
+			out, err := factory("dur_test", []byte(tt.yaml), nil, nil)
 			if tt.wantErr {
 				require.Error(t, err, "expected a parse error for YAML: %s", tt.yaml)
 				assert.Contains(t, err.Error(), "duration",
@@ -163,7 +163,7 @@ basic_auth:
   password: secret
 bearer_token: tok-should-not-coexist
 `)
-	_, err := factory("conflict_auth", rawYAML, nil)
+	_, err := factory("conflict_auth", rawYAML, nil, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrConfigInvalid,
 		"auth conflict must wrap audit.ErrConfigInvalid")
@@ -186,7 +186,7 @@ func TestLokiFactory_GzipDefaultTrue(t *testing.T) {
 	require.NotNil(t, factory)
 
 	rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\n")
-	out, err := factory("gzip_default", rawYAML, nil)
+	out, err := factory("gzip_default", rawYAML, nil, nil)
 	require.NoError(t, err, "valid config with default gzip should succeed")
 	require.NotNil(t, out)
 	require.NoError(t, out.Close())
@@ -202,7 +202,7 @@ func TestLokiFactory_GzipExplicitFalse(t *testing.T) {
 	require.NotNil(t, factory)
 
 	rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\ngzip: false\n")
-	out, err := factory("gzip_explicit_false", rawYAML, nil)
+	out, err := factory("gzip_explicit_false", rawYAML, nil, nil)
 	require.NoError(t, err, "gzip: false should be accepted")
 	require.NotNil(t, out)
 	require.NoError(t, out.Close())
@@ -227,7 +227,7 @@ labels:
   dynamic:
     actor_id: true
 `)
-	_, err := factory("bad_dynamic_label", rawYAML, nil)
+	_, err := factory("bad_dynamic_label", rawYAML, nil, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrConfigInvalid,
 		"unknown dynamic label must wrap audit.ErrConfigInvalid")
@@ -263,7 +263,7 @@ func TestLokiFactory_StaticLabels_InvalidName(t *testing.T) {
 			t.Parallel()
 
 			rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\nlabels:\n  static:\n    " + tt.labelName + ": somevalue\n")
-			_, err := factory("invalid_label_"+tt.name, rawYAML, nil)
+			_, err := factory("invalid_label_"+tt.name, rawYAML, nil, nil)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, audit.ErrConfigInvalid,
 				"invalid static label must wrap audit.ErrConfigInvalid")
@@ -293,7 +293,7 @@ timeout: 5s
 max_retries: 2
 buffer_size: 500
 `)
-	out, err := factory("valid", rawYAML, nil)
+	out, err := factory("valid", rawYAML, nil, nil)
 	require.NoError(t, err, "valid config should produce an output")
 	require.NotNil(t, out)
 	assert.Equal(t, "valid", out.Name(),
@@ -331,7 +331,7 @@ func TestLokiFactory_ValidConfig_WithAllAuthOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := factory("auth_test", []byte(tt.yaml), nil)
+			out, err := factory("auth_test", []byte(tt.yaml), nil, nil)
 			require.NoError(t, err, "%s auth variant should produce output", tt.name)
 			require.NotNil(t, out)
 			require.NoError(t, out.Close())
@@ -358,7 +358,7 @@ func TestLokiFactory_NewFactory_NilMetrics(t *testing.T) {
 	factory := audit.LookupOutputFactory("loki")
 	require.NotNil(t, factory)
 
-	out, err := factory("nil_metrics_path", []byte("url: https://loki.example.com/loki/api/v1/push\n"), nil)
+	out, err := factory("nil_metrics_path", []byte("url: https://loki.example.com/loki/api/v1/push\n"), nil, nil)
 	require.NoError(t, err, "nil coreMetrics must not panic")
 	require.NotNil(t, out)
 	require.NoError(t, out.Close())
@@ -393,7 +393,7 @@ func TestLokiFactory_DynamicLabels_ExcludeFields(t *testing.T) {
 			t.Parallel()
 
 			rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\nlabels:\n  dynamic:\n    " + labelName + ": false\n")
-			out, err := factory("dyn_"+labelName, rawYAML, nil)
+			out, err := factory("dyn_"+labelName, rawYAML, nil, nil)
 			require.NoError(t, err,
 				"disabling dynamic label %q should produce output", labelName)
 			require.NotNil(t, out)
@@ -418,7 +418,7 @@ labels:
     event_type: true
     severity: false
 `)
-	out, err := factory("mixed_dynamic", rawYAML, nil)
+	out, err := factory("mixed_dynamic", rawYAML, nil, nil)
 	require.NoError(t, err, "mixed include/exclude dynamic labels should produce output")
 	require.NotNil(t, out)
 	require.NoError(t, out.Close())

--- a/middleware.go
+++ b/middleware.go
@@ -172,7 +172,7 @@ func serveAudit(w http.ResponseWriter, r *http.Request, next http.Handler, audit
 
 	reqID := r.Header.Get("X-Request-Id")
 	if !validRequestID(reqID) {
-		reqID = newRequestID()
+		reqID = newRequestID(auditor.logger)
 	}
 
 	rw := &responseWriter{ResponseWriter: w}

--- a/middleware_export_test.go
+++ b/middleware_export_test.go
@@ -16,6 +16,7 @@ package audit
 
 import (
 	"bufio"
+	"log/slog"
 	"net"
 	"net/http"
 )
@@ -27,7 +28,21 @@ func ClientIP(r *http.Request) string { return clientIP(r) }
 func TransportSecurity(r *http.Request) string { return transportSecurity(r) }
 
 // NewRequestID exports newRequestID for testing.
-func NewRequestID() string { return newRequestID() }
+func NewRequestID() string { return newRequestID(nil) }
+
+// NewRequestIDWithLogger exports newRequestID with a specific logger
+// for tests that need to capture the crypto/rand-failure warning path.
+func NewRequestIDWithLogger(logger *slog.Logger) string { return newRequestID(logger) }
+
+// SetRandRead swaps the package-level randRead seam used by
+// newRequestID. Returns a restore function that reinstates the
+// original. For test use only — callers are responsible for
+// ensuring serial execution as randRead is process-global.
+func SetRandRead(r func([]byte) (int, error)) (restore func()) {
+	original := randRead
+	randRead = r
+	return func() { randRead = original }
+}
 
 // ValidRequestID exports validRequestID for testing.
 func ValidRequestID(id string) bool { return validRequestID(id) }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -16,6 +16,7 @@ package audit_test
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -632,4 +633,47 @@ func BenchmarkMiddleware(b *testing.B) {
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 	}
+}
+
+// TestMiddleware_NewRequestIDWarningsRoutedToAuditorLogger verifies
+// that the crypto/rand fallback warning in newRequestID routes through
+// the caller-supplied logger rather than slog.Default. Closes #490.
+func TestMiddleware_NewRequestIDWarningsRoutedToAuditorLogger(t *testing.T) {
+	// Force crypto/rand to fail via the randRead seam.
+	restore := audit.SetRandRead(func(_ []byte) (int, error) {
+		return 0, fmt.Errorf("test: simulated crypto/rand failure")
+	})
+	t.Cleanup(restore)
+
+	var buf strings.Builder
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	injected := slog.New(handler)
+
+	id := audit.NewRequestIDWithLogger(injected)
+
+	// Zero UUID sentinel from the fallback path.
+	assert.Equal(t, "00000000-0000-4000-8000-000000000000", id,
+		"expected zero UUID when crypto/rand fails")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "crypto/rand failed",
+		"expected rand-failure warning on injected logger, got: %q", logged)
+}
+
+// TestMiddleware_NewRequestIDNilLoggerFallsBackToDefault verifies
+// that passing nil does not panic and emits via slog.Default.
+func TestMiddleware_NewRequestIDNilLoggerFallsBackToDefault(t *testing.T) {
+	restore := audit.SetRandRead(func(_ []byte) (int, error) {
+		return 0, fmt.Errorf("test: simulated crypto/rand failure")
+	})
+	t.Cleanup(restore)
+
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	id := audit.NewRequestIDWithLogger(nil)
+	assert.Equal(t, "00000000-0000-4000-8000-000000000000", id)
+	assert.Contains(t, buf.String(), "crypto/rand failed")
 }

--- a/outputconfig/options.go
+++ b/outputconfig/options.go
@@ -15,6 +15,7 @@
 package outputconfig
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/axonops/audit"
@@ -33,6 +34,7 @@ type loadOptions struct {
 	coreMetrics          audit.Metrics
 	outputMetricsFactory audit.OutputMetricsFactory
 	factories            map[string]audit.OutputFactory
+	diagnosticLogger     *slog.Logger
 	providers            []secrets.Provider
 	secretTimeout        time.Duration
 	secretTimeoutSet     bool // true when WithSecretTimeout was called explicitly
@@ -95,6 +97,22 @@ func WithFactory(typeName string, factory audit.OutputFactory) LoadOption {
 			o.factories = make(map[string]audit.OutputFactory)
 		}
 		o.factories[typeName] = factory
+	}
+}
+
+// WithDiagnosticLogger sets the diagnostic logger that is threaded
+// through to every output constructed by [Load]. The logger reaches
+// each output's [OutputFactory] via its logger parameter, so
+// construction-time warnings (TLS policy, file permission mode) route
+// to the consumer's configured handler rather than [slog.Default].
+//
+// Pair this with [audit.WithDiagnosticLogger] on the [audit.Auditor]
+// so that construction-time AND runtime warnings route through the
+// same handler. Passing nil is valid and equivalent to not calling
+// this option — factories fall back to [slog.Default].
+func WithDiagnosticLogger(l *slog.Logger) LoadOption {
+	return func(o *loadOptions) {
+		o.diagnosticLogger = l
 	}
 }
 

--- a/outputconfig/output.go
+++ b/outputconfig/output.go
@@ -17,6 +17,7 @@ package outputconfig
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/axonops/audit"
@@ -35,7 +36,7 @@ type outputFields struct { //nolint:govet // fieldalignment: readability preferr
 
 // buildOutput constructs a single named output from its raw YAML value.
 // Returns nil (not error) when the output is disabled (enabled: false).
-func buildOutput(ctx context.Context, name string, raw any, taxonomy *audit.Taxonomy, globalTLSRaw any, globalAppName, globalHost string, coreMetrics audit.Metrics, factories map[string]audit.OutputFactory, r *resolver) (*NamedOutput, error) { //nolint:gocyclo,cyclop // linear pipeline with secret resolution added
+func buildOutput(ctx context.Context, name string, raw any, taxonomy *audit.Taxonomy, globalTLSRaw any, globalAppName, globalHost string, coreMetrics audit.Metrics, factories map[string]audit.OutputFactory, logger *slog.Logger, r *resolver) (*NamedOutput, error) { //nolint:gocyclo,cyclop // linear pipeline with secret resolution added
 	fields, err := extractOutputFields(name, raw)
 	if err != nil {
 		return nil, err
@@ -60,7 +61,7 @@ func buildOutput(ctx context.Context, name string, raw any, taxonomy *audit.Taxo
 		return nil, fmtErr
 	}
 
-	output, err := invokeFactory(name, fields, globalTLSRaw, globalAppName, globalHost, coreMetrics, factories)
+	output, err := invokeFactory(name, fields, globalTLSRaw, globalAppName, globalHost, coreMetrics, factories, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +256,7 @@ type yamlTLSPolicy struct {
 	AllowWeakCiphers bool `yaml:"allow_weak_ciphers"`
 }
 
-func invokeFactory(name string, f *outputFields, globalTLSRaw any, globalAppName, globalHost string, coreMetrics audit.Metrics, factories map[string]audit.OutputFactory) (audit.Output, error) {
+func invokeFactory(name string, f *outputFields, globalTLSRaw any, globalAppName, globalHost string, coreMetrics audit.Metrics, factories map[string]audit.OutputFactory, logger *slog.Logger) (audit.Output, error) {
 	// Per-call factory overrides take precedence over global registry.
 	factory := factories[f.typeName]
 	if factory == nil {
@@ -290,7 +291,7 @@ func invokeFactory(name string, f *outputFields, globalTLSRaw any, globalAppName
 			return nil, fmt.Errorf("output %q: marshal %q config: %w", name, f.typeName, err)
 		}
 	}
-	output, err := factory(name, rawConfig, coreMetrics)
+	output, err := factory(name, rawConfig, coreMetrics, logger)
 	if err != nil {
 		return nil, fmt.Errorf("output %q: %w", name, err)
 	}

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -283,7 +283,7 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 		}
 		seen[name] = struct{}{}
 
-		no, err := buildOutput(secretCtx, name, item.Value, taxonomy, top.tlsPolicyRaw, top.appName, top.host, lo.coreMetrics, lo.factories, secretResolver)
+		no, err := buildOutput(secretCtx, name, item.Value, taxonomy, top.tlsPolicyRaw, top.appName, top.host, lo.coreMetrics, lo.factories, lo.diagnosticLogger, secretResolver)
 		if err != nil {
 			closeAll(outputs)
 			return nil, fmt.Errorf("%w: %w", ErrOutputConfigInvalid, err)

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -17,6 +17,7 @@ package outputconfig_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -2781,4 +2782,95 @@ outputs:
 	for _, o := range result.Outputs {
 		_ = o.Output.Close()
 	}
+}
+
+// TestLoad_DiagnosticLogger_PlumbedThroughFactory verifies that
+// outputconfig.WithDiagnosticLogger threads the caller's logger all
+// the way to the registered OutputFactory's 4th argument. Closes #490.
+//
+// Uses a per-call custom factory via WithFactory so the captured
+// pointer comparison is deterministic — no init-registered factory
+// pollutes the assertion.
+func TestLoad_DiagnosticLogger_PlumbedThroughFactory(t *testing.T) {
+	t.Parallel()
+	var captured atomic.Pointer[slog.Logger]
+
+	factory := func(name string, _ []byte, _ audit.Metrics, logger *slog.Logger) (audit.Output, error) {
+		captured.Store(logger)
+		return audit.WrapOutput(&lokiStubOutput{}, name), nil
+	}
+
+	want := slog.New(slog.NewTextHandler(io.Discard, nil))
+	tax := testTaxonomy(t)
+	data := []byte(`
+version: 1
+app_name: t
+host: h
+outputs:
+  probe:
+    type: probe-output
+    probe-output: {}
+`)
+	result, err := outputconfig.Load(
+		context.Background(),
+		data,
+		tax,
+		outputconfig.WithFactory("probe-output", factory),
+		outputconfig.WithDiagnosticLogger(want),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, o := range result.Outputs {
+			_ = o.Output.Close()
+		}
+	})
+
+	got := captured.Load()
+	require.NotNil(t, got, "factory must have been called")
+	assert.Same(t, want, got,
+		"factory must receive the exact logger passed via WithDiagnosticLogger")
+}
+
+// TestLoad_DiagnosticLogger_NilWhenUnset verifies that when the caller
+// does NOT pass WithDiagnosticLogger, the factory receives a nil logger.
+// Each output module is responsible for falling back to slog.Default
+// via its own resolveOptions — this test only pins the outputconfig
+// plumbing behaviour: "absent LoadOption = nil passed to factory".
+func TestLoad_DiagnosticLogger_NilWhenUnset(t *testing.T) {
+	t.Parallel()
+	var called atomic.Bool
+	var loggerWasNil atomic.Bool
+
+	factory := func(name string, _ []byte, _ audit.Metrics, logger *slog.Logger) (audit.Output, error) {
+		called.Store(true)
+		loggerWasNil.Store(logger == nil)
+		return audit.WrapOutput(&lokiStubOutput{}, name), nil
+	}
+
+	tax := testTaxonomy(t)
+	data := []byte(`
+version: 1
+app_name: t
+host: h
+outputs:
+  probe:
+    type: probe-output-nil
+    probe-output-nil: {}
+`)
+	result, err := outputconfig.Load(
+		context.Background(),
+		data,
+		tax,
+		outputconfig.WithFactory("probe-output-nil", factory),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, o := range result.Outputs {
+			_ = o.Output.Close()
+		}
+	})
+
+	require.True(t, called.Load(), "factory must have been invoked")
+	assert.True(t, loggerWasNil.Load(),
+		"without WithDiagnosticLogger, factory must receive nil logger")
 }

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -17,6 +17,7 @@ package outputconfig_test
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,7 +153,7 @@ func (l *lokiStubOutput) Close() error       { return nil }
 func (l *lokiStubOutput) Name() string       { return "loki-stub" }
 
 func init() {
-	audit.RegisterOutputFactory("loki", func(_ string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("loki", func(_ string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		return &lokiStubOutput{}, nil
 	})
 }
@@ -830,7 +831,7 @@ func (s *spyOutput) Name() string       { return "spy" }
 
 func TestLoad_ClosesOutputOnRouteError(t *testing.T) {
 	spy := &spyOutput{}
-	audit.RegisterOutputFactory("spy", func(_ string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("spy", func(_ string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		return spy, nil
 	})
 	tax := testTaxonomy(t)
@@ -842,7 +843,7 @@ func TestLoad_ClosesOutputOnRouteError(t *testing.T) {
 
 func TestLoad_ClosesOutputOnFormatterError(t *testing.T) {
 	spy := &spyOutput{}
-	audit.RegisterOutputFactory("spy", func(_ string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("spy", func(_ string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		return spy, nil
 	})
 	tax := testTaxonomy(t)
@@ -854,7 +855,7 @@ func TestLoad_ClosesOutputOnFormatterError(t *testing.T) {
 
 func TestLoad_ClosesEarlierOutputsWhenLaterFails(t *testing.T) {
 	spy := &spyOutput{}
-	audit.RegisterOutputFactory("spy", func(_ string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("spy", func(_ string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		return spy, nil
 	})
 	tax := testTaxonomy(t)
@@ -1552,7 +1553,7 @@ func TestLoad_GlobalTLSPolicy_InjectedViaFactory(t *testing.T) {
 	// Register a test factory under the "webhook" type name so
 	// the injection logic recognises it as TLS-capable.
 	var captured atomic.Value
-	audit.RegisterOutputFactory("webhook", func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("webhook", func(name string, rawConfig []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		captured.Store(string(rawConfig))
 		return &testOutput{name: name}, nil
 	})
@@ -1587,7 +1588,7 @@ outputs:
 func TestLoad_GlobalTLSPolicy_PerOutputOverride(t *testing.T) {
 	t.Parallel()
 	var captured atomic.Value
-	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		captured.Store(string(rawConfig))
 		return &testOutput{name: name}, nil
 	})
@@ -2228,7 +2229,7 @@ func TestLoad_TimezoneAtMaxLength_Accepted(t *testing.T) {
 // registration and must run exclusively with other syslog factory tests.
 func TestLoad_InjectStringField_SyslogHostnameNotOverridden(t *testing.T) {
 	var captured atomic.Value
-	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		captured.Store(string(rawConfig))
 		return &testOutput{name: name}, nil
 	})
@@ -2271,7 +2272,7 @@ outputs:
 // registration and must run exclusively with other syslog factory tests.
 func TestLoad_InjectStringField_SyslogHostnameInjected(t *testing.T) {
 	var captured atomic.Value
-	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		captured.Store(string(rawConfig))
 		return &testOutput{name: name}, nil
 	})
@@ -2313,7 +2314,7 @@ outputs:
 // does not override it.
 func TestLoad_InjectStringField_SyslogAppNameNotOverridden(t *testing.T) {
 	var captured atomic.Value
-	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("syslog", func(name string, rawConfig []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		captured.Store(string(rawConfig))
 		return &testOutput{name: name}, nil
 	})
@@ -2354,7 +2355,7 @@ outputs:
 // registration and must run exclusively with other webhook factory tests.
 func TestLoad_InjectStringField_NonSyslogOutputNoInjection(t *testing.T) {
 	var captured atomic.Value
-	audit.RegisterOutputFactory("webhook", func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("webhook", func(name string, rawConfig []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		captured.Store(string(rawConfig))
 		return &testOutput{name: name}, nil
 	})
@@ -2546,7 +2547,7 @@ func TestLoad_WithFactory(t *testing.T) {
 	t.Parallel()
 	tax := testTaxonomy(t)
 	data := []byte("version: 1\napp_name: test\nhost: test\noutputs:\n  custom:\n    type: test-custom\n")
-	customFactory := func(name string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	customFactory := func(name string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		so, soErr := audit.NewStdoutOutput(audit.StdoutConfig{})
 		if soErr != nil {
 			return nil, soErr

--- a/outputconfig/tests/bdd/steps/steps.go
+++ b/outputconfig/tests/bdd/steps/steps.go
@@ -18,6 +18,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +36,7 @@ func init() {
 	// outputconfig formatter behaviour without depending on the real
 	// Loki module. The stub ignores the raw config and returns a
 	// minimal output.
-	audit.RegisterOutputFactory("loki", func(_ string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	audit.RegisterOutputFactory("loki", func(_ string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		return &lokiStub{}, nil
 	})
 }

--- a/registry.go
+++ b/registry.go
@@ -21,7 +21,7 @@ import (
 )
 
 // OutputFactory creates a named [Output] from raw YAML configuration
-// bytes and core pipeline metrics.
+// bytes, core pipeline metrics, and an optional diagnostic logger.
 //
 // name is the consumer-chosen output name from the YAML config (e.g.
 // "compliance_file"). The factory SHOULD use this to set the output's
@@ -39,7 +39,14 @@ import (
 // per-output metrics automatically. For separate per-output metrics
 // implementations, use the output's NewFactory with
 // outputconfig.WithFactory.
-type OutputFactory func(name string, rawConfig []byte, coreMetrics Metrics) (Output, error)
+//
+// logger is the auditor's diagnostic logger, plumbed through from
+// [outputconfig.WithDiagnosticLogger] or [audit.WithDiagnosticLogger]
+// so that construction-time warnings (TLS policy, file permission
+// mode) reach the consumer's configured handler. Factories SHOULD
+// pass it via the output module's WithDiagnosticLogger option. A nil
+// logger is valid and is treated as [slog.Default].
+type OutputFactory func(name string, rawConfig []byte, coreMetrics Metrics, logger *slog.Logger) (Output, error)
 
 // registry is a global mutable map protected by registryMu. This is an
 // intentional exception to the "no global mutable state" convention in

--- a/registry_test.go
+++ b/registry_test.go
@@ -29,7 +29,7 @@ import (
 func TestRegisterOutputFactory_Success(t *testing.T) {
 	t.Cleanup(audit.SaveAndResetRegistryForTest())
 
-	factory := func(name string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	factory := func(name string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		return testhelper.NewMockOutput(name), nil
 	}
 	audit.RegisterOutputFactory("test", factory)
@@ -41,10 +41,10 @@ func TestRegisterOutputFactory_Success(t *testing.T) {
 func TestRegisterOutputFactory_Overwrite(t *testing.T) {
 	t.Cleanup(audit.SaveAndResetRegistryForTest())
 
-	first := func(name string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	first := func(_ string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		return testhelper.NewMockOutput("first"), nil
 	}
-	second := func(name string, _ []byte, _ audit.Metrics) (audit.Output, error) {
+	second := func(_ string, _ []byte, _ audit.Metrics, _ *slog.Logger) (audit.Output, error) {
 		return testhelper.NewMockOutput("second"), nil
 	}
 
@@ -55,7 +55,7 @@ func TestRegisterOutputFactory_Overwrite(t *testing.T) {
 	require.NotNil(t, got)
 
 	// Verify the second factory is the one registered.
-	out, err := got("check", nil, nil)
+	out, err := got("check", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "second", out.Name())
 }
@@ -70,7 +70,7 @@ func TestLookupOutputFactory_NotRegistered_ReturnsNil(t *testing.T) {
 func TestRegisteredOutputTypes_Sorted(t *testing.T) {
 	t.Cleanup(audit.SaveAndResetRegistryForTest())
 
-	dummy := func(string, []byte, audit.Metrics) (audit.Output, error) { return nil, nil }
+	dummy := func(string, []byte, audit.Metrics, *slog.Logger) (audit.Output, error) { return nil, nil }
 	audit.RegisterOutputFactory("webhook", dummy)
 	audit.RegisterOutputFactory("file", dummy)
 	audit.RegisterOutputFactory("syslog", dummy)
@@ -83,7 +83,7 @@ func TestRegisterOutputFactory_EmptyName_Panics(t *testing.T) {
 	t.Cleanup(audit.SaveAndResetRegistryForTest())
 
 	assert.Panics(t, func() {
-		audit.RegisterOutputFactory("", func(string, []byte, audit.Metrics) (audit.Output, error) {
+		audit.RegisterOutputFactory("", func(string, []byte, audit.Metrics, *slog.Logger) (audit.Output, error) {
 			return nil, nil
 		})
 	})

--- a/stdout.go
+++ b/stdout.go
@@ -17,12 +17,13 @@ package audit
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sync"
 )
 
 func init() {
-	RegisterOutputFactory("stdout", func(name string, rawConfig []byte, _ Metrics) (Output, error) {
+	RegisterOutputFactory("stdout", func(name string, rawConfig []byte, _ Metrics, _ *slog.Logger) (Output, error) {
 		if len(rawConfig) > 0 {
 			return nil, fmt.Errorf("audit: stdout output %q: stdout does not accept configuration", name)
 		}

--- a/stdout_registry_test.go
+++ b/stdout_registry_test.go
@@ -31,7 +31,7 @@ func TestStdoutFactory_RegisteredByInit(t *testing.T) {
 	factory := audit.LookupOutputFactory("stdout")
 	require.NotNil(t, factory, "stdout factory must be registered by init()")
 
-	out, err := factory("my_stdout", nil, nil)
+	out, err := factory("my_stdout", nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 
@@ -44,12 +44,12 @@ func TestStdoutFactory_AcceptsNoConfig(t *testing.T) {
 	require.NotNil(t, factory)
 
 	// nil config — accepted (the normal case)
-	out, err := factory("no_config", nil, nil)
+	out, err := factory("no_config", nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 
 	// empty byte slice — also accepted
-	out2, err := factory("empty_config", []byte{}, nil)
+	out2, err := factory("empty_config", []byte{}, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out2.Close() })
 }
@@ -58,7 +58,7 @@ func TestStdoutFactory_RejectsConfig(t *testing.T) {
 	factory := audit.LookupOutputFactory("stdout")
 	require.NotNil(t, factory)
 
-	_, err := factory("bad_stdout", []byte("some_option: true\n"), nil)
+	_, err := factory("bad_stdout", []byte("some_option: true\n"), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not accept configuration")
 	assert.Contains(t, err.Error(), "bad_stdout")

--- a/syslog/options.go
+++ b/syslog/options.go
@@ -1,0 +1,59 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syslog
+
+import "log/slog"
+
+// Option configures a syslog [Output] at construction time. Options
+// are passed as variadic arguments to [New] and applied in order
+// before any configuration validation, TLS setup, or warning emission.
+type Option func(*options)
+
+// options holds resolved construction-time settings. Zero value is
+// valid — all fields receive sensible defaults inside [New].
+type options struct {
+	logger *slog.Logger
+}
+
+// WithDiagnosticLogger routes construction-time and runtime warnings
+// (TLS policy, reconnection backoff, buffer-full drops) to the given
+// logger. When nil or not supplied, warnings go to [slog.Default].
+//
+// Consumers normally do not call this directly when using
+// [github.com/axonops/audit/outputconfig.Load] — outputconfig plumbs
+// the auditor's diagnostic logger into every output it constructs.
+// Use this option when constructing a syslog output programmatically
+// and you want its warnings to match your application's log handler.
+//
+// The option mirrors [github.com/axonops/audit.WithDiagnosticLogger]
+// at the auditor level; the same logger may be passed to both for
+// consistent routing.
+func WithDiagnosticLogger(l *slog.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// resolveOptions applies the given options over a defaulted value.
+// A nil logger (either absent or explicitly WithDiagnosticLogger(nil))
+// falls back to [slog.Default].
+func resolveOptions(opts []Option) options {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.logger == nil {
+		o.logger = slog.Default()
+	}
+	return o
+}

--- a/syslog/register.go
+++ b/syslog/register.go
@@ -17,6 +17,7 @@ package syslog
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 
 	"github.com/axonops/audit"
 	"github.com/goccy/go-yaml"
@@ -28,20 +29,21 @@ func init() {
 
 // defaultFactory creates a syslog output from YAML config. Per-output
 // metrics are auto-detected via type assertion on coreMetrics.
-func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
+// The logger is plumbed through to construction-time TLS warnings.
+func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics, logger *slog.Logger) (audit.Output, error) {
 	var syslogMetrics Metrics
 	if sm, ok := coreMetrics.(Metrics); ok {
 		syslogMetrics = sm
 	}
-	return buildOutput(name, rawConfig, syslogMetrics)
+	return buildOutput(name, rawConfig, syslogMetrics, logger)
 }
 
 // NewFactory returns an [audit.OutputFactory] that creates syslog
 // outputs from YAML configuration with the provided syslog-specific
 // metrics captured in the closure. Pass nil to disable syslog metrics.
 func NewFactory(syslogMetrics Metrics) audit.OutputFactory {
-	return func(name string, rawConfig []byte, _ audit.Metrics) (audit.Output, error) {
-		return buildOutput(name, rawConfig, syslogMetrics)
+	return func(name string, rawConfig []byte, _ audit.Metrics, logger *slog.Logger) (audit.Output, error) {
+		return buildOutput(name, rawConfig, syslogMetrics, logger)
 	}
 }
 
@@ -84,7 +86,7 @@ func intPtrOrDefault(p *int, def int) int {
 	return *p
 }
 
-func buildOutput(name string, rawConfig []byte, syslogMetrics Metrics) (audit.Output, error) {
+func buildOutput(name string, rawConfig []byte, syslogMetrics Metrics, logger *slog.Logger) (audit.Output, error) {
 	if len(rawConfig) == 0 {
 		return nil, fmt.Errorf("audit: syslog output %q: config is required", name)
 	}
@@ -114,7 +116,7 @@ func buildOutput(name string, rawConfig []byte, syslogMetrics Metrics) (audit.Ou
 		}
 	}
 
-	out, err := New(cfg, syslogMetrics)
+	out, err := New(cfg, syslogMetrics, WithDiagnosticLogger(logger))
 	if err != nil {
 		return nil, fmt.Errorf("audit: syslog output %q: %w", name, err)
 	}

--- a/syslog/register_test.go
+++ b/syslog/register_test.go
@@ -41,7 +41,7 @@ func TestSyslogFactory_ValidConfig(t *testing.T) {
 
 	// syslog.New eagerly connects — this may fail without a server.
 	// We test parsing separately from connectivity.
-	out, err := factory("siem_syslog", yaml, nil)
+	out, err := factory("siem_syslog", yaml, nil, nil)
 	if err != nil {
 		// Connection failure is expected without Docker — verify it
 		// got past YAML parsing (error should be about connection).
@@ -58,7 +58,7 @@ func TestSyslogFactory_InvalidConfig_EmptyAddress(t *testing.T) {
 	factory := audit.LookupOutputFactory("syslog")
 	require.NotNil(t, factory)
 
-	_, err := factory("bad_syslog", yaml, nil)
+	_, err := factory("bad_syslog", yaml, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "bad_syslog")
 }
@@ -69,7 +69,7 @@ func TestSyslogFactory_UnknownYAMLField_Rejected(t *testing.T) {
 	factory := audit.LookupOutputFactory("syslog")
 	require.NotNil(t, factory)
 
-	_, err := factory("test", yaml, nil)
+	_, err := factory("test", yaml, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "bogus")
 }
@@ -78,7 +78,7 @@ func TestSyslogFactory_EmptyConfig_ReturnsError(t *testing.T) {
 	factory := audit.LookupOutputFactory("syslog")
 	require.NotNil(t, factory)
 
-	_, err := factory("empty", nil, nil)
+	_, err := factory("empty", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "config is required")
 }
@@ -90,7 +90,7 @@ func TestSyslogFactory_WithTLSPolicy(t *testing.T) {
 	require.NotNil(t, factory)
 
 	// Will fail to connect without Docker, but should parse YAML OK.
-	_, err := factory("tls_syslog", yaml, nil)
+	_, err := factory("tls_syslog", yaml, nil, nil)
 	if err != nil {
 		assert.Contains(t, err.Error(), "tls_syslog")
 	}
@@ -102,7 +102,7 @@ func TestSyslogFactory_InsecureSkipVerify_Rejected(t *testing.T) {
 	factory := audit.LookupOutputFactory("syslog")
 	require.NotNil(t, factory)
 
-	_, err := factory("insecure", rawYAML, nil)
+	_, err := factory("insecure", rawYAML, nil, nil)
 	assert.Error(t, err, "insecure_skip_verify must not be settable via YAML")
 	assert.Contains(t, err.Error(), "insecure_skip_verify")
 }
@@ -112,7 +112,7 @@ func TestSyslogNewFactory_WithMetrics(t *testing.T) {
 	factory := syslog.NewFactory(metrics)
 
 	rawYAML := []byte("network: tcp\naddress: localhost:5514\n")
-	out, err := factory("with_metrics", rawYAML, nil)
+	out, err := factory("with_metrics", rawYAML, nil, nil)
 	if err != nil {
 		// Connection failure expected without Docker.
 		t.Logf("skipping connectivity assertion: %v", err)
@@ -126,7 +126,7 @@ func TestSyslogNewFactory_NilMetrics(t *testing.T) {
 	factory := syslog.NewFactory(nil)
 
 	rawYAML := []byte("network: tcp\naddress: localhost:5514\n")
-	out, err := factory("nil_metrics", rawYAML, nil)
+	out, err := factory("nil_metrics", rawYAML, nil, nil)
 	if err != nil {
 		t.Logf("skipping connectivity assertion: %v", err)
 		return

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -178,7 +178,14 @@ func (s *Output) SetDiagnosticLogger(l *slog.Logger) {
 // It validates the config, establishes the initial connection, and
 // starts the background writeLoop goroutine.
 // The syslogMetrics parameter is optional (may be nil).
-func New(cfg *Config, syslogMetrics Metrics) (*Output, error) {
+//
+// Optional [Option] arguments tune construction-time behaviour. Pass
+// [WithDiagnosticLogger] to route TLS-policy warnings (emitted before
+// the auditor's diagnostic logger is propagated post-construction) to
+// a custom logger.
+func New(cfg *Config, syslogMetrics Metrics, opts ...Option) (*Output, error) {
+	o := resolveOptions(opts)
+
 	if err := validateSyslogConfig(cfg); err != nil {
 		return nil, err
 	}
@@ -198,7 +205,7 @@ func New(cfg *Config, syslogMetrics Metrics) (*Output, error) {
 
 	var tlsCfg *tls.Config
 	if cfg.Network == "tcp+tls" {
-		tlsCfg, err = buildSyslogTLSConfig(cfg)
+		tlsCfg, err = buildSyslogTLSConfig(cfg, o.logger)
 		if err != nil {
 			return nil, fmt.Errorf("audit: syslog tls config: %w", err)
 		}
@@ -216,7 +223,7 @@ func New(cfg *Config, syslogMetrics Metrics) (*Output, error) {
 
 	s := &Output{
 		tlsCfg:   tlsCfg,
-		logger:   slog.Default(),
+		logger:   o.logger,
 		ch:       make(chan syslogEntry, bufSize),
 		closeCh:  make(chan struct{}),
 		done:     make(chan struct{}),

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -24,6 +24,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"math/big"
 	"net"
 	"os"
@@ -2731,4 +2733,103 @@ func TestOutputMetrics_RecordRetry_CalledOnRetryableError(t *testing.T) {
 
 	assert.Positive(t, om.retries.Load(),
 		"RecordRetry must be called during reconnection attempt")
+}
+
+// TestSyslog_TLSWarningsRoutedToInjectedLogger verifies that
+// TLS-policy warnings emitted during New() route through the
+// WithDiagnosticLogger-supplied logger rather than slog.Default().
+// Closes #490.
+//
+// Uses a TLS policy that triggers the "weak ciphers permitted"
+// warning — the simplest path that produces a TLS.Apply warning.
+// A local TLS listener stands in for a real syslog-ng so
+// syslog.New's dial succeeds long enough for buildSyslogTLSConfig
+// to run.
+func TestSyslog_TLSWarningsRoutedToInjectedLogger(t *testing.T) {
+	// Start a TLS listener that accepts any connection — we don't
+	// need it to speak syslog, only to let dial succeed.
+	certs := generateTestCerts(t)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", certs.tlsCfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				_, _ = io.Copy(io.Discard, c)
+			}(conn)
+		}
+	}()
+
+	var buf strings.Builder
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	injected := slog.New(handler)
+
+	out, err := syslog.New(&syslog.Config{
+		Network:  "tcp+tls",
+		Address:  listener.Addr().String(),
+		Facility: "local0",
+		AppName:  "syslog-logger-test",
+		TLSCA:    certs.caPath,
+		TLSPolicy: &audit.TLSPolicy{
+			AllowTLS12:       true,
+			AllowWeakCiphers: true,
+		},
+	}, nil, syslog.WithDiagnosticLogger(injected))
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	logged := buf.String()
+	assert.Contains(t, logged, "weak ciphers",
+		"expected weak-ciphers warning on injected logger, got: %q", logged)
+	assert.Contains(t, logged, "output=syslog",
+		"warning should carry output=syslog attribute: %q", logged)
+}
+
+// TestSyslog_NilDiagnosticLoggerFallsBackToDefault verifies
+// WithDiagnosticLogger(nil) does not nil-deref and falls back to
+// slog.Default for warning emission.
+func TestSyslog_NilDiagnosticLoggerFallsBackToDefault(t *testing.T) {
+	certs := generateTestCerts(t)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", certs.tlsCfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				_, _ = io.Copy(io.Discard, c)
+			}(conn)
+		}
+	}()
+
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	out, err := syslog.New(&syslog.Config{
+		Network:  "tcp+tls",
+		Address:  listener.Addr().String(),
+		Facility: "local0",
+		AppName:  "syslog-nil-logger-test",
+		TLSCA:    certs.caPath,
+		TLSPolicy: &audit.TLSPolicy{
+			AllowTLS12:       true,
+			AllowWeakCiphers: true,
+		},
+	}, nil, syslog.WithDiagnosticLogger(nil))
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	assert.Contains(t, buf.String(), "weak ciphers",
+		"WithDiagnosticLogger(nil) should fall back to slog.Default")
 }

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -2754,8 +2754,8 @@ func TestSyslog_TLSWarningsRoutedToInjectedLogger(t *testing.T) {
 	t.Cleanup(func() { _ = listener.Close() })
 	go func() {
 		for {
-			conn, err := listener.Accept()
-			if err != nil {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
 				return
 			}
 			go func(c net.Conn) {
@@ -2800,8 +2800,8 @@ func TestSyslog_NilDiagnosticLoggerFallsBackToDefault(t *testing.T) {
 	t.Cleanup(func() { _ = listener.Close() })
 	go func() {
 		for {
-			conn, err := listener.Accept()
-			if err != nil {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
 				return
 			}
 			go func(c net.Conn) {

--- a/syslog/tls.go
+++ b/syslog/tls.go
@@ -22,10 +22,13 @@ import (
 	"os"
 )
 
-func buildSyslogTLSConfig(cfg *Config) (*tls.Config, error) {
+// buildSyslogTLSConfig constructs a TLS config from the syslog config.
+// Warnings emitted by [audit.TLSPolicy.Apply] are routed through the
+// given logger (pass [slog.Default] for caller-default behaviour).
+func buildSyslogTLSConfig(cfg *Config, logger *slog.Logger) (*tls.Config, error) {
 	tlsCfg, warnings := cfg.TLSPolicy.Apply(nil)
 	for _, w := range warnings {
-		slog.Warn(w, "output", "syslog", "address", cfg.Address)
+		logger.Warn(w, "output", "syslog", "address", cfg.Address)
 	}
 
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {

--- a/tests/bdd/steps/loki_steps.go
+++ b/tests/bdd/steps/loki_steps.go
@@ -166,7 +166,7 @@ func registerLokiGivenValidationSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 		if factory == nil {
 			return fmt.Errorf("loki factory not registered")
 		}
-		_, err := factory("test", []byte(yamlCfg), nil)
+		_, err := factory("test", []byte(yamlCfg), nil, nil)
 		tc.LastErr = err
 		return nil
 	})

--- a/transport.go
+++ b/transport.go
@@ -80,6 +80,14 @@ func transportSecurity(r *http.Request) string {
 // Tests override this to exercise the failure path; production code
 // never swaps it. Defined here (not in a *_test.go helper) because
 // export_test files cannot introduce new package-level variables.
+//
+// Thread-safety: this is an unsynchronised package-level variable.
+// Any test that swaps it via [SetRandRead] MUST NOT use t.Parallel
+// (and neither may any test in the same binary that exercises
+// newRequestID) — the seam is a process-global and concurrent
+// read/write would race. The race detector cannot catch it because
+// all accesses go through the same var indirection. If future tests
+// need parallelism here, convert to [atomic.Pointer].
 var randRead = rand.Read
 
 // newRequestID generates a v4 UUID using crypto/rand. The format

--- a/transport.go
+++ b/transport.go
@@ -76,16 +76,28 @@ func transportSecurity(r *http.Request) string {
 	return "tls"
 }
 
+// randRead is the crypto/rand.Read indirection used by newRequestID.
+// Tests override this to exercise the failure path; production code
+// never swaps it. Defined here (not in a *_test.go helper) because
+// export_test files cannot introduce new package-level variables.
+var randRead = rand.Read
+
 // newRequestID generates a v4 UUID using crypto/rand. The format
-// follows RFC 4122: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx.
-func newRequestID() string {
+// follows RFC 4122: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx. The
+// logger argument receives the crypto/rand-failure fallback warning;
+// pass the auditor's diagnostic logger so the warning routes to the
+// consumer's configured handler.
+func newRequestID(logger *slog.Logger) string {
 	var uuid [16]byte
 	// crypto/rand.Read always returns len(p) bytes on supported
 	// platforms; the only realistic failure is a broken OS RNG.
-	if _, err := rand.Read(uuid[:]); err != nil {
+	if _, err := randRead(uuid[:]); err != nil {
 		// Fallback: return a zero UUID rather than panicking in a
 		// library. This should never happen on any supported OS.
-		slog.Warn("audit: crypto/rand failed, using zero UUID", "error", err)
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("audit: crypto/rand failed, using zero UUID", "error", err)
 		return "00000000-0000-4000-8000-000000000000"
 	}
 	// Set version (4) and variant (RFC 4122).

--- a/webhook/config.go
+++ b/webhook/config.go
@@ -271,13 +271,16 @@ func validateWebhookLimits(cfg *Config) error {
 // buildWebhookTLSConfig creates a TLS configuration for webhook
 // connections using the [audit.TLSPolicy] from the config (defaulting to
 // TLS 1.3 only when nil). InsecureSkipVerify is never set.
-func buildWebhookTLSConfig(cfg *Config) (*tls.Config, error) {
+//
+// Warnings emitted by [audit.TLSPolicy.Apply] are routed through the
+// given logger (pass [slog.Default] for caller-default behaviour).
+func buildWebhookTLSConfig(cfg *Config, logger *slog.Logger) (*tls.Config, error) {
 	tlsCfg, warnings := cfg.TLSPolicy.Apply(nil)
 	for _, w := range warnings {
 		// Log only scheme+host to avoid leaking query-parameter tokens.
 		u, _ := url.Parse(cfg.URL)
 		sanitised := u.Scheme + "://" + u.Host
-		slog.Warn(w, "output", "webhook", "url", sanitised)
+		logger.Warn(w, "output", "webhook", "url", sanitised)
 	}
 
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {

--- a/webhook/options.go
+++ b/webhook/options.go
@@ -1,0 +1,59 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import "log/slog"
+
+// Option configures a webhook [Output] at construction time. Options
+// are passed as variadic arguments to [New] and applied in order
+// before any configuration validation, TLS setup, or warning emission.
+type Option func(*options)
+
+// options holds resolved construction-time settings. Zero value is
+// valid — all fields receive sensible defaults inside [New].
+type options struct {
+	logger *slog.Logger
+}
+
+// WithDiagnosticLogger routes construction-time and runtime warnings
+// (TLS policy, connection, retry, and buffer-full drop notices) to the
+// given logger. When nil or not supplied, warnings go to
+// [slog.Default].
+//
+// Consumers normally do not call this directly when using
+// [github.com/axonops/audit/outputconfig.Load] — outputconfig plumbs
+// the auditor's diagnostic logger into every output it constructs.
+// Use this option when constructing a webhook output programmatically
+// and you want its warnings to match your application's log handler.
+//
+// The option mirrors [audit.WithDiagnosticLogger] at the auditor level;
+// the same logger may be passed to both for consistent routing.
+func WithDiagnosticLogger(l *slog.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// resolveOptions applies the given options over a defaulted value.
+// A nil logger (either absent or explicitly WithDiagnosticLogger(nil))
+// falls back to [slog.Default].
+func resolveOptions(opts []Option) options {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.logger == nil {
+		o.logger = slog.Default()
+	}
+	return o
+}

--- a/webhook/register.go
+++ b/webhook/register.go
@@ -17,6 +17,7 @@ package webhook
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/axonops/audit"
@@ -30,8 +31,9 @@ func init() {
 // defaultFactory creates a webhook output from YAML config. Core
 // metrics are forwarded for delivery reporting. Per-output metrics
 // are injected via OutputMetricsReceiver after construction.
-func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
-	return buildOutput(name, rawConfig, coreMetrics)
+// The logger is plumbed through to construction-time TLS warnings.
+func defaultFactory(name string, rawConfig []byte, coreMetrics audit.Metrics, logger *slog.Logger) (audit.Output, error) {
+	return buildOutput(name, rawConfig, coreMetrics, logger)
 }
 
 // yamlWebhookConfig is the YAML-specific representation of webhook
@@ -92,7 +94,7 @@ func intPtrOrDefault(p *int, def int) int {
 	return *p
 }
 
-func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics) (audit.Output, error) {
+func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics, logger *slog.Logger) (audit.Output, error) {
 	if len(rawConfig) == 0 {
 		return nil, fmt.Errorf("audit: webhook output %q: config is required", name)
 	}
@@ -124,7 +126,7 @@ func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics) (audi
 		}
 	}
 
-	out, err := New(cfg, coreMetrics)
+	out, err := New(cfg, coreMetrics, WithDiagnosticLogger(logger))
 	if err != nil {
 		return nil, fmt.Errorf("audit: webhook output %q: %w", name, err)
 	}

--- a/webhook/register_test.go
+++ b/webhook/register_test.go
@@ -34,7 +34,7 @@ func TestWebhookFactory_ValidConfig(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	out, err := factory("splunk_hec", yaml, nil)
+	out, err := factory("splunk_hec", yaml, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 
@@ -47,7 +47,7 @@ func TestWebhookFactory_InvalidConfig_EmptyURL(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	_, err := factory("bad_webhook", yaml, nil)
+	_, err := factory("bad_webhook", yaml, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "bad_webhook")
 }
@@ -58,7 +58,7 @@ func TestWebhookFactory_UnknownYAMLField_Rejected(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	_, err := factory("test", yaml, nil)
+	_, err := factory("test", yaml, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown_field")
 }
@@ -69,7 +69,7 @@ func TestWebhookFactory_AllowInsecureHTTP_AcceptsHTTPURL(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	out, err := factory("insecure", rawYAML, nil)
+	out, err := factory("insecure", rawYAML, nil, nil)
 	require.NoError(t, err, "allow_insecure_http: true should accept HTTP URLs")
 	t.Cleanup(func() { _ = out.Close() })
 	assert.Equal(t, "insecure", out.Name())
@@ -81,7 +81,7 @@ func TestWebhookFactory_AllowInsecureHTTP_DefaultFalse_RejectsHTTPURL(t *testing
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	_, err := factory("no_insecure", rawYAML, nil)
+	_, err := factory("no_insecure", rawYAML, nil, nil)
 	assert.Error(t, err, "HTTP URL without allow_insecure_http should be rejected")
 	assert.Contains(t, err.Error(), "must be https")
 }
@@ -92,7 +92,7 @@ func TestWebhookFactory_AllowInsecureHTTP_ExplicitFalse_RejectsHTTPURL(t *testin
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	_, err := factory("explicit_false", rawYAML, nil)
+	_, err := factory("explicit_false", rawYAML, nil, nil)
 	assert.Error(t, err, "allow_insecure_http: false should still reject HTTP URLs")
 	assert.Contains(t, err.Error(), "must be https")
 }
@@ -103,7 +103,7 @@ func TestWebhookFactory_AllowPrivateRanges_Accepted(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	out, err := factory("private", rawYAML, nil)
+	out, err := factory("private", rawYAML, nil, nil)
 	require.NoError(t, err, "allow_private_ranges: true should be accepted")
 	t.Cleanup(func() { _ = out.Close() })
 	assert.Equal(t, "private", out.Name())
@@ -115,7 +115,7 @@ func TestWebhookFactory_BothInsecureFields_Accepted(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	out, err := factory("both", rawYAML, nil)
+	out, err := factory("both", rawYAML, nil, nil)
 	require.NoError(t, err, "both insecure fields should be accepted together")
 	t.Cleanup(func() { _ = out.Close() })
 	assert.Equal(t, "both", out.Name())
@@ -125,7 +125,7 @@ func TestWebhookFactory_EmptyConfig_ReturnsError(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	_, err := factory("empty", nil, nil)
+	_, err := factory("empty", nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "config is required")
 }
@@ -136,7 +136,7 @@ func TestWebhookFactory_WithHeaders(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	out, err := factory("with_headers", yaml, nil)
+	out, err := factory("with_headers", yaml, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 	assert.Equal(t, "with_headers", out.Name())
@@ -148,7 +148,7 @@ func TestWebhookFactory_WithTLSPolicy(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	out, err := factory("tls_webhook", yaml, nil)
+	out, err := factory("tls_webhook", yaml, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 }
@@ -172,7 +172,7 @@ func TestWebhookFactory_DurationParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := factory("dur_test", []byte(tt.yaml), nil)
+			out, err := factory("dur_test", []byte(tt.yaml), nil, nil)
 			if out != nil {
 				t.Cleanup(func() { _ = out.Close() })
 			}
@@ -194,7 +194,7 @@ func TestWebhookFactory_ExplicitZeroMaxRetries_Rejected(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	_, err := factory("zero_retries", yaml, nil)
+	_, err := factory("zero_retries", yaml, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_retries must be at least 1")
 }
@@ -205,7 +205,7 @@ func TestWebhookFactory_ExplicitZeroBatchSize_Rejected(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	_, err := factory("zero_batch", yaml, nil)
+	_, err := factory("zero_batch", yaml, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "batch_size must be at least 1")
 }
@@ -216,7 +216,7 @@ func TestWebhookFactory_OmittedMaxRetries_DefaultsTo3(t *testing.T) {
 	factory := audit.LookupOutputFactory("webhook")
 	require.NotNil(t, factory)
 
-	out, err := factory("default_retries", yaml, nil)
+	out, err := factory("default_retries", yaml, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = out.Close() })
 }

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -115,16 +115,23 @@ func (w *Output) SetDiagnosticLogger(l *slog.Logger) {
 // the background batch goroutine. The metrics parameter is optional
 // (may be nil). Per-output metrics are injected via
 // [audit.OutputMetricsReceiver.SetOutputMetrics] after construction.
-func New(cfg *Config, metrics audit.Metrics) (*Output, error) {
+//
+// Optional [Option] arguments tune construction-time behaviour. Pass
+// [WithDiagnosticLogger] to route TLS-policy warnings (emitted before
+// the auditor's diagnostic logger is propagated post-construction) to
+// a custom logger.
+func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 	// Copy config so validation/defaults don't mutate the caller's struct.
 	cfgCopy := *cfg
 	cfg = &cfgCopy
+
+	o := resolveOptions(opts)
 
 	if err := validateWebhookConfig(cfg); err != nil {
 		return nil, err
 	}
 
-	tlsCfg, err := buildWebhookTLSConfig(cfg)
+	tlsCfg, err := buildWebhookTLSConfig(cfg, o.logger)
 	if err != nil {
 		return nil, fmt.Errorf("audit: webhook tls: %w", err)
 	}
@@ -168,7 +175,7 @@ func New(cfg *Config, metrics audit.Metrics) (*Output, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	w := &Output{
-		logger:     slog.Default(),
+		logger:     o.logger,
 		client:     client,
 		url:        cfg.URL,
 		name:       webhookName(cfg.URL),

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -25,6 +25,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/big"
 	"net"
 	"net/http"
@@ -1533,4 +1534,60 @@ func TestWebhookConfig_Format_RedactsHeaders(t *testing.T) {
 	}
 	out := fmt.Sprintf("%+v", cfg)
 	assert.NotContains(t, out, "my-hec-token", "Format must not leak header values via %%+v")
+}
+
+// TestWebhook_ConstructionWarningsRoutedToInjectedLogger verifies that
+// TLS-policy warnings emitted during New() route through the
+// WithDiagnosticLogger-supplied logger rather than slog.Default().
+// Closes #490.
+func TestWebhook_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
+	// TLSPolicy with AllowTLS12=true triggers a "TLS 1.2 allowed" warning
+	// from audit.TLSPolicy.Apply. Any non-default policy with warnings works.
+	var buf strings.Builder
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	injected := slog.New(handler)
+
+	out, err := webhook.New(&webhook.Config{
+		URL:                "https://example.com/events",
+		TLSPolicy:          &audit.TLSPolicy{AllowTLS12: true, AllowWeakCiphers: true},
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      10 * time.Millisecond,
+		Timeout:            1 * time.Second,
+		BufferSize:         10,
+	}, nil, webhook.WithDiagnosticLogger(injected))
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	logged := buf.String()
+	assert.Contains(t, logged, "TLS",
+		"expected TLS-policy warning on injected logger, got: %q", logged)
+	assert.Contains(t, logged, "output=webhook",
+		"warning should carry output=webhook attribute: %q", logged)
+}
+
+// TestWebhook_NilDiagnosticLoggerFallsBackToDefault verifies that
+// WithDiagnosticLogger(nil) does not nil-deref and falls back to
+// slog.Default for warning emission.
+func TestWebhook_NilDiagnosticLoggerFallsBackToDefault(t *testing.T) {
+	// Capture slog.Default temporarily.
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	out, err := webhook.New(&webhook.Config{
+		URL:                "https://example.com/events",
+		TLSPolicy:          &audit.TLSPolicy{AllowTLS12: true, AllowWeakCiphers: true},
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      10 * time.Millisecond,
+		Timeout:            1 * time.Second,
+		BufferSize:         10,
+	}, nil, webhook.WithDiagnosticLogger(nil))
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	assert.Contains(t, buf.String(), "TLS",
+		"WithDiagnosticLogger(nil) should fall back to slog.Default")
 }

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1540,9 +1540,12 @@ func TestWebhookConfig_Format_RedactsHeaders(t *testing.T) {
 // TLS-policy warnings emitted during New() route through the
 // WithDiagnosticLogger-supplied logger rather than slog.Default().
 // Closes #490.
+//
+// AllowTLS12 + AllowWeakCiphers triggers the "weak ciphers permitted"
+// warning inside audit.TLSPolicy.Apply — the only code path in the
+// TLS policy that emits a warning. Matches the syslog, loki, and
+// file peer tests for consistent assertion phrasing.
 func TestWebhook_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
-	// TLSPolicy with AllowTLS12=true triggers a "TLS 1.2 allowed" warning
-	// from audit.TLSPolicy.Apply. Any non-default policy with warnings works.
 	var buf strings.Builder
 	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
 	injected := slog.New(handler)
@@ -1560,8 +1563,8 @@ func TestWebhook_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
 	require.NoError(t, out.Close())
 
 	logged := buf.String()
-	assert.Contains(t, logged, "TLS",
-		"expected TLS-policy warning on injected logger, got: %q", logged)
+	assert.Contains(t, logged, "weak ciphers",
+		"expected weak-ciphers warning on injected logger, got: %q", logged)
 	assert.Contains(t, logged, "output=webhook",
 		"warning should carry output=webhook attribute: %q", logged)
 }


### PR DESCRIPTION
## Summary

Closes #490. Threads the auditor's diagnostic logger through every output module's construction path so construction-time warnings (TLS policy, file permission mode, crypto/rand failure) route to the consumer's configured handler rather than `slog.Default()`.

**Must merge before #474** (atomic.Pointer logger migration) — #474 assumes the logger field on each output is the single source of truth. #490 creates the wiring; #474 makes it atomic.

## API changes

### New (non-breaking additions)

Each output module gains a `WithDiagnosticLogger(*slog.Logger) Option` functional option:
- `webhook.WithDiagnosticLogger`
- `syslog.WithDiagnosticLogger`
- `loki.WithDiagnosticLogger`
- `file.WithDiagnosticLogger`

`outputconfig` gains a matching LoadOption:
- `outputconfig.WithDiagnosticLogger(*slog.Logger) LoadOption`

Pass the same `*slog.Logger` to `audit.WithDiagnosticLogger` AND `outputconfig.WithDiagnosticLogger` for consistent routing of both construction-time and runtime warnings.

### Breaking (pre-v1.0 only — per project rules, no shim)

`audit.OutputFactory` signature gains a 4th parameter:

```go
// Before:
type OutputFactory func(name string, rawConfig []byte, coreMetrics Metrics) (Output, error)

// After:
type OutputFactory func(name string, rawConfig []byte, coreMetrics Metrics, logger *slog.Logger) (Output, error)
```

Custom factory authors must add the parameter (nil is valid — treated as `slog.Default`). See `docs/writing-custom-outputs.md` for the propagation pattern.

## Agent gates

**API design** (api-ergonomics-reviewer consulted BEFORE coding):
- `WithDiagnosticLogger` matches the auditor's `audit.WithDiagnosticLogger` — consistent naming across the stack.
- In-package `Option` type (grpc/mongo/redis precedent). Collision with `audit.Option` handled by package qualifier.
- Rejected V2-factory suffix naming — pre-v1.0 means clean break.
- `outputconfig.WithDiagnosticLogger` mirrors the sibling name.

**Post-coding gates:**
- code-reviewer: found 1 BLOCKER (missing plumbing test) + 2 IMPORTANT (weak webhook assertion, randRead comment). All fixed before push.
- go-quality: PASS (all make check green).
- All 5 commits carry the #490 reference.

## Commits (5)

1. `feat(outputs): add WithDiagnosticLogger to webhook/syslog/loki/file (#490)` — per-module Option + tests.
2. `fix(middleware): route newRequestID crypto/rand warning to auditor logger (#490)` — middleware wiring + randRead seam.
3. `feat!(core): thread diagnostic logger through OutputFactory (#490)` — breaking signature + outputconfig plumbing.
4. `docs(#490): document WithDiagnosticLogger propagation through outputs` — CHANGELOG + docs/output-configuration.md + docs/writing-custom-outputs.md.
5. `test+docs: strengthen #490 per code-review findings` — plumbing test, webhook assertion tightening, randRead thread-safety comment.

## Tests added

Per the issue AC:
- `TestWebhook_ConstructionWarningsRoutedToInjectedLogger`
- `TestSyslog_TLSWarningsRoutedToInjectedLogger`
- `TestLoki_ConstructionWarningsRoutedToInjectedLogger`
- `TestFile_ConstructionWarningsRoutedToInjectedLogger`
- `TestMiddleware_NewRequestIDWarningsRoutedToAuditorLogger`

Plus sibling nil-safe tests and (per blocker B1):
- `TestLoad_DiagnosticLogger_PlumbedThroughFactory` — outputconfig → factory pointer-identity assertion.
- `TestLoad_DiagnosticLogger_NilWhenUnset` — absent LoadOption → nil at factory boundary.

## Test plan

- [x] `make check` passes locally
- [x] Each module's new test passes in isolation
- [x] `TestLoad_DiagnosticLogger_PlumbedThroughFactory` passes (plumbing end-to-end)
- [x] No race detector failures
- [ ] CI green on PR
- [ ] Manual merge approval

## Next up

Per V1-RELEASE-PLAN.md, after this merges: **Track A #474** (atomic.Pointer logger migration). #474 depends on the wiring this PR establishes.