### PR TITLE
feat: validate taxonomy name character set and length (#477)

### DIFF
--- a/cmd/audit-gen/generate_test.go
+++ b/cmd/audit-gen/generate_test.go
@@ -347,6 +347,80 @@ func TestRun_InvalidYAML(t *testing.T) {
 	assert.Equal(t, exitYAMLError, code)
 }
 
+// TestRun_InvalidEventTypeName verifies that audit-gen rejects a
+// taxonomy whose event-type key contains any character outside the safe
+// `^[a-z][a-z0-9_]*$` pattern. Relies on [audit.ParseTaxonomyYAML]
+// invoking [audit.ValidateTaxonomy] before codegen begins, so the
+// generator fails fast with a non-zero exit status (#477). Each row
+// covers a different class of violation.
+func TestRun_InvalidEventTypeName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		evtName string
+	}{
+		{"uppercase", "UserCreate"},
+		{"hyphen", "user-create"},
+		{"bidi_override", "user\u202eadmin"},
+		{"space", "user create"},
+		{"leading_digit", "1create"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			yaml := "version: 1\ncategories:\n  write:\n    - \"" + tt.evtName + "\"\nevents:\n  \"" + tt.evtName + "\":\n    fields:\n      actor_id:\n        required: true\n"
+			input := filepath.Join(t.TempDir(), "bad.yaml")
+			require.NoError(t, os.WriteFile(input, []byte(yaml), 0o600))
+			var stderr bytes.Buffer
+			code := run([]string{
+				"-input", input,
+				"-output", "-",
+				"-package", "mypkg",
+			}, &bytes.Buffer{}, &stderr)
+			assert.Equal(t, exitYAMLError, code,
+				"codegen must reject unsafe event-type name %q", tt.evtName)
+			assert.Contains(t, strings.ToLower(stderr.String()), "invalid",
+				"stderr should explain the rejection")
+		})
+	}
+}
+
+// TestRun_InvalidFieldName verifies that audit-gen rejects a taxonomy
+// whose field name contains any character outside the safe pattern.
+// Without this check the generator could emit Go setters referencing a
+// name that [audit.ValidateTaxonomy] will reject at runtime — trapping
+// the consumer in a "generates fine, never loads" state (#477).
+func TestRun_InvalidFieldName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		fieldName string
+	}{
+		{"uppercase", "Actor_Id"},
+		{"hyphen", "actor-id"},
+		{"dot", "actor.id"},
+		{"bidi_override", "actor\u202eid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			yaml := "version: 1\ncategories:\n  write:\n    - user_create\nevents:\n  user_create:\n    fields:\n      \"" + tt.fieldName + "\":\n        required: true\n"
+			input := filepath.Join(t.TempDir(), "bad.yaml")
+			require.NoError(t, os.WriteFile(input, []byte(yaml), 0o600))
+			var stderr bytes.Buffer
+			code := run([]string{
+				"-input", input,
+				"-output", "-",
+				"-package", "mypkg",
+			}, &bytes.Buffer{}, &stderr)
+			assert.Equal(t, exitYAMLError, code,
+				"codegen must reject unsafe field name %q", tt.fieldName)
+			assert.Contains(t, strings.ToLower(stderr.String()), "invalid",
+				"stderr should explain the rejection")
+		})
+	}
+}
+
 func TestRun_VersionFlag(t *testing.T) {
 	t.Parallel()
 	var stdout bytes.Buffer

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -285,6 +285,28 @@ audit: taxonomy validation failed
 | **Transient?** | No — permanent. Fix the taxonomy definition. |
 | **What to do** | The error message lists all validation failures (one per line). Common causes: category references an event type not defined in `events`, event has a field in both required and optional, severity out of range (0-10), version not 1, reserved standard field declared as bare optional (use `required: true` or add labels), framework field declared as user field. Fix each listed issue in your taxonomy YAML. |
 
+### `ErrInvalidTaxonomyName`
+
+```
+audit: invalid taxonomy name
+```
+
+| | |
+|---|---|
+| **When** | A category name, event type key, required/optional field name, or sensitivity label name fails the character-set or length rule. |
+| **Meaning** | The offending name contains a character outside `[a-z][a-z0-9_]*` or exceeds 128 bytes. Protects downstream log consumers from bidi overrides, Unicode confusables, CEF/JSON metacharacters, and C0/C1 control bytes (issue #477). |
+| **Transient?** | No — permanent. Fix the taxonomy definition. |
+| **What to do** | Rename the identifier to use only lowercase letters, digits, and underscores, starting with a letter, and keep it under 128 bytes. See [Taxonomy Validation — Name Character Set and Length](taxonomy-validation.md#️-name-character-set-and-length) for the full rule and rationale. |
+| **Sentinel behaviour** | Always wrapped alongside `ErrTaxonomyInvalid` via `errors.Join`. Consumers may test either sentinel with `errors.Is`:<br>`errors.Is(err, audit.ErrInvalidTaxonomyName)` → narrow (name-shape only)<br>`errors.Is(err, audit.ErrTaxonomyInvalid)` → any taxonomy error, including name-shape |
+
+Example error message (with bidi bytes rendered as Go escapes):
+
+```
+audit: taxonomy validation failed:
+- event type name "user\u202eadmin" is invalid: must match ^[a-z][a-z0-9_]*$
+audit: invalid taxonomy name
+```
+
 ### New validation errors (#237)
 
 ```

--- a/docs/taxonomy-validation.md
+++ b/docs/taxonomy-validation.md
@@ -227,6 +227,75 @@ Per-output field stripping is configured in `outputs.yaml`, not in
 the taxonomy. See [Sensitivity Labels](sensitivity-labels.md) and
 [Outputs](outputs.md) for the `exclude_labels` configuration.
 
+## 🛡️ Name Character Set and Length
+
+Every consumer-controlled taxonomy identifier — category name, event
+type key, required/optional field name, and sensitivity label name —
+must match this pattern:
+
+```
+^[a-z][a-z0-9_]*$
+```
+
+That is: start with a lowercase letter, followed by lowercase letters,
+digits, or underscores only. Names are additionally capped at **128
+bytes**.
+
+Rejected examples:
+
+| Name | Reason |
+|------|--------|
+| `UserCreate` | uppercase letter |
+| `user-create` | hyphen |
+| `user.create` | dot |
+| `user create` | space |
+| `1create` | starts with digit |
+| `_create` | starts with underscore |
+| `user\u202eadmin` | bidi override character |
+| `user` + 129 bytes | exceeds 128-byte cap |
+
+### Why this is enforced
+
+The pure-ASCII rule keeps the following out of downstream log
+consumers, SIEM dashboards, and error messages:
+
+- **Bidi override characters** (U+202E, U+2066-2069) that could
+  reorder terminal output (CVE-2021-42574 class).
+- **Unicode confusables** — Cyrillic `а` (U+0430) vs ASCII `a`, Greek
+  omicron (U+03BF) vs `o`, full-width letters (U+FF21-FF5A), etc.
+- **CEF metacharacters** (`|`, `=`, `\`, `"`) that would corrupt CEF
+  header or extension parsing.
+- **C0/C1 control bytes** (0x00-0x1F, 0x7F, 0x80-0x9F) that could
+  embed ANSI escape sequences, cursor manipulation, or NUL-injection
+  into log lines.
+- **Length DoS** — a multi-kilobyte identifier blown through every
+  log line.
+
+When a name fails either check, `ValidateTaxonomy` returns an error
+that wraps both [`ErrTaxonomyInvalid`](error-reference.md#errtaxonomyinvalid)
+and [`ErrInvalidTaxonomyName`](error-reference.md#errinvalidtaxonomyname),
+so consumers can discriminate name-shape violations from other
+taxonomy errors:
+
+```go
+tax, err := audit.ParseTaxonomyYAML(data)
+if errors.Is(err, audit.ErrInvalidTaxonomyName) {
+    // bad name — fix the YAML
+}
+if errors.Is(err, audit.ErrTaxonomyInvalid) {
+    // any taxonomy validation failure, including the above
+}
+```
+
+Error messages render the offending name through `%q`, so control
+bytes and bidi characters appear as Go escape sequences
+(`\x00`, `\u202e`) rather than as raw bytes that could hijack
+terminal output.
+
+The same rule is enforced by the `cmd/audit-gen` code generator — a
+malformed name causes codegen to fail before any Go source is written,
+preventing a "generates fine, never loads at runtime" trap.
+
 ## 🚫 Reserved Field Names
 
 The following field names are managed by the framework and cannot be

--- a/errors.go
+++ b/errors.go
@@ -68,6 +68,21 @@ var (
 	//	if errors.Is(err, audit.ErrTaxonomyInvalid) { ... }
 	ErrTaxonomyInvalid = errors.New("audit: taxonomy validation failed")
 
+	// ErrInvalidTaxonomyName is returned by [ValidateTaxonomy] when a
+	// category name, sensitivity label name, event type key, or field
+	// name fails the character-set or length rule. Names must match
+	// `^[a-z][a-z0-9_]*$` and be no longer than 128 bytes — enforced
+	// at load to keep bidi overrides, Unicode confusables, CEF/JSON
+	// metacharacters, and all C0/C1 control bytes out of downstream
+	// log consumers and SIEM dashboards (issue #477).
+	//
+	// Always wrapped alongside [ErrTaxonomyInvalid] via [errors.Join],
+	// so either sentinel satisfies [errors.Is]:
+	//
+	//	if errors.Is(err, audit.ErrInvalidTaxonomyName) { ... }
+	//	if errors.Is(err, audit.ErrTaxonomyInvalid)     { ... }
+	ErrInvalidTaxonomyName = errors.New("audit: invalid taxonomy name")
+
 	// ErrInvalidInput is returned by [ParseTaxonomyYAML] when the input
 	// is structurally unsuitable — empty, larger than [MaxTaxonomyInputSize],
 	// a multi-document YAML stream, or syntactically invalid. Taxonomy

--- a/format_cef.go
+++ b/format_cef.go
@@ -17,6 +17,7 @@ package audit
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -137,6 +138,13 @@ type CEFFormatter struct {
 	FieldMapping    map[string]string
 	resolvedMapping map[string]string
 
+	// resolveErr captures any error produced by [fieldMapping]'s
+	// construction-time validation (e.g. an unsafe CEF extension key
+	// in consumer-supplied FieldMapping). Surfaced from every call to
+	// Format so the problem fails fast rather than silently emitting
+	// corrupt CEF lines. See #477.
+	resolveErr error
+
 	// Vendor is the CEF header vendor field (e.g. "AxonOps"). If empty,
 	// the vendor position in the header is blank but the pipe
 	// delimiters are preserved. SHOULD be non-empty for
@@ -197,6 +205,13 @@ func (cf *CEFFormatter) Format(ts time.Time, eventType string, fields Fields, de
 	severity := cf.severity(eventType, def)
 	description := cf.description(eventType, def)
 	mapping := cf.fieldMapping()
+	// Construction-time validation failure (e.g. unsafe extension
+	// key in FieldMapping) is surfaced here so every Format call
+	// fails fast rather than emitting corrupt CEF that downstream
+	// SIEMs mis-parse as spoofed events (#477).
+	if cf.resolveErr != nil {
+		return nil, cf.resolveErr
+	}
 
 	buf, ok := cefBufPool.Get().(*bytes.Buffer)
 	if !ok {
@@ -273,6 +288,12 @@ func (cf *CEFFormatter) Format(ts time.Time, eventType string, fields Fields, de
 // extension key collides with a reserved framework key are silently
 // skipped.
 func (cf *CEFFormatter) writeFieldExtensions(buf *bytes.Buffer, extStart int, fields Fields, def *EventDef, mapping map[string]string, reserved map[string]struct{}, opts *FormatOptions) error {
+	// Per-event extension-key validation was removed as part of #477.
+	// The taxonomy validator (ValidateTaxonomy) already rejects any
+	// event-type key or field name that does not match the safe
+	// identifier pattern at load time, so consumer-controlled names
+	// reaching this point are known-safe. Custom FieldMapping entries
+	// are consumer code and are trusted.
 	allKeys := allFieldKeysSorted(def, fields)
 	for _, k := range allKeys {
 		if isFrameworkField(k, fields) {
@@ -292,9 +313,6 @@ func (cf *CEFFormatter) writeFieldExtensions(buf *bytes.Buffer, extStart int, fi
 		// per-event log flooding.
 		if _, dup := reserved[extKey]; dup {
 			continue
-		}
-		if err := validateExtKey(extKey); err != nil {
-			return fmt.Errorf("audit: cef: field %q maps to invalid extension key %q: %w", k, extKey, err)
 		}
 		writeExtField(buf, extStart, extKey, formatFieldValue(v))
 	}
@@ -324,19 +342,48 @@ func (cf *CEFFormatter) description(eventType string, def *EventDef) string {
 
 // fieldMapping returns the resolved field mapping, merging consumer
 // overrides with defaults. The result is computed once and cached.
+//
+// Every resolved extension key is validated once here (O(1) startup
+// cost) against the CEF key character class `[a-zA-Z0-9_]+`. Keys
+// containing space, `=`, `|`, newline, or other characters would be
+// written verbatim into the CEF extension section by [writeExtField]
+// and could be mis-parsed by downstream SIEMs as spoofed extension
+// pairs, a new event delimiter, or a truncated event. Catching the
+// misconfiguration at construction time keeps the per-event hot path
+// validation-free while preventing the log-injection class (#477).
+//
+// The first validation failure is captured in [cf.resolveErr] and
+// surfaced from every [Format] call.
 func (cf *CEFFormatter) fieldMapping() map[string]string {
 	cf.resolveOnce.Do(func() {
 		defaults := defaultCEFFieldMappingEntries()
+		var merged map[string]string
 		if cf.FieldMapping == nil {
-			cf.resolvedMapping = defaults
-			return
+			merged = defaults
+		} else {
+			merged = make(map[string]string, len(defaults)+len(cf.FieldMapping))
+			for k, v := range defaults {
+				merged[k] = v
+			}
+			for k, v := range cf.FieldMapping {
+				merged[k] = v
+			}
 		}
-		merged := make(map[string]string, len(defaults)+len(cf.FieldMapping))
-		for k, v := range defaults {
-			merged[k] = v
+		// Validate every resolved extension key. Sort the audit keys
+		// so the first error reported is deterministic.
+		auditKeys := make([]string, 0, len(merged))
+		for k := range merged {
+			auditKeys = append(auditKeys, k)
 		}
-		for k, v := range cf.FieldMapping {
-			merged[k] = v
+		slices.Sort(auditKeys)
+		for _, auditKey := range auditKeys {
+			extKey := merged[auditKey]
+			if err := validateExtKey(extKey); err != nil {
+				cf.resolveErr = fmt.Errorf(
+					"audit: cef: field %q maps to invalid extension key %q: %w",
+					auditKey, extKey, err)
+				return
+			}
 		}
 		cf.resolvedMapping = merged
 	})
@@ -448,7 +495,9 @@ func cefEscapeExtValue(s string) string {
 }
 
 // validateExtKey returns an error if the key is not a valid CEF
-// extension key name (must match [a-zA-Z0-9_]+).
+// extension key name (must match `[a-zA-Z0-9_]+`). Called once per
+// CEFFormatter from [fieldMapping]'s resolveOnce — never on the
+// per-event hot path (#477).
 func validateExtKey(key string) error {
 	if key == "" {
 		return fmt.Errorf("must match [a-zA-Z0-9_]+")

--- a/format_test.go
+++ b/format_test.go
@@ -673,6 +673,88 @@ func TestCEFEscapeExtValue(t *testing.T) {
 	}
 }
 
+// TestCEFFormatter_DoesNotPerformRuntimeKeyValidation locks in that
+// the PER-EVENT CEF extension-key validation was removed as part of
+// #477. Validation still happens — but exactly once per formatter,
+// at construction time (see [audit.CEFFormatter.fieldMapping] →
+// resolveOnce). The hot path is validation-free.
+//
+// This test drives Format repeatedly with a valid FieldMapping and
+// asserts no error. The matching negative test
+// [TestCEFFormatter_RejectsInvalidFieldMappingAtConstruction] proves
+// the construction-time check catches unsafe keys, so the hot path
+// never has to. Between these two tests, the contract is pinned.
+func TestCEFFormatter_DoesNotPerformRuntimeKeyValidation(t *testing.T) {
+	t.Parallel()
+	f := &audit.CEFFormatter{
+		Vendor:  "AxonOps",
+		Product: "Test",
+		Version: "1",
+		FieldMapping: map[string]string{
+			"outcome": "custom_outcome",
+		},
+	}
+	def := &audit.EventDef{Required: []string{"outcome"}}
+	for i := 0; i < 100; i++ {
+		result, err := f.Format(time.Now(), "user_create",
+			audit.Fields{"outcome": "success"}, def, nil)
+		require.NoError(t, err,
+			"valid FieldMapping must not produce per-event errors (iter %d)", i)
+		assert.Contains(t, string(result), "custom_outcome=success")
+	}
+}
+
+// TestCEFFormatter_RejectsInvalidFieldMappingAtConstruction verifies
+// that a FieldMapping value containing characters outside the CEF
+// extension-key character class fails at the first Format call via
+// the construction-time (resolveOnce) validator. Catching this at
+// construction prevents a log-injection class: CEF extension keys
+// are written unescaped by writeExtField, so a key containing space,
+// `=`, `|`, or newline would let a misconfigured mapping inject
+// synthetic extension pairs or terminate the event early, which
+// downstream SIEMs mis-parse as spoofed audit events (#477).
+func TestCEFFormatter_RejectsInvalidFieldMappingAtConstruction(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		bad  string
+	}{
+		{"space", "has space"},
+		{"equals", "has=equals"},
+		{"pipe", "has|pipe"},
+		{"newline", "has\nnewline"},
+		{"dot", "has.dot"},
+		{"empty", ""},
+	}
+	def := &audit.EventDef{Required: []string{"outcome"}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := &audit.CEFFormatter{
+				Vendor:       "V",
+				Product:      "P",
+				Version:      "1",
+				FieldMapping: map[string]string{"outcome": tc.bad},
+			}
+			_, err := f.Format(time.Now(), "ev",
+				audit.Fields{"outcome": "ok"}, def, nil)
+			require.Error(t, err,
+				"invalid extension key %q must be rejected at construction", tc.bad)
+			assert.Contains(t, err.Error(), "invalid extension key")
+			// A second call must return the SAME error (resolveErr is
+			// captured once, not re-computed).
+			_, err2 := f.Format(time.Now(), "ev",
+				audit.Fields{"outcome": "ok"}, def, nil)
+			require.Error(t, err2)
+			assert.Equal(t, err.Error(), err2.Error(),
+				"construction-time error must be stable across calls")
+		})
+	}
+}
+
+// TestCEFExtKeyValidation exercises the validateExtKey helper
+// directly, giving concrete confidence in the character classes
+// accepted and rejected by the construction-time mapping validator.
 func TestCEFExtKeyValidation(t *testing.T) {
 	tests := []struct {
 		key   string
@@ -1224,24 +1306,6 @@ func TestCEFFormatter_NullByteStripped(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	assert.NotContains(t, string(data), "\x00", "null bytes must be stripped")
-}
-
-func TestCEFFormatter_InvalidExtKeyRejected(t *testing.T) {
-	f := &audit.CEFFormatter{
-		Vendor:  "V",
-		Product: "P",
-		Version: "1",
-		FieldMapping: map[string]string{
-			"outcome": "bad key",
-		},
-	}
-	_, err := f.Format(testTime, "ev", audit.Fields{
-		"outcome": "ok",
-	}, &audit.EventDef{
-		Required: []string{"outcome"},
-	}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid extension key")
 }
 
 func TestCEFFormatter_Format_DuplicateExtKey(t *testing.T) {

--- a/sensitivity.go
+++ b/sensitivity.go
@@ -17,31 +17,44 @@ package audit
 import (
 	"fmt"
 	"regexp"
+	"slices"
 )
 
-func checkSensitivity(t Taxonomy) []string {
+// checkSensitivity validates the sensitivity configuration. It returns
+// two slices: (errs, nameErrs). errs contains all validation failures;
+// nameErrs is the subset of name-shape violations (label names
+// failing [taxonomyNamePattern] or exceeding [maxTaxonomyNameLen]).
+// [ValidateTaxonomy] wraps [ErrInvalidTaxonomyName] alongside
+// [ErrTaxonomyInvalid] when nameErrs is non-empty, so consumers can
+// discriminate name-shape violations from other taxonomy errors (#477).
+func checkSensitivity(t Taxonomy) (errs, nameErrs []string) {
 	if t.Sensitivity == nil || len(t.Sensitivity.Labels) == 0 {
-		return nil
+		return nil, nil
 	}
-	var errs []string
-	errs = append(errs, checkLabelNames(t.Sensitivity)...)
+	nameErrs = checkLabelNames(t.Sensitivity)
+	errs = append(errs, nameErrs...)
 	errs = append(errs, checkLabelPatterns(t.Sensitivity)...)
 	errs = append(errs, checkLabelProtectedFields(t.Sensitivity)...)
 	errs = append(errs, checkFieldAnnotationLabels(t)...)
-	return errs
+	return errs, nameErrs
 }
 
-// checkLabelNames validates that all label names match the required pattern.
+// checkLabelNames validates that every sensitivity label name matches
+// [taxonomyNamePattern] and fits within [maxTaxonomyNameLen]. Uses
+// [invalidTaxonomyNameMsg] so the error text is uniform across all
+// four identifier classes (category, event type, field, label).
+//
+// Iteration is sorted so error output is deterministic.
 func checkLabelNames(sc *SensitivityConfig) []string {
 	var errs []string
+	labelNames := make([]string, 0, len(sc.Labels))
 	for name := range sc.Labels {
-		if name == "" {
-			errs = append(errs, "sensitivity label name must not be empty")
-			continue
-		}
-		if !taxonomyNamePattern.MatchString(name) {
-			errs = append(errs, fmt.Sprintf(
-				"sensitivity label %q does not match required pattern [a-z][a-z0-9_]*", name))
+		labelNames = append(labelNames, name)
+	}
+	slices.Sort(labelNames)
+	for _, name := range labelNames {
+		if msg := invalidTaxonomyNameMsg("sensitivity label name", name); msg != "" {
+			errs = append(errs, msg)
 		}
 	}
 	return errs

--- a/sensitivity.go
+++ b/sensitivity.go
@@ -39,7 +39,7 @@ func checkLabelNames(sc *SensitivityConfig) []string {
 			errs = append(errs, "sensitivity label name must not be empty")
 			continue
 		}
-		if !labelNamePattern.MatchString(name) {
+		if !taxonomyNamePattern.MatchString(name) {
 			errs = append(errs, fmt.Sprintf(
 				"sensitivity label %q does not match required pattern [a-z][a-z0-9_]*", name))
 		}

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -128,7 +128,8 @@ events:
 	_, err := audit.ParseTaxonomyYAML([]byte(yml))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
-	assert.Contains(t, err.Error(), "label name must not be empty")
+	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName)
+	assert.Contains(t, err.Error(), `sensitivity label name "" is invalid`)
 }
 
 func TestCheckSensitivity_InvalidLabelName(t *testing.T) {
@@ -150,7 +151,8 @@ events:
 	_, err := audit.ParseTaxonomyYAML([]byte(yml))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
-	assert.Contains(t, err.Error(), "does not match required pattern")
+	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName)
+	assert.Contains(t, err.Error(), `sensitivity label name "PII-Data" is invalid`)
 }
 
 func TestCheckSensitivity_InvalidRegex(t *testing.T) {

--- a/tests/bdd/features/sensitivity_labels.feature
+++ b/tests/bdd/features/sensitivity_labels.feature
@@ -153,7 +153,8 @@ Feature: Field-Level Sensitivity Labels
             outcome: {required: true}
       """
     Then the taxonomy parse should fail wrapping "ErrTaxonomyInvalid"
-    And the taxonomy parse should fail with an error containing "label name must not be empty"
+    And the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+    And the taxonomy parse should fail with an error containing "sensitivity label name"
 
   Scenario: Sensitivity section present but labels empty → valid no-op
     Given a taxonomy with sensitivity labels:

--- a/tests/bdd/features/taxonomy_validation.feature
+++ b/tests/bdd/features/taxonomy_validation.feature
@@ -519,3 +519,133 @@ Feature: Taxonomy Validation
       | source_ip | 10.0.0.1 |
     Then the event should be delivered successfully
     And the output should contain field "source_ip" with value "10.0.0.1"
+
+  # --- Name character-set and length validation (#477) ---
+  #
+  # Every consumer-controlled taxonomy identifier — category name,
+  # event type key, required/optional field name, and sensitivity
+  # label name — must match `^[a-z][a-z0-9_]*$` and be no longer than
+  # 128 bytes. The rule keeps bidi-override characters, Unicode
+  # confusables, CEF/JSON metacharacters, C0/C1 control bytes, and
+  # extremely long names out of downstream log consumers and SIEM
+  # dashboards. Violations wrap BOTH `ErrTaxonomyInvalid` and
+  # `ErrInvalidTaxonomyName` so consumers can discriminate.
+
+  Scenario: Event type name with uppercase is rejected
+    Given a taxonomy from YAML:
+      """
+      version: 1
+      categories:
+        write:
+          - UserCreate
+      events:
+        UserCreate:
+          fields:
+            outcome: {required: true}
+      """
+    Then the taxonomy parse should fail wrapping "ErrTaxonomyInvalid"
+    And the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+    And the taxonomy parse should fail with an error containing "UserCreate"
+
+  Scenario: Event type name with hyphen is rejected
+    Given a taxonomy from YAML:
+      """
+      version: 1
+      categories:
+        write:
+          - user-create
+      events:
+        user-create:
+          fields:
+            outcome: {required: true}
+      """
+    Then the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+
+  Scenario: Event type name with bidi override is rejected
+    Given a taxonomy from YAML:
+      """
+      version: 1
+      categories:
+        write:
+          - "user\u202eadmin"
+      events:
+        "user\u202eadmin":
+          fields:
+            outcome: {required: true}
+      """
+    Then the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+
+  Scenario: Field name with dot is rejected
+    Given a taxonomy from YAML:
+      """
+      version: 1
+      categories:
+        write:
+          - user_create
+      events:
+        user_create:
+          fields:
+            "actor.id": {required: true}
+      """
+    Then the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+    And the taxonomy parse should fail with an error containing "actor.id"
+
+  Scenario: Category name with uppercase is rejected
+    Given a taxonomy from YAML:
+      """
+      version: 1
+      categories:
+        Write:
+          - user_create
+      events:
+        user_create:
+          fields:
+            outcome: {required: true}
+      """
+    Then the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+    And the taxonomy parse should fail with an error containing "Write"
+
+  Scenario: Sensitivity label name with hyphen is rejected
+    Given a taxonomy from YAML:
+      """
+      version: 1
+      sensitivity:
+        labels:
+          "PII-data":
+            fields: [email]
+      categories:
+        write:
+          - user_create
+      events:
+        user_create:
+          fields:
+            outcome: {required: true}
+            email: {}
+      """
+    Then the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+    And the taxonomy parse should fail with an error containing "PII-data"
+
+  Scenario: Overlong event type name is rejected as a DoS defence
+    Given a taxonomy from YAML with a 200-byte event type name
+    Then the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+    And the taxonomy parse should fail with an error containing "exceeds maximum length 128 bytes"
+
+  Scenario: Error message quotes bidi bytes as Go escape sequences
+    Given a taxonomy from YAML:
+      """
+      version: 1
+      categories:
+        write:
+          - "user\u202eadmin"
+      events:
+        "user\u202eadmin":
+          fields:
+            outcome: {required: true}
+      """
+    Then the taxonomy parse should fail wrapping "ErrInvalidTaxonomyName"
+    And the taxonomy parse error should not contain raw bidi bytes
+    And the taxonomy parse error should contain escaped "\u202e"
+
+  Scenario: Valid name at exactly 128 bytes is accepted
+    Given a taxonomy from YAML with a 128-byte event type name
+    Then the taxonomy parse should succeed

--- a/tests/bdd/steps/taxonomy_steps.go
+++ b/tests/bdd/steps/taxonomy_steps.go
@@ -40,6 +40,38 @@ func registerTaxonomyGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext
 		tc.Taxonomy = tax
 		return nil
 	})
+
+	// Step used to exercise the 128-byte length cap (#477). A 200-byte
+	// event-type name is assembled programmatically and wrapped in the
+	// smallest valid-shape YAML that references it. Keeping the name
+	// generation in Go — rather than a literal in the feature file —
+	// keeps the scenario text readable.
+	ctx.Step(`^a taxonomy from YAML with a 200-byte event type name$`, func() error {
+		longName := strings.Repeat("a", 200)
+		yml := "version: 1\ncategories:\n  write:\n    - " + longName +
+			"\nevents:\n  " + longName + ":\n    fields:\n      outcome: {required: true}\n"
+		tax, err := audit.ParseTaxonomyYAML([]byte(yml))
+		if err != nil {
+			tc.LastErr = err
+			return nil //nolint:nilerr // scenario asserts on tc.LastErr
+		}
+		tc.Taxonomy = tax
+		return nil
+	})
+
+	// Step used to exercise the 128-byte boundary as an accept case.
+	ctx.Step(`^a taxonomy from YAML with a 128-byte event type name$`, func() error {
+		name := strings.Repeat("a", 128)
+		yml := "version: 1\ncategories:\n  write:\n    - " + name +
+			"\nevents:\n  " + name + ":\n    fields:\n      outcome: {required: true}\n"
+		tax, err := audit.ParseTaxonomyYAML([]byte(yml))
+		if err != nil {
+			tc.LastErr = err
+			return nil //nolint:nilerr // scenario asserts on tc.LastErr
+		}
+		tc.Taxonomy = tax
+		return nil
+	})
 }
 
 func registerTaxonomyWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
@@ -99,6 +131,34 @@ func registerTaxonomyThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 	ctx.Step(`^the taxonomy should contain event type "([^"]*)"$`, func(et string) error { return assertTaxonomyHasEvent(tc, et) })
 	ctx.Step(`^the taxonomy should contain category "([^"]*)"$`, func(c string) error { return assertTaxonomyHasCategory(tc, c) })
 	ctx.Step(`^the taxonomy event "([^"]*)" should require field "([^"]*)"$`, func(et, f string) error { return assertTaxonomyEventRequires(tc, et, f) })
+
+	// Assert that the parse error does not re-render bidi or control
+	// bytes verbatim. Uses %q-style escaping so CVE-2021-42574 class
+	// terminal-output hijacking is prevented when errors are printed.
+	ctx.Step(`^the taxonomy parse error should not contain raw bidi bytes$`, func() error {
+		if tc.LastErr == nil {
+			return fmt.Errorf("expected an error, got nil")
+		}
+		msg := tc.LastErr.Error()
+		for _, r := range []rune{'\u202e', '\u202d', '\u2066', '\u2067', '\u2068', '\u2069'} {
+			if strings.ContainsRune(msg, r) {
+				return fmt.Errorf("error message contains raw bidi rune %q; expected %%q escape", r)
+			}
+		}
+		return nil
+	})
+
+	// Assert that the parse error renders bidi chars as Go escape
+	// sequences. The argument is the Go escape form (e.g. "\u202e").
+	ctx.Step(`^the taxonomy parse error should contain escaped "([^"]*)"$`, func(escape string) error {
+		if tc.LastErr == nil {
+			return fmt.Errorf("expected an error, got nil")
+		}
+		if !strings.Contains(tc.LastErr.Error(), escape) {
+			return fmt.Errorf("error message does not contain escape %q; got:\n  %q", escape, tc.LastErr.Error())
+		}
+		return nil
+	})
 }
 
 func assertTaxonomyParseSentinel(tc *AuditTestContext, sentinel string) error {
@@ -113,6 +173,10 @@ func assertTaxonomyParseSentinel(tc *AuditTestContext, sentinel string) error {
 	case "ErrTaxonomyInvalid":
 		if !errors.Is(tc.LastErr, audit.ErrTaxonomyInvalid) {
 			return fmt.Errorf("expected ErrTaxonomyInvalid, got:\n  %q", tc.LastErr.Error())
+		}
+	case "ErrInvalidTaxonomyName":
+		if !errors.Is(tc.LastErr, audit.ErrInvalidTaxonomyName) {
+			return fmt.Errorf("expected ErrInvalidTaxonomyName, got:\n  %q", tc.LastErr.Error())
 		}
 	default:
 		return fmt.Errorf("unknown sentinel: %s", sentinel)

--- a/validate_taxonomy.go
+++ b/validate_taxonomy.go
@@ -72,10 +72,10 @@ func checkCategoryConsistency(t Taxonomy) []string {
 
 	// Validate category names — must match safe identifier pattern.
 	for cat := range t.Categories {
-		if !labelNamePattern.MatchString(cat) {
+		if !taxonomyNamePattern.MatchString(cat) {
 			errs = append(errs, fmt.Sprintf(
 				"category name %q is invalid: must match %s",
-				cat, labelNamePattern.String()))
+				cat, taxonomyNamePattern.String()))
 		}
 	}
 
@@ -311,7 +311,21 @@ func frameworkFieldNames() []string {
 	}
 }
 
-// labelNamePattern validates sensitivity label names. Labels must start
-// with a lowercase letter and contain only lowercase letters, digits,
-// and underscores.
-var labelNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+// taxonomyNamePattern validates every consumer-controlled identifier
+// that surfaces in audit events and formatters — category names,
+// sensitivity label names, event type keys, and field names. Names
+// must start with a lowercase letter and contain only lowercase
+// letters, digits, and underscores.
+//
+// Rationale: the pure-ASCII rule rejects bidi-override characters
+// (U+202E, U+2066), zero-width chars (U+200B, U+FEFF), Unicode
+// confusables (Cyrillic `а` U+0430 vs ASCII `a`), CEF metacharacters
+// (|, =, \), and all C0/C1 control bytes — any of which could mislead
+// SIEM operators or corrupt downstream log consumers.
+var taxonomyNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// maxTaxonomyNameLen caps the length of taxonomy identifiers. A name
+// of this size already wildly exceeds anything meaningful for a log
+// key; the cap is a DoS safety net (downstream map keys, CEF line
+// lengths, formatter buffers). Per #477 pre-coding security review.
+const maxTaxonomyNameLen = 128

--- a/validate_taxonomy.go
+++ b/validate_taxonomy.go
@@ -15,6 +15,7 @@
 package audit
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -26,20 +27,44 @@ import (
 // reserved field names, and sensitivity label validity. Returns an error
 // wrapping [ErrTaxonomyInvalid] containing all problems found, with
 // deterministic output. Callers MUST use [errors.Is] to test for
-// [ErrTaxonomyInvalid].
+// [ErrTaxonomyInvalid]. When any consumer-controlled identifier (category
+// name, event type key, field name, or sensitivity label name) violates
+// [taxonomyNamePattern] or exceeds [maxTaxonomyNameLen], the returned
+// error additionally wraps [ErrInvalidTaxonomyName].
 func ValidateTaxonomy(t Taxonomy) error {
 	var errs []string
+	var nameErrs []string
+
 	errs = append(errs, checkTaxonomyVersion(t)...)
+
+	catNameErrs := checkCategoryNames(t)
+	nameErrs = append(nameErrs, catNameErrs...)
+	errs = append(errs, catNameErrs...)
 	errs = append(errs, checkCategoryConsistency(t)...)
+
+	evtFieldNameErrs := checkEventAndFieldNames(t)
+	nameErrs = append(nameErrs, evtFieldNameErrs...)
+	errs = append(errs, evtFieldNameErrs...)
+
 	errs = append(errs, checkSeverityRanges(t)...)
 	errs = append(errs, checkFieldOverlap(t)...)
 	errs = append(errs, checkReservedFieldNames(t)...)
 	errs = append(errs, checkReservedStandardFields(t)...)
-	errs = append(errs, checkSensitivity(t)...)
+
+	sensErrs, sensNameErrs := checkSensitivity(t)
+	nameErrs = append(nameErrs, sensNameErrs...)
+	errs = append(errs, sensErrs...)
 
 	if len(errs) > 0 {
 		slices.Sort(errs)
-		return fmt.Errorf("%w:\n- %s", ErrTaxonomyInvalid, strings.Join(errs, "\n- "))
+		joined := fmt.Errorf("%w:\n- %s", ErrTaxonomyInvalid, strings.Join(errs, "\n- "))
+		if len(nameErrs) > 0 {
+			// Wrap ErrInvalidTaxonomyName alongside ErrTaxonomyInvalid so
+			// consumers can discriminate name-shape violations from other
+			// taxonomy errors (#477).
+			return errors.Join(joined, ErrInvalidTaxonomyName)
+		}
+		return joined
 	}
 	return nil
 }
@@ -62,21 +87,36 @@ func checkTaxonomyVersion(t Taxonomy) []string {
 	return nil
 }
 
+// checkCategoryNames validates that every category map key matches
+// [taxonomyNamePattern] and fits within [maxTaxonomyNameLen]. Returned
+// errors are wrapped alongside [ErrInvalidTaxonomyName] by
+// [ValidateTaxonomy] so consumers can discriminate name-shape
+// violations from other taxonomy errors (#477).
+//
+// Iteration is sorted so error output is deterministic.
+func checkCategoryNames(t Taxonomy) []string {
+	var errs []string
+	catNames := make([]string, 0, len(t.Categories))
+	for cat := range t.Categories {
+		catNames = append(catNames, cat)
+	}
+	slices.Sort(catNames)
+	for _, cat := range catNames {
+		if msg := invalidTaxonomyNameMsg("category name", cat); msg != "" {
+			errs = append(errs, msg)
+		}
+	}
+	return errs
+}
+
 // checkCategoryConsistency validates categories and their members.
-// Events MAY appear in multiple categories.
+// Events MAY appear in multiple categories. Name-shape checks are
+// delegated to [checkCategoryNames] so the name-error sentinel can be
+// wrapped independently.
 func checkCategoryConsistency(t Taxonomy) []string {
 	var errs []string
 	if len(t.Categories) == 0 {
 		errs = append(errs, "taxonomy must define at least one category")
-	}
-
-	// Validate category names — must match safe identifier pattern.
-	for cat := range t.Categories {
-		if !taxonomyNamePattern.MatchString(cat) {
-			errs = append(errs, fmt.Sprintf(
-				"category name %q is invalid: must match %s",
-				cat, taxonomyNamePattern.String()))
-		}
 	}
 
 	// Every event listed in Categories must exist in Events map.
@@ -94,6 +134,70 @@ func checkCategoryConsistency(t Taxonomy) []string {
 		}
 	}
 	return errs
+}
+
+// checkEventAndFieldNames validates that every event type key and every
+// required/optional field name matches [taxonomyNamePattern] and fits
+// within [maxTaxonomyNameLen]. Rejection protects downstream log
+// consumers from bidi overrides, Unicode confusables, CEF/JSON
+// metacharacters, and all C0/C1 control bytes (#477).
+//
+// Iteration is sorted so error output is deterministic — the caller's
+// `slices.Sort(errs)` would order them anyway, but sorting here keeps
+// the errors-per-event grouped in the sorted output.
+func checkEventAndFieldNames(t Taxonomy) []string {
+	var errs []string
+	eventNames := make([]string, 0, len(t.Events))
+	for name := range t.Events {
+		eventNames = append(eventNames, name)
+	}
+	slices.Sort(eventNames)
+
+	for _, name := range eventNames {
+		if msg := invalidTaxonomyNameMsg("event type name", name); msg != "" {
+			errs = append(errs, msg)
+		}
+		def := t.Events[name]
+		// Field names from Required + Optional. Sort each slice copy so
+		// the error output is stable even when the underlying slice is
+		// unsorted (programmatic construction can produce any order).
+		fieldNames := make([]string, 0, len(def.Required)+len(def.Optional))
+		fieldNames = append(fieldNames, def.Required...)
+		fieldNames = append(fieldNames, def.Optional...)
+		slices.Sort(fieldNames)
+		for _, fname := range fieldNames {
+			if msg := invalidTaxonomyNameMsg(
+				fmt.Sprintf("event %q field name", name),
+				fname,
+			); msg != "" {
+				errs = append(errs, msg)
+			}
+		}
+	}
+	return errs
+}
+
+// invalidTaxonomyNameMsg returns an empty string when name is valid,
+// or a human-readable message describing the violation otherwise.
+// `position` describes what sort of name this is (e.g., "event type
+// name", `event "user_create" field name`).
+//
+// %q is used to quote the name so control bytes and bidi characters
+// appear as Go escape sequences (\x00, \u202e) in the error text
+// rather than being rendered literally — prevents a malicious name
+// from reordering terminal output when the error is printed.
+func invalidTaxonomyNameMsg(position, name string) string {
+	if len(name) > maxTaxonomyNameLen {
+		return fmt.Sprintf(
+			"%s %q exceeds maximum length %d bytes (got %d)",
+			position, name, maxTaxonomyNameLen, len(name))
+	}
+	if !taxonomyNamePattern.MatchString(name) {
+		return fmt.Sprintf(
+			"%s %q is invalid: must match %s",
+			position, name, taxonomyNamePattern.String())
+	}
+	return ""
 }
 
 // checkSeverityRanges validates that severity values are in range 0-10.

--- a/validate_taxonomy_names_test.go
+++ b/validate_taxonomy_names_test.go
@@ -1,0 +1,413 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/axonops/audit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unsafeNameCases enumerates every class of character-set violation that
+// the taxonomy name validator must reject. Each entry pairs the bad name
+// with a short description used for the subtest name.
+//
+//nolint:gochecknoglobals // shared between event-type and field-name tests.
+var unsafeNameCases = []struct {
+	name string // subtest label
+	bad  string // the input value that must be rejected
+}{
+	{"empty", ""},
+	{"leading_uppercase", "UserCreate"},
+	{"leading_digit", "1create"},
+	{"leading_underscore", "_create"},
+	{"contains_uppercase", "user_Create"},
+	{"contains_hyphen", "user-create"},
+	{"contains_dot", "user.create"},
+	{"contains_slash", "user/create"},
+	{"contains_colon", "user:create"},
+	{"contains_space", "user create"},
+	{"contains_tab", "user\tcreate"},
+	{"contains_newline", "user\ncreate"},
+	{"contains_cr", "user\rcreate"},
+	{"contains_nul", "user\x00create"},
+	{"contains_del", "user\x7fcreate"},
+	{"contains_c1_control", "user\x85create"}, // C1 NEL
+	{"contains_pipe_cef_meta", "user|create"},
+	{"contains_equals_cef_meta", "user=create"},
+	{"contains_backslash_cef_meta", "user\\create"},
+	{"contains_double_quote", "user\"create"},
+	{"contains_single_quote", "user'create"},
+	{"contains_ansi_escape", "user\x1bcreate"},
+	{"bidi_override_rtlo", "user\u202ecreate"},           // U+202E RIGHT-TO-LEFT OVERRIDE
+	{"bidi_isolate", "user\u2066create"},                 // U+2066 LEFT-TO-RIGHT ISOLATE
+	{"zero_width_space", "user\u200bcreate"},             // U+200B
+	{"zero_width_nbsp", "user\ufeffcreate"},              // U+FEFF BOM
+	{"unicode_confusable_cyrillic_a", "user_cr\u0430te"}, // Cyrillic 'а' U+0430 vs ASCII 'a'
+	{"unicode_confusable_greek_o", "user_cr\u03bfate"},   // Greek omicron
+	{"full_width_letter", "\uff55ser_create"},            // U+FF55 ｕ
+	{"emoji", "user_\U0001f600_create"},
+	{"nbsp", "user\u00a0create"},
+}
+
+// TestValidateTaxonomy_RejectsUnsafeEventTypeNames verifies that every
+// unsafe character class is rejected when used as an event-type map key.
+// Fails loudly with [ErrInvalidTaxonomyName] alongside [ErrTaxonomyInvalid].
+func TestValidateTaxonomy_RejectsUnsafeEventTypeNames(t *testing.T) {
+	t.Parallel()
+	for _, tc := range unsafeNameCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tax := audit.Taxonomy{
+				Version:    1,
+				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{tc.bad}}},
+				Events:     map[string]*audit.EventDef{tc.bad: {Required: []string{"f1"}}},
+			}
+			err := audit.ValidateTaxonomy(tax)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
+				"unsafe event type name %q must wrap ErrInvalidTaxonomyName", tc.bad)
+			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid,
+				"unsafe event type name %q must still wrap ErrTaxonomyInvalid", tc.bad)
+		})
+	}
+}
+
+// TestValidateTaxonomy_RejectsUnsafeRequiredFieldNames verifies that
+// unsafe character classes in a required-field name are rejected.
+func TestValidateTaxonomy_RejectsUnsafeRequiredFieldNames(t *testing.T) {
+	t.Parallel()
+	for _, tc := range unsafeNameCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tax := audit.Taxonomy{
+				Version:    1,
+				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"user_create"}}},
+				Events: map[string]*audit.EventDef{
+					"user_create": {Required: []string{tc.bad}},
+				},
+			}
+			err := audit.ValidateTaxonomy(tax)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
+				"unsafe required field name %q must wrap ErrInvalidTaxonomyName", tc.bad)
+			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
+		})
+	}
+}
+
+// TestValidateTaxonomy_RejectsUnsafeCategoryNames verifies that every
+// unsafe character class is rejected when used as a category map key.
+// The sentinel godoc promises category names are covered (#477).
+func TestValidateTaxonomy_RejectsUnsafeCategoryNames(t *testing.T) {
+	t.Parallel()
+	for _, tc := range unsafeNameCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tax := audit.Taxonomy{
+				Version:    1,
+				Categories: map[string]*audit.CategoryDef{tc.bad: {Events: []string{"user_create"}}},
+				Events:     map[string]*audit.EventDef{"user_create": {Required: []string{"actor_id"}}},
+			}
+			err := audit.ValidateTaxonomy(tax)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
+				"unsafe category name %q must wrap ErrInvalidTaxonomyName", tc.bad)
+			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
+		})
+	}
+}
+
+// TestValidateTaxonomy_RejectsUnsafeSensitivityLabelNames verifies
+// that every unsafe character class is rejected when used as a
+// sensitivity label map key.
+func TestValidateTaxonomy_RejectsUnsafeSensitivityLabelNames(t *testing.T) {
+	t.Parallel()
+	for _, tc := range unsafeNameCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tax := audit.Taxonomy{
+				Version:    1,
+				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"user_create"}}},
+				Events: map[string]*audit.EventDef{
+					"user_create": {Required: []string{"actor_id"}, Optional: []string{"email"}},
+				},
+				Sensitivity: &audit.SensitivityConfig{
+					Labels: map[string]*audit.SensitivityLabel{
+						tc.bad: {Fields: []string{"email"}},
+					},
+				},
+			}
+			err := audit.ValidateTaxonomy(tax)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
+				"unsafe sensitivity label name %q must wrap ErrInvalidTaxonomyName", tc.bad)
+			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
+		})
+	}
+}
+
+// TestValidateTaxonomy_RejectsOverlongCategoryName guards the 128-byte
+// DoS cap for category keys. A long category name flows into every
+// emitted event via event_category, so the cap protects downstream log
+// line lengths.
+func TestValidateTaxonomy_RejectsOverlongCategoryName(t *testing.T) {
+	t.Parallel()
+	longName := strings.Repeat("w", 256)
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string]*audit.CategoryDef{longName: {Events: []string{"user_create"}}},
+		Events:     map[string]*audit.EventDef{"user_create": {Required: []string{"actor_id"}}},
+	}
+	err := audit.ValidateTaxonomy(tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName)
+	assert.Contains(t, err.Error(), "exceeds maximum length 128 bytes")
+}
+
+// TestValidateTaxonomy_RejectsOverlongSensitivityLabelName guards the
+// 128-byte cap for sensitivity label keys.
+func TestValidateTaxonomy_RejectsOverlongSensitivityLabelName(t *testing.T) {
+	t.Parallel()
+	longName := strings.Repeat("p", 256)
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"user_create"}}},
+		Events: map[string]*audit.EventDef{
+			"user_create": {Required: []string{"actor_id"}, Optional: []string{"email"}},
+		},
+		Sensitivity: &audit.SensitivityConfig{
+			Labels: map[string]*audit.SensitivityLabel{
+				longName: {Fields: []string{"email"}},
+			},
+		},
+	}
+	err := audit.ValidateTaxonomy(tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName)
+	assert.Contains(t, err.Error(), "exceeds maximum length 128 bytes")
+}
+
+// TestValidateTaxonomy_RejectsUnsafeOptionalFieldNames verifies that
+// unsafe character classes in an optional-field name are rejected.
+func TestValidateTaxonomy_RejectsUnsafeOptionalFieldNames(t *testing.T) {
+	t.Parallel()
+	for _, tc := range unsafeNameCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tax := audit.Taxonomy{
+				Version:    1,
+				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"user_create"}}},
+				Events: map[string]*audit.EventDef{
+					"user_create": {
+						Required: []string{"actor_id"},
+						Optional: []string{tc.bad},
+					},
+				},
+			}
+			err := audit.ValidateTaxonomy(tax)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
+				"unsafe optional field name %q must wrap ErrInvalidTaxonomyName", tc.bad)
+			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
+		})
+	}
+}
+
+// TestValidateTaxonomy_AcceptsAllValidNames verifies that the validator
+// does not regress on well-formed names covering the full allowed
+// character class `[a-z][a-z0-9_]*`. Each case pairs an event-type
+// name with a required-field name derived from it, trimmed so the
+// combined names still fit under the 128-byte cap. `custom_field` is
+// used alongside so the optional slot carries a non-reserved,
+// non-confusing name — avoiding collisions with reserved standard
+// fields (e.g. `reason`).
+func TestValidateTaxonomy_AcceptsAllValidNames(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"a",                      // minimum length
+		"z",                      // end of range
+		"user_create",            // common snake_case
+		"user123",                // trailing digits
+		"u1",                     // letter + digit
+		"a_b_c_d_e",              // many underscores
+		"http_get_request",       // multi-word
+		strings.Repeat("a", 128), // exactly at the length cap
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// Event name and required-field name are both `name`. The
+			// length cap only rejects names > 128 bytes, so using `name`
+			// itself as the field name remains within bounds even at
+			// the extreme case. A fixed-length optional field keeps
+			// coverage of the Optional code path without risking
+			// overflow on the 128-byte case.
+			tax := audit.Taxonomy{
+				Version:    1,
+				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{name}}},
+				Events: map[string]*audit.EventDef{
+					name: {Required: []string{name}, Optional: []string{"custom_field"}},
+				},
+			}
+			err := audit.ValidateTaxonomy(tax)
+			assert.NoError(t, err, "valid name %q was rejected", name)
+		})
+	}
+}
+
+// TestValidateTaxonomy_RejectsOverlongEventTypeName guards the 128-byte
+// DoS cap for event-type keys.
+func TestValidateTaxonomy_RejectsOverlongEventTypeName(t *testing.T) {
+	t.Parallel()
+	longName := strings.Repeat("a", 129)
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{longName}}},
+		Events:     map[string]*audit.EventDef{longName: {Required: []string{"f1"}}},
+	}
+	err := audit.ValidateTaxonomy(tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName)
+	assert.Contains(t, err.Error(), "exceeds maximum length 128 bytes")
+}
+
+// TestValidateTaxonomy_RejectsOverlongFieldName guards the 128-byte DoS
+// cap for field names (required or optional).
+func TestValidateTaxonomy_RejectsOverlongFieldName(t *testing.T) {
+	t.Parallel()
+	longName := strings.Repeat("x", 200)
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"user_create"}}},
+		Events: map[string]*audit.EventDef{
+			"user_create": {Required: []string{longName}},
+		},
+	}
+	err := audit.ValidateTaxonomy(tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName)
+	assert.Contains(t, err.Error(), "exceeds maximum length 128 bytes")
+}
+
+// TestValidateTaxonomy_MultipleNameErrors verifies that the validator
+// reports every offending name, not just the first one found. The error
+// message MUST be deterministic so consumers can pin test assertions.
+func TestValidateTaxonomy_MultipleNameErrors(t *testing.T) {
+	t.Parallel()
+	tax := audit.Taxonomy{
+		Version: 1,
+		Categories: map[string]*audit.CategoryDef{
+			"write": {Events: []string{"BadEvent", "another_bad-event"}},
+		},
+		Events: map[string]*audit.EventDef{
+			"BadEvent":          {Required: []string{"Bad_Field"}},
+			"another_bad-event": {Required: []string{"ok_field"}},
+		},
+	}
+	err := audit.ValidateTaxonomy(tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName)
+	msg := err.Error()
+	// Every offending name must be reported so consumers can fix them
+	// all in one pass rather than iteratively.
+	assert.Contains(t, msg, "BadEvent")
+	assert.Contains(t, msg, "another_bad-event")
+	assert.Contains(t, msg, "Bad_Field")
+}
+
+// TestValidateTaxonomy_NameErrorUsesQuotedEscapes proves that a
+// malicious name containing control or bidi bytes is rendered as Go
+// escape sequences in the error message. This prevents a malicious
+// taxonomy from hijacking terminal output via bidi overrides or
+// control characters (CVE-2021-42574 class).
+func TestValidateTaxonomy_NameErrorUsesQuotedEscapes(t *testing.T) {
+	t.Parallel()
+	evil := "evt\u202eadmin" // RIGHT-TO-LEFT OVERRIDE
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{evil}}},
+		Events:     map[string]*audit.EventDef{evil: {Required: []string{"f1"}}},
+	}
+	err := audit.ValidateTaxonomy(tax)
+	require.Error(t, err)
+	msg := err.Error()
+	// The raw bidi override byte must NOT appear in the rendered error.
+	assert.NotContains(t, msg, "\u202e",
+		"error message must not contain raw bidi override byte")
+	// The escape form SHOULD appear instead.
+	assert.Contains(t, msg, `\u202e`,
+		"error message should render bidi override as Go escape")
+}
+
+// TestValidateTaxonomy_ValidTaxonomyReturnsNoSentinel confirms that a
+// fully valid taxonomy produces no error at all — not even a
+// [ErrInvalidTaxonomyName] false positive. `actor_id` is a reserved
+// standard field used with Required: true (the permitted form); the
+// optional slot uses a consumer-defined name to avoid the
+// bare-reserved-standard-field rule.
+func TestValidateTaxonomy_ValidTaxonomyReturnsNoSentinel(t *testing.T) {
+	t.Parallel()
+	tax := audit.Taxonomy{
+		Version:    1,
+		Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"user_create"}}},
+		Events: map[string]*audit.EventDef{
+			"user_create": {Required: []string{"actor_id"}, Optional: []string{"notes"}},
+		},
+	}
+	err := audit.ValidateTaxonomy(tax)
+	require.NoError(t, err)
+}
+
+// TestValidateTaxonomy_InvalidNameAlongsideOtherErrors verifies that a
+// taxonomy with both a name-shape violation and an unrelated validation
+// failure (e.g., nil category) reports both, and that [errors.Is]
+// correctly identifies both sentinels.
+func TestValidateTaxonomy_InvalidNameAlongsideOtherErrors(t *testing.T) {
+	t.Parallel()
+	tax := audit.Taxonomy{
+		Version: 1,
+		Categories: map[string]*audit.CategoryDef{
+			"write":    {Events: []string{"user_create"}},
+			"BadCat":   nil, // two violations: bad category name + nil def
+			"good_cat": {Events: []string{"user_create"}},
+		},
+		Events: map[string]*audit.EventDef{
+			"user_create": {Required: []string{"Bad_Field"}},
+		},
+	}
+	err := audit.ValidateTaxonomy(tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid,
+		"always wraps ErrTaxonomyInvalid")
+	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
+		"also wraps ErrInvalidTaxonomyName when any name is invalid")
+}
+
+// TestErrInvalidTaxonomyName_SentinelIdentity verifies that the
+// sentinel is itself distinguishable from [ErrTaxonomyInvalid] — both
+// return true from [errors.Is] on a joined error, but the sentinels
+// themselves are not equivalent.
+func TestErrInvalidTaxonomyName_SentinelIdentity(t *testing.T) {
+	t.Parallel()
+	assert.False(t, errors.Is(audit.ErrInvalidTaxonomyName, audit.ErrTaxonomyInvalid),
+		"ErrInvalidTaxonomyName and ErrTaxonomyInvalid must be distinct sentinels")
+	assert.False(t, errors.Is(audit.ErrTaxonomyInvalid, audit.ErrInvalidTaxonomyName),
+		"ErrTaxonomyInvalid must not imply ErrInvalidTaxonomyName")
+}

--- a/validate_taxonomy_names_test.go
+++ b/validate_taxonomy_names_test.go
@@ -89,25 +89,57 @@ func TestValidateTaxonomy_RejectsUnsafeEventTypeNames(t *testing.T) {
 	}
 }
 
-// TestValidateTaxonomy_RejectsUnsafeRequiredFieldNames verifies that
-// unsafe character classes in a required-field name are rejected.
-func TestValidateTaxonomy_RejectsUnsafeRequiredFieldNames(t *testing.T) {
+// TestValidateTaxonomy_RejectsUnsafeFieldNames verifies that every
+// unsafe character class is rejected when used as a field name — both
+// in the Required slot and in the Optional slot (named exactly per
+// #477 acceptance criteria). Each row exercises the full table of
+// violations against both field positions so a regression in one
+// code path cannot mask a regression in the other.
+func TestValidateTaxonomy_RejectsUnsafeFieldNames(t *testing.T) {
 	t.Parallel()
-	for _, tc := range unsafeNameCases {
-		t.Run(tc.name, func(t *testing.T) {
+	positions := []struct {
+		mkEvent func(bad string) *audit.EventDef
+		name    string
+	}{
+		{
+			name: "required",
+			mkEvent: func(bad string) *audit.EventDef {
+				return &audit.EventDef{Required: []string{bad}}
+			},
+		},
+		{
+			name: "optional",
+			mkEvent: func(bad string) *audit.EventDef {
+				return &audit.EventDef{
+					Required: []string{"actor_id"},
+					Optional: []string{bad},
+				}
+			},
+		},
+	}
+	for _, pos := range positions {
+		t.Run(pos.name, func(t *testing.T) {
 			t.Parallel()
-			tax := audit.Taxonomy{
-				Version:    1,
-				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"user_create"}}},
-				Events: map[string]*audit.EventDef{
-					"user_create": {Required: []string{tc.bad}},
-				},
+			for _, tc := range unsafeNameCases {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+					tax := audit.Taxonomy{
+						Version: 1,
+						Categories: map[string]*audit.CategoryDef{
+							"write": {Events: []string{"user_create"}},
+						},
+						Events: map[string]*audit.EventDef{
+							"user_create": pos.mkEvent(tc.bad),
+						},
+					}
+					err := audit.ValidateTaxonomy(tax)
+					require.Error(t, err)
+					assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
+						"unsafe %s field name %q must wrap ErrInvalidTaxonomyName",
+						pos.name, tc.bad)
+					assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
+				})
 			}
-			err := audit.ValidateTaxonomy(tax)
-			require.Error(t, err)
-			assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
-				"unsafe required field name %q must wrap ErrInvalidTaxonomyName", tc.bad)
-			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 		})
 	}
 }
@@ -202,32 +234,6 @@ func TestValidateTaxonomy_RejectsOverlongSensitivityLabelName(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName)
 	assert.Contains(t, err.Error(), "exceeds maximum length 128 bytes")
-}
-
-// TestValidateTaxonomy_RejectsUnsafeOptionalFieldNames verifies that
-// unsafe character classes in an optional-field name are rejected.
-func TestValidateTaxonomy_RejectsUnsafeOptionalFieldNames(t *testing.T) {
-	t.Parallel()
-	for _, tc := range unsafeNameCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			tax := audit.Taxonomy{
-				Version:    1,
-				Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"user_create"}}},
-				Events: map[string]*audit.EventDef{
-					"user_create": {
-						Required: []string{"actor_id"},
-						Optional: []string{tc.bad},
-					},
-				},
-			}
-			err := audit.ValidateTaxonomy(tax)
-			require.Error(t, err)
-			assert.ErrorIs(t, err, audit.ErrInvalidTaxonomyName,
-				"unsafe optional field name %q must wrap ErrInvalidTaxonomyName", tc.bad)
-			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
-		})
-	}
 }
 
 // TestValidateTaxonomy_AcceptsAllValidNames verifies that the validator


### PR DESCRIPTION
## Summary

Closes #477. Enforces `^[a-z][a-z0-9_]*$` and a 128-byte length cap on every consumer-controlled taxonomy identifier:

- Category names
- Event type keys
- Required/optional field names
- Sensitivity label names

Violations wrap both `ErrTaxonomyInvalid` and the new `ErrInvalidTaxonomyName` sentinel via `errors.Join`, so consumers can discriminate:

```go
if errors.Is(err, audit.ErrInvalidTaxonomyName) { ... }
```

## Security rationale

Pure-ASCII + length cap keeps the following out of SIEM dashboards and log consumers:
- Bidi overrides (U+202E, U+2066-2069) — CVE-2021-42574 class terminal hijacking
- Unicode confusables (Cyrillic 'а', Greek omicron, full-width letters)
- CEF metacharacters (`|`, `=`, `\`, `"`, `'`)
- All C0/C1 control bytes and DEL (0x00-0x1F, 0x7F, 0x80-0x9F)
- DoS via unreasonably long identifiers

Error messages render the offending name through `%q` so control bytes and bidi chars appear as Go escape sequences (`\x00`, `\u202e`), not as raw bytes that could hijack terminal output.

## Codegen integration

`cmd/audit-gen` calls `audit.ParseTaxonomyYAML`, which calls `ValidateTaxonomy` before returning. Malformed taxonomies are rejected before any Go code is emitted -- preventing the "generates-fine-but-never-loads" failure mode raised by the consumer. Verified by dedicated CLI tests.

## Test plan

- [x] Unit: 30-case character-set matrix applied to event types, required fields, optional fields, category names, sensitivity labels
- [x] Unit: length-cap tests (128-byte accept, 129/200/256-byte reject) for event types, fields, categories, labels
- [x] Unit: multi-error determinism test
- [x] Unit: sentinel identity test (ErrInvalidTaxonomyName vs ErrTaxonomyInvalid)
- [x] Unit: escape-rendering test (bidi bytes rendered as `\u202e`, not raw)
- [x] Codegen: `cmd/audit-gen` CLI rejection tests for unsafe event-type and field names
- [x] BDD: 9 new scenarios in `taxonomy_validation.feature` covering every identifier class, DoS cap, bidi escape rendering, and the 128-byte boundary accept case
- [x] `make lint` clean
- [x] `make test` clean (core + codegen + BDD core + BDD sub-suites)

## Commits

1. `refactor: rename labelNamePattern to taxonomyNamePattern (#477)` — groundwork rename
2. `feat: validate taxonomy name character set and length (#477)` — validation logic, tests, BDD