### PR TITLE
security: minimise and document secret memory retention (#479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Security
 
 - HMAC now authenticates the `_hmac_v` salt version identifier. Previously `_hmac_v` was appended AFTER HMAC computation, leaving it outside the authenticated region. An in-transit attacker could flip the version from `v1` to `v2` to redirect a verifier's salt lookup without detection. `_hmac_v` is now inside the authenticated bytes; any modification invalidates the HMAC tag. Pre-v1.0 consumers using external verifiers that strip both `_hmac` and `_hmac_v` must update the verifier to strip only `_hmac` (#473)
+- Document memory retention windows for credential-carrying fields. `HMACConfig.SaltValue`, `loki.Config.BearerToken`, `loki.BasicAuth.Password`, `webhook.Config.Headers`, and `loki.Config.TenantID` retain resolved plaintext for the auditor's lifetime; Go strings cannot be zeroed. The library best-effort zeroes provider `[]byte` token storage in `Provider.Close()` and drops HTTP header map entries after each request, but these are narrowings of the retention window, not zeroing guarantees. `outputconfig.Load()` now explicitly clears the short-lived resolver caches before return as defence-in-depth. Full model + operator rotation strategy: [`SECURITY.md` §Secrets and Memory Retention](SECURITY.md#secrets-and-memory-retention) and [`docs/secrets.md` §Memory Retention and Rotation Strategy](docs/secrets.md#memory-retention-and-rotation-strategy) (#479)
 
 ### Added
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,6 +131,71 @@ intercept `%+v` (struct-tag reflection) which would otherwise bypass a
 `String` method. Consumers who print individual fields directly
 (`slog.Info("url", cfg.URL)`) bypass these safeguards; do not do this.
 
+## Secrets and Memory Retention
+
+The library resolves secrets from `vault://` / `openbao://` providers
+and threads the plaintext values into output configurations. Because
+Go strings are immutable and cannot be zeroed in memory, values
+persist until the garbage collector reclaims them — which is not
+under the library's control. This section documents what the library
+does to minimise retention and what operators must do to bound it.
+
+### What the library does
+
+- **Provider token storage.** `secrets/vault` and `secrets/openbao`
+  store the auth token as `[]byte` internally (not `string`).
+  `Provider.Close()` zeroes the byte slice best-effort. This is
+  genuine zeroing; subsequent reads of the slice see `0x00`.
+- **HTTP request headers.** Building a Vault request calls
+  `req.Header.Set("X-Vault-Token", string(p.token))`, which creates
+  an immutable `string` copy of the token bytes. After the response
+  is handled, the library `Header.Del`s the entry to drop the
+  map-held reference; the underlying string persists until GC. This
+  is defence-in-depth, not zeroing.
+- **Resolver caches.** `outputconfig.Load()` builds a short-lived
+  resolver with in-memory `pathCache` / `refCache` maps to
+  deduplicate provider calls within one Load invocation. The
+  resolver is local to Load and becomes GC-unreachable at return.
+  A deferred `clear()` call drops map-held references before Load
+  unwinds to narrow the window before GC.
+
+### What the library cannot do
+
+Resolved plaintext values land in the following output-config fields
+and **persist for the auditor's lifetime** as Go strings / byte
+slices:
+
+- `loki.Config.BearerToken`, `loki.Config.TenantID`
+- `loki.BasicAuth.Password`
+- `webhook.Config.Headers` (e.g. `Authorization` values)
+- `HMACConfig.SaltValue` (`[]byte` — the library cannot zero this
+  because consumers may hold references)
+
+Zeroing these is impossible from inside the library: the strings are
+immutable, the byte slices are consumer-reachable, and Go's GC does
+not expose a "scrub on free" hook. Memory dumps, core files, and
+heap profiles captured while the auditor is running will contain
+these values.
+
+### Operational mitigation
+
+- Use **short-lived tokens** (TTL ≤ 1 hour where the provider
+  supports it).
+- Use **workload identity** (AWS IAM roles, Kubernetes service
+  accounts, GCP workload identity) where available, so bootstrap
+  credentials never touch the library.
+- **Restart the auditor** periodically to bound the in-memory
+  lifetime of resolved values. A credential exfiltrated from a
+  running process remains valid only until the next rotation +
+  restart cycle.
+- **Do not** build custom diagnostic logging that echoes
+  `outputconfig.LoadResult` or raw `Config` structs after
+  resolution — the library redacts via `String()` / `GoString()` /
+  `%+v`, but ad-hoc reflection will surface the plaintext.
+
+Operator guidance with rotation patterns: see
+[docs/secrets.md](docs/secrets.md#memory-retention-and-rotation-strategy).
+
 ## Software Bill of Materials (SBOM)
 
 Every release includes SBOMs in two formats, published as assets in

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -619,6 +619,36 @@ func reload(ctx context.Context, yamlData []byte, taxonomy *audit.Taxonomy) (*au
 Trigger the reload on SIGHUP or via an admin endpoint. Close the old
 logger before replacing it -- `Close` drains buffered events.
 
+## Memory Retention and Rotation Strategy
+
+Secrets resolved from a provider flow into output-configuration
+fields that persist in process memory for the auditor's lifetime.
+Go strings are immutable and cannot be zeroed; byte slices can be
+zeroed but the library cannot do so for values that consumers may
+reference. Memory dumps, core files, and heap profiles captured
+while the auditor is running will contain resolved plaintext.
+
+**Rotation is the primary mitigation.** The auditor's lifetime is
+the upper bound on how long a compromised credential remains
+valid in process memory. Plan accordingly:
+
+| Mitigation | Effect |
+|---|---|
+| **Short-lived tokens (TTL ≤ 1 hour)** | Bounds the window in which an exfiltrated token is usable against the provider. Does not reduce the in-memory retention window of the resolved plaintext, but limits the damage if it is extracted. |
+| **Workload identity** (AWS IAM role, K8s service account, GCP workload identity) | Eliminates long-lived bootstrap credentials from the library's reach. Token is minted per-process and rotated by the platform. |
+| **Periodic auditor restart** | Frees retained plaintext at process exit. Combined with short-lived tokens, bounds the in-memory lifetime to the restart interval. |
+| **Provider-side audit logging** | Detects exfiltration even when the in-memory lifetime itself cannot be shortened. OpenBao/Vault audit logs record every token-use attempt. |
+
+The library's `Provider.Close()` zeroes the `[]byte` token storage
+best-effort — see [Token Handling](#security-model) above. HTTP
+request headers built from tokens contain string copies that
+cannot be zeroed; the library drops the header-map references
+after each request (defence-in-depth per #479).
+
+For the full memory-retention model — including the specific
+config fields that retain plaintext — see
+[SECURITY.md §Secrets and Memory Retention](../SECURITY.md#secrets-and-memory-retention).
+
 ## Security Model
 
 ### HTTPS by Default

--- a/outputconfig/export_test.go
+++ b/outputconfig/export_test.go
@@ -28,3 +28,41 @@ var ToStringSliceForTest = toStringSlice
 
 // DeepCopyValueForTest exposes deepCopyValue for black-box testing.
 var DeepCopyValueForTest = deepCopyValue
+
+// NewResolverForTest exposes newResolver for tests that need to drive
+// the resolver directly — used by [TestClearCaches_EmptiesBothMaps]
+// to verify clearCaches() empties both maps (#479).
+var NewResolverForTest = newResolver
+
+// ResolverCacheSizesForTest returns the current (pathCache, refCache)
+// lengths for a resolver built via [NewResolverForTest].
+func ResolverCacheSizesForTest(r any) (pathLen, refLen int) {
+	rr, ok := r.(*resolver)
+	if !ok || rr == nil {
+		return 0, 0
+	}
+	return len(rr.pathCache), len(rr.refCache)
+}
+
+// ResolverSeedCacheForTest seeds both caches with a single dummy
+// entry so the clearCaches contract can be verified with non-empty
+// starting state.
+func ResolverSeedCacheForTest(r any) {
+	rr, ok := r.(*resolver)
+	if !ok || rr == nil {
+		return
+	}
+	rr.pathCache["scheme://path"] = map[string]string{"key": "value"}
+	rr.refCache["scheme://path#key"] = "value"
+}
+
+// ResolverClearCachesForTest exposes the unexported clearCaches
+// method directly so tests exercise the contract in isolation from
+// Load (#479).
+func ResolverClearCachesForTest(r any) {
+	rr, ok := r.(*resolver)
+	if !ok {
+		return
+	}
+	rr.clearCaches()
+}

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -218,6 +218,12 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 	if rErr != nil {
 		return nil, rErr
 	}
+	// Drop resolved-value references from the resolver caches on the
+	// way out. The resolver is already local to this call and becomes
+	// GC-unreachable at return; clearing the caches narrows the live
+	// reference set by one layer before GC runs. Defence-in-depth per
+	// #479 — not a zeroing guarantee.
+	defer secretResolver.clearCaches()
 
 	// Derive a context with the secret timeout applied.
 	secretCtx := ctx

--- a/outputconfig/secrets.go
+++ b/outputconfig/secrets.go
@@ -37,6 +37,22 @@ type resolver struct {
 	refCache  map[string]string            // "scheme://path#key" → value (non-batch providers)
 }
 
+// clearCaches drops map-held references to resolved secret values
+// from the resolver's caches. Called from [Load] before return so the
+// intermediate plaintext values held in [resolver.pathCache] and
+// [resolver.refCache] become GC-reachable only via any copies the
+// output configs captured — narrowing the live reference set by one
+// layer. The resolver struct itself is already local to [Load] and
+// becomes unreachable at return; this call is defence-in-depth per
+// #479, not a zeroing guarantee (Go strings cannot be zeroed).
+func (r *resolver) clearCaches() {
+	if r == nil {
+		return
+	}
+	clear(r.pathCache)
+	clear(r.refCache)
+}
+
 // newResolver builds a resolver from the providers registered via
 // [WithSecretProvider]. Returns (nil, nil) when no providers are
 // registered. Returns an error if duplicate schemes are detected.

--- a/outputconfig/secrets_test.go
+++ b/outputconfig/secrets_test.go
@@ -351,6 +351,104 @@ func TestLoad_WithSecretProvider_ErrorNeverContainsSecretValue(t *testing.T) {
 	assert.NotContains(t, err.Error(), secretValue)
 }
 
+// TestClearCaches_EmptiesBothMaps is the direct unit test for the
+// defence-in-depth call site. Removing or breaking the `clear()`
+// calls in resolver.clearCaches() MUST fail this test — exercised
+// via the [outputconfig.ResolverClearCachesForTest] hook so the
+// contract is locked in at the line level, not just at the Load
+// level where the resolver is already local to the call (#479).
+func TestClearCaches_EmptiesBothMaps(t *testing.T) {
+	t.Parallel()
+
+	// nil receiver is a no-op — covered explicitly so the guard
+	// is not quietly removed in a refactor.
+	outputconfig.ResolverClearCachesForTest(nil)
+
+	mock := newMockProvider("mock", nil)
+	r, err := outputconfig.NewResolverForTest([]secrets.Provider{mock})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	outputconfig.ResolverSeedCacheForTest(r)
+	pathLen, refLen := outputconfig.ResolverCacheSizesForTest(r)
+	require.Equal(t, 1, pathLen, "seed must populate pathCache")
+	require.Equal(t, 1, refLen, "seed must populate refCache")
+
+	outputconfig.ResolverClearCachesForTest(r)
+	pathLen, refLen = outputconfig.ResolverCacheSizesForTest(r)
+	assert.Equal(t, 0, pathLen, "clearCaches() must empty pathCache")
+	assert.Equal(t, 0, refLen, "clearCaches() must empty refCache")
+}
+
+// TestLoad_ClearsResolverCacheBeforeReturn is the named contract test
+// from #479 Testing Requirements. It proves the resolver's path and
+// ref caches do not persist across Load invocations — a second Load
+// with the same provider and same refs must produce fresh provider
+// calls, never hitting a stale intra-process cache.
+//
+// This is the observable companion to the defence-in-depth
+// clearCaches() call in Load: even if a future refactor accidentally
+// shares a resolver across Loads, this test fails closed.
+func TestLoad_ClearsResolverCacheBeforeReturn(t *testing.T) {
+	t.Parallel()
+	tax := testTaxonomy(t)
+	mock := newMockProvider("mock", map[string]map[string]string{
+		"secret/data/hmac": {
+			"salt":      "cached-salt-value-32-bytes!!!!!!",
+			"version":   "v1",
+			"algorithm": "HMAC-SHA-256",
+			"enabled":   "true",
+		},
+	})
+	data := yamlWithHMACRefs(
+		"ref+mock://secret/data/hmac#salt",
+		"ref+mock://secret/data/hmac#version",
+		"ref+mock://secret/data/hmac#algorithm",
+		"ref+mock://secret/data/hmac#enabled",
+	)
+
+	// First Load — BatchProvider resolves the path once.
+	result1, err := outputconfig.Load(
+		context.Background(), data, tax,
+		outputconfig.WithSecretProvider(mock),
+	)
+	require.NoError(t, err)
+	callsAfterFirst := mock.calls.Load()
+	require.Equal(t, int64(1), callsAfterFirst,
+		"first Load should produce exactly one provider call (path-level cache)")
+
+	// Second Load with the SAME provider and SAME refs. If Load did
+	// not clear the resolver caches before returning (or if caches
+	// somehow survived as package state), this second Load would
+	// produce zero additional provider calls. The contract is that
+	// each Load is self-contained: a fresh resolver is built, the
+	// provider is consulted anew.
+	result2, err := outputconfig.Load(
+		context.Background(), data, tax,
+		outputconfig.WithSecretProvider(mock),
+	)
+	require.NoError(t, err)
+	callsAfterSecond := mock.calls.Load()
+	assert.Equal(t, int64(2), callsAfterSecond,
+		"second Load must produce a second provider call — resolver caches must not persist across Loads (#479)")
+
+	// Sanity: both Loads produced the same resolved values.
+	require.Len(t, result1.Outputs, 1)
+	require.Len(t, result2.Outputs, 1)
+	hmac1, hmac2 := result1.Outputs[0].HMACConfig, result2.Outputs[0].HMACConfig
+	require.NotNil(t, hmac1)
+	require.NotNil(t, hmac2)
+	assert.Equal(t, hmac1.SaltValue, hmac2.SaltValue)
+	assert.Equal(t, hmac1.SaltVersion, hmac2.SaltVersion)
+
+	for _, o := range result1.Outputs {
+		_ = o.Output.Close()
+	}
+	for _, o := range result2.Outputs {
+		_ = o.Output.Close()
+	}
+}
+
 func TestLoad_WithSecretProvider_PathLevelCache_OneCallForMultipleKeys(t *testing.T) {
 	t.Parallel()
 	tax := testTaxonomy(t)

--- a/outputconfig/tests/bdd/features/secret_resolution.feature
+++ b/outputconfig/tests/bdd/features/secret_resolution.feature
@@ -327,6 +327,38 @@ Feature: Secret reference resolution in output configuration
     And the mock provider call count should be 1
 
   # ---------------------------------------------------------------------------
+  # Scenario: Resolver cache does not leak across Load invocations (#479)
+  # ---------------------------------------------------------------------------
+  # Proves the resolver's in-memory caches (pathCache, refCache) do
+  # not persist across Load calls — a second Load with the same
+  # provider and same refs must re-consult the provider. This is the
+  # observable contract of the clearCaches() call in Load plus the
+  # natural fact that each Load builds a fresh resolver. Defence
+  # against a future refactor accidentally sharing state across
+  # Loads (e.g. a package-level cache).
+  Scenario: Resolver cache does not leak across Load invocations
+    Given a mock secret provider with scheme "mock"
+    And the mock provider has secret at path "secret/data/hmac" key "salt" value "salt-32-bytes-long-value!!!!!!!!"
+    And the mock provider has secret at path "secret/data/hmac" key "version" value "v1"
+    When I load the following output configuration YAML with secret providers twice:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: ref+mock://secret/data/hmac#version
+              value: ref+mock://secret/data/hmac#salt
+            hash: HMAC-SHA-256
+      """
+    Then the config load should succeed
+    And the mock provider call count should be 2
+
+  # ---------------------------------------------------------------------------
   # Scenario 15: Provider timeout produces a clear error
   # ---------------------------------------------------------------------------
   Scenario: A secret provider that does not respond within the timeout produces a clear error

--- a/outputconfig/tests/bdd/steps/secret_steps.go
+++ b/outputconfig/tests/bdd/steps/secret_steps.go
@@ -160,6 +160,11 @@ func registerSecretSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 	)
 
 	ctx.Step(
+		`^I load the following output configuration YAML with secret providers twice:$`,
+		tc.stepLoadYAMLWithProvidersTwice,
+	)
+
+	ctx.Step(
 		`^the config load should fail$`,
 		tc.stepAssertConfigLoadFailed,
 	)
@@ -249,6 +254,22 @@ func (tc *TestContext) stepLoadYAMLWithProviders(doc *godog.DocString) error {
 func (tc *TestContext) stepAssertConfigLoadFailed() error {
 	if tc.LastErr == nil {
 		return fmt.Errorf("expected config load to fail, but it succeeded")
+	}
+	return nil
+}
+
+// stepLoadYAMLWithProvidersTwice loads the same YAML through two
+// back-to-back Load invocations, asserting both succeed. Used by the
+// #479 BDD scenario proving that resolver caches do not persist
+// across Loads — each invocation must hit the provider fresh.
+func (tc *TestContext) stepLoadYAMLWithProvidersTwice(doc *godog.DocString) error {
+	for i := 0; i < 2; i++ {
+		if err := tc.stepLoadYAMLWithProviders(doc); err != nil {
+			return fmt.Errorf("iteration %d: %w", i+1, err)
+		}
+		if tc.LastErr != nil {
+			return fmt.Errorf("iteration %d: unexpected load error: %w", i+1, tc.LastErr)
+		}
 	}
 	return nil
 }

--- a/secrets/openbao/export_test.go
+++ b/secrets/openbao/export_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file exports internal state for black-box tests that need to
+// assert on the provider's token byte-slice state — specifically, the
+// zeroing behaviour exercised by [TestOpenBaoClose_ZeroesTokenSlice].
+
+package openbao
+
+// TokenBytesForTest returns a copy of the provider's current token
+// byte slice. Used by [openbao_test.TestOpenBaoClose_ZeroesTokenSlice]
+// to assert every byte is 0x00 after Close (#479).
+func TokenBytesForTest(p *Provider) []byte {
+	if p == nil {
+		return nil
+	}
+	out := make([]byte, len(p.token))
+	copy(out, p.token)
+	return out
+}

--- a/secrets/openbao/openbao.go
+++ b/secrets/openbao/openbao.go
@@ -291,10 +291,25 @@ func (p *Provider) fetchPath(ctx context.Context, path string) (map[string]strin
 		// Strip stdlib error to prevent vault path leakage.
 		return nil, fmt.Errorf("%w: failed to build HTTP request", secrets.ErrSecretResolveFailed)
 	}
+	// Setting these headers converts p.token ([]byte) into an
+	// immutable Go string via string(p.token). Close() zeroes the
+	// underlying byte slice, but the string copy cannot be zeroed.
+	// We Delete the header entries after Do returns to drop the
+	// request-object reference — a best-effort narrowing of the
+	// retention window, since the string values persist until GC.
+	// See SECURITY.md §Secrets and Memory Retention (#479).
 	req.Header.Set("X-Vault-Token", string(p.token))
 	if p.ns != "" {
 		req.Header.Set("X-Vault-Namespace", p.ns)
 	}
+	defer func() {
+		// Drop the map-held references after the request completes.
+		// The string values already copied into the header map
+		// cannot be zeroed; GC reclaims them once req itself is
+		// unreachable. Best-effort defence-in-depth per #479.
+		req.Header.Del("X-Vault-Token")
+		req.Header.Del("X-Vault-Namespace")
+	}()
 
 	// Execute request. Strip *url.Error wrapper to prevent vault
 	// path leakage — url.Error.Error() embeds the full request URL.

--- a/secrets/openbao/openbao_test.go
+++ b/secrets/openbao/openbao_test.go
@@ -349,6 +349,134 @@ func TestClose_ZerosToken(t *testing.T) {
 	require.NoError(t, p.Close())
 }
 
+// TestOpenBaoClose_ZerosTokenSlice mirrors [TestVaultClose_ZeroesTokenSlice]
+// for openbao parity (#479). Asserts every byte of the internal
+// token slice is 0x00 after Close.
+func TestOpenBaoClose_ZerosTokenSlice(t *testing.T) {
+	t.Parallel()
+	const secretToken = "super-secret-openbao-token-v1"
+	p, err := openbao.New(&openbao.Config{
+		Address: "https://vault.example.com",
+		Token:   secretToken,
+	})
+	require.NoError(t, err)
+
+	before := openbao.TokenBytesForTest(p)
+	require.Equal(t, []byte(secretToken), before)
+
+	require.NoError(t, p.Close())
+
+	after := openbao.TokenBytesForTest(p)
+	require.Len(t, after, len(secretToken))
+	for i, b := range after {
+		assert.Equal(t, byte(0), b,
+			"token byte %d must be zero after Close, got %#x", i, b)
+	}
+}
+
+// TestOpenBaoResolve_ClearsHeaderAfterDo mirrors
+// [TestVaultResolve_ClearsHeaderAfterDo] for openbao parity (#479).
+// Asserts the request's X-Vault-Token and X-Vault-Namespace header
+// entries are deleted after client.Do returns.
+func TestOpenBaoResolve_ClearsHeaderAfterDo(t *testing.T) {
+	t.Parallel()
+	const testToken = "bearer-in-transit-openbao"
+	const testNamespace = "tenants/def"
+
+	backend := kvV2Handler(map[string]any{"k": "v"}, testToken)
+	srv := newTestServer(t, backend)
+
+	var captured *http.Request
+	capturingRT := &captureRoundTripperOpenBao{
+		inner: srv.Client().Transport,
+		onRoundTrip: func(req *http.Request) {
+			assert.Equal(t, testToken, req.Header.Get("X-Vault-Token"),
+				"token must be present when the request hits the transport")
+			assert.Equal(t, testNamespace, req.Header.Get("X-Vault-Namespace"))
+			captured = req
+		},
+	}
+
+	p, err := openbao.NewWithHTTPClient(
+		&openbao.Config{
+			Address:            srv.URL,
+			Token:              testToken,
+			Namespace:          testNamespace,
+			AllowPrivateRanges: true,
+		},
+		&http.Client{Transport: capturingRT},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+
+	_, err = p.Resolve(context.Background(),
+		secrets.Ref{Scheme: "openbao", Path: "secret/data/x", Key: "k"})
+	require.NoError(t, err)
+
+	require.NotNil(t, captured)
+	assert.Empty(t, captured.Header.Get("X-Vault-Token"),
+		"X-Vault-Token must be cleared from the request header after Do (#479)")
+	assert.Empty(t, captured.Header.Get("X-Vault-Namespace"),
+		"X-Vault-Namespace must be cleared from the request header after Do (#479)")
+}
+
+type captureRoundTripperOpenBao struct {
+	inner       http.RoundTripper
+	onRoundTrip func(req *http.Request)
+}
+
+func (c *captureRoundTripperOpenBao) RoundTrip(req *http.Request) (*http.Response, error) {
+	if c.onRoundTrip != nil {
+		c.onRoundTrip(req)
+	}
+	return c.inner.RoundTrip(req)
+}
+
+// TestOpenBaoResolve_ClearsHeaderAfterDoError mirrors
+// [TestVaultResolve_ClearsHeaderAfterDoError] for openbao parity
+// (#479). The deferred header-clear must run on error paths too.
+func TestOpenBaoResolve_ClearsHeaderAfterDoError(t *testing.T) {
+	t.Parallel()
+	const testToken = "bearer-on-error-openbao"
+	const testNamespace = "tenants/err"
+
+	var captured *http.Request
+	errRT := &captureRoundTripperOpenBao{
+		inner: errRoundTripperOpenBao{},
+		onRoundTrip: func(req *http.Request) {
+			captured = req
+		},
+	}
+
+	p, err := openbao.NewWithHTTPClient(
+		&openbao.Config{
+			Address:            "https://openbao.example.com",
+			Token:              testToken,
+			Namespace:          testNamespace,
+			AllowPrivateRanges: true,
+		},
+		&http.Client{Transport: errRT},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+
+	_, err = p.Resolve(context.Background(),
+		secrets.Ref{Scheme: "openbao", Path: "secret/data/x", Key: "k"})
+	require.Error(t, err)
+
+	require.NotNil(t, captured)
+	assert.Empty(t, captured.Header.Get("X-Vault-Token"),
+		"X-Vault-Token must be cleared even when Do returns an error (#479)")
+	assert.Empty(t, captured.Header.Get("X-Vault-Namespace"),
+		"X-Vault-Namespace must be cleared even when Do returns an error (#479)")
+}
+
+type errRoundTripperOpenBao struct{}
+
+func (errRoundTripperOpenBao) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("simulated transport error")
+}
+
 // ---------------------------------------------------------------------------
 // Namespace header
 // ---------------------------------------------------------------------------

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -75,12 +75,28 @@ type Provider interface {
 	// Errors should wrap the appropriate sentinel:
 	//   - [ErrSecretNotFound] when the path or key does not exist
 	//   - [ErrSecretResolveFailed] for transient or auth failures
+	//
+	// Memory retention: the returned string is a Go string and
+	// cannot be zeroed. Providers SHOULD store their authentication
+	// material as `[]byte` and zero it in [Close] to reduce the
+	// retention window for bootstrap credentials, but the resolved
+	// VALUE returned from Resolve persists in memory until GC
+	// reclaims it. Callers (notably [outputconfig.Load]) embed
+	// resolved values in long-lived config structs; see SECURITY.md
+	// §Secrets and Memory Retention for the full model.
 	Resolve(ctx context.Context, ref Ref) (string, error)
 
 	// Close releases resources held by the provider (HTTP clients,
 	// connection pools). Errors are informational — the caller
 	// cannot recover from a close failure but should log it.
 	// Close is idempotent.
+	//
+	// Memory retention: implementations SHOULD zero any `[]byte`
+	// storage of authentication material (e.g. the provider token)
+	// to minimise the retention window. This is best-effort —
+	// Go strings derived from the bytes (e.g. HTTP header copies)
+	// cannot be zeroed and persist until GC. See SECURITY.md
+	// §Secrets and Memory Retention.
 	Close() error
 }
 

--- a/secrets/vault/export_test.go
+++ b/secrets/vault/export_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file exports internal state for black-box tests that need to
+// assert on the provider's token byte-slice state — specifically, the
+// zeroing behaviour exercised by [TestVaultClose_ZeroesTokenSlice].
+
+package vault
+
+// TokenBytesForTest returns a copy of the provider's current token
+// byte slice. Used by [vault_test.TestVaultClose_ZeroesTokenSlice] to
+// assert every byte is 0x00 after Close (#479).
+func TokenBytesForTest(p *Provider) []byte {
+	if p == nil {
+		return nil
+	}
+	out := make([]byte, len(p.token))
+	copy(out, p.token)
+	return out
+}

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -294,10 +294,25 @@ func (p *Provider) fetchPath(ctx context.Context, path string) (map[string]strin
 		// Strip stdlib error to prevent vault path leakage.
 		return nil, fmt.Errorf("%w: failed to build HTTP request", secrets.ErrSecretResolveFailed)
 	}
+	// Setting these headers converts p.token ([]byte) into an
+	// immutable Go string via string(p.token). Close() zeroes the
+	// underlying byte slice, but the string copy cannot be zeroed.
+	// We Delete the header entries after Do returns to drop the
+	// request-object reference — a best-effort narrowing of the
+	// retention window, since the string values persist until GC.
+	// See SECURITY.md §Secrets and Memory Retention (#479).
 	req.Header.Set("X-Vault-Token", string(p.token))
 	if p.ns != "" {
 		req.Header.Set("X-Vault-Namespace", p.ns)
 	}
+	defer func() {
+		// Drop the map-held references after the request completes.
+		// The string values already copied into the header map
+		// cannot be zeroed; GC reclaims them once req itself is
+		// unreachable. Best-effort defence-in-depth per #479.
+		req.Header.Del("X-Vault-Token")
+		req.Header.Del("X-Vault-Namespace")
+	}()
 
 	// Execute request. Strip *url.Error wrapper to prevent vault
 	// path leakage — url.Error.Error() embeds the full request URL.

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -279,6 +279,169 @@ func TestClose_ZerosToken_Idempotent(t *testing.T) {
 	require.NoError(t, p.Close())
 }
 
+// TestVaultClose_ZerosTokenSlice is the named contract test from
+// #479 Testing Requirements. Asserts every byte of the internal
+// token slice is 0x00 after Close() returns, proving the best-effort
+// byte-slice zeroing guarantee documented in SECURITY.md §Secrets
+// and Memory Retention. The separate Go string copy created at
+// fetchPath (string(p.token) → HTTP header) cannot be zeroed and is
+// not covered by this test — see TestVaultResolve_ClearsHeaderAfterDo
+// for the request-header narrowing coverage.
+func TestVaultClose_ZerosTokenSlice(t *testing.T) {
+	t.Parallel()
+	const secretToken = "super-secret-vault-token-v1"
+	p, err := vault.New(&vault.Config{
+		Address: "https://vault.example.com",
+		Token:   secretToken,
+	})
+	require.NoError(t, err)
+
+	// Sanity: before Close the token slice contains the original
+	// bytes (rules out "New didn't store it" false positive).
+	before := vault.TokenBytesForTest(p)
+	require.Equal(t, []byte(secretToken), before,
+		"token bytes must match Config.Token before Close")
+
+	require.NoError(t, p.Close())
+
+	after := vault.TokenBytesForTest(p)
+	require.Len(t, after, len(secretToken),
+		"Close must not resize the token slice — it zeroes in place")
+	for i, b := range after {
+		assert.Equal(t, byte(0), b,
+			"token byte %d must be zero after Close, got %#x", i, b)
+	}
+}
+
+// TestVaultResolve_ClearsHeaderAfterDo asserts the request's
+// X-Vault-Token and X-Vault-Namespace header entries are deleted
+// after client.Do returns. Best-effort narrowing of the retention
+// window — the string values already exist in memory and cannot be
+// zeroed, but dropping the map entry removes one live reference
+// held by the request object (#479).
+//
+// Uses a capturing RoundTripper: the request is snapshotted during
+// RoundTrip (headers still present — they must reach the transport)
+// and inspected after Resolve returns (headers must be cleared).
+func TestVaultResolve_ClearsHeaderAfterDo(t *testing.T) {
+	t.Parallel()
+	const testToken = "bearer-in-transit-token"
+	const testNamespace = "tenants/abc"
+
+	// Inner handler verifies the token reached the server side —
+	// the clear happens AFTER Do returns, so the header must still
+	// be present during transport.
+	backend := kvV2Handler(map[string]any{"k": "v"}, testToken)
+
+	var captured *http.Request
+	capturingRT := &captureRoundTripper{
+		inner: http.DefaultTransport,
+		onRoundTrip: func(req *http.Request) {
+			// Snapshot at transport send: header MUST contain the token.
+			assert.Equal(t, testToken, req.Header.Get("X-Vault-Token"),
+				"token must be present when the request hits the transport")
+			assert.Equal(t, testNamespace, req.Header.Get("X-Vault-Namespace"))
+			captured = req
+		},
+	}
+
+	srv := newTestServer(t, backend)
+	capturingRT.inner = srv.Client().Transport // keep TLS config
+
+	p, err := vault.NewWithHTTPClient(
+		&vault.Config{
+			Address:            srv.URL,
+			Token:              testToken,
+			Namespace:          testNamespace,
+			AllowPrivateRanges: true,
+		},
+		&http.Client{Transport: capturingRT},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+
+	_, err = p.Resolve(context.Background(),
+		secrets.Ref{Scheme: "vault", Path: "secret/data/x", Key: "k"})
+	require.NoError(t, err)
+
+	// Post-Do: the map entries must have been deleted by the defer.
+	require.NotNil(t, captured, "RoundTripper must have captured the request")
+	assert.Empty(t, captured.Header.Get("X-Vault-Token"),
+		"X-Vault-Token must be cleared from the request header after Do (#479)")
+	assert.Empty(t, captured.Header.Get("X-Vault-Namespace"),
+		"X-Vault-Namespace must be cleared from the request header after Do (#479)")
+}
+
+// captureRoundTripper wraps an inner http.RoundTripper and invokes
+// onRoundTrip just before delegating. Used by
+// TestVaultResolve_ClearsHeaderAfterDo to observe the request state
+// at the transport boundary.
+type captureRoundTripper struct {
+	inner       http.RoundTripper
+	onRoundTrip func(req *http.Request)
+}
+
+func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if c.onRoundTrip != nil {
+		c.onRoundTrip(req)
+	}
+	return c.inner.RoundTrip(req)
+}
+
+// TestVaultResolve_ClearsHeaderAfterDoError proves the deferred
+// header-clear runs on the error path too — not just on the
+// Do-success path covered by
+// [TestVaultResolve_ClearsHeaderAfterDo]. A RoundTripper that
+// captures the request then returns an error simulates any
+// transport-level failure. The defer must still delete the
+// token/namespace entries (#479).
+func TestVaultResolve_ClearsHeaderAfterDoError(t *testing.T) {
+	t.Parallel()
+	const testToken = "bearer-on-error-token"
+	const testNamespace = "tenants/err"
+
+	var captured *http.Request
+	errRT := &captureRoundTripper{
+		inner: errRoundTripper{},
+		onRoundTrip: func(req *http.Request) {
+			captured = req
+		},
+	}
+
+	p, err := vault.NewWithHTTPClient(
+		&vault.Config{
+			Address:            "https://vault.example.com",
+			Token:              testToken,
+			Namespace:          testNamespace,
+			AllowPrivateRanges: true,
+		},
+		&http.Client{Transport: errRT},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+
+	// Resolve must fail because the inner RoundTripper errors,
+	// but the deferred header-clear must STILL run.
+	_, err = p.Resolve(context.Background(),
+		secrets.Ref{Scheme: "vault", Path: "secret/data/x", Key: "k"})
+	require.Error(t, err,
+		"Resolve must return an error when the transport errors")
+
+	require.NotNil(t, captured, "RoundTripper must have captured the request")
+	assert.Empty(t, captured.Header.Get("X-Vault-Token"),
+		"X-Vault-Token must be cleared even when Do returns an error (#479)")
+	assert.Empty(t, captured.Header.Get("X-Vault-Namespace"),
+		"X-Vault-Namespace must be cleared even when Do returns an error (#479)")
+}
+
+// errRoundTripper always returns a network-ish error. Paired with
+// captureRoundTripper to verify post-Do cleanup on error paths.
+type errRoundTripper struct{}
+
+func (errRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("simulated transport error")
+}
+
 func TestResolve_DifferentKeys(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t, kvV2Handler(map[string]any{


### PR DESCRIPTION
## Summary

Closes #479. Addresses two attack surfaces and documents the retention model operators need to plan rotation against.

## Code changes

**Provider tokens (vault + openbao):**
- `fetchPath` now defers `req.Header.Del("X-Vault-Token")` and `req.Header.Del("X-Vault-Namespace")` after `client.Do` returns. The Go string created by `string(p.token)` for the header cannot be zeroed, but the map-held reference on `req` is dropped so it no longer keeps the string alive past the request's natural lifetime. Defence-in-depth — not a zeroing guarantee.
- `Provider.Close()` continues to zero the `[]byte` token slice as before; new tests pin the contract.

**outputconfig resolver caches:**
- New `resolver.clearCaches()` method explicitly empties `pathCache` and `refCache`.
- `Load()` defers `clearCaches()` so map-held references are dropped before the resolver is GC-reclaimed.

## Tests (all named per issue ACs + agent recommendations)

- `TestVaultClose_ZerosTokenSlice` + openbao parity — asserts byte-slice is all-zero after Close.
- `TestVaultResolve_ClearsHeaderAfterDo` + openbao parity — capturing RoundTripper proves header present at transport send, cleared after Do.
- `TestVaultResolve_ClearsHeaderAfterDoError` + openbao parity — error-path coverage (test-analyst MEDIUM).
- `TestLoad_ClearsResolverCacheBeforeReturn` — two Loads on same provider produce two Get calls.
- `TestClearCaches_EmptiesBothMaps` — direct unit test for the `clearCaches()` contract via `ResolverClearCachesForTest` export hook (test-analyst HIGH — closes the "removing clearCaches has no failing test" gap).
- BDD: "Resolver cache does not leak across Load invocations" in `secret_resolution.feature`.

## Documentation

- `SECURITY.md` — new "Secrets and Memory Retention" subsection naming every retained field and distinguishing zeroing from defence-in-depth.
- `docs/secrets.md` — new "Memory Retention and Rotation Strategy" with operator guidance (short-lived tokens, workload identity, periodic restart).
- `secrets.Provider.Resolve/Close` godoc — retention contract for implementers.
- `CHANGELOG.md` — entry under `### Security`.

## Agent gates

- [x] Plan agent
- [x] Pre-coding security-reviewer — confirmed "clear + document" approach; expanded scope to include `X-Vault-Namespace` and `loki.TenantID` per their findings
- [x] Pre-coding test-analyst — test matrix approved; directed the export-hook pattern
- [x] Pre-coding docs-writer — corrected 3 blocker claims before prose was written
- [x] Post-coding code-reviewer — APPROVED with 3 nits (N1 rename applied; N2/N3 cosmetic)
- [x] Post-coding security-reviewer — APPROVED, 0 blockers
- [x] Post-coding test-analyst — HIGH finding addressed (`TestClearCaches_EmptiesBothMaps` + export hook); MEDIUM addressed (error-path tests); LOW deferred (BDD equal-values assertion) — Go test covers it
- [x] `make lint` — 0 issues
- [x] `go test -race -count=1 ./secrets/... ./outputconfig/... .` — all pass
- [x] commit-message-reviewer — PASS

## Test plan

- [x] Vault + openbao unit tests pass under `-race`
- [x] outputconfig unit tests pass
- [x] outputconfig BDD passes
- [x] No hot-path code change — no benchmark impact expected
- [ ] issue-closer verification **before merge** (final gate)