### PR TITLE
test: move race tests to *_external_test.go files (#474)

### DIFF
--- a/file/file_external_test.go
+++ b/file/file_external_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file_test
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/axonops/audit/file"
+)
+
+// TestFile_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
+// and Write concurrently to prove the logger field is safe under the
+// race detector. Closes #474 AC #3.
+//
+// Lives in file_external_test.go (not file_test.go) per the explicit
+// file-naming acceptance criterion in #474 Testing Requirements.
+// Per-test goleak.VerifyNone(t) complements the package-level
+// goleak.VerifyTestMain to catch leaks originating in this test's
+// goroutines.
+func TestFile_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
+	dir := t.TempDir()
+	out, err := file.New(file.Config{
+		Path:       filepath.Join(dir, "race.log"),
+		BufferSize: 1000,
+	}, nil)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	const iters = 100
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iters {
+			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iters {
+			_ = out.Write([]byte(`{"event":"race"}` + "\n"))
+		}
+	}()
+	wg.Wait()
+
+	// Close BEFORE goleak check so the rotate-mill background
+	// goroutine has exited by the time we assert no leaks.
+	require.NoError(t, out.Close())
+	goleak.VerifyNone(t)
+}

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -16,7 +16,6 @@ package file_test
 
 import (
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -886,36 +885,6 @@ func TestFile_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
 	logged := buf.String()
 	assert.Contains(t, logged, "permissions grant group/world access",
 		"expected permission warning on injected logger, got: %q", logged)
-}
-
-// TestFile_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
-// and Write concurrently to prove the logger field is safe under the
-// race detector. Closes #474 AC #3.
-func TestFile_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
-	dir := t.TempDir()
-	out, err := file.New(file.Config{
-		Path:       filepath.Join(dir, "race.log"),
-		BufferSize: 1000,
-	}, nil)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = out.Close() })
-
-	var wg sync.WaitGroup
-	const iters = 100
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		for range iters {
-			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for range iters {
-			_ = out.Write([]byte(`{"event":"race"}` + "\n"))
-		}
-	}()
-	wg.Wait()
 }
 
 // TestFile_NilDiagnosticLoggerFallsBackToDefault verifies

--- a/loki/config_test.go
+++ b/loki/config_test.go
@@ -17,13 +17,11 @@ package loki_test
 import (
 	"crypto/tls"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -911,41 +909,6 @@ func TestLoki_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
 		"expected weak-ciphers warning on injected logger, got: %q", logged)
 	assert.Contains(t, logged, "output=loki",
 		"warning should carry output=loki attribute: %q", logged)
-}
-
-// TestLoki_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
-// and WriteWithMetadata concurrently to prove the logger field is safe
-// under the race detector. Closes #474 AC #3.
-func TestLoki_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
-	out, err := loki.New(&loki.Config{
-		URL:                "http://127.0.0.1:3100/loki/api/v1/push",
-		AllowInsecureHTTP:  true,
-		AllowPrivateRanges: true,
-		BatchSize:          1,
-		FlushInterval:      100 * time.Millisecond,
-		Timeout:            1 * time.Second,
-		BufferSize:         1000,
-	}, nil)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = out.Close() })
-
-	var wg sync.WaitGroup
-	const iters = 100
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		for range iters {
-			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		meta := audit.EventMetadata{EventType: "race", Severity: 1}
-		for range iters {
-			_ = out.WriteWithMetadata([]byte(`{"event":"race"}`), meta)
-		}
-	}()
-	wg.Wait()
 }
 
 // TestLoki_NilDiagnosticLoggerFallsBackToDefault verifies

--- a/loki/loki_external_test.go
+++ b/loki/loki_external_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loki_test
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/loki"
+)
+
+// TestLoki_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
+// and WriteWithMetadata concurrently to prove the logger field is safe
+// under the race detector. Closes #474 AC #3.
+//
+// Lives in loki_external_test.go (not config_test.go) per the explicit
+// file-naming acceptance criterion in #474 Testing Requirements.
+// Per-test goleak.VerifyNone(t) complements the package-level
+// goleak.VerifyTestMain to catch leaks from this test's goroutines
+// specifically.
+func TestLoki_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
+	out, err := loki.New(&loki.Config{
+		URL:                "http://127.0.0.1:3100/loki/api/v1/push",
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          1,
+		FlushInterval:      100 * time.Millisecond,
+		Timeout:            1 * time.Second,
+		BufferSize:         1000,
+	}, nil)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	const iters = 100
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iters {
+			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		meta := audit.EventMetadata{EventType: "race", Severity: 1}
+		for range iters {
+			_ = out.WriteWithMetadata([]byte(`{"event":"race"}`), meta)
+		}
+	}()
+	wg.Wait()
+
+	// Close BEFORE goleak so the loki batch/flush goroutines have
+	// exited by the time we assert no leaks.
+	require.NoError(t, out.Close())
+	goleak.VerifyNone(t)
+}

--- a/syslog/syslog_external_test.go
+++ b/syslog/syslog_external_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syslog_test
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/axonops/audit/syslog"
+)
+
+// TestSyslog_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
+// and Write concurrently to prove the logger field is safe under the
+// race detector. Closes #474 AC #3.
+//
+// Uses a local TCP listener to accept the syslog connection so New
+// succeeds. The listener just drains bytes — we do not validate
+// delivery, only that the logger field survives concurrent access.
+//
+// Lives in syslog_external_test.go (not syslog_test.go) per the
+// explicit file-naming acceptance criterion in #474 Testing
+// Requirements. Per-test goleak.VerifyNone(t) complements the
+// package-level goleak.VerifyTestMain to catch leaks from this
+// test's goroutines specifically.
+func TestSyslog_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+
+	// Accept loop goroutine — exits when the listener is closed at end
+	// of test. Tracked so goleak does not flag it as a leak.
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				_, _ = io.Copy(io.Discard, c)
+			}(conn)
+		}
+	}()
+
+	out, err := syslog.New(&syslog.Config{
+		Network:  "tcp",
+		Address:  listener.Addr().String(),
+		Facility: "local0",
+		AppName:  "race-test",
+	}, nil)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	const iters = 100
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iters {
+			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iters {
+			_ = out.Write([]byte(`{"event":"race"}`))
+		}
+	}()
+	wg.Wait()
+
+	// Close the syslog output and the listener BEFORE goleak runs so
+	// their background goroutines have exited by the time we assert.
+	require.NoError(t, out.Close())
+	_ = listener.Close()
+	<-acceptDone
+	goleak.VerifyNone(t)
+}

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -2790,57 +2790,6 @@ func TestSyslog_TLSWarningsRoutedToInjectedLogger(t *testing.T) {
 		"warning should carry output=syslog attribute: %q", logged)
 }
 
-// TestSyslog_SetDiagnosticLoggerUnderEventLoad drives SetDiagnosticLogger
-// and Write concurrently to prove the logger field is safe under the
-// race detector. Closes #474 AC #3.
-//
-// Uses a local TCP listener to accept the syslog connection so New
-// succeeds. The listener just drains bytes — we do not validate
-// delivery, only that the logger field survives concurrent access.
-func TestSyslog_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-	go func() {
-		for {
-			conn, acceptErr := listener.Accept()
-			if acceptErr != nil {
-				return
-			}
-			go func(c net.Conn) {
-				defer func() { _ = c.Close() }()
-				_, _ = io.Copy(io.Discard, c)
-			}(conn)
-		}
-	}()
-
-	out, err := syslog.New(&syslog.Config{
-		Network:  "tcp",
-		Address:  listener.Addr().String(),
-		Facility: "local0",
-		AppName:  "race-test",
-	}, nil)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = out.Close() })
-
-	var wg sync.WaitGroup
-	const iters = 100
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		for range iters {
-			out.SetDiagnosticLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for range iters {
-			_ = out.Write([]byte(`{"event":"race"}`))
-		}
-	}()
-	wg.Wait()
-}
-
 // TestSyslog_NilDiagnosticLoggerFallsBackToDefault verifies
 // WithDiagnosticLogger(nil) does not nil-deref and falls back to
 // slog.Default for warning emission.

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1783,7 +1783,6 @@ func TestWebhook_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(func() { srv.Close() })
 
 	out, err := webhook.New(&webhook.Config{
 		URL:                srv.URL,
@@ -1795,7 +1794,6 @@ func TestWebhook_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
 		BufferSize:         100,
 	}, nil)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = out.Close() })
 
 	// 100 concurrent SetDiagnosticLogger calls against a hot Write path.
 	// Run under -race; any unsynchronised read/write will fail here.
@@ -1815,6 +1813,13 @@ func TestWebhook_SetDiagnosticLoggerUnderEventLoad(t *testing.T) {
 		}
 	}()
 	wg.Wait()
+
+	// Close BEFORE per-test goleak so webhook's async batch/flush
+	// goroutines AND the httptest server's accept loop have exited by
+	// the time we assert no leaks (#474).
+	require.NoError(t, out.Close())
+	srv.Close()
+	goleak.VerifyNone(t)
 }
 
 // TestWebhook_NilDiagnosticLoggerFallsBackToDefault verifies that


### PR DESCRIPTION
## Summary

Remediation PR for a gap identified by the retrospective issue-closer audit on 2026-04-18.

Issue #474 AC3 named specific file locations and per-test goleak form. PR #629 placed webhook correctly but put the other three tests in the package's primary `*_test.go` file and relied on package-level `goleak.VerifyTestMain` instead of per-test `goleak.VerifyNone(t)`. This closes both gaps.

## Changes

- **Move** `TestFile_SetDiagnosticLoggerUnderEventLoad` → `file/file_external_test.go`
- **Move** `TestSyslog_SetDiagnosticLoggerUnderEventLoad` → `syslog/syslog_external_test.go`
- **Move** `TestLoki_SetDiagnosticLoggerUnderEventLoad` → `loki/loki_external_test.go`
- **Add** per-test `goleak.VerifyNone(t)` to all four race tests (webhook already lived in the right file, but also lacked per-test goleak).
- Each test now explicitly closes the output BEFORE the goleak call so background goroutines (rotate-mill, batch flush, accept loop) have exited when the assertion runs.

## No production code change

Purely test reorganisation. All four tests still drive 100 concurrent iterations under `-race`. Functional behaviour unchanged.

## AC coverage (re-verified by issue-closer)

- [x] AC1: `atomic.Pointer[slog.Logger]` on all four outputs (unchanged)
- [x] AC2: `-race -count=100` passes on all four (verified locally)
- [x] AC3: Tests in the exactly-named `*_external_test.go` files, each calling `goleak.VerifyNone(t)`
- [x] AC4: No functional behaviour change
- [ ] AC5: bench-compare regression — out of scope for this remediation (no hot-path code change). Raise separately if re-verification required.

## Test plan

- [x] `go test -race -count=1 ./file/... ./syslog/... ./loki/... ./webhook/...` — all pass
- [x] `make lint` — 0 issues
- [x] issue-closer — READY TO MERGE (4 of 4 applicable ACs met)