### PR TITLE
fix: atomic.Pointer for diagnostic logger in async outputs (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - HMAC `SaltVersion` character set restricted to `[A-Za-z0-9._:-]` (length 1–64) at config-time validation — values containing spaces, control characters, CEF/JSON metacharacters, or other ambiguous bytes are rejected (#473)
 - `OutputFactory` signature grew a `*slog.Logger` parameter: `func(name string, rawConfig []byte, coreMetrics Metrics, logger *slog.Logger) (Output, error)`. Custom factories must add the parameter (nil is valid; treated as `slog.Default`). The logger is plumbed from `outputconfig.WithDiagnosticLogger` / `audit.WithDiagnosticLogger` so construction-time warnings reach the consumer's handler (#490)
 
+### Fixed
+
+- Data race on the diagnostic logger field in `webhook`, `file`, `syslog`, `loki` outputs. `SetDiagnosticLogger` performed a plain field assignment while background goroutines concurrently read the same field. Race detector now passes `-count=100` across all four outputs. The field is `atomic.Pointer[slog.Logger]`; writers use `Store`, readers use `Load`. No API-shape change; no functional behaviour change (#474)
+
 ### Security
 
 - HMAC now authenticates the `_hmac_v` salt version identifier. Previously `_hmac_v` was appended AFTER HMAC computation, leaving it outside the authenticated region. An in-transit attacker could flip the version from `v1` to `v2` to redirect a verifier's salt lookup without detection. `_hmac_v` is now inside the authenticated bytes; any modification invalidates the HMAC tag. Pre-v1.0 consumers using external verifiers that strip both `_hmac` and `_hmac_v` must update the verifier to strip only `_hmac` (#473)

--- a/file/file.go
+++ b/file/file.go
@@ -138,7 +138,7 @@ const dropWarnInterval = 10 * time.Second
 // to [Output.Write] and [Output.Close].
 type Output struct {
 	writer        *rotate.Writer
-	logger        *slog.Logger
+	logger        atomic.Pointer[slog.Logger] // diagnostic logger; swapped atomically post-construction (#474)
 	outputMetrics atomic.Pointer[audit.OutputMetrics]
 	fileMetrics   atomic.Pointer[Metrics]
 	ch            chan []byte
@@ -153,8 +153,15 @@ type Output struct {
 }
 
 // SetDiagnosticLogger receives the library's diagnostic logger.
+//
+// Safe for concurrent use with the background write goroutine and any
+// active [Output.Write] caller — the logger field is an
+// [atomic.Pointer] so readers always see a fully-published value.
 func (f *Output) SetDiagnosticLogger(l *slog.Logger) {
-	f.logger = l
+	if l == nil {
+		l = slog.Default()
+	}
+	f.logger.Store(l)
 }
 
 // resolvePath normalises the path to an absolute form, resolving
@@ -227,11 +234,13 @@ func New(cfg Config, fileMetrics Metrics, opts ...Option) (*Output, error) { //n
 	out := &Output{
 		path:    cfg.Path,
 		name:    "file:" + cfg.Path,
-		logger:  logger,
 		ch:      make(chan []byte, cfg.BufferSize),
 		closeCh: make(chan struct{}),
 		done:    make(chan struct{}),
 	}
+	// Publish the initial logger BEFORE any goroutine starts reading
+	// it. resolveOptions has already replaced nil with slog.Default.
+	out.logger.Store(logger)
 	if fileMetrics != nil {
 		out.fileMetrics.Store(&fileMetrics)
 	}
@@ -244,7 +253,7 @@ func New(cfg Config, fileMetrics Metrics, opts ...Option) (*Output, error) { //n
 		MaxBackups: cfg.MaxBackups,
 		Compress:   compress,
 		OnError: func(err error) {
-			out.logger.Warn("audit: file output background error",
+			out.logger.Load().Warn("audit: file output background error",
 				"path", logPath, "error", err)
 		},
 	}
@@ -284,7 +293,7 @@ func (f *Output) Write(data []byte) error {
 		return nil
 	default:
 		f.drops.record(dropWarnInterval, func(dropped int64) {
-			f.logger.Warn("audit: output file: event dropped (buffer full)",
+			f.logger.Load().Warn("audit: output file: event dropped (buffer full)",
 				"dropped", dropped,
 				"buffer_size", cap(f.ch))
 		})
@@ -318,7 +327,7 @@ func (f *Output) Close() error {
 	case <-f.done:
 	case <-timer.C:
 		remaining := len(f.ch)
-		f.logger.Error("audit: output file: shutdown timeout, events lost",
+		f.logger.Load().Error("audit: output file: shutdown timeout, events lost",
 			"timeout", shutdownTimeout,
 			"events_lost", remaining)
 	}
@@ -373,12 +382,16 @@ func (f *Output) writeEvent(data []byte) {
 	if omp := f.outputMetrics.Load(); omp != nil {
 		om = *omp
 	}
+	// Cache the logger once per event so a concurrent
+	// SetDiagnosticLogger swap mid-event still logs through the
+	// pre-swap logger (benign; next event picks up the new one).
+	logger := f.logger.Load()
 
 	defer func() {
 		if r := recover(); r != nil {
 			buf := make([]byte, 4096)
 			n := runtime.Stack(buf, false)
-			f.logger.Error("audit: output file: panic recovered",
+			logger.Error("audit: output file: panic recovered",
 				"panic", r,
 				"stack", string(buf[:n]))
 			if om != nil {
@@ -398,7 +411,7 @@ func (f *Output) writeEvent(data []byte) {
 		start = time.Now()
 	}
 	if _, err := f.writer.Write(data); err != nil {
-		f.logger.Error("audit: output file: delivery failed",
+		logger.Error("audit: output file: delivery failed",
 			"error", err)
 		if om != nil {
 			om.RecordError()

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -16,6 +16,7 @@ package file_test
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -885,6 +886,36 @@ func TestFile_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
 	logged := buf.String()
 	assert.Contains(t, logged, "permissions grant group/world access",
 		"expected permission warning on injected logger, got: %q", logged)
+}
+
+// TestFile_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
+// and Write concurrently to prove the logger field is safe under the
+// race detector. Closes #474 AC #3.
+func TestFile_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
+	dir := t.TempDir()
+	out, err := file.New(file.Config{
+		Path:       filepath.Join(dir, "race.log"),
+		BufferSize: 1000,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+
+	var wg sync.WaitGroup
+	const iters = 100
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iters {
+			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iters {
+			_ = out.Write([]byte(`{"event":"race"}` + "\n"))
+		}
+	}()
+	wg.Wait()
 }
 
 // TestFile_NilDiagnosticLoggerFallsBackToDefault verifies

--- a/loki/config_test.go
+++ b/loki/config_test.go
@@ -17,10 +17,12 @@ package loki_test
 import (
 	"crypto/tls"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -816,6 +818,41 @@ func TestLoki_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
 		"expected weak-ciphers warning on injected logger, got: %q", logged)
 	assert.Contains(t, logged, "output=loki",
 		"warning should carry output=loki attribute: %q", logged)
+}
+
+// TestLoki_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
+// and WriteWithMetadata concurrently to prove the logger field is safe
+// under the race detector. Closes #474 AC #3.
+func TestLoki_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
+	out, err := loki.New(&loki.Config{
+		URL:                "http://127.0.0.1:3100/loki/api/v1/push",
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      100 * time.Millisecond,
+		Timeout:            1 * time.Second,
+		BufferSize:         1000,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+
+	var wg sync.WaitGroup
+	const iters = 100
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iters {
+			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		meta := audit.EventMetadata{EventType: "race", Severity: 1}
+		for range iters {
+			_ = out.WriteWithMetadata([]byte(`{"event":"race"}`), meta)
+		}
+	}()
+	wg.Wait()
 }
 
 // TestLoki_NilDiagnosticLoggerFallsBackToDefault verifies

--- a/loki/http.go
+++ b/loki/http.go
@@ -50,6 +50,10 @@ const maxResponseBody = 64 << 10 // 64 KiB
 // buffers that are safe to use because flush() is synchronous.
 func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int, compressed bool) {
 	start := time.Now()
+	// Cache the logger pointer once per batch so repeated warn/error
+	// calls inside the retry loop pay a single atomic.Load. Matches
+	// the webhook doPostWithRetry pattern (#474).
+	logger := o.logger.Load()
 	o.retryHint = 0 // clear stale hint from previous batch
 
 	for attempt := range o.cfg.MaxRetries {
@@ -80,7 +84,7 @@ func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int
 		}
 
 		if !retryable {
-			o.logger.Load().Error("audit: loki non-retryable error",
+			logger.Error("audit: loki non-retryable error",
 				"error", err,
 				"batch_size", batchSize)
 			o.recordError()
@@ -89,14 +93,14 @@ func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int
 		}
 
 		o.recordRetry(attempt + 1)
-		o.logger.Load().Warn("audit: loki retryable error",
+		logger.Warn("audit: loki retryable error",
 			"attempt", attempt+1,
 			"max_retries", o.cfg.MaxRetries,
 			"error", err)
 	}
 
 	// All retries exhausted.
-	o.logger.Load().Error("audit: loki retries exhausted, dropping batch",
+	logger.Error("audit: loki retries exhausted, dropping batch",
 		"batch_size", batchSize,
 		"max_retries", o.cfg.MaxRetries)
 	o.recordDrop(batchSize)

--- a/loki/http.go
+++ b/loki/http.go
@@ -80,7 +80,7 @@ func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int
 		}
 
 		if !retryable {
-			o.logger.Error("audit: loki non-retryable error",
+			o.logger.Load().Error("audit: loki non-retryable error",
 				"error", err,
 				"batch_size", batchSize)
 			o.recordError()
@@ -89,14 +89,14 @@ func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int
 		}
 
 		o.recordRetry(attempt + 1)
-		o.logger.Warn("audit: loki retryable error",
+		o.logger.Load().Warn("audit: loki retryable error",
 			"attempt", attempt+1,
 			"max_retries", o.cfg.MaxRetries,
 			"error", err)
 	}
 
 	// All retries exhausted.
-	o.logger.Error("audit: loki retries exhausted, dropping batch",
+	o.logger.Load().Error("audit: loki retries exhausted, dropping batch",
 		"batch_size", batchSize,
 		"max_retries", o.cfg.MaxRetries)
 	o.recordDrop(batchSize)

--- a/loki/loki.go
+++ b/loki/loki.go
@@ -87,8 +87,8 @@ type Output struct { //nolint:govet // fieldalignment: readability preferred
 	mu            sync.Mutex
 	closed        atomic.Bool
 	fw            atomic.Pointer[frameworkFields]
-	logger        *slog.Logger
-	drops         dropLimiter // rate-limits buffer-full warnings
+	logger        atomic.Pointer[slog.Logger] // swapped atomically post-construction (#474)
+	drops         dropLimiter                 // rate-limits buffer-full warnings
 
 	// Flush-path state — owned exclusively by batchLoop goroutine.
 	streams      map[string]*lokiStream // reused across flushes
@@ -170,7 +170,6 @@ func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 	o := &Output{
 		cfg:     cfg,
 		metrics: metrics,
-		logger:  resolved.logger,
 		ch:      make(chan lokiEntry, cfg.BufferSize),
 		closeCh: make(chan struct{}),
 		cancel:  cancel,
@@ -179,6 +178,8 @@ func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 		name:    lokiName(cfg.URL),
 		streams: make(map[string]*lokiStream),
 	}
+	// Publish the initial logger BEFORE starting the batch goroutine.
+	o.logger.Store(resolved.logger)
 	o.compressDest = &o.compressBuf // default; overridden in tests
 
 	go o.batchLoop(ctx)
@@ -194,8 +195,15 @@ func (o *Output) SetFrameworkFields(appName, host, timezone string, pid int) {
 }
 
 // SetDiagnosticLogger receives the library's diagnostic logger.
+//
+// Safe for concurrent use with the background batch goroutine and any
+// active [Output.WriteWithMetadata] caller — the logger field is an
+// [atomic.Pointer] so readers always see a fully-published value.
 func (o *Output) SetDiagnosticLogger(l *slog.Logger) {
-	o.logger = l
+	if l == nil {
+		l = slog.Default()
+	}
+	o.logger.Store(l)
 }
 
 // WriteWithMetadata enqueues a serialised audit event with per-event
@@ -215,7 +223,7 @@ func (o *Output) WriteWithMetadata(data []byte, meta audit.EventMetadata) error 
 		return nil
 	default:
 		o.drops.record(dropWarnInterval, func(dropped int64) {
-			o.logger.Warn("audit: output loki: event dropped (buffer full)",
+			o.logger.Load().Warn("audit: output loki: event dropped (buffer full)",
 				"dropped", dropped,
 				"buffer_size", cap(o.ch))
 		})
@@ -262,7 +270,7 @@ func (o *Output) Close() error {
 	select {
 	case <-o.done:
 	case <-timer.C:
-		o.logger.Error("audit: loki batch goroutine did not exit",
+		o.logger.Load().Error("audit: loki batch goroutine did not exit",
 			"timeout", shutdownTimeout)
 	}
 
@@ -377,7 +385,7 @@ func (o *Output) flush(ctx context.Context, batch []lokiEntry) {
 
 	body, compressed, err := o.maybeCompress()
 	if err != nil {
-		o.logger.Warn("audit: loki compression failed, sending uncompressed",
+		o.logger.Load().Warn("audit: loki compression failed, sending uncompressed",
 			"error", err, "batch_size", len(batch))
 		body = o.payloadBuf.Bytes()
 		compressed = false

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -151,7 +151,7 @@ type Output struct {
 	tlsCfg        *tls.Config                         // cached for reconnection; nil for non-TLS
 	syslogMetrics atomic.Pointer[Metrics]             // extension: RecordSyslogReconnect (may be nil)
 	outputMetrics atomic.Pointer[audit.OutputMetrics] // unified per-output metrics (may be nil)
-	logger        *slog.Logger                        // diagnostic logger; set via SetDiagnosticLogger
+	logger        atomic.Pointer[slog.Logger]         // diagnostic logger; swapped atomically post-construction (#474)
 	ch            chan syslogEntry                    // async buffer
 	closeCh       chan struct{}                       // signals writeLoop to drain and exit
 	done          chan struct{}                       // closed when writeLoop exits
@@ -170,8 +170,15 @@ type Output struct {
 }
 
 // SetDiagnosticLogger receives the library's diagnostic logger.
+//
+// Safe for concurrent use with the background write goroutine and any
+// active [Output.Write] caller — the logger field is an
+// [atomic.Pointer] so readers always see a fully-published value.
 func (s *Output) SetDiagnosticLogger(l *slog.Logger) {
-	s.logger = l
+	if l == nil {
+		l = slog.Default()
+	}
+	s.logger.Store(l)
 }
 
 // New creates a new [Output] from the given config.
@@ -223,7 +230,6 @@ func New(cfg *Config, syslogMetrics Metrics, opts ...Option) (*Output, error) {
 
 	s := &Output{
 		tlsCfg:   tlsCfg,
-		logger:   o.logger,
 		ch:       make(chan syslogEntry, bufSize),
 		closeCh:  make(chan struct{}),
 		done:     make(chan struct{}),
@@ -235,6 +241,9 @@ func New(cfg *Config, syslogMetrics Metrics, opts ...Option) (*Output, error) {
 		facility: priority, // parseFacility returns facility bits only
 		maxRetry: maxRetry,
 	}
+	// Publish the initial logger BEFORE starting the write goroutine.
+	// resolveOptions already replaced nil with slog.Default.
+	s.logger.Store(o.logger)
 	if syslogMetrics != nil {
 		s.syslogMetrics.Store(&syslogMetrics)
 	}
@@ -278,7 +287,7 @@ func (s *Output) enqueue(data []byte, priority srslog.Priority) error {
 		return nil
 	default:
 		s.drops.record(dropWarnInterval, func(dropped int64) {
-			s.logger.Warn("audit: output syslog: event dropped (buffer full)",
+			s.logger.Load().Warn("audit: output syslog: event dropped (buffer full)",
 				"dropped", dropped,
 				"buffer_size", cap(s.ch))
 		})
@@ -312,7 +321,7 @@ func (s *Output) Close() error {
 	case <-s.done:
 	case <-timer.C:
 		remaining := len(s.ch)
-		s.logger.Error("audit: output syslog: shutdown timeout, events lost",
+		s.logger.Load().Error("audit: output syslog: shutdown timeout, events lost",
 			"timeout", shutdownTimeout,
 			"events_lost", remaining)
 	}
@@ -413,7 +422,7 @@ func (s *Output) writeEntry(entry syslogEntry) { //nolint:gocyclo,cyclop // even
 		if r := recover(); r != nil {
 			buf := make([]byte, 4096)
 			n := runtime.Stack(buf, false)
-			s.logger.Error("audit: output syslog: panic recovered",
+			s.logger.Load().Error("audit: output syslog: panic recovered",
 				"panic", r,
 				"stack", string(buf[:n]))
 			if om != nil {
@@ -462,7 +471,7 @@ func (s *Output) handleWriteFailure(entry syslogEntry, writeErr error, om audit.
 	s.failures++
 
 	if s.failures > s.maxRetry {
-		s.logger.Error("audit: output syslog: retries exhausted, dropping event",
+		s.logger.Load().Error("audit: output syslog: retries exhausted, dropping event",
 			"address", s.address,
 			"failures", s.failures,
 			"last_error", writeErr)
@@ -479,7 +488,7 @@ func (s *Output) handleWriteFailure(entry syslogEntry, writeErr error, om audit.
 	}
 
 	backoff := backoffDuration(s.failures)
-	s.logger.Warn("audit: output syslog: reconnecting",
+	s.logger.Load().Warn("audit: output syslog: reconnecting",
 		"address", s.address,
 		"attempt", s.failures,
 		"backoff", backoff)
@@ -507,7 +516,7 @@ func (s *Output) handleWriteFailure(entry syslogEntry, writeErr error, om audit.
 	}
 
 	if err := s.connect(); err != nil {
-		s.logger.Error("audit: output syslog: reconnect failed",
+		s.logger.Load().Error("audit: output syslog: reconnect failed",
 			"address", s.address,
 			"attempt", s.failures,
 			"error", err)
@@ -517,14 +526,14 @@ func (s *Output) handleWriteFailure(entry syslogEntry, writeErr error, om audit.
 		return
 	}
 
-	s.logger.Info("audit: syslog reconnected", "address", s.address)
+	s.logger.Load().Info("audit: syslog reconnected", "address", s.address)
 	if sm != nil {
 		sm.RecordSyslogReconnect(s.address, true)
 	}
 
 	// Retry the write on the new connection.
 	if _, err := s.writer.WriteWithPriority(entry.priority, entry.data); err != nil {
-		s.logger.Error("audit: output syslog: delivery failed after reconnect",
+		s.logger.Load().Error("audit: output syslog: delivery failed after reconnect",
 			"error", err)
 		if om != nil {
 			om.RecordError()
@@ -565,7 +574,7 @@ func (s *Output) drainOne(entry syslogEntry) {
 		if r := recover(); r != nil {
 			buf := make([]byte, 4096)
 			n := runtime.Stack(buf, false)
-			s.logger.Error("audit: output syslog: panic recovered during drain",
+			s.logger.Load().Error("audit: output syslog: panic recovered during drain",
 				"panic", r,
 				"stack", string(buf[:n]))
 			if om != nil {
@@ -583,7 +592,7 @@ func (s *Output) drainOne(entry syslogEntry) {
 		start = time.Now()
 	}
 	if _, err := s.writer.WriteWithPriority(entry.priority, entry.data); err != nil {
-		s.logger.Error("audit: output syslog: delivery failed during drain",
+		s.logger.Load().Error("audit: output syslog: delivery failed during drain",
 			"error", err)
 		if om != nil {
 			om.RecordError()

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -2790,6 +2790,57 @@ func TestSyslog_TLSWarningsRoutedToInjectedLogger(t *testing.T) {
 		"warning should carry output=syslog attribute: %q", logged)
 }
 
+// TestSyslog_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
+// and Write concurrently to prove the logger field is safe under the
+// race detector. Closes #474 AC #3.
+//
+// Uses a local TCP listener to accept the syslog connection so New
+// succeeds. The listener just drains bytes — we do not validate
+// delivery, only that the logger field survives concurrent access.
+func TestSyslog_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				_, _ = io.Copy(io.Discard, c)
+			}(conn)
+		}
+	}()
+
+	out, err := syslog.New(&syslog.Config{
+		Network:  "tcp",
+		Address:  listener.Addr().String(),
+		Facility: "local0",
+		AppName:  "race-test",
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+
+	var wg sync.WaitGroup
+	const iters = 100
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iters {
+			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iters {
+			_ = out.Write([]byte(`{"event":"race"}`))
+		}
+	}()
+	wg.Wait()
+}
+
 // TestSyslog_NilDiagnosticLoggerFallsBackToDefault verifies
 // WithDiagnosticLogger(nil) does not nil-deref and falls back to
 // slog.Default for warning emission.

--- a/webhook/http.go
+++ b/webhook/http.go
@@ -30,6 +30,11 @@ import (
 func (w *Output) doPostWithRetry(ctx context.Context, batch [][]byte) { //nolint:gocognit // retry loop with metrics recording
 	start := time.Now()
 	body := buildNDJSON(batch)
+	// Cache the logger pointer once per batch so repeated warn/error
+	// calls inside the retry loop pay a single atomic.Load. The field
+	// is atomic.Pointer (#474) — a concurrent SetDiagnosticLogger
+	// will only be visible on the next batch, which is fine.
+	logger := w.logger.Load()
 
 	for attempt := range w.maxRetries {
 		if attempt > 0 {
@@ -51,7 +56,7 @@ func (w *Output) doPostWithRetry(ctx context.Context, batch [][]byte) { //nolint
 		}
 
 		if !retryable {
-			w.logger.Error("audit: output webhook: non-retryable error",
+			logger.Error("audit: output webhook: non-retryable error",
 				"error", err,
 				"batch_size", len(batch))
 			if omp := w.outputMetrics.Load(); omp != nil {
@@ -61,7 +66,7 @@ func (w *Output) doPostWithRetry(ctx context.Context, batch [][]byte) { //nolint
 			return
 		}
 
-		w.logger.Warn("audit: output webhook: retrying",
+		logger.Warn("audit: output webhook: retrying",
 			"attempt", attempt+1,
 			"max_retries", w.maxRetries,
 			"error", err)
@@ -71,7 +76,7 @@ func (w *Output) doPostWithRetry(ctx context.Context, batch [][]byte) { //nolint
 	}
 
 	// All retries exhausted.
-	w.logger.Error("audit: output webhook: retries exhausted, dropping batch",
+	logger.Error("audit: output webhook: retries exhausted, dropping batch",
 		"batch_size", len(batch),
 		"max_retries", w.maxRetries)
 	if omp := w.outputMetrics.Load(); omp != nil {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -87,8 +87,8 @@ var errRedirectBlocked = errors.New("audit: webhook redirects are not followed")
 type Output struct {
 	metrics       audit.Metrics
 	outputMetrics atomic.Pointer[audit.OutputMetrics] // unified per-output metrics (may be nil)
+	logger        atomic.Pointer[slog.Logger]         // diagnostic logger; swapped atomically post-construction (#474)
 	client        *http.Client
-	logger        *slog.Logger
 	cancel        context.CancelFunc
 	done          chan struct{}
 	closeCh       chan struct{} // signals batchLoop to drain and exit
@@ -106,8 +106,15 @@ type Output struct {
 }
 
 // SetDiagnosticLogger receives the library's diagnostic logger.
+//
+// Safe for concurrent use with the background batch goroutine and any
+// active [Output.Write] caller — the logger field is an
+// [atomic.Pointer] so readers always see a fully-published value.
 func (w *Output) SetDiagnosticLogger(l *slog.Logger) {
-	w.logger = l
+	if l == nil {
+		l = slog.Default()
+	}
+	w.logger.Store(l)
 }
 
 // New creates a new [Output] from the given config.
@@ -175,7 +182,6 @@ func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	w := &Output{
-		logger:     o.logger,
 		client:     client,
 		url:        cfg.URL,
 		name:       webhookName(cfg.URL),
@@ -190,6 +196,9 @@ func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 		flushIvl:   cfg.FlushInterval,
 		timeout:    cfg.Timeout,
 	}
+	// Publish the initial logger BEFORE starting the batch goroutine
+	// so the goroutine's first read observes a non-nil pointer.
+	w.logger.Store(o.logger)
 
 	go w.batchLoop(ctx)
 	return w, nil
@@ -212,7 +221,7 @@ func (w *Output) Write(data []byte) error {
 		return nil
 	default:
 		w.drops.record(dropWarnInterval, func(dropped int64) {
-			w.logger.Warn("audit: output webhook: event dropped (buffer full)",
+			w.logger.Load().Warn("audit: output webhook: event dropped (buffer full)",
 				"dropped", dropped,
 				"buffer_size", cap(w.ch))
 		})
@@ -254,7 +263,7 @@ func (w *Output) Close() error {
 	select {
 	case <-w.done:
 	case <-timer.C:
-		w.logger.Error("audit: webhook batch goroutine did not exit",
+		w.logger.Load().Error("audit: webhook batch goroutine did not exit",
 			"timeout", shutdownTimeout)
 	}
 

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1569,6 +1569,47 @@ func TestWebhook_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
 		"warning should carry output=webhook attribute: %q", logged)
 }
 
+// TestWebhook_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
+// and Write concurrently to prove the logger field is safe under the
+// race detector. Closes #474 AC #3.
+func TestWebhook_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	out, err := webhook.New(&webhook.Config{
+		URL:                srv.URL,
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      10 * time.Millisecond,
+		Timeout:            1 * time.Second,
+		BufferSize:         100,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+
+	// 100 concurrent SetDiagnosticLogger calls against a hot Write path.
+	// Run under -race; any unsynchronised read/write will fail here.
+	var wg sync.WaitGroup
+	const iters = 100
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iters {
+			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iters {
+			_ = out.Write([]byte(`{"event":"race"}`))
+		}
+	}()
+	wg.Wait()
+}
+
 // TestWebhook_NilDiagnosticLoggerFallsBackToDefault verifies that
 // WithDiagnosticLogger(nil) does not nil-deref and falls back to
 // slog.Default for warning emission.


### PR DESCRIPTION
## Summary

Closes #474. The diagnostic logger field on webhook, file, syslog, loki outputs was a plain `*slog.Logger`. `SetDiagnosticLogger` (called post-construction by the auditor's `propagateLogger`) performed a plain field assignment while the background delivery goroutine (batchLoop / writeLoop) was actively reading the same field. Unsynchronised read+write — a data race the race detector had not yet caught due to timing luck.

Targeted race tests added per output now prove the race is closed under `go test -race -count=100`.

## What changed

**The template** (identical shape across all four modules):

```go
// Before
type Output struct {
    logger *slog.Logger
    ...
}
func (o *Output) SetDiagnosticLogger(l *slog.Logger) { o.logger = l }
// readers: o.logger.Warn(...)

// After
type Output struct {
    logger atomic.Pointer[slog.Logger]
    ...
}
func (o *Output) SetDiagnosticLogger(l *slog.Logger) {
    if l == nil { l = slog.Default() }
    o.logger.Store(l)
}
// readers: cached `logger := o.logger.Load()` once per entry, then use `logger`
```

**Key details:**
- `New` publishes the initial logger via `Store` BEFORE starting the background goroutine, so first read observes a non-nil pointer.
- `SetDiagnosticLogger(nil)` is now nil-safe via coercion to `slog.Default`. Previously this would have silently stored nil and nil-deref'd on the next read.
- Hot-path loops (`webhook.doPostWithRetry`, `file.writeEvent`, `loki.doPostWithRetry`) cache the Load result into a local so repeated warn/error calls pay one atomic load per scope, not per site.

This is the exact template established by the existing `atomic.Pointer[audit.OutputMetrics]` field — same lifecycle constraint (init-once at construction, swapped once post-construction), same solution.

## Tests

Per the issue AC:
- `TestWebhook_SetDiagnosticLoggerUnderEventLoad`
- `TestFile_SetDiagnosticLoggerUnderEventLoad`
- `TestSyslog_SetDiagnosticLoggerUnderEventLoad`
- `TestLoki_SetDiagnosticLoggerUnderEventLoad`

Each runs 100 concurrent iterations of `SetDiagnosticLogger / Write` against a live goroutine. All pass `go test -race -count=100` locally.

## Agent gates

- **code-reviewer**: PASS with 1 MINOR (loki/http.go doPostWithRetry caching for symmetry) — **applied in commit 2**.
- **performance-reviewer**: PASS with 0 BLOCKER / 0 IMPORTANT / 1 MINOR (same loki symmetry — fixed). Benchmark analysis: no measurable regression attributable to #474. `atomic.Pointer[slog.Logger]` is size-neutral with `*slog.Logger` on 64-bit. Per-event hot paths (file `writeEvent`, webhook `doPostWithRetry`) cache the Load result. Syslog success path performs zero Load calls. Error/reconnect paths pay a negligible atomic.Load per event which is dwarfed by the underlying I/O.
- `make check` passes. `make bench-compare` ran and was analysed by performance-reviewer; no regression in the four output modules' hot-path benchmarks.

## Commits

1. `fix(outputs): atomic.Pointer for diagnostic logger in async outputs (#474)` — the main change + 4 race tests + CHANGELOG entry.
2. `perf(loki): cache logger pointer in doPostWithRetry for symmetry (#474)` — 3-line symmetry fix per agent reviews.

## Test plan

- [x] `make check` passes
- [x] `go test -race -count=100 ./{file,syslog,webhook,loki}/...` passes
- [x] `make bench-compare` shows no regression attributable to #474
- [ ] CI green on PR
- [ ] Manual merge approval

## Related

- Depends on #490 (merged) for the logger wiring.
- Closes #474.
- After merge: next Track A issue per V1-RELEASE-PLAN.md.