### PR TITLE
fix(ssrf): panic loudly if hardcoded SSRF CIDR fails to parse (#488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Panic loudly at init if any hardcoded SSRF CIDR or IP literal fails to parse. Previously `cgnatBlock` / `deprecatedSiteLocalBlock` / `awsIPv6MetadataIP` init used `_, n, _ := net.ParseCIDR(...)` (or `net.ParseIP(...)` with no check); a source-level corruption or stdlib regression would have silently produced `nil`, and every subsequent SSRF check would have nil-deref panicked inside `Contains` / `Equal`. A new `mustParseCIDR` / `mustParseIP` wrapper panics with a clear `audit: SSRF init: failed to parse hardcoded CIDR ...` message at package load instead (#488)
 - Data race on the diagnostic logger field in `webhook`, `file`, `syslog`, `loki` outputs. `SetDiagnosticLogger` performed a plain field assignment while background goroutines concurrently read the same field. Race detector now passes `-count=100` across all four outputs. The field is `atomic.Pointer[slog.Logger]`; writers use `Store`, readers use `Load`. No API-shape change; no functional behaviour change (#474)
 
 ### Security

--- a/ssrf.go
+++ b/ssrf.go
@@ -21,28 +21,46 @@ import (
 	"syscall"
 )
 
+// mustParseCIDR parses a hardcoded CIDR literal and panics at init if
+// the parse fails. The input strings below are package constants —
+// a parse failure indicates a corrupted source constant (or an
+// unexpected stdlib regression), not a runtime input, so failing
+// loudly at package load is safer than a silent nil-deref on every
+// SSRF check later (#488).
+func mustParseCIDR(cidr string) *net.IPNet {
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic("audit: SSRF init: failed to parse hardcoded CIDR " + cidr + ": " + err.Error())
+	}
+	return n
+}
+
+// mustParseIP parses a hardcoded IP literal and panics at init if the
+// parse fails. Same rationale as [mustParseCIDR] (#488).
+func mustParseIP(ip string) net.IP {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		panic("audit: SSRF init: failed to parse hardcoded IP " + ip)
+	}
+	return parsed
+}
+
 // cgnatBlock is the RFC 6598 Shared Address Space (100.64.0.0/10),
 // used by CGNAT and some cloud providers for internal routing.
 // Always blocked regardless of AllowPrivateRanges.
-var cgnatBlock = func() *net.IPNet {
-	_, n, _ := net.ParseCIDR("100.64.0.0/10")
-	return n
-}()
+var cgnatBlock = mustParseCIDR("100.64.0.0/10")
 
 // deprecatedSiteLocalBlock is RFC 3513 site-local IPv6 (fec0::/10).
 // RFC 3879 deprecated this range, but some legacy stacks still route
 // it — Go's net.IP.IsPrivate() does NOT classify it, so we block it
 // explicitly. Always blocked regardless of AllowPrivateRanges.
-var deprecatedSiteLocalBlock = func() *net.IPNet {
-	_, n, _ := net.ParseCIDR("fec0::/10")
-	return n
-}()
+var deprecatedSiteLocalBlock = mustParseCIDR("fec0::/10")
 
 // awsIPv6MetadataIP is the AWS IMDSv2 over-IPv6 endpoint, documented
 // at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-v2-how-it-works.html.
 // An explicit Equal check is required (not relying on IsPrivate) so
 // AllowPrivateRanges cannot open a metadata-exfiltration hole.
-var awsIPv6MetadataIP = net.ParseIP("fd00:ec2::254")
+var awsIPv6MetadataIP = mustParseIP("fd00:ec2::254")
 
 // Azure IPv6 IMDS is not yet blocked: no authoritative Microsoft
 // Learn citation was identified during #480. Tracked in #643;

--- a/ssrf_internal_test.go
+++ b/ssrf_internal_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal tests for ssrf.go package-level variables initialised via
+// [mustParseCIDR] and [mustParseIP]. Lives in package audit so it can
+// observe the unexported cgnatBlock / deprecatedSiteLocalBlock /
+// awsIPv6MetadataIP symbols directly (#488).
+
+package audit
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestSSRFInit_CGNATBlockNotNil asserts that the CGNAT block variable
+// was populated at init. If mustParseCIDR were ever to silently fail
+// (for example after a future stdlib regression) and the init fell
+// back to a nil *net.IPNet, every SSRF check would nil-deref on
+// cgnatBlock.Contains. The mustParseCIDR wrapper panics at load
+// instead, but this test guards against a refactor that re-introduces
+// the silent-failure pattern (#488).
+func TestSSRFInit_CGNATBlockNotNil(t *testing.T) {
+	t.Parallel()
+	if cgnatBlock == nil {
+		t.Fatal("cgnatBlock is nil — init failed silently")
+	}
+	// Sanity: 100.64.0.1 lies inside 100.64.0.0/10.
+	if !cgnatBlock.Contains(net.ParseIP("100.64.0.1")) {
+		t.Fatal("cgnatBlock does not contain 100.64.0.1 — wrong CIDR parsed")
+	}
+	// Sanity: 10.0.0.1 lies outside.
+	if cgnatBlock.Contains(net.ParseIP("10.0.0.1")) {
+		t.Fatal("cgnatBlock unexpectedly contains 10.0.0.1")
+	}
+}
+
+// TestSSRFInit_DeprecatedSiteLocalBlockNotNil is the companion guard
+// for the fec0::/10 block, which shares the same mustParseCIDR
+// wrapper (#488).
+func TestSSRFInit_DeprecatedSiteLocalBlockNotNil(t *testing.T) {
+	t.Parallel()
+	if deprecatedSiteLocalBlock == nil {
+		t.Fatal("deprecatedSiteLocalBlock is nil — init failed silently")
+	}
+	if !deprecatedSiteLocalBlock.Contains(net.ParseIP("fec0::1")) {
+		t.Fatal("deprecatedSiteLocalBlock does not contain fec0::1")
+	}
+	if deprecatedSiteLocalBlock.Contains(net.ParseIP("fc00::1")) {
+		t.Fatal("deprecatedSiteLocalBlock unexpectedly contains fc00::1")
+	}
+}
+
+// TestSSRFInit_AWSIPv6MetadataIPNotNil is the companion guard for the
+// AWS IPv6 IMDS endpoint, initialised via [mustParseIP] (#488).
+func TestSSRFInit_AWSIPv6MetadataIPNotNil(t *testing.T) {
+	t.Parallel()
+	if awsIPv6MetadataIP == nil {
+		t.Fatal("awsIPv6MetadataIP is nil — init failed silently")
+	}
+	if !awsIPv6MetadataIP.Equal(net.ParseIP("fd00:ec2::254")) {
+		t.Fatalf("awsIPv6MetadataIP = %v; want fd00:ec2::254", awsIPv6MetadataIP)
+	}
+}
+
+// TestMustParseCIDR_PanicsOnInvalid verifies the wrapper panics on a
+// malformed literal so a future edit that breaks a CIDR constant
+// fails at package load rather than silently nil-deref'ing on every
+// SSRF check (#488).
+func TestMustParseCIDR_PanicsOnInvalid(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("mustParseCIDR did not panic on invalid input")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("mustParseCIDR panic value type = %T; want string", r)
+		}
+		const want = "audit: SSRF init: failed to parse hardcoded CIDR"
+		if !strings.Contains(msg, want) {
+			t.Fatalf("mustParseCIDR panic %q does not contain %q", msg, want)
+		}
+	}()
+	mustParseCIDR("not-a-cidr")
+}
+
+// TestMustParseIP_PanicsOnInvalid is the companion for [mustParseIP].
+func TestMustParseIP_PanicsOnInvalid(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("mustParseIP did not panic on invalid input")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("mustParseIP panic value type = %T; want string", r)
+		}
+		const want = "audit: SSRF init: failed to parse hardcoded IP"
+		if !strings.Contains(msg, want) {
+			t.Fatalf("mustParseIP panic %q does not contain %q", msg, want)
+		}
+	}()
+	mustParseIP("not-an-ip")
+}


### PR DESCRIPTION
## Summary

- `ssrf.go` initialised `cgnatBlock` via `_, n, _ := net.ParseCIDR(...)` — the error was discarded. A corrupted literal (source edit or stdlib regression) would have silently produced a `nil *net.IPNet`. `(*net.IPNet)(nil).Contains()` returns `false`, which means the SSRF check would have **silently allowed 100.64.0.0/10 through the gate** — an availability failure masquerading as a security bypass.
- New `mustParseCIDR` / `mustParseIP` wrappers panic at package load with a clear message. Applied to `cgnatBlock`, `deprecatedSiteLocalBlock` (fec0::/10), and `awsIPv6MetadataIP` (fd00:ec2::254).
- Scope expanded from the issue's CGNAT-only wording to the two sibling sites sharing the identical silent-discard pattern (code-reviewer confirmed appropriate in-scope expansion).

## Closes

Closes #488.

## Test plan

- [x] `TestSSRFInit_CGNATBlockNotNil` + two companions assert non-nil init for all three SSRF globals
- [x] `TestMustParseCIDR_PanicsOnInvalid` + `TestMustParseIP_PanicsOnInvalid` verify the panic message contains "audit: SSRF init: failed to parse hardcoded ..."
- [x] `make check` clean — 0 lint issues, all tests pass, coverage 95.9% for core
- [x] code-reviewer APPROVED (one IMPORTANT — swap home-rolled substring helper for `strings.Contains` — addressed)
- [x] security-reviewer APPROVED — fail-loudly-at-init strictly reduces attack surface; previously a silent `nil *net.IPNet` would have silently permitted the blocked range
- [x] go-quality READY TO COMMIT

## Docs

- Godoc on `mustParseCIDR` / `mustParseIP` explains the rationale and references #488
- `CHANGELOG.md`: Fixed entry