### PR TITLE
docs(droplimit): document window-boundary counting semantics (#492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Documentation
 
+- Document the window-boundary counting semantics of `dropLimiter.record`. The lock-free two-atomic design (lastWarn + count) allows a drop's `count.Add(1)` that races with a winning goroutine's `count.Swap(0)` to be reported in the NEXT window rather than the one whose boundary just closed. Total drops across all windows are conserved; per-window counts are slightly smeared under concurrent bursts. Callers needing a monotonic SLA-grade drop total should use `OutputMetrics.RecordDrop` (pure `atomic.Add`, no windowing). Adds `TestDropLimiter_TotalConservedAcrossWindows` which proves conservation under 64 goroutines × 2000 records (#492)
 - Document the required placement of `audit.Middleware` relative to panic-recovery middleware. `Middleware` MUST be placed OUTSIDE any panic-recovery middleware; reversing the order silently breaks the re-raise contract. `Middleware` godoc gained a new `# Placement` section with correct / wrong examples, `docs/http-middleware.md` gained a `Placement: Audit Must Wrap Panic Recovery` section with framework-specific examples (chi, Gin), and two BDD scenarios in `tests/bdd/features/http_middleware.feature` document the observable behaviour of both placements (#491)
 
 ### Fixed

--- a/audit_export_test.go
+++ b/audit_export_test.go
@@ -55,3 +55,10 @@ type DropLimiterForTest struct {
 func (w *DropLimiterForTest) Record(interval time.Duration, warnFn func(dropped int64)) {
 	w.D.record(interval, warnFn)
 }
+
+// PendingCount returns the number of drops accumulated since the
+// last emitted warning. Used by conservation tests (#492) to prove
+// total drops across all windows equals total records.
+func (w *DropLimiterForTest) PendingCount() int64 {
+	return w.D.count.Load()
+}

--- a/audit_test.go
+++ b/audit_test.go
@@ -2816,6 +2816,49 @@ func TestDropLimiter_SubsequentDropsSuppressed(t *testing.T) {
 	assert.Equal(t, 1, triggered, "drops within interval must not trigger")
 }
 
+// TestDropLimiter_TotalConservedAcrossWindows guards the conservation
+// invariant documented on dropLimiter.record: every Record call must
+// be accounted for either in a warnFn callback or in the pending
+// counter — no drop is ever uncounted, even under concurrent bursts
+// that straddle a window boundary (#492).
+//
+// The test launches G goroutines each calling Record N times with a
+// very short interval so multiple windows fire. It captures the
+// sum of all warnFn-reported counts and adds the residual pending
+// count; that total must equal G*N exactly.
+func TestDropLimiter_TotalConservedAcrossWindows(t *testing.T) {
+	t.Parallel()
+
+	const (
+		goroutines     = 64
+		recordsPerG    = 2000
+		windowInterval = 1 * time.Microsecond // fire many windows across the run
+	)
+
+	dl := &audit.DropLimiterForTest{}
+	var reported atomic.Int64 // sum of all warnFn(dropped) values
+	warn := func(dropped int64) { reported.Add(dropped) }
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range recordsPerG {
+				dl.Record(windowInterval, warn)
+			}
+		}()
+	}
+	wg.Wait()
+
+	pending := dl.PendingCount()
+	total := reported.Load() + pending
+	want := int64(goroutines * recordsPerG)
+	assert.Equalf(t, want, total,
+		"conservation violated: %d reported + %d pending != %d total records",
+		reported.Load(), pending, want)
+}
+
 func TestLogger_DisableEvent_UncategorisedEvent(t *testing.T) {
 	tax := &audit.Taxonomy{
 		Version: 1,

--- a/droplimit.go
+++ b/droplimit.go
@@ -32,6 +32,38 @@ type dropLimiter struct {
 // record records a drop event. If at least interval has elapsed since
 // the last warning, warnFn is called with the number of drops
 // accumulated since the previous warning.
+//
+// # Window-boundary counting semantics (#492)
+//
+// Counting uses two atomics (lastWarn + count) that are not updated
+// under a shared lock. The call sequence is:
+//
+//  1. count.Add(1)        — producer bumps the pending-drops counter.
+//  2. lastWarn.Load()     — producer reads the last-warn time.
+//  3. CompareAndSwap      — producer races to claim the window boundary.
+//  4. count.Swap(0)       — winner resets the counter and observes N.
+//  5. warnFn(N)           — winner emits the diagnostic.
+//
+// A producer that performed its Add(1) AFTER another producer's
+// Swap(0) (step 4) will have its drop counted in the NEXT window
+// rather than the one whose boundary just closed. The total number
+// of drops reported across all windows is conserved — no drop is
+// ever uncounted — but individual per-window counts are slightly
+// smeared across the boundary under high-concurrency bursts.
+//
+// This is deliberate. A lock-free design means the ordering between
+// "my Add has landed" and "someone else's Swap has run" is not
+// serialised, and adding a mutex just to serialise a diagnostic
+// counter would cost more than the smear is worth. Every drop
+// shifted forward is simply counted in the subsequent window, so
+// the running total stays accurate — only the per-window boundary
+// blurs. The interval is already a diagnostic sampling hint
+// (default 10s), not an SLA, so exact window-aligned counts are not
+// a contract the caller can rely on.
+//
+// Callers needing an SLA-grade monotonic drop total should use the
+// [OutputMetrics.RecordDrop] counter, which is bumped via a pure
+// atomic.Add on every drop with no windowing involved.
 func (d *dropLimiter) record(interval time.Duration, warnFn func(dropped int64)) {
 	d.count.Add(1)
 


### PR DESCRIPTION
## Summary

- \`dropLimiter\` uses a lock-free two-atomic design (lastWarn + count). A drop whose \`count.Add(1)\` lands after a winning goroutine's \`count.Swap(0)\` is reported in the NEXT window — the per-window boundary smears under concurrent bursts, but the total is conserved.
- Add godoc explaining the ordering and conservation invariant so future maintainers see it on the declaration. Callers needing an SLA-grade monotonic total are pointed to \`OutputMetrics.RecordDrop\`.
- Add \`TestDropLimiter_TotalConservedAcrossWindows\` — 64 goroutines × 2000 records with a 1μs window so many windows fire; asserts reported + pending == total.

## Closes

Closes #492. **Last Track A item** — Security & Correctness track complete 🎯

## Test plan

- [x] 3 droplimit tests pass (-race); new conservation test fires many windows
- [x] \`make check\` clean
- [x] code-reviewer APPROVED (godoc is accurate against the atomic ordering; both nits addressed — godoc wording tightened, declaration simplified)
- [x] go-quality READY TO COMMIT

## Docs

- \`droplimit.go\`: full godoc on \`record\` covering the smear, conservation, and the pointer to \`RecordDrop\` for SLA-grade accuracy
- \`CHANGELOG.md\`: Documentation entry