### PR TITLE
security: strip credentials from Config.String and HTTP error logs (#475)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,6 +77,60 @@ should be reported as regular GitHub issues, not security reports:
 - Issues in test infrastructure or CI/CD pipelines
 - Feature requests
 
+## Credential Safety in Log Output
+
+The library never writes credentials to the diagnostic logger under
+normal operation. For defence in depth, the output modules also guard
+the common debug pattern of passing a Config value to `fmt.Printf`,
+`slog.Debug`, or any other reflection-based formatter:
+
+- **Webhook** (`webhook.Config`): `String`, `GoString`, and `Format`
+  drop the URL path, query, and fragment — only `scheme://host` is
+  printed. Headers are included with values replaced by `[REDACTED]`
+  when the header name (case-insensitive substring) contains `auth`,
+  `key`, `secret`, or `token`. Non-matching header names print their
+  value verbatim so operators can see non-sensitive trace headers.
+- **Loki** (`loki.Config`): `String` and `Format` drop the URL path,
+  query, and fragment. `BasicAuth` prints as `BasicAuth{REDACTED}` for
+  both `%v` and `%#v`. `BearerToken` and `TenantID` are never printed;
+  only the presence of bearer authentication is surfaced (`auth=bearer_token`).
+  Custom headers are not printed at all.
+- **Syslog** (`syslog.Config`): `String`, `GoString`, and `Format`
+  print only `network`, `address`, `tls` (none/tls/mtls marker), and
+  `facility`. TLS certificate and key file paths, custom hostname, and
+  app name are omitted from the stringer output even though they are
+  not secrets — they simply are not useful for debug-log
+  disambiguation.
+- **Secret references** (`secrets.Ref`): `String` emits
+  `ref+SCHEME://[REDACTED]#KEY` — the value is never logged, only the
+  scheme and key are surfaced for debugging.
+- **OpenBao / HashiCorp Vault configs** (`openbao.Config`,
+  `vault.Config`): `String`, `GoString`, and `Format` strip the
+  Address URL to scheme+host, print `token=[REDACTED]` (or `unset`
+  when empty), and surface the presence of `Namespace` and TLS client
+  cert without the values themselves.
+- **File output** (`file.Config`): no credential fields. No stringer
+  is required; consumer logging of the Config reveals only path,
+  permissions, and rotation settings — all non-sensitive.
+
+In-transit error leakage is closed too: HTTP retry-loop errors from
+webhook and Loki outputs pass through a `sanitiseClientError` helper
+that replaces the URL in any `*url.Error` returned by
+`http.Client.Do` with the sanitised scheme+host form. Path tokens
+(Slack, Splunk HEC) and query-string credentials no longer appear in
+diagnostic log lines produced by failed retries or connection errors.
+
+The `ErrDuplicateDestination` error returned from `WithOutputs` /
+`WithNamedOutput` no longer includes the raw destination key, because
+that key is URL-path-bearing for webhook and Loki outputs. The error
+message names the two conflicting outputs only — enough to identify
+the misconfiguration without surfacing token material.
+
+The `fmt.Formatter` interface is implemented on every Config type to
+intercept `%+v` (struct-tag reflection) which would otherwise bypass a
+`String` method. Consumers who print individual fields directly
+(`slog.Info("url", cfg.URL)`) bypass these safeguards; do not do this.
+
 ## Software Bill of Materials (SBOM)
 
 Every release includes SBOMs in two formats, published as assets in

--- a/loki/config.go
+++ b/loki/config.go
@@ -217,6 +217,12 @@ type Config struct { //nolint:govet // fieldalignment: readability preferred
 
 // String returns a safe representation of the config without credentials.
 // Value receiver ensures both Config and *Config are protected.
+//
+// URL is sanitised to scheme+host only — path, query, and fragment are
+// dropped. Common Loki token placements include tenant IDs in the path
+// (`/tenants/<TENANT>/push`) and bearer tokens in query strings —
+// stripping everything beyond the host keeps these out of debug logs.
+// Network traffic itself is unaffected; this is a debug-log safety net.
 func (c Config) String() string {
 	auth := "none"
 	if c.BasicAuth != nil {
@@ -225,7 +231,24 @@ func (c Config) String() string {
 		auth = "bearer_token"
 	}
 	return fmt.Sprintf("LokiConfig{url=%q, auth=%s, compress=%t, batch_size=%d}",
-		c.URL, auth, c.Compress, c.BatchSize)
+		sanitizeURLForLog(c.URL), auth, c.Compress, c.BatchSize)
+}
+
+// sanitizeURLForLog returns the scheme+host portion of a URL, dropping
+// path, query, and fragment. Used in [Config.String] and the TLS
+// warning log site to keep secrets (bearer tokens in query strings,
+// tenant IDs in path segments) out of diagnostic output.
+//
+// Returns "<invalid-url>" when raw cannot be parsed, so
+// [Config.String] remains safe to call on unvalidated configs.
+//
+// Duplicated in webhook/config.go — intentional per #542.
+func sanitizeURLForLog(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "<invalid-url>"
+	}
+	return u.Scheme + "://" + u.Host
 }
 
 // Format implements [fmt.Formatter] to prevent credential leakage via

--- a/loki/config_test.go
+++ b/loki/config_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -607,8 +608,13 @@ func TestConfigString_Redaction(t *testing.T) {
 		cfg := &loki.Config{URL: "https://loki.example.com/loki/api/v1/push", BatchSize: 50}
 		s := cfg.String()
 
-		assert.Contains(t, s, "https://loki.example.com/loki/api/v1/push",
-			"String() must include the URL")
+		// URL is sanitised to scheme+host — path/query/fragment dropped
+		// to keep token placements (tenant in path, bearer in query)
+		// out of debug logs. See TestLokiConfig_String_RedactsURLQueryAndFragment.
+		assert.Contains(t, s, "https://loki.example.com",
+			"String() must include the sanitised URL")
+		assert.NotContains(t, s, "/loki/api/v1/push",
+			"path must be stripped from sanitised URL")
 		assert.Contains(t, s, "none",
 			"String() must show auth=none when no credentials are set")
 	})
@@ -790,6 +796,93 @@ func TestBuildLokiTLSConfig(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no valid pem blocks")
 	})
+}
+
+// TestLokiConfig_String_RedactsURLQueryAndFragment verifies that
+// common Loki token placements — tenant IDs in path, bearer tokens
+// or tenant_id query strings, URL fragments — are dropped by
+// Config.String(). Closes #475 AC #2.
+func TestLokiConfig_String_RedactsURLQueryAndFragment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		url        string
+		mustAppear string
+		mustNot    []string
+	}{
+		{
+			name: "tenant_id query and auth query",
+			url:  "https://loki.example.com/loki/api/v1/push?tenant_id=leak-tenant&auth_key=leak-auth-XYZ",
+			mustNot: []string{
+				"leak-tenant", "leak-auth-XYZ",
+				"tenant_id", "auth_key",
+			},
+			// NOTE: "auth=" appears in the output as the auth-type
+			// marker ("auth=none"), so we cannot assert its absence
+			// — that's a legitimate part of the String format.
+			mustAppear: "https://loki.example.com",
+		},
+		{
+			name:       "tenant in path",
+			url:        "https://loki.example.com/tenants/LEAK-TENANT/push",
+			mustNot:    []string{"LEAK-TENANT", "/tenants", "/push"},
+			mustAppear: "https://loki.example.com",
+		},
+		{
+			name:       "fragment",
+			url:        "https://loki.example.com/push#session=LEAK-FRAG",
+			mustNot:    []string{"LEAK-FRAG", "session=", "#"},
+			mustAppear: "https://loki.example.com",
+		},
+		{
+			name:       "invalid URL falls back to placeholder",
+			url:        "::://not-a-url",
+			mustNot:    []string{"not-a-url"},
+			mustAppear: "<invalid-url>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := loki.Config{URL: tt.url}
+			s := cfg.String()
+			for _, forbidden := range tt.mustNot {
+				assert.NotContains(t, s, forbidden,
+					"String() leaked %q from URL %q", forbidden, tt.url)
+			}
+			assert.Contains(t, s, tt.mustAppear,
+				"String() must include the sanitised form")
+		})
+	}
+}
+
+// TestLokiSanitiseClientError_RedactsURLInUrlError verifies that an
+// *url.Error from http.Client.Do has its URL stripped to scheme+host
+// before being logged. Closes #475 H1.
+func TestLokiSanitiseClientError_RedactsURLInUrlError(t *testing.T) {
+	t.Parallel()
+	in := &url.Error{
+		Op:  "Post",
+		URL: "https://loki.example.com/tenants/LEAK-TENANT/push?token=LEAK",
+		Err: fmt.Errorf("connection refused"),
+	}
+	out := loki.SanitiseClientError(in)
+	msg := out.Error()
+	assert.Contains(t, msg, "Post")
+	assert.Contains(t, msg, "connection refused")
+	assert.Contains(t, msg, "https://loki.example.com")
+	assert.NotContains(t, msg, "LEAK-TENANT")
+	assert.NotContains(t, msg, "LEAK", "query-string token must be stripped")
+	assert.NotContains(t, msg, "/tenants", "path must be stripped")
+}
+
+// TestLokiSanitiseClientError_PassesThroughNonUrlErrors verifies that
+// plain errors not wrapping *url.Error are unchanged.
+func TestLokiSanitiseClientError_PassesThroughNonUrlErrors(t *testing.T) {
+	t.Parallel()
+	plain := fmt.Errorf("plain error, no URL")
+	got := loki.SanitiseClientError(plain)
+	assert.Equal(t, plain, got)
 }
 
 // TestLoki_ConstructionWarningsRoutedToInjectedLogger verifies that

--- a/loki/export_test.go
+++ b/loki/export_test.go
@@ -32,10 +32,11 @@ func (fw *FailingWriter) Write(_ []byte) (int, error) {
 
 // Exported aliases for internal functions needed by black-box tests.
 var (
-	ValidateLokiConfig = validateLokiConfig
-	BuildLokiTLSConfig = buildLokiTLSConfig
-	LokiBackoff        = lokiBackoff
-	ParseRetryAfter    = parseRetryAfter
+	ValidateLokiConfig  = validateLokiConfig
+	BuildLokiTLSConfig  = buildLokiTLSConfig
+	LokiBackoff         = lokiBackoff
+	ParseRetryAfter     = parseRetryAfter
+	SanitiseClientError = sanitiseClientError // #475 — error-URL redaction
 )
 
 // TestEvent is a test-only event for building payloads.

--- a/loki/http.go
+++ b/loki/http.go
@@ -23,9 +23,30 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
+
+// sanitiseClientError returns a copy of err with any embedded
+// [*url.Error] stripped of its URL — the URL is replaced with the
+// sanitised scheme+host form to prevent path/query/fragment tokens
+// (tenant IDs, bearer tokens) from leaking into diagnostic logs.
+// Non-*url.Error values pass through unchanged.
+//
+// Mirror of webhook.sanitiseClientError — intentional duplication
+// per #542 to keep sub-modules self-contained.
+func sanitiseClientError(err error) error {
+	var uerr *url.Error
+	if !errors.As(err, &uerr) {
+		return err
+	}
+	return &url.Error{
+		Op:  uerr.Op,
+		URL: sanitizeURLForLog(uerr.URL),
+		Err: uerr.Err,
+	}
+}
 
 // Backoff constants for retry logic. Hardcoded to match the webhook
 // output pattern — MaxRetries is the user's control surface.
@@ -85,7 +106,7 @@ func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int
 
 		if !retryable {
 			logger.Error("audit: loki non-retryable error",
-				"error", err,
+				"error", sanitiseClientError(err),
 				"batch_size", batchSize)
 			o.recordError()
 			o.recordDrop(batchSize)
@@ -96,7 +117,7 @@ func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int
 		logger.Warn("audit: loki retryable error",
 			"attempt", attempt+1,
 			"max_retries", o.cfg.MaxRetries,
-			"error", err)
+			"error", sanitiseClientError(err))
 	}
 
 	// All retries exhausted.

--- a/loki/loki.go
+++ b/loki/loki.go
@@ -127,11 +127,10 @@ func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 		return nil, err
 	}
 	// Log TLS policy warnings via the injected logger (falls back to
-	// slog.Default when no option supplied).
-	u, _ := url.Parse(cfg.URL) // already validated
-	host := u.Scheme + "://" + u.Host
+	// slog.Default when no option supplied). Sanitised URL mirrors
+	// Config.String — path/query/fragment dropped.
 	for _, w := range warnings {
-		resolved.logger.Warn(w, "output", "loki", "url", host)
+		resolved.logger.Warn(w, "output", "loki", "url", sanitizeURLForLog(cfg.URL))
 	}
 
 	var ssrfOpts []audit.SSRFOption

--- a/options.go
+++ b/options.go
@@ -433,7 +433,12 @@ func checkDestinationDup(o Output, name string, seen map[string]string) error {
 		return nil
 	}
 	if existing, dup := seen[key]; dup {
-		return fmt.Errorf("%w: outputs %q and %q share %q", ErrDuplicateDestination, existing, name, key)
+		// Deliberately omit the destination key from the error message:
+		// for webhook/loki outputs the key contains the URL path, which
+		// may carry a secret (Slack /services/<TOKEN>, Splunk HEC path).
+		// The two output names are sufficient to identify the conflict
+		// (#475).
+		return fmt.Errorf("%w: outputs %q and %q share the same destination", ErrDuplicateDestination, existing, name)
 	}
 	seen[key] = name
 	return nil

--- a/secrets/openbao/openbao.go
+++ b/secrets/openbao/openbao.go
@@ -84,6 +84,50 @@ type Config struct { //nolint:govet // readability over alignment
 	AllowInsecureHTTP bool
 }
 
+// String returns a credential-free representation of the config,
+// suitable for debug logging via %v or %+v. Token is never printed;
+// Address path/query/fragment are stripped; presence of TLS client
+// cert and namespace is surfaced without the values (#475).
+func (c Config) String() string {
+	tokenState := "unset"
+	if c.Token != "" {
+		tokenState = "[REDACTED]"
+	}
+	namespaceState := "unset"
+	if c.Namespace != "" {
+		namespaceState = "set"
+	}
+	tlsMode := "none"
+	if c.TLSCert != "" {
+		tlsMode = "mtls"
+	} else if c.TLSCA != "" {
+		tlsMode = "tls"
+	}
+	return fmt.Sprintf("openbao.Config{address=%q, token=%s, namespace=%s, tls=%s}",
+		sanitizeAddressForLog(c.Address), tokenState, namespaceState, tlsMode)
+}
+
+// GoString returns the same redacted representation as [Config.String].
+// Prevents credential leakage when a Config is formatted via %#v.
+func (c Config) GoString() string { return c.String() } //nolint:gocritic // hugeParam: value receiver required by fmt.GoStringer
+
+// Format writes the redacted representation to the formatter.
+// Prevents credential leakage via %+v and all other format verbs.
+func (c Config) Format(f fmt.State, _ rune) { //nolint:gocritic // hugeParam: value receiver required by fmt.Formatter
+	_, _ = fmt.Fprint(f, c.String())
+}
+
+// sanitizeAddressForLog returns the scheme+host portion of the
+// configured Address URL, dropping path/query/fragment. Returns
+// "<invalid-url>" for unparseable input.
+func sanitizeAddressForLog(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "<invalid-url>"
+	}
+	return u.Scheme + "://" + u.Host
+}
+
 // Provider resolves secret references from an OpenBao KV v2 engine.
 // Construction validates the address and builds an SSRF-safe HTTP
 // client but performs no network I/O. The first [Resolve] call

--- a/secrets/openbao/openbao_test.go
+++ b/secrets/openbao/openbao_test.go
@@ -871,3 +871,52 @@ func generateTestCertAndKey(t *testing.T, certPath, keyPath string) {
 	defer func() { _ = kf.Close() }()
 	require.NoError(t, pem.Encode(kf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
 }
+
+// TestConfig_String_RedactsCredentials verifies openbao.Config String,
+// GoString, and Format never leak the Token, and strip the Address to
+// scheme+host. Closes #475 openbao coverage.
+func TestConfig_String_RedactsCredentials(t *testing.T) {
+	t.Parallel()
+	cfg := openbao.Config{
+		Address:   "https://bao.example.com/v1/secret/data/path?query=LEAK-QUERY",
+		Token:     "LEAK-TOKEN-VALUE",
+		Namespace: "my-ns",
+	}
+	// Each formatter exercises a different fmt code path:
+	// %v hits String via Format, %+v same, %#v via GoString.
+	outs := []string{
+		cfg.String(),
+		cfg.GoString(),
+	}
+	// Use format strings via a local rather than hardcoded verbs so
+	// gocritic doesn't flag redundantSprint when the literal equals cfg.String().
+	for _, verb := range []string{"%v", "%+v", "%#v"} {
+		outs = append(outs, fmt.Sprintf(verb, cfg))
+	}
+	for _, out := range outs {
+		assert.NotContains(t, out, "LEAK-TOKEN-VALUE",
+			"Token must never appear in any format verb")
+		assert.NotContains(t, out, "LEAK-QUERY",
+			"URL query must be stripped")
+		assert.NotContains(t, out, "/v1/secret",
+			"URL path must be stripped")
+		assert.NotContains(t, out, "my-ns",
+			"Namespace value must not leak (only its presence)")
+		assert.Contains(t, out, "https://bao.example.com",
+			"scheme+host must appear")
+		assert.Contains(t, out, "[REDACTED]",
+			"token presence must be indicated")
+	}
+}
+
+// TestConfig_String_TokenUnsetShowsUnsetMarker verifies that an empty
+// Token prints "unset" rather than "[REDACTED]".
+func TestConfig_String_TokenUnsetShowsUnsetMarker(t *testing.T) {
+	t.Parallel()
+	cfg := openbao.Config{
+		Address: "https://bao.example.com",
+	}
+	out := cfg.String()
+	assert.Contains(t, out, "token=unset")
+	assert.NotContains(t, out, "[REDACTED]")
+}

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -84,6 +84,50 @@ type Config struct { //nolint:govet // readability over alignment
 	AllowInsecureHTTP bool
 }
 
+// String returns a credential-free representation of the config,
+// suitable for debug logging via %v or %+v. Token is never printed;
+// Address path/query/fragment are stripped; presence of TLS client
+// cert and namespace is surfaced without the values (#475).
+func (c Config) String() string {
+	tokenState := "unset"
+	if c.Token != "" {
+		tokenState = "[REDACTED]"
+	}
+	namespaceState := "unset"
+	if c.Namespace != "" {
+		namespaceState = "set"
+	}
+	tlsMode := "none"
+	if c.TLSCert != "" {
+		tlsMode = "mtls"
+	} else if c.TLSCA != "" {
+		tlsMode = "tls"
+	}
+	return fmt.Sprintf("vault.Config{address=%q, token=%s, namespace=%s, tls=%s}",
+		sanitizeAddressForLog(c.Address), tokenState, namespaceState, tlsMode)
+}
+
+// GoString returns the same redacted representation as [Config.String].
+// Prevents credential leakage when a Config is formatted via %#v.
+func (c Config) GoString() string { return c.String() } //nolint:gocritic // hugeParam: value receiver required by fmt.GoStringer
+
+// Format writes the redacted representation to the formatter.
+// Prevents credential leakage via %+v and all other format verbs.
+func (c Config) Format(f fmt.State, _ rune) { //nolint:gocritic // hugeParam: value receiver required by fmt.Formatter
+	_, _ = fmt.Fprint(f, c.String())
+}
+
+// sanitizeAddressForLog returns the scheme+host portion of the
+// configured Address URL, dropping path/query/fragment. Returns
+// "<invalid-url>" for unparseable input.
+func sanitizeAddressForLog(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "<invalid-url>"
+	}
+	return u.Scheme + "://" + u.Host
+}
+
 // Provider resolves secret references from a HashiCorp Vault KV v2
 // engine. Construction validates the address and builds an SSRF-safe
 // HTTP client but performs no network I/O. The first [Resolve] call

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -773,3 +773,52 @@ func generateTestCertAndKey(t *testing.T, certPath, keyPath string) {
 	defer func() { _ = kf.Close() }()
 	require.NoError(t, pem.Encode(kf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
 }
+
+// TestConfig_String_RedactsCredentials verifies vault.Config String,
+// GoString, and Format never leak the Token, and strip the Address to
+// scheme+host. Closes #475 vault coverage.
+func TestConfig_String_RedactsCredentials(t *testing.T) {
+	t.Parallel()
+	cfg := vault.Config{
+		Address:   "https://vault.example.com/v1/secret/data/path?query=LEAK-QUERY",
+		Token:     "LEAK-TOKEN-VALUE",
+		Namespace: "my-ns",
+	}
+	// Each formatter exercises a different fmt code path:
+	// %v hits String via Format, %+v same, %#v via GoString.
+	outs := []string{
+		cfg.String(),
+		cfg.GoString(),
+	}
+	// Use format strings via a local rather than hardcoded verbs so
+	// gocritic doesn't flag redundantSprint when the literal equals cfg.String().
+	for _, verb := range []string{"%v", "%+v", "%#v"} {
+		outs = append(outs, fmt.Sprintf(verb, cfg))
+	}
+	for _, out := range outs {
+		assert.NotContains(t, out, "LEAK-TOKEN-VALUE",
+			"Token must never appear in any format verb")
+		assert.NotContains(t, out, "LEAK-QUERY",
+			"URL query must be stripped")
+		assert.NotContains(t, out, "/v1/secret",
+			"URL path must be stripped")
+		assert.NotContains(t, out, "my-ns",
+			"Namespace value must not leak (only its presence)")
+		assert.Contains(t, out, "https://vault.example.com",
+			"scheme+host must appear")
+		assert.Contains(t, out, "[REDACTED]",
+			"token presence must be indicated")
+	}
+}
+
+// TestConfig_String_TokenUnsetShowsUnsetMarker verifies that an empty
+// Token prints "unset" rather than "[REDACTED]".
+func TestConfig_String_TokenUnsetShowsUnsetMarker(t *testing.T) {
+	t.Parallel()
+	cfg := vault.Config{
+		Address: "https://vault.example.com",
+	}
+	out := cfg.String()
+	assert.Contains(t, out, "token=unset")
+	assert.NotContains(t, out, "[REDACTED]")
+}

--- a/webhook/config.go
+++ b/webhook/config.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -63,9 +64,18 @@ type Config struct { //nolint:govet // fieldalignment: pointer field TLSPolicy e
 
 	// Headers are custom HTTP headers added to every request.
 	// Common use: "Authorization: Bearer <token>" or
-	// "Authorization: Splunk <token>". Header values containing
-	// "auth", "key", "secret", or "token" (case-insensitive) are
-	// redacted in log output. Header names must not contain CRLF.
+	// "Authorization: Splunk <token>".
+	//
+	// Header NAMES whose lower-case form contains any of "auth",
+	// "key", "secret", or "token" have their VALUES replaced with
+	// "[REDACTED]" in [Config.String], [Config.GoString], and
+	// [Config.Format] output — a defence-in-depth safety net against
+	// `fmt.Sprintf("%+v", cfg)` and `slog.Debug("cfg", cfg)` leakage.
+	// Header names themselves are NOT redacted — they appear in full
+	// so that operators can identify which headers are configured.
+	//
+	// Header names must not contain CRLF. Values are sent verbatim in
+	// the HTTP request regardless of redaction in debug output.
 	Headers map[string]string
 
 	// TLSCA is the path to a custom CA certificate for the webhook
@@ -125,12 +135,18 @@ type Config struct { //nolint:govet // fieldalignment: pointer field TLSPolicy e
 }
 
 // String returns a human-readable representation of the config with
-// sensitive header values redacted. This prevents credential leakage
-// when configs are accidentally logged via %v or %+v.
+// credentials redacted. This prevents credential leakage when configs
+// are accidentally logged via %v or %+v.
+//
+// URL is sanitised to scheme+host only — path, query, and fragment are
+// dropped (common token placements: Slack /services/.../<TOKEN>,
+// Datadog ?dd-api-key=, Splunk HEC ?token=). Header values for names
+// matching the credential-name rule described on [Config.Headers] are
+// replaced with [REDACTED]. Network traffic itself is unaffected;
+// this is a debug-log safety net, not the primary defence.
 func (c Config) String() string {
-	hdrs := len(c.Headers)
-	return fmt.Sprintf("WebhookConfig{url=%q, headers=%d, batch_size=%d, timeout=%s}",
-		c.URL, hdrs, c.BatchSize, c.Timeout)
+	return fmt.Sprintf("WebhookConfig{url=%q, headers=%s, batch_size=%d, timeout=%s}",
+		sanitizeURLForLog(c.URL), redactHeaders(c.Headers), c.BatchSize, c.Timeout)
 }
 
 // GoString returns the same redacted representation as [Config.String].
@@ -140,6 +156,95 @@ func (c Config) GoString() string { return c.String() } //nolint:gocritic // hug
 // Format writes the redacted representation to the formatter.
 // This prevents credential leakage via %+v and all other format verbs.
 func (c Config) Format(f fmt.State, _ rune) { _, _ = fmt.Fprint(f, c.String()) } //nolint:gocritic // hugeParam: value receiver required by fmt.Formatter
+
+// sanitizeURLForLog returns the scheme+host portion of a URL, dropping
+// path, query, and fragment. Used in Config.String / TLS warning log
+// sites to keep secrets (tokens in path, query-string API keys) out
+// of diagnostic output.
+//
+// Returns "<invalid-url>" when raw cannot be parsed, so
+// [Config.String] remains safe to call on unvalidated configs.
+//
+// Duplicated in loki/config.go — intentional per #542.
+func sanitizeURLForLog(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "<invalid-url>"
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+// credentialHeaderPatterns is the case-insensitive substring set used
+// by [redactHeaders] to decide whether a header value is sensitive.
+// The set is deliberately broad — over-redaction is cheap, a missed
+// credential is the whole reason the mechanism exists. Patterns:
+//
+//   - auth       — Authorization, X-Auth-Token, WWW-Authenticate
+//   - key        — X-API-Key, X-Public-Key, Api-Key
+//   - secret     — X-Shared-Secret
+//   - token      — Bearer tokens, CSRF-Token
+//   - cookie     — Cookie, Set-Cookie (session tokens)
+//   - password   — basic-auth legacy carriers
+//   - credential — X-Credential, X-Credentials
+//   - signature  — GitHub X-Hub-Signature, HMAC request signing
+//   - hmac       — X-Hmac, Hmac-Request
+//   - session    — X-Session-Id, Session-Id
+var credentialHeaderPatterns = []string{
+	"auth",
+	"key",
+	"secret",
+	"token",
+	"cookie",
+	"password",
+	"credential",
+	"signature",
+	"hmac",
+	"session",
+}
+
+// redactHeaders returns a deterministic map-style string
+// representation of hdrs with credential values replaced by
+// [REDACTED]. Keys are sorted so output is byte-stable across calls.
+// Empty or nil maps return "map[]".
+func redactHeaders(hdrs map[string]string) string {
+	if len(hdrs) == 0 {
+		return "map[]"
+	}
+	names := make([]string, 0, len(hdrs))
+	for name := range hdrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteString("map[")
+	for i, name := range names {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(name)
+		b.WriteByte(':')
+		if isCredentialHeader(name) {
+			b.WriteString("[REDACTED]")
+		} else {
+			b.WriteString(hdrs[name])
+		}
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// isCredentialHeader reports whether a header name's lower-case form
+// contains any of the [credentialHeaderPatterns].
+func isCredentialHeader(name string) bool {
+	lower := strings.ToLower(name)
+	for _, p := range credentialHeaderPatterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
 
 // validateWebhookConfig checks the config for correctness, applying
 // defaults where needed.
@@ -278,9 +383,7 @@ func buildWebhookTLSConfig(cfg *Config, logger *slog.Logger) (*tls.Config, error
 	tlsCfg, warnings := cfg.TLSPolicy.Apply(nil)
 	for _, w := range warnings {
 		// Log only scheme+host to avoid leaking query-parameter tokens.
-		u, _ := url.Parse(cfg.URL)
-		sanitised := u.Scheme + "://" + u.Host
-		logger.Warn(w, "output", "webhook", "url", sanitised)
+		logger.Warn(w, "output", "webhook", "url", sanitizeURLForLog(cfg.URL))
 	}
 
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {

--- a/webhook/http.go
+++ b/webhook/http.go
@@ -23,8 +23,33 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"time"
 )
+
+// sanitiseClientError returns a copy of err with any embedded
+// [*url.Error] stripped of its URL — the URL is replaced with the
+// sanitised scheme+host form to prevent path/query/fragment tokens
+// (Slack, Datadog, Splunk) from leaking into diagnostic logs.
+// Non-*url.Error values pass through unchanged.
+//
+// This is the transport-level counterpart of [Config.String]'s
+// sanitisation: Config.String handles direct logging of the Config
+// value; this handles indirect logging via errors returned from
+// http.Client.Do.
+func sanitiseClientError(err error) error {
+	var uerr *url.Error
+	if !errors.As(err, &uerr) {
+		return err
+	}
+	// Reconstruct *url.Error with the URL replaced. Preserve Op and
+	// the underlying Err so observability is unchanged.
+	return &url.Error{
+		Op:  uerr.Op,
+		URL: sanitizeURLForLog(uerr.URL),
+		Err: uerr.Err,
+	}
+}
 
 // doPostWithRetry attempts HTTP POST with exponential backoff retry.
 func (w *Output) doPostWithRetry(ctx context.Context, batch [][]byte) { //nolint:gocognit // retry loop with metrics recording
@@ -57,7 +82,7 @@ func (w *Output) doPostWithRetry(ctx context.Context, batch [][]byte) { //nolint
 
 		if !retryable {
 			logger.Error("audit: output webhook: non-retryable error",
-				"error", err,
+				"error", sanitiseClientError(err),
 				"batch_size", len(batch))
 			if omp := w.outputMetrics.Load(); omp != nil {
 				(*omp).RecordError()
@@ -69,7 +94,7 @@ func (w *Output) doPostWithRetry(ctx context.Context, batch [][]byte) { //nolint
 		logger.Warn("audit: output webhook: retrying",
 			"attempt", attempt+1,
 			"max_retries", w.maxRetries,
-			"error", err)
+			"error", sanitiseClientError(err))
 		if omp := w.outputMetrics.Load(); omp != nil {
 			(*omp).RecordRetry(attempt + 1) // 1-indexed: attempt+1 = first retry
 		}

--- a/webhook/webhook_export_test.go
+++ b/webhook/webhook_export_test.go
@@ -19,3 +19,7 @@ var WebhookBackoff = webhookBackoff
 
 // BuildNDJSON is exported for testing only.
 var BuildNDJSON = buildNDJSON
+
+// SanitiseClientError is exported for testing only — exercises the
+// error-URL redaction path used in the retry loop's log sites (#475).
+var SanitiseClientError = sanitiseClientError

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -30,6 +30,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -406,10 +407,10 @@ func (s *webhookTestServer) requestCount() int {
 
 // newTestWebhookOutput creates a webhook output for testing with
 // AllowInsecureHTTP and AllowPrivateRanges (httptest uses http://127.0.0.1).
-func newTestWebhookOutput(t *testing.T, url string, opts ...func(*webhook.Config)) *webhook.Output {
+func newTestWebhookOutput(t *testing.T, rawURL string, opts ...func(*webhook.Config)) *webhook.Output {
 	t.Helper()
 	cfg := &webhook.Config{
-		URL:                url,
+		URL:                rawURL,
 		AllowInsecureHTTP:  true,
 		AllowPrivateRanges: true,
 		BatchSize:          10,
@@ -1493,7 +1494,7 @@ func TestNewWebhookOutput_TLSCA_IsDirectory(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Config.String() credential redaction tests (#325)
+// Config.String() credential redaction tests (#325, #475)
 // ---------------------------------------------------------------------------
 
 func TestWebhookConfig_String_RedactsHeaders(t *testing.T) {
@@ -1505,8 +1506,15 @@ func TestWebhookConfig_String_RedactsHeaders(t *testing.T) {
 	}
 	s := cfg.String()
 	assert.Contains(t, s, "WebhookConfig{")
-	assert.Contains(t, s, "https://example.com/hook")
-	assert.Contains(t, s, "headers=1")
+	// URL is sanitised to scheme+host — path is dropped to keep
+	// common token placements (Slack /services/.../<TOKEN>) out of
+	// log output.
+	assert.Contains(t, s, "https://example.com")
+	assert.NotContains(t, s, "/hook", "path must be stripped from sanitised URL")
+	// Header names are preserved so operators can see what's configured;
+	// sensitive values are replaced with [REDACTED].
+	assert.Contains(t, s, "Authorization")
+	assert.Contains(t, s, "[REDACTED]")
 	assert.NotContains(t, s, "super-secret-token")
 	assert.NotContains(t, s, "Bearer")
 }
@@ -1514,7 +1522,8 @@ func TestWebhookConfig_String_RedactsHeaders(t *testing.T) {
 func TestWebhookConfig_String_NoHeaders(t *testing.T) {
 	cfg := webhook.Config{URL: "https://example.com/hook"}
 	s := cfg.String()
-	assert.Contains(t, s, "headers=0")
+	assert.Contains(t, s, "headers=map[]",
+		"empty headers should appear as map[] (deterministic sorted form)")
 }
 
 func TestWebhookConfig_GoString_RedactsHeaders(t *testing.T) {
@@ -1529,11 +1538,209 @@ func TestWebhookConfig_GoString_RedactsHeaders(t *testing.T) {
 
 func TestWebhookConfig_Format_RedactsHeaders(t *testing.T) {
 	cfg := webhook.Config{
-		URL:     "https://example.com/hook",
+		URL:     "https://example.com/hook?api_key=leak-me",
 		Headers: map[string]string{"Authorization": "Splunk my-hec-token"},
 	}
 	out := fmt.Sprintf("%+v", cfg)
 	assert.NotContains(t, out, "my-hec-token", "Format must not leak header values via %%+v")
+	assert.NotContains(t, out, "leak-me", "Format must not leak URL query values via %%+v")
+	assert.NotContains(t, out, "api_key", "Format must not leak URL query keys via %%+v")
+}
+
+// TestWebhookConfig_String_RedactsURLQueryAndFragment verifies that
+// common token placements in URL path, query, and fragment are dropped
+// by Config.String(). Closes #475 AC #1.
+func TestWebhookConfig_String_RedactsURLQueryAndFragment(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		mustAppear string   // the sanitised URL that should appear
+		mustNot    []string // substrings that must NOT appear
+	}{
+		{
+			name:       "Slack path token",
+			url:        "https://hooks.slack.com/services/T0A1B2/B0C1D2/XYZ-slack-secret",
+			mustNot:    []string{"XYZ-slack-secret", "T0A1B2", "B0C1D2", "/services"},
+			mustAppear: "https://hooks.slack.com",
+		},
+		{
+			name:       "Datadog query API key",
+			url:        "https://http-intake.logs.datadoghq.com/v1/input?dd-api-key=DD_APIKEY_123",
+			mustNot:    []string{"DD_APIKEY_123", "dd-api-key", "/v1/input"},
+			mustAppear: "https://http-intake.logs.datadoghq.com",
+		},
+		{
+			name:       "Splunk HEC path token",
+			url:        "https://splunk.example.com/services/collector/raw/TOKEN-SECRET",
+			mustNot:    []string{"TOKEN-SECRET", "collector", "/services"},
+			mustAppear: "https://splunk.example.com",
+		},
+		{
+			name:       "Fragment with session",
+			url:        "https://x.example.com/hook#session=sec-frag-leak",
+			mustNot:    []string{"sec-frag-leak", "session=", "#"},
+			mustAppear: "https://x.example.com",
+		},
+		{
+			name:       "Invalid URL falls back to placeholder",
+			url:        "::://not-a-url",
+			mustNot:    []string{"not-a-url"},
+			mustAppear: "<invalid-url>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := webhook.Config{URL: tt.url}
+			s := cfg.String()
+			for _, forbidden := range tt.mustNot {
+				assert.NotContains(t, s, forbidden,
+					"String() leaked %q from URL %q", forbidden, tt.url)
+			}
+			assert.Contains(t, s, tt.mustAppear,
+				"String() must include the sanitised form")
+		})
+	}
+}
+
+// TestWebhookConfig_String_RedactsCredentialHeaders verifies that
+// header values are [REDACTED] when the header NAME matches the
+// credential-pattern set (case-insensitive substring: auth, key,
+// secret, token, cookie, password, credential, signature, hmac,
+// session). Closes #475 AC #3 and AC #4.
+func TestWebhookConfig_String_RedactsCredentialHeaders(t *testing.T) {
+	cfg := webhook.Config{
+		URL: "https://example.com",
+		Headers: map[string]string{
+			"Authorization":   "Bearer ABC-AUTH-LEAK",
+			"X-API-Key":       "XYZ-KEY-LEAK",
+			"X-Auth-Token":    "ATK-TRIPLE-LEAK",
+			"Secret-Value":    "SEC-LEAK",
+			"AUTHORIZATION":   "UPPERCASE-LEAK",
+			"authorization":   "LOWERCASE-LEAK",
+			"Cookie":          "SESSION=COOKIE-LEAK",
+			"X-Hub-Signature": "sha256=SIG-LEAK",
+			"X-Hmac":          "HMAC-LEAK",
+			"X-Password":      "PASS-LEAK",
+			"X-Credential":    "CRED-LEAK",
+			"X-Session-Id":    "SESS-LEAK",
+		},
+	}
+	s := cfg.String()
+	for _, leak := range []string{
+		"ABC-AUTH-LEAK",
+		"XYZ-KEY-LEAK",
+		"ATK-TRIPLE-LEAK",
+		"SEC-LEAK",
+		"UPPERCASE-LEAK",
+		"LOWERCASE-LEAK",
+		"COOKIE-LEAK",
+		"SIG-LEAK",
+		"HMAC-LEAK",
+		"PASS-LEAK",
+		"CRED-LEAK",
+		"SESS-LEAK",
+	} {
+		assert.NotContains(t, s, leak,
+			"sensitive header value leaked in String(): %q", leak)
+	}
+	// Every matching header should produce exactly one [REDACTED] marker,
+	// and the header name is preserved.
+	assert.Contains(t, s, "[REDACTED]")
+	assert.Contains(t, s, "Authorization")
+	assert.Contains(t, s, "Cookie")
+	assert.Contains(t, s, "X-Hub-Signature")
+}
+
+// TestSanitiseClientError_RedactsURLInUrlError verifies that an
+// *url.Error from http.Client.Do has its URL stripped to scheme+host
+// before being logged. Closes #475 H1.
+func TestSanitiseClientError_RedactsURLInUrlError(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputURL   string
+		wantKept   string
+		wantLeaked []string
+	}{
+		{
+			name:       "Slack path token",
+			inputURL:   "https://hooks.slack.com/services/T0A1B2/B0C1D2/XYZ-slack-secret",
+			wantKept:   "https://hooks.slack.com",
+			wantLeaked: []string{"XYZ-slack-secret", "T0A1B2", "/services"},
+		},
+		{
+			name:       "Datadog query key",
+			inputURL:   "https://http-intake.logs.datadoghq.com/v1/input?dd-api-key=DD_LEAK",
+			wantKept:   "https://http-intake.logs.datadoghq.com",
+			wantLeaked: []string{"DD_LEAK", "dd-api-key", "/v1/input"},
+		},
+		{
+			name:       "Splunk HEC path token",
+			inputURL:   "https://splunk.example.com/services/collector/raw/HEC-LEAK",
+			wantKept:   "https://splunk.example.com",
+			wantLeaked: []string{"HEC-LEAK", "collector"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := fmt.Errorf("connection refused")
+			in := &url.Error{Op: "Post", URL: tt.inputURL, Err: inner}
+			out := webhook.SanitiseClientError(in)
+
+			msg := out.Error()
+			assert.Contains(t, msg, "Post", "Op must survive")
+			assert.Contains(t, msg, "connection refused", "inner err must survive")
+			assert.Contains(t, msg, tt.wantKept)
+			for _, leak := range tt.wantLeaked {
+				assert.NotContains(t, msg, leak,
+					"sanitiseClientError leaked %q", leak)
+			}
+		})
+	}
+}
+
+// TestSanitiseClientError_PassesThroughNonUrlErrors verifies that
+// plain errors not wrapping *url.Error are returned unchanged, and
+// wrapped *url.Error is still reached via errors.As and redacted.
+func TestSanitiseClientError_PassesThroughNonUrlErrors(t *testing.T) {
+	plain := fmt.Errorf("plain error, no URL")
+	got := webhook.SanitiseClientError(plain)
+	assert.Equal(t, plain, got, "non-url errors must pass through unchanged")
+
+	wrapped := fmt.Errorf("outer: %w", &url.Error{
+		Op:  "Post",
+		URL: "https://hooks.slack.com/services/T/B/LEAKED",
+		Err: fmt.Errorf("timeout"),
+	})
+	gotWrapped := webhook.SanitiseClientError(wrapped)
+	assert.NotContains(t, gotWrapped.Error(), "LEAKED",
+		"wrapped url.Error must still be sanitised")
+}
+
+// TestWebhookConfig_String_PreservesNonSensitiveHeaders verifies that
+// non-credential header values appear verbatim in String() so operators
+// can see configured trace/content headers. Closes #475 AC Tests.
+func TestWebhookConfig_String_PreservesNonSensitiveHeaders(t *testing.T) {
+	cfg := webhook.Config{
+		URL: "https://example.com",
+		Headers: map[string]string{
+			"X-Request-Id":    "trace-42",
+			"Content-Type":    "application/json",
+			"User-Agent":      "audit/v1",
+			"Accept-Encoding": "gzip",
+		},
+	}
+	s := cfg.String()
+	for _, wanted := range []string{
+		"trace-42",
+		"application/json",
+		"audit/v1",
+		"gzip",
+	} {
+		assert.Contains(t, s, wanted,
+			"non-sensitive header value unexpectedly dropped from String(): %q", wanted)
+	}
+	assert.NotContains(t, s, "[REDACTED]",
+		"no [REDACTED] marker expected when all header names are non-sensitive")
 }
 
 // TestWebhook_ConstructionWarningsRoutedToInjectedLogger verifies that


### PR DESCRIPTION
## Summary

Closes #475. Closes the full credential-leakage surface in debug log output:

- `webhook.Config.String()` / `loki.Config.String()` sanitise URL to scheme+host (drops path/query/fragment) and redact sensitive header values.
- `webhook/http.go` and `loki/http.go` retry-loop logs pass errors through `sanitiseClientError` which strips the URL in any wrapped `*url.Error` returned by `http.Client.Do`.
- `ErrDuplicateDestination` no longer embeds the raw destination key (which carries Slack/Splunk path tokens).
- `openbao.Config` / `vault.Config` gain redacted `String` / `GoString` / `Format` — previously they had no stringer, so `%+v` leaked the Token.

## Attack scenarios closed

| Scenario | Before | After |
|---|---|---|
| `slog.Debug("cfg", cfg)` with Slack URL | Prints `url="https://hooks.slack.com/services/T/B/<TOKEN>"` | `url="https://hooks.slack.com"` |
| Datadog query API key in URL | Prints `?dd-api-key=<KEY>` | Query dropped |
| Webhook POST times out, retry logs `err` | `Post "https://hooks.slack.com/services/.../<TOKEN>": i/o timeout` × 6 retries | `Post "https://hooks.slack.com": i/o timeout` |
| Duplicate Slack webhook registration | Error embeds `<TOKEN>` in key | "outputs %q and %q share the same destination" |
| `fmt.Printf("%+v", openbaoCfg)` | Prints raw `Token` field | `token=[REDACTED]` |
| `Cookie: session=…` header in webhook Config | Value printed | `[REDACTED]` |

## Agent gates

- **security-reviewer**: found **2 HIGH** (H1 HTTP error URL leak, H2 ErrDuplicateDestination key leak) + **2 MEDIUM** (M1 pattern set too narrow, M2 SECURITY.md wrong for syslog + missing openbao/vault). All four fixed in-PR per the "never defer bugs" rule rather than filing follow-ups.
- **go-quality**: PASS (make check green, godoc complete, imports correct).

Pattern set expanded per M1 from 4 patterns (`auth`, `key`, `secret`, `token`) to 10 (adds `cookie`, `password`, `credential`, `signature`, `hmac`, `session`). These cover `X-Hub-Signature` (GitHub webhooks), `Cookie` / `Set-Cookie`, `X-Password`, `X-Credential`, `X-Hmac`, `X-Session-Id` — all real-world credential carriers the initial set missed.

Decision A (confirmed): scheme+host stripping, not path-preserving. The issue wording mentioned "scheme://host/path" but AC1 (Slack path token) requires dropping the path. Chose the stricter form matching the existing TLS-warning precedent.

Decision on redaction string: `[REDACTED]` (matches existing repo convention — `secrets/*.go`, `outputconfig/provider_config.go`, `loki/config.go:BasicAuth`). Issue body said `***redacted***` but using `[REDACTED]` for consistency.

## Tests

- 10 new unit tests covering URL sanitisation (path/query/fragment/invalid), header redaction, `sanitiseClientError`, openbao/vault Config stringers.
- 4 existing tests strengthened (path-strip assertions).
- All per-AC named tests present and passing.

## Test plan

- [x] `make check` passes
- [x] 100% of new tests pass
- [x] Existing webhook/loki/openbao/vault test suites pass (no regressions)
- [ ] CI green on PR
- [ ] Manual merge approval

## Files changed

```
SECURITY.md                              | + enumerated credential-safety per module
loki/config.go                           | sanitizeURLForLog helper + String path-strip
loki/loki.go                             | TLS warning site uses helper
loki/http.go                             | sanitiseClientError + retry log sanitisation
loki/config_test.go                      | URL redaction + sanitiseClientError tests
loki/export_test.go                      | exports SanitiseClientError
options.go                               | ErrDuplicateDestination drops key from msg
webhook/config.go                        | sanitizeURLForLog + redactHeaders + expanded pattern set
webhook/http.go                          | sanitiseClientError + retry log sanitisation
webhook/webhook_export_test.go           | exports SanitiseClientError
webhook/webhook_external_test.go         | URL+header redaction + sanitiseClientError tests
secrets/openbao/openbao.go               | String/GoString/Format with token redaction
secrets/openbao/openbao_test.go          | Config stringer tests
secrets/vault/vault.go                   | String/GoString/Format with token redaction
secrets/vault/vault_test.go              | Config stringer tests
```

## Related

- Closes #475
- After merge: next Track A issue per `V1-RELEASE-PLAN.md` (#476).