### PR TITLE
docs: document NewEvent heap cost and promote EventHandle (#498)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -74,6 +74,24 @@ The CI pipeline runs `make bench` on every PR and compares against `bench-baseli
 | NewEventKV | 124 | 360 | 2 | slog-style event construction |
 | FilterCheck | 16 | 0 | 0 | isEnabled lock-free (syncmap) |
 
+### Emission-Path Comparison
+
+Same auditor, same taxonomy, same `Fields` literal — what does the
+caller-side choice cost? `NoopOutput` isolates the emission path by
+removing output-side work. See `BenchmarkAudit_ViaHandle_vs_NewEvent`.
+
+| Emission path | ns/op | B/op | allocs/op | Notes |
+|---------------|------:|-----:|----------:|-------|
+| `Auditor.AuditEvent(NewEvent(...))` | ~400 | 24 | **1** | One `basicEvent` escapes through the `Event` interface return |
+| `EventHandle.Audit(fields)` | ~369 | **0** | **0** | No interface wrapping; defensive `Fields` copy recycles from `sync.Pool` after warm-up |
+
+Observation: `EventHandle.Audit` eliminates the single remaining
+caller-side allocation on the dynamic-event-type path (−1 alloc/op,
+−24 B/op, ~8 % wall-clock). For event types known at compile time,
+generated typed builders satisfying `FieldsDonor` additionally skip
+the defensive `Fields` map copy — that is the zero-allocation
+drain-side fast path, benchmarked as `BenchmarkAudit_FastPath_FanOut4_NoopOutputs`.
+
 ### Formatters
 
 | Benchmark | ns/op | B/op | allocs/op | Notes |

--- a/audit.go
+++ b/audit.go
@@ -653,9 +653,13 @@ func (a *Auditor) OutputRoute(outputName string) (EventRoute, error) {
 	return oe.getRoute(), nil
 }
 
-// Handle returns an [EventHandle] for the named event type. The
-// handle enables zero-allocation audit calls. Returns
-// [ErrHandleNotFound] if the event type is not registered.
+// Handle returns an [EventHandle] for the named event type. Call
+// once at startup (for example during DI wiring), cache the returned
+// handle, and emit via [EventHandle.Audit] per event — this avoids
+// the per-call basicEvent allocation that [NewEvent] incurs via
+// interface escape. Returns [ErrHandleNotFound] if the event type is
+// not registered. For event types known at compile time, prefer
+// generated typed builders from audit-gen.
 func (a *Auditor) Handle(eventType string) (*EventHandle, error) {
 	if a.disabled {
 		return &EventHandle{name: eventType, auditor: a}, nil

--- a/audit_test.go
+++ b/audit_test.go
@@ -2575,6 +2575,48 @@ func BenchmarkAuditDisabledAuditor(b *testing.B) {
 	}
 }
 
+// BenchmarkAudit_ViaHandle_vs_NewEvent quantifies the caller-side
+// cost of EventHandle.Audit vs Auditor.AuditEvent(NewEvent(...)) on
+// the same auditor, taxonomy, and fields. Both sub-benchmarks hit
+// the drain slow path (defensive Fields copy; neither implements
+// FieldsDonor); the only difference is that NewEvent allocates a
+// *basicEvent that escapes through the Event interface return,
+// whereas EventHandle.Audit calls auditInternal directly without
+// wrapping. The delta is one allocation per event. NoopOutput is
+// used to exclude output-side defensive-copy noise and isolate the
+// emission-path cost — see [internal/testhelper.NoopOutput]. #498.
+func BenchmarkAudit_ViaHandle_vs_NewEvent(b *testing.B) {
+	silenceSlog(b)
+	out := testhelper.NewNoopOutput("bench")
+	auditor, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithOutputs(out),
+	)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = auditor.Close() })
+
+	fields := audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+		"subject":  "my-topic",
+	}
+
+	b.Run("NewEvent", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = auditor.AuditEvent(audit.NewEvent("schema_register", fields))
+		}
+	})
+
+	b.Run("EventHandle", func(b *testing.B) {
+		h := auditor.MustHandle("schema_register")
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = h.Audit(fields)
+		}
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Additional benchmarks — caller path
 // ---------------------------------------------------------------------------

--- a/doc.go
+++ b/doc.go
@@ -78,10 +78,30 @@
 //
 // # Events
 //
+// There are three emission paths, in order of recommendation:
+//
+//  1. Generated typed builders from cmd/audit-gen — compile-time
+//     field safety, built-in [FieldsDonor] sentinel for the
+//     zero-drain-side-allocations fast path. Use these whenever
+//     event types are known at compile time.
+//  2. [EventHandle] obtained via [Auditor.Handle] or
+//     [Auditor.MustHandle] — the recommended path when the event
+//     type is known at startup but not at compile time (from
+//     configuration, a database, or a plugin registry). Cache the
+//     handle at startup; per-event calls via [EventHandle.Audit]
+//     skip the basicEvent allocation that [NewEvent] pays via
+//     interface escape.
+//  3. [NewEvent] and [NewEventKV] — the map-based escape hatch for
+//     ad-hoc emission and quick exploration. Each call allocates
+//     one basicEvent on the heap (interface escape); [NewEventKV]
+//     additionally allocates the intermediate [Fields] map.
+//
+// Symbols in this group:
+//
 //   - [Event] — interface for typed audit events; pass to [Auditor.AuditEvent]
+//   - [EventHandle] — pre-validated handle for zero-caller-side-allocation audit calls; see [Auditor.Handle] and [Auditor.MustHandle]
 //   - [NewEvent] — creates an event for dynamic use without code generation
 //   - [NewEventKV] — creates an event from alternating key-value pairs (slog-style)
-//   - [EventHandle] — pre-validated handle for zero-allocation audit calls; see [Auditor.MustHandle]
 //   - [Fields] — defined type over map[string]any with [Fields.Has], [Fields.String], [Fields.Int] accessors
 //
 // # Outputs
@@ -229,8 +249,13 @@
 //   - Slow path: events constructed via [NewEvent] or [NewEventKV] do
 //     not implement FieldsDonor, so the auditor defensively copies the
 //     caller's Fields map. Per-event allocation cost is the map clone
-//     plus any-boxing of non-string values; the drain-side serialisation
-//     still benefits from the zero-copy buffer lease.
+//     plus any-boxing of non-string values, plus one basicEvent on
+//     the heap from the interface escape. The drain-side serialisation
+//     still benefits from the zero-copy buffer lease. When the event
+//     type is dynamic but known at startup, [EventHandle.Audit]
+//     eliminates the basicEvent allocation (no interface escape)
+//     while still taking the same defensive-copy path for the Fields
+//     map.
 //
 // Outputs receive bytes from the leased formatter buffer. Per the
 // [Output.Write] contract, implementations MUST NOT retain data past

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -101,6 +101,20 @@ The slow path still benefits from every other W2 optimisation: the
 formatter buffer is leased from the pool; sorted-key slices are pooled;
 per-output post-fields are appended in place into the scratch buffer.
 
+> **Dynamic event type but throughput matters?** If your event type is
+> known at startup (from configuration, a database, or a plugin
+> registry) but not at compile time, use
+> [`EventHandle.Audit(fields)`](https://pkg.go.dev/github.com/axonops/audit#EventHandle.Audit)
+> instead of `NewEvent`. Obtain the handle once via
+> [`Auditor.Handle`](https://pkg.go.dev/github.com/axonops/audit#Auditor.Handle)
+> or [`Auditor.MustHandle`](https://pkg.go.dev/github.com/axonops/audit#Auditor.MustHandle)
+> at startup and cache it. `EventHandle.Audit` bypasses the `basicEvent`
+> heap allocation that `NewEvent` incurs via interface escape — after
+> `sync.Pool` warm-up the defensive `Fields` copy is also recycled, so
+> the amortised cost is `0 allocs/op` end-to-end. See the
+> `BenchmarkAudit_ViaHandle_vs_NewEvent` numbers in
+> [`BENCHMARKS.md`](../BENCHMARKS.md#emission-path-comparison).
+
 ---
 
 ## The drain-side zero-copy pipeline

--- a/event.go
+++ b/event.go
@@ -61,6 +61,14 @@ type basicEvent struct {
 // builders from audit-gen for compile-time field safety. This function
 // exists for consumers who construct events dynamically or do not use
 // code generation.
+//
+// Allocation note: each call allocates one basicEvent on the heap
+// because the returned [Event] interface value forces the pointer to
+// escape. For high-throughput callers whose event type is known but
+// dynamic (from configuration, a database, or a plugin), prefer
+// [EventHandle] — it pre-validates the event type once and emits
+// without the per-call basicEvent allocation. See [Auditor.Handle]
+// and [Auditor.MustHandle].
 func NewEvent(eventType string, fields Fields) Event {
 	return &basicEvent{
 		eventType: eventType,
@@ -79,6 +87,12 @@ func (e *basicEvent) Fields() Fields    { return e.fields }
 // NewEventKV panics if keysAndValues has an odd number of elements or
 // if any key is not a string. These are always programming errors, not
 // runtime conditions — the same convention as [slog.Info].
+//
+// Allocation note: NewEventKV allocates the intermediate [Fields] map
+// plus the basicEvent returned by [NewEvent] — two heap allocations
+// per call (plus any-boxing of non-string values). For high-throughput
+// callers, prefer generated typed builders (zero caller-side
+// allocations after warm-up) or [EventHandle] for dynamic event types.
 func NewEventKV(eventType string, keysAndValues ...any) Event {
 	if len(keysAndValues)%2 != 0 {
 		panic(fmt.Sprintf("audit: NewEventKV requires even number of arguments, got %d", len(keysAndValues)))
@@ -95,19 +109,33 @@ func NewEventKV(eventType string, keysAndValues ...any) Event {
 }
 
 // EventHandle is a pre-validated reference to a registered event type.
-// It carries the event type name and a reference to the owning [Auditor],
-// enabling audit calls without repeated string lookup. Use generated
-// builders for static event types; use [Auditor.Handle] or
-// [Auditor.MustHandle] for dynamically-determined event types (e.g.
-// event type names from configuration or a database).
+// It is the recommended emission path when the event type is known at
+// startup but not at compile time — for example, event type names
+// pulled from configuration, a database, or a plugin registry.
+//
+// Obtain one handle per event type at startup via [Auditor.Handle]
+// (returns an error) or [Auditor.MustHandle] (panics on unknown event
+// type), cache it, and emit via [EventHandle.Audit] on each event.
+// The handle validates the event type once at construction; per-event
+// calls go straight into the audit pipeline without re-validating the
+// name and without the basicEvent heap allocation paid by
+// [NewEvent].
+//
+// For event types known at compile time, prefer generated typed
+// builders from audit-gen — they add compile-time field safety and
+// implement [FieldsDonor] for the zero-allocation drain-side fast
+// path.
 type EventHandle struct {
 	auditor *Auditor
 	name    string
 }
 
 // Audit emits an audit event using this handle's bound event type.
-// This method bypasses [NewEvent] to avoid a per-event heap allocation
-// from interface escape, calling the internal audit path directly.
+// Zero per-event caller-side allocations (no basicEvent
+// construction, no [Event] interface escape) — the internal audit
+// path is called directly. For the zero-drain-side-allocations fast
+// path (the [FieldsDonor] contract), emit a generated typed builder
+// directly via [Auditor.AuditEvent].
 func (e *EventHandle) Audit(fields Fields) error {
 	return e.auditor.auditInternal(e.name, fields)
 }
@@ -118,6 +146,12 @@ func (e *EventHandle) Audit(fields Fields) error {
 // bound type — the handle provides the auditor binding only. This
 // method accepts any [Event] implementation, making it composable
 // with code-generated typed builders.
+//
+// Allocation note: this method takes the standard [Auditor.AuditEvent]
+// path. Allocation behaviour depends on evt: generated builders that
+// implement [FieldsDonor] reach 0 drain-side allocs per event; plain
+// [Event] values (including [NewEvent] output) pay the defensive-copy
+// cost described in [docs/performance.md].
 func (e *EventHandle) AuditEvent(evt Event) error {
 	return e.auditor.AuditEvent(evt)
 }

--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -82,6 +82,15 @@ This means `AuditEvent()` is fast — it doesn't block on I/O. The
 trade-off: output may appear slightly after the `fmt.Println` that
 precedes it in your code.
 
+> **For production workloads**, prefer generated typed builders
+> (see [`02-code-generation/`](../02-code-generation/)) or, when the
+> event type is only known at startup, a pre-validated
+> [`EventHandle`](https://pkg.go.dev/github.com/axonops/audit#EventHandle).
+> `NewEvent` and `NewEventKV` each pay one heap allocation per call
+> (the `basicEvent` interface escape); the other paths do not. The
+> [performance guide](../../docs/performance.md) has the full
+> breakdown.
+
 ### Closing the Logger
 
 ```go

--- a/examples/17-capstone/README.md
+++ b/examples/17-capstone/README.md
@@ -223,6 +223,25 @@ result, err := outputconfig.Load(ctx, outputsYAML, tax,
 No `RegisterOutputFactory` calls needed. Adding a new output type to
 `outputs.yaml` is a config change, not a code change.
 
+### Emission Paths
+
+This demo emits every event through generated typed builders in
+`audit_generated.go` — `NewUserLoginEvent(...)`, `NewItemCreatedEvent(...)`,
+and so on. That path is the library's zero-allocation fast path:
+the builders implement the internal `FieldsDonor` sentinel so the
+auditor takes ownership of the `Fields` map without a defensive
+copy. Compile-time field safety is a bonus.
+
+For dynamic event types — say, a plugin registry that emits event
+types discovered at runtime — use
+[`auditor.MustHandle("my_event")`](https://pkg.go.dev/github.com/axonops/audit#Auditor.MustHandle)
+at registration time, cache the `EventHandle`, and call
+`h.Audit(fields)` per event. Do not call `audit.NewEvent(...)` on a
+hot path: each call pays one heap allocation via interface escape.
+
+See [`docs/performance.md`](../../docs/performance.md) for the full
+breakdown.
+
 ### Lifecycle Events (Best Practice)
 
 Always emit audit events for application startup and shutdown. These


### PR DESCRIPTION
## Summary

`NewEvent` returns `&basicEvent{...}` wrapped in the `Event`
interface; the pointer escapes to the heap — one allocation per
call. The library already provides `EventHandle.Audit(fields)`,
which avoids this allocation (and, after `sync.Pool` warm-up, the
defensive `Fields` copy too — reaching 0 allocs/op). The
documentation did not promote it.

This PR closes the documentation gap. No production code changes.

Closes #498.

## What Changed

### Godoc

- **`event.go`**
  - `NewEvent`: new "Allocation note" paragraph explaining the
    `basicEvent` interface escape; cross-link to `EventHandle`.
  - `NewEventKV`: same allocation note plus the intermediate
    `Fields` map cost.
  - `EventHandle` (type-level): rewritten to frame it as the
    **recommended** emission path when the event type is known at
    startup but not at compile time. Usage pattern documented
    (obtain once, cache, emit per event).
  - `EventHandle.Audit`: explicit "zero per-event caller-side
    allocations" claim + pointer to the `FieldsDonor` drain-side
    fast path for static event types.
  - `EventHandle.AuditEvent`: allocation note clarifying this
    method delegates to `Auditor.AuditEvent` and the handle adds no
    fast-path behaviour of its own.
- **`audit.go` — `Auditor.Handle`**: emphasise the
  once-at-startup usage pattern; link the allocation win to
  `NewEvent`'s `basicEvent` escape.

### Package documentation (`doc.go`)

- `# Events` section restructured to rank emission paths:
  1. Generated typed builders (`audit-gen`).
  2. `EventHandle` for dynamic event types.
  3. `NewEvent` / `NewEventKV` for ad-hoc emission.
- `# Performance — Fast Path and Slow Path` extended with one
  sentence on `EventHandle.Audit` clarifying how it eliminates
  the `basicEvent` allocation on the dynamic path.

### New benchmark (`audit_test.go`)

`BenchmarkAudit_ViaHandle_vs_NewEvent` — two sub-benchmarks, same
auditor, same `Fields` literal, `NoopOutput` to isolate the
emission-path cost.

Results at `count=5, -benchtime=1s`, Go 1.26 / AMD Ryzen 9 7950X:

| Path | ns/op | B/op | allocs/op |
|------|------:|-----:|----------:|
| `AuditEvent(NewEvent(...))` | ~400 | 24 | **1** |
| `EventHandle.Audit(fields)` | ~369 | 0 | **0** |

After `sync.Pool` warm-up the EventHandle path reaches 0 allocs/op
end-to-end because the defensive `Fields` copy recycles a pooled
map. The 1-alloc delta against `NewEvent` is exactly the
`basicEvent` interface escape.

### Documentation files

- **`BENCHMARKS.md`**: new "Emission-Path Comparison" subsection
  with the measured numbers and a 2-line observation.
- **`docs/performance.md`**: blockquote callout in "Slow path"
  pointing dynamic event-type emitters at `EventHandle` with
  pkg.go.dev links.
- **`examples/01-basic/README.md`**: short 6-line callout at the
  end of "Emitting Events" — first-contact narrative preserved
  per user-guide-reviewer guidance.
- **`examples/17-capstone/README.md`**: new `### Emission Paths`
  subsection under Key Concepts (15 lines) — frames the
  generated-builder fast path and points plugin-registry /
  dynamic-type scenarios at `EventHandle.Audit`.

## Acceptance criteria (issue #498)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `event.go` `NewEvent` godoc documents the allocation cost explicitly | ✅ |
| 2 | `EventHandle` godoc and `doc.go` cross-link as the recommended high-throughput API | ✅ |
| 3 | `BenchmarkAudit_ViaHandle_vs_NewEvent` runs clean + numbers in `BENCHMARKS.md` | ✅ |
| 4 | `examples/01-basic/README.md` + `examples/17-capstone/README.md` updated; `make test-examples` passes | ✅ |

## Agent gates

| Gate | Result |
|------|--------|
| docs-writer (pre-coding consult) | Applied: RFC 2119 restraint, `[Symbol]` link syntax, place ranking in `doc.go`'s `# Events` not a new section, clarify `EventHandle.AuditEvent` doesn't confer fast-path behaviour |
| user-guide-reviewer (pre-coding consult) | Applied: don't restructure example 01's "Emitting Events" — short callout only; don't add `MustHandle` to `main.go`; capstone subsection under Key Concepts, not a top-level H2 |
| docs-writer (post-coding) | FAIL → fix applied → PASS |
| user-guide-reviewer (post-coding) | PASS |
| go-quality (post-coding) | PASS |
| commit-message-reviewer | PASS |

## Test plan

- [x] `make check` green locally (full gate — lint, vet, tests, coverage, vuln, cross-build)
- [x] `make test-examples` passes
- [x] `go doc` preview renders cleanly for `NewEvent`, `EventHandle`, `Auditor.Handle`
- [x] New benchmark runs to 0 allocs/op (EventHandle) and 1 alloc/op (NewEvent)
- [ ] CI green (watching)