### PR TITLE
perf: consolidate pre-HMAC post-field appends (#508)

### DIFF
--- a/bench-baseline.txt
+++ b/bench-baseline.txt
@@ -3,391 +3,62 @@ goos: linux
 goarch: amd64
 pkg: github.com/axonops/audit
 cpu: AMD Ryzen 9 7950X 16-Core Processor            
-BenchmarkAudit-32                                          	 2852246	       382.0 ns/op	     184 B/op	       1 allocs/op
-BenchmarkAudit-32                                          	 3255637	       367.0 ns/op	     171 B/op	       1 allocs/op
-BenchmarkAudit-32                                          	 3069825	       366.2 ns/op	     176 B/op	       1 allocs/op
-BenchmarkAudit-32                                          	 3270908	       379.8 ns/op	     184 B/op	       1 allocs/op
-BenchmarkAudit-32                                          	 3327252	       372.5 ns/op	     185 B/op	       1 allocs/op
-BenchmarkAuditDisabledCategory-32                          	 3891846	       305.5 ns/op	     152 B/op	       1 allocs/op
-BenchmarkAuditDisabledCategory-32                          	 3779458	       296.0 ns/op	     152 B/op	       1 allocs/op
-BenchmarkAuditDisabledCategory-32                          	 3693685	       284.6 ns/op	     149 B/op	       1 allocs/op
-BenchmarkAuditDisabledCategory-32                          	 3530290	       295.9 ns/op	     155 B/op	       1 allocs/op
-BenchmarkAuditDisabledCategory-32                          	 3846928	       302.3 ns/op	     152 B/op	       1 allocs/op
-BenchmarkAuditDisabledAuditor-32                           	64336171	        18.14 ns/op	      24 B/op	       1 allocs/op
-BenchmarkAuditDisabledAuditor-32                           	70005316	        19.52 ns/op	      24 B/op	       1 allocs/op
-BenchmarkAuditDisabledAuditor-32                           	64625606	        17.61 ns/op	      24 B/op	       1 allocs/op
-BenchmarkAuditDisabledAuditor-32                           	52911086	        19.45 ns/op	      24 B/op	       1 allocs/op
-BenchmarkAuditDisabledAuditor-32                           	71290928	        18.40 ns/op	      24 B/op	       1 allocs/op
-BenchmarkAudit_RealisticFields-32                          	 1446433	       792.8 ns/op	     325 B/op	       1 allocs/op
-BenchmarkAudit_RealisticFields-32                          	 1540418	       787.5 ns/op	     307 B/op	       1 allocs/op
-BenchmarkAudit_RealisticFields-32                          	 1475539	       788.7 ns/op	     319 B/op	       1 allocs/op
-BenchmarkAudit_RealisticFields-32                          	 1477888	       802.7 ns/op	     328 B/op	       1 allocs/op
-BenchmarkAudit_RealisticFields-32                          	 1491992	       805.9 ns/op	     324 B/op	       1 allocs/op
-BenchmarkAudit_Parallel-32                                 	15649586	        67.86 ns/op	      25 B/op	       1 allocs/op
-BenchmarkAudit_Parallel-32                                 	20708326	        58.07 ns/op	      24 B/op	       1 allocs/op
-BenchmarkAudit_Parallel-32                                 	19194798	        61.56 ns/op	      25 B/op	       1 allocs/op
-BenchmarkAudit_Parallel-32                                 	18650690	        60.14 ns/op	      24 B/op	       1 allocs/op
-BenchmarkAudit_Parallel-32                                 	19213102	        58.04 ns/op	      24 B/op	       1 allocs/op
-BenchmarkAudit_PoolAmortised-32                            	 2816769	       386.5 ns/op	     190 B/op	       1 allocs/op
-BenchmarkAudit_PoolAmortised-32                            	 2895391	       398.4 ns/op	     177 B/op	       1 allocs/op
-BenchmarkAudit_PoolAmortised-32                            	 2703396	       382.0 ns/op	     180 B/op	       1 allocs/op
-BenchmarkAudit_PoolAmortised-32                            	 2798928	       373.8 ns/op	     175 B/op	       1 allocs/op
-BenchmarkAudit_PoolAmortised-32                            	 2836983	       391.4 ns/op	     179 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_SharedFormatter-32                   	 2809317	       384.1 ns/op	     351 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_SharedFormatter-32                   	 3267643	       350.6 ns/op	     323 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_SharedFormatter-32                   	 3107878	       356.9 ns/op	     317 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_SharedFormatter-32                   	 2880936	       354.7 ns/op	     317 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_SharedFormatter-32                   	 3337934	       357.0 ns/op	     325 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_MixedFormatters-32                   	 3012765	       365.2 ns/op	     244 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_MixedFormatters-32                   	 3137232	       339.6 ns/op	     230 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_MixedFormatters-32                   	 3369144	       338.0 ns/op	     224 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_MixedFormatters-32                   	 3367723	       350.1 ns/op	     229 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_MixedFormatters-32                   	 3322942	       340.9 ns/op	     226 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_FilteredOutputs-32                   	 2833046	       382.5 ns/op	     274 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_FilteredOutputs-32                   	 3280012	       361.4 ns/op	     246 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_FilteredOutputs-32                   	 3182590	       376.9 ns/op	     254 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_FilteredOutputs-32                   	 3222960	       397.3 ns/op	     257 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_FilteredOutputs-32                   	 3240691	       368.1 ns/op	     252 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_5Outputs-32                          	 3042190	       360.2 ns/op	     442 B/op	       2 allocs/op
-BenchmarkAudit_FanOut_5Outputs-32                          	 3443995	       342.4 ns/op	     379 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_5Outputs-32                          	 3432633	       337.6 ns/op	     376 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_5Outputs-32                          	 3240145	       341.5 ns/op	     382 B/op	       1 allocs/op
-BenchmarkAudit_FanOut_5Outputs-32                          	 3363422	       341.0 ns/op	     382 B/op	       1 allocs/op
-BenchmarkAudit_EndToEnd-32                                 	 2631555	       388.0 ns/op	     189 B/op	       1 allocs/op
-BenchmarkAudit_EndToEnd-32                                 	 2768805	       402.5 ns/op	     189 B/op	       1 allocs/op
-BenchmarkAudit_EndToEnd-32                                 	 2695072	       402.1 ns/op	     191 B/op	       1 allocs/op
-BenchmarkAudit_EndToEnd-32                                 	 2700128	       385.8 ns/op	     189 B/op	       1 allocs/op
-BenchmarkAudit_EndToEnd-32                                 	 2591355	       397.1 ns/op	     192 B/op	       1 allocs/op
-BenchmarkAudit_WithHMAC-32                                 	 3007488	       375.4 ns/op	     169 B/op	       1 allocs/op
-BenchmarkAudit_WithHMAC-32                                 	 3070981	       361.0 ns/op	     166 B/op	       1 allocs/op
-BenchmarkAudit_WithHMAC-32                                 	 2845508	       373.4 ns/op	     173 B/op	       1 allocs/op
-BenchmarkAudit_WithHMAC-32                                 	 3037587	       376.9 ns/op	     167 B/op	       1 allocs/op
-BenchmarkAudit_WithHMAC-32                                 	 2981059	       375.1 ns/op	     171 B/op	       1 allocs/op
-BenchmarkStandardFieldDefaults_Applied-32                  	 1840318	       590.1 ns/op	     301 B/op	       4 allocs/op
-BenchmarkStandardFieldDefaults_Applied-32                  	 1992128	       587.6 ns/op	     292 B/op	       4 allocs/op
-BenchmarkStandardFieldDefaults_Applied-32                  	 2022954	       597.2 ns/op	     294 B/op	       4 allocs/op
-BenchmarkStandardFieldDefaults_Applied-32                  	 1887667	       592.7 ns/op	     301 B/op	       4 allocs/op
-BenchmarkStandardFieldDefaults_Applied-32                  	 1933546	       596.6 ns/op	     298 B/op	       4 allocs/op
-BenchmarkDeliverToOutputs_WithMetadataWriter-32            	 2666046	       425.2 ns/op	     322 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithMetadataWriter-32            	 2798242	       403.6 ns/op	     312 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithMetadataWriter-32            	 2688318	       409.1 ns/op	     318 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithMetadataWriter-32            	 2646126	       405.1 ns/op	     323 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithMetadataWriter-32            	 2617224	       405.2 ns/op	     323 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MixedOutputs-32                  	 2932760	       383.8 ns/op	     362 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MixedOutputs-32                  	 2792539	       376.4 ns/op	     362 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MixedOutputs-32                  	 2828454	       381.4 ns/op	     361 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MixedOutputs-32                  	 2906107	       379.1 ns/op	     354 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MixedOutputs-32                  	 2988332	       378.7 ns/op	     360 B/op	       1 allocs/op
-BenchmarkProcessEntry_AsyncOutputs-32                      	  881077	      1489 ns/op	     665 B/op	       3 allocs/op
-BenchmarkProcessEntry_AsyncOutputs-32                      	  705914	      1492 ns/op	     665 B/op	       3 allocs/op
-BenchmarkProcessEntry_AsyncOutputs-32                      	  702812	      1479 ns/op	     665 B/op	       3 allocs/op
-BenchmarkProcessEntry_AsyncOutputs-32                      	  737298	      1451 ns/op	     665 B/op	       3 allocs/op
-BenchmarkProcessEntry_AsyncOutputs-32                      	  810942	      1471 ns/op	     665 B/op	       3 allocs/op
-BenchmarkOutputClose_Drain/events=100-32                   	   55927	     20919 ns/op	    4706 B/op	      23 allocs/op
-BenchmarkOutputClose_Drain/events=100-32                   	   52758	     21585 ns/op	    4881 B/op	      24 allocs/op
-BenchmarkOutputClose_Drain/events=100-32                   	   51362	     21505 ns/op	    4762 B/op	      23 allocs/op
-BenchmarkOutputClose_Drain/events=100-32                   	   59918	     19627 ns/op	    4399 B/op	      22 allocs/op
-BenchmarkOutputClose_Drain/events=100-32                   	   52510	     20862 ns/op	    4663 B/op	      23 allocs/op
-BenchmarkOutputClose_Drain/events=1000-32                  	    2574	    469285 ns/op	  198119 B/op	     644 allocs/op
-BenchmarkOutputClose_Drain/events=1000-32                  	    2296	    481809 ns/op	  195709 B/op	     635 allocs/op
-BenchmarkOutputClose_Drain/events=1000-32                  	    2614	    467413 ns/op	  194914 B/op	     633 allocs/op
-BenchmarkOutputClose_Drain/events=1000-32                  	    2550	    474081 ns/op	  198949 B/op	     645 allocs/op
-BenchmarkOutputClose_Drain/events=1000-32                  	    2724	    468366 ns/op	  202110 B/op	     656 allocs/op
-BenchmarkOutputClose_Drain/events=10000-32                 	     345	   3550628 ns/op	 1820377 B/op	    4693 allocs/op
-BenchmarkOutputClose_Drain/events=10000-32                 	     325	   3714087 ns/op	 1994806 B/op	    5149 allocs/op
-BenchmarkOutputClose_Drain/events=10000-32                 	     332	   3547184 ns/op	 1808767 B/op	    4674 allocs/op
-BenchmarkOutputClose_Drain/events=10000-32                 	     327	   3559514 ns/op	 1850581 B/op	    4781 allocs/op
-BenchmarkOutputClose_Drain/events=10000-32                 	     346	   3533452 ns/op	 1849337 B/op	    4798 allocs/op
-BenchmarkFilterCheck-32                                    	73701186	        16.30 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck-32                                    	71874828	        16.37 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck-32                                    	73054280	        16.49 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck-32                                    	71676918	        16.40 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck-32                                    	75296979	        16.38 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_Parallel-32                           	1000000000	         1.044 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_Parallel-32                           	1000000000	         1.037 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_Parallel-32                           	1000000000	         1.044 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_Parallel-32                           	1000000000	         1.046 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_Parallel-32                           	1000000000	         1.043 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_ReadWriteContention-32                	1000000000	         1.023 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_ReadWriteContention-32                	1000000000	         1.022 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_ReadWriteContention-32                	1000000000	         1.044 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_ReadWriteContention-32                	1000000000	         1.042 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFilterCheck_ReadWriteContention-32                	1000000000	         1.031 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAppendPostFields_JSON-32                          	14449831	        92.11 ns/op	     160 B/op	       1 allocs/op
-BenchmarkAppendPostFields_JSON-32                          	18148044	        76.87 ns/op	     160 B/op	       1 allocs/op
-BenchmarkAppendPostFields_JSON-32                          	14673483	        84.00 ns/op	     160 B/op	       1 allocs/op
-BenchmarkAppendPostFields_JSON-32                          	15334126	        88.14 ns/op	     160 B/op	       1 allocs/op
-BenchmarkAppendPostFields_JSON-32                          	12620486	        92.15 ns/op	     160 B/op	       1 allocs/op
-BenchmarkAppendPostFields_CEF-32                           	22262818	        57.57 ns/op	     128 B/op	       1 allocs/op
-BenchmarkAppendPostFields_CEF-32                           	18760066	        74.59 ns/op	     128 B/op	       1 allocs/op
-BenchmarkAppendPostFields_CEF-32                           	18994328	        64.10 ns/op	     128 B/op	       1 allocs/op
-BenchmarkAppendPostFields_CEF-32                           	20273853	        61.35 ns/op	     128 B/op	       1 allocs/op
-BenchmarkAppendPostFields_CEF-32                           	16316786	        67.30 ns/op	     128 B/op	       1 allocs/op
-BenchmarkAppendPostFields_Disabled-32                      	911701656	         1.324 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAppendPostFields_Disabled-32                      	893337278	         1.321 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAppendPostFields_Disabled-32                      	913866379	         1.315 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAppendPostFields_Disabled-32                      	920882607	         1.314 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAppendPostFields_Disabled-32                      	911731448	         1.318 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_PipelineOnly-32                    	 2642846	       434.4 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_PipelineOnly-32                    	 2824794	       427.8 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_PipelineOnly-32                    	 2485927	       454.6 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_PipelineOnly-32                    	 2789824	       427.7 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_PipelineOnly-32                    	 2621592	       446.8 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_EndToEnd-32                        	  826468	      1472 ns/op	     816 B/op	       5 allocs/op
-BenchmarkAudit_FastPath_EndToEnd-32                        	  878624	      1543 ns/op	     804 B/op	       5 allocs/op
-BenchmarkAudit_FastPath_EndToEnd-32                        	  912135	      1496 ns/op	     803 B/op	       5 allocs/op
-BenchmarkAudit_FastPath_EndToEnd-32                        	  837231	      1520 ns/op	     794 B/op	       5 allocs/op
-BenchmarkAudit_FastPath_EndToEnd-32                        	  741120	      1448 ns/op	     766 B/op	       5 allocs/op
-BenchmarkAudit_FastPath_Parallel-32                        	 9602546	       132.7 ns/op	     361 B/op	       3 allocs/op
-BenchmarkAudit_FastPath_Parallel-32                        	 8777071	       126.3 ns/op	     361 B/op	       3 allocs/op
-BenchmarkAudit_FastPath_Parallel-32                        	 9792669	       122.8 ns/op	     360 B/op	       3 allocs/op
-BenchmarkAudit_FastPath_Parallel-32                        	 9484227	       123.3 ns/op	     364 B/op	       3 allocs/op
-BenchmarkAudit_FastPath_Parallel-32                        	 8012224	       136.4 ns/op	     361 B/op	       3 allocs/op
-BenchmarkAudit_FastPath_FanOut4_NoopOutputs-32             	 2629694	       413.9 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_FanOut4_NoopOutputs-32             	 2613486	       408.7 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_FanOut4_NoopOutputs-32             	 2724754	       425.0 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_FanOut4_NoopOutputs-32             	 2509362	       430.4 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_FanOut4_NoopOutputs-32             	 2700728	       405.4 ns/op	       0 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_WithHMAC_Noop-32                   	 4639508	       250.4 ns/op	      15 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_WithHMAC_Noop-32                   	 4440230	       256.0 ns/op	      15 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_WithHMAC_Noop-32                   	 4731738	       256.2 ns/op	      15 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_WithHMAC_Noop-32                   	 4348704	       253.6 ns/op	      15 B/op	       0 allocs/op
-BenchmarkAudit_FastPath_WithHMAC_Noop-32                   	 4374204	       253.0 ns/op	      15 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_5DistinctFormatters-32               	 4963864	       235.6 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_5DistinctFormatters-32               	 5030672	       233.1 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_5DistinctFormatters-32               	 5038396	       231.9 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_5DistinctFormatters-32               	 5031330	       234.6 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_5DistinctFormatters-32               	 5145001	       232.6 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_8DistinctFormatters-32               	 5098156	       229.2 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_8DistinctFormatters-32               	 5043072	       229.5 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_8DistinctFormatters-32               	 4984196	       228.9 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_8DistinctFormatters-32               	 5115886	       228.2 ns/op	       1 B/op	       0 allocs/op
-BenchmarkAudit_FanOut_8DistinctFormatters-32               	 5150695	       228.6 ns/op	       1 B/op	       0 allocs/op
-BenchmarkNewEventKV-32                                     	 8338903	       130.8 ns/op	     360 B/op	       3 allocs/op
-BenchmarkNewEventKV-32                                     	 7687077	       155.4 ns/op	     360 B/op	       3 allocs/op
-BenchmarkNewEventKV-32                                     	11671216	       141.1 ns/op	     360 B/op	       3 allocs/op
-BenchmarkNewEventKV-32                                     	 9155088	       137.0 ns/op	     360 B/op	       3 allocs/op
-BenchmarkNewEventKV-32                                     	 9674196	       111.8 ns/op	     360 B/op	       3 allocs/op
-BenchmarkMatchesRoute/empty_route-32                       	711060448	         1.696 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/empty_route-32                       	705672900	         1.693 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/empty_route-32                       	707063689	         1.698 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/empty_route-32                       	709616810	         1.695 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/empty_route-32                       	706075784	         1.689 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_categories-32                	333587040	         3.584 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_categories-32                	323738616	         3.557 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_categories-32                	332338957	         3.574 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_categories-32                	330015994	         3.575 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_categories-32                	334701493	         3.611 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/exclude_categories-32                	144981255	         8.413 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/exclude_categories-32                	143009336	         8.409 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/exclude_categories-32                	142965984	         8.377 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/exclude_categories-32                	141852094	         8.346 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/exclude_categories-32                	143467873	         8.363 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_event_types-32               	289315197	         4.131 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_event_types-32               	287250192	         4.150 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_event_types-32               	287538870	         4.194 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_event_types-32               	279622368	         4.180 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_event_types-32               	288850580	         4.170 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_20_categories-32             	127982397	         9.340 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_20_categories-32             	128347063	         9.389 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_20_categories-32             	127091022	         9.360 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_20_categories-32             	125749384	         9.623 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute/include_20_categories-32             	128049057	         9.288 ns/op	       0 B/op	       0 allocs/op
-BenchmarkJSONFormatter_Format-32                           	 3186206	       380.6 ns/op	     176 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format-32                           	 3168409	       348.8 ns/op	     176 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format-32                           	 3134240	       378.4 ns/op	     176 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format-32                           	 3260000	       376.0 ns/op	     176 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format-32                           	 3418203	       362.9 ns/op	     176 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format-32                            	 3021820	       377.8 ns/op	     160 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format-32                            	 2964823	       406.9 ns/op	     160 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format-32                            	 3137720	       386.2 ns/op	     160 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format-32                            	 3048355	       391.7 ns/op	     160 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format-32                            	 3031790	       397.7 ns/op	     160 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format_LargeEvent-32                	  925275	      1191 ns/op	     640 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format_LargeEvent-32                	  989000	      1154 ns/op	     640 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format_LargeEvent-32                	  933340	      1179 ns/op	     640 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format_LargeEvent-32                	  974775	      1188 ns/op	     640 B/op	       1 allocs/op
-BenchmarkJSONFormatter_Format_LargeEvent-32                	  873400	      1182 ns/op	     640 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent-32                 	  890686	      1225 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent-32                 	  870351	      1236 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent-32                 	  916335	      1204 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent-32                 	  853052	      1213 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent-32                 	  910364	      1203 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent_Escaping-32        	  504874	      2211 ns/op	    1515 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent_Escaping-32        	  525524	      2261 ns/op	    1515 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent_Escaping-32        	  533162	      2256 ns/op	    1515 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent_Escaping-32        	  489453	      2232 ns/op	    1515 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_LargeEvent_Escaping-32        	  485562	      2194 ns/op	    1515 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_Numeric-32                    	  786920	      1388 ns/op	     745 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_Numeric-32                    	  827008	      1383 ns/op	     745 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_Numeric-32                    	  849974	      1269 ns/op	     745 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_Numeric-32                    	  780384	      1376 ns/op	     745 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_Numeric-32                    	  812047	      1382 ns/op	     745 B/op	       4 allocs/op
-BenchmarkCEFFormatter_Format_Parallel-32                   	 4617806	       245.0 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_Parallel-32                   	 5364031	       268.0 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_Parallel-32                   	 4541910	       253.8 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_Parallel-32                   	 5593034	       296.0 ns/op	     576 B/op	       1 allocs/op
-BenchmarkCEFFormatter_Format_Parallel-32                   	 5374897	       246.7 ns/op	     576 B/op	       1 allocs/op
-BenchmarkFormatJSON_WithConfigFields-32                    	 2515723	       473.0 ns/op	     240 B/op	       2 allocs/op
-BenchmarkFormatJSON_WithConfigFields-32                    	 2535052	       453.2 ns/op	     240 B/op	       2 allocs/op
-BenchmarkFormatJSON_WithConfigFields-32                    	 2527024	       467.5 ns/op	     240 B/op	       2 allocs/op
-BenchmarkFormatJSON_WithConfigFields-32                    	 2727518	       465.0 ns/op	     240 B/op	       2 allocs/op
-BenchmarkFormatJSON_WithConfigFields-32                    	 2743402	       435.9 ns/op	     240 B/op	       2 allocs/op
-BenchmarkFormatCEF_WithConfigFields-32                     	 2944206	       402.6 ns/op	     160 B/op	       1 allocs/op
-BenchmarkFormatCEF_WithConfigFields-32                     	 3059148	       402.5 ns/op	     160 B/op	       1 allocs/op
-BenchmarkFormatCEF_WithConfigFields-32                     	 2951504	       392.4 ns/op	     160 B/op	       1 allocs/op
-BenchmarkFormatCEF_WithConfigFields-32                     	 2940961	       405.1 ns/op	     160 B/op	       1 allocs/op
-BenchmarkFormatCEF_WithConfigFields-32                     	 2971064	       395.9 ns/op	     160 B/op	       1 allocs/op
-BenchmarkFormatJSON_WithAllReservedFields-32               	  959763	      1118 ns/op	     448 B/op	       2 allocs/op
-BenchmarkFormatJSON_WithAllReservedFields-32               	  978657	      1123 ns/op	     448 B/op	       2 allocs/op
-BenchmarkFormatJSON_WithAllReservedFields-32               	 1000000	      1101 ns/op	     448 B/op	       2 allocs/op
-BenchmarkFormatJSON_WithAllReservedFields-32               	  922039	      1149 ns/op	     448 B/op	       2 allocs/op
-BenchmarkFormatJSON_WithAllReservedFields-32               	 1050190	      1154 ns/op	     448 B/op	       2 allocs/op
-BenchmarkFormatCEF_WithAllReservedFields-32                	  841357	      1351 ns/op	     809 B/op	       4 allocs/op
-BenchmarkFormatCEF_WithAllReservedFields-32                	  807729	      1374 ns/op	     809 B/op	       4 allocs/op
-BenchmarkFormatCEF_WithAllReservedFields-32                	  892861	      1276 ns/op	     809 B/op	       4 allocs/op
-BenchmarkFormatCEF_WithAllReservedFields-32                	  852278	      1389 ns/op	     809 B/op	       4 allocs/op
-BenchmarkFormatCEF_WithAllReservedFields-32                	  833482	      1336 ns/op	     809 B/op	       4 allocs/op
-BenchmarkHMAC_SHA256_SmallEvent-32                         	 2382703	       474.6 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_SmallEvent-32                         	 2375662	       506.0 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_SmallEvent-32                         	 2582546	       421.2 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_SmallEvent-32                         	 2687580	       449.5 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_SmallEvent-32                         	 2360560	       496.1 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_LargeEvent-32                         	  917284	      1233 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_LargeEvent-32                         	 1000000	      1250 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_LargeEvent-32                         	  837565	      1266 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_LargeEvent-32                         	  898492	      1195 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA256_LargeEvent-32                         	  989461	      1183 ns/op	     640 B/op	       8 allocs/op
-BenchmarkHMAC_SHA512_SmallEvent-32                         	 1000000	      1138 ns/op	    1120 B/op	       8 allocs/op
-BenchmarkHMAC_SHA512_SmallEvent-32                         	  973550	      1124 ns/op	    1120 B/op	       8 allocs/op
-BenchmarkHMAC_SHA512_SmallEvent-32                         	 1000000	      1128 ns/op	    1120 B/op	       8 allocs/op
-BenchmarkHMAC_SHA512_SmallEvent-32                         	  896180	      1145 ns/op	    1120 B/op	       8 allocs/op
-BenchmarkHMAC_SHA512_SmallEvent-32                         	 1000000	      1173 ns/op	    1120 B/op	       8 allocs/op
-BenchmarkMiddleware-32                                     	  795450	      1328 ns/op	    1812 B/op	      15 allocs/op
-BenchmarkMiddleware-32                                     	  816343	      1425 ns/op	    1804 B/op	      15 allocs/op
-BenchmarkMiddleware-32                                     	  888746	      1345 ns/op	    1826 B/op	      15 allocs/op
-BenchmarkMiddleware-32                                     	  931718	      1322 ns/op	    1818 B/op	      15 allocs/op
-BenchmarkMiddleware-32                                     	  887122	      1355 ns/op	    1829 B/op	      15 allocs/op
-BenchmarkNew_Construction-32                               	   44518	     28999 ns/op	   90011 B/op	     119 allocs/op
-BenchmarkNew_Construction-32                               	   45662	     29731 ns/op	   90003 B/op	     119 allocs/op
-BenchmarkNew_Construction-32                               	   54037	     27023 ns/op	   90002 B/op	     119 allocs/op
-BenchmarkNew_Construction-32                               	   41547	     28864 ns/op	   90007 B/op	     119 allocs/op
-BenchmarkNew_Construction-32                               	   37810	     30735 ns/op	   90004 B/op	     118 allocs/op
-BenchmarkDeliverToOutputs_NoSensitivity-32                 	 2727811	       407.5 ns/op	     185 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_NoSensitivity-32                 	 2892174	       393.0 ns/op	     180 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_NoSensitivity-32                 	 3000588	       396.4 ns/op	     191 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_NoSensitivity-32                 	 2982771	       384.7 ns/op	     175 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_NoSensitivity-32                 	 2780103	       397.4 ns/op	     182 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_SensitivityNoExclusions-32       	 2970973	       398.2 ns/op	     178 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_SensitivityNoExclusions-32       	 2786160	       405.5 ns/op	     185 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_SensitivityNoExclusions-32       	 2824053	       425.1 ns/op	     184 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_SensitivityNoExclusions-32       	 2922884	       400.5 ns/op	     180 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_SensitivityNoExclusions-32       	 2979102	       427.6 ns/op	     193 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithExclusions-32                	 2757408	       396.4 ns/op	     234 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithExclusions-32                	 2937062	       392.4 ns/op	     229 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithExclusions-32                	 3098722	       372.6 ns/op	     225 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithExclusions-32                	 2744935	       385.0 ns/op	     236 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_WithExclusions-32                	 2826366	       395.0 ns/op	     234 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_AllFieldsExcluded-32             	 2944561	       383.4 ns/op	     203 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_AllFieldsExcluded-32             	 2896994	       402.3 ns/op	     208 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_AllFieldsExcluded-32             	 2837146	       389.3 ns/op	     206 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_AllFieldsExcluded-32             	 2911633	       415.7 ns/op	     210 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_AllFieldsExcluded-32             	 2880302	       392.0 ns/op	     207 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion-32    	 3193702	       340.1 ns/op	     206 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion-32    	 2799566	       367.6 ns/op	     208 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion-32    	 3396843	       349.7 ns/op	     209 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion-32    	 3094767	       370.4 ns/op	     214 B/op	       1 allocs/op
-BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion-32    	 2950743	       353.3 ns/op	     215 B/op	       1 allocs/op
-BenchmarkMatchesRoute_Severity/nil_severity-32             	706584297	         1.689 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/nil_severity-32             	701264112	         1.683 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/nil_severity-32             	708907435	         1.688 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/nil_severity-32             	703752949	         1.695 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/nil_severity-32             	713344132	         1.703 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_min-32        	511766373	         2.275 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_min-32        	517439691	         2.277 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_min-32        	510378501	         2.271 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_min-32        	516156646	         2.266 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_min-32        	524698855	         2.274 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_range-32      	488237821	         2.441 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_range-32      	475451872	         2.451 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_range-32      	491018943	         2.461 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_range-32      	489147205	         2.461 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_only_range-32      	486362721	         2.440 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/include_categories_with_severity-32         	351439453	         3.388 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/include_categories_with_severity-32         	356807648	         3.380 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/include_categories_with_severity-32         	351783217	         3.455 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/include_categories_with_severity-32         	350541904	         3.378 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/include_categories_with_severity-32         	351498922	         3.410 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_reject-32                          	782104942	         1.502 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_reject-32                          	788965527	         1.668 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_reject-32                          	786146227	         1.545 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_reject-32                          	791913867	         1.510 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_reject-32                          	799889311	         1.601 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_accept-32                          	357401536	         3.396 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_accept-32                          	355146950	         3.381 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_accept-32                          	337347492	         3.409 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_accept-32                          	356194452	         3.430 ns/op	       0 B/op	       0 allocs/op
-BenchmarkMatchesRoute_Severity/severity_accept-32                          	344115760	         3.385 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParseTaxonomyYAML-32                                              	    8296	    140611 ns/op	  140735 B/op	    2257 allocs/op
-BenchmarkParseTaxonomyYAML-32                                              	   10000	    117395 ns/op	  140721 B/op	    2257 allocs/op
-BenchmarkParseTaxonomyYAML-32                                              	    9369	    130381 ns/op	  140713 B/op	    2257 allocs/op
-BenchmarkParseTaxonomyYAML-32                                              	    9690	    126716 ns/op	  140720 B/op	    2257 allocs/op
-BenchmarkParseTaxonomyYAML-32                                              	    9196	    130126 ns/op	  140730 B/op	    2257 allocs/op
-BenchmarkNewRequestID-32                                                   	14442998	        84.55 ns/op	      64 B/op	       2 allocs/op
-BenchmarkNewRequestID-32                                                   	17716539	        76.95 ns/op	      64 B/op	       2 allocs/op
-BenchmarkNewRequestID-32                                                   	14672038	        87.33 ns/op	      64 B/op	       2 allocs/op
-BenchmarkNewRequestID-32                                                   	14403926	        81.68 ns/op	      64 B/op	       2 allocs/op
-BenchmarkNewRequestID-32                                                   	12972932	        95.11 ns/op	      64 B/op	       2 allocs/op
-BenchmarkClientIP-32                                                       	14712181	        89.53 ns/op	      48 B/op	       1 allocs/op
-BenchmarkClientIP-32                                                       	16605789	        75.59 ns/op	      48 B/op	       1 allocs/op
-BenchmarkClientIP-32                                                       	14677143	        83.78 ns/op	      48 B/op	       1 allocs/op
-BenchmarkClientIP-32                                                       	15425871	        78.47 ns/op	      48 B/op	       1 allocs/op
-BenchmarkClientIP-32                                                       	15915271	        74.92 ns/op	      48 B/op	       1 allocs/op
-BenchmarkValidRequestID-32                                                 	57585132	        20.39 ns/op	       0 B/op	       0 allocs/op
-BenchmarkValidRequestID-32                                                 	82694426	        14.65 ns/op	       0 B/op	       0 allocs/op
-BenchmarkValidRequestID-32                                                 	67703228	        16.61 ns/op	       0 B/op	       0 allocs/op
-BenchmarkValidRequestID-32                                                 	70377903	        14.86 ns/op	       0 B/op	       0 allocs/op
-BenchmarkValidRequestID-32                                                 	72010924	        19.08 ns/op	       0 B/op	       0 allocs/op
-PASS
-ok  	github.com/axonops/audit	580.840s
-PASS
-ok  	github.com/axonops/audit/audittest	0.004s
-?   	github.com/axonops/audit/examples/01-basic	[no test files]
-?   	github.com/axonops/audit/examples/02-code-generation	[no test files]
-?   	github.com/axonops/audit/examples/03-file-output	[no test files]
-PASS
-ok  	github.com/axonops/audit/examples/04-testing	0.004s
-?   	github.com/axonops/audit/examples/05-formatters	[no test files]
-?   	github.com/axonops/audit/examples/06-middleware	[no test files]
-?   	github.com/axonops/audit/examples/07-syslog-output	[no test files]
-?   	github.com/axonops/audit/examples/08-webhook-output	[no test files]
-?   	github.com/axonops/audit/examples/09-multi-output	[no test files]
-?   	github.com/axonops/audit/examples/10-event-routing	[no test files]
-?   	github.com/axonops/audit/examples/11-sensitivity-labels	[no test files]
-?   	github.com/axonops/audit/examples/12-hmac-integrity	[no test files]
-?   	github.com/axonops/audit/examples/13-standard-fields	[no test files]
-?   	github.com/axonops/audit/examples/14-loki-output	[no test files]
-?   	github.com/axonops/audit/examples/15-tls-policy	[no test files]
-?   	github.com/axonops/audit/examples/16-buffering	[no test files]
-?   	github.com/axonops/audit/internal/testhelper	[no test files]
-?   	github.com/axonops/audit/tests/bdd/steps	[no test files]
-=== bench file ===
+BenchmarkAudit-32                                          	 2701732	       381.3 ns/op	     187 B/op	       1 allocs/op
+BenchmarkAudit-32                                          	 3192331	       377.8 ns/op	     188 B/op	       1 allocs/op
+BenchmarkAudit-32                                          	 3317162	       375.2 ns/op	     185 B/op	       1 allocs/op
+BenchmarkAudit-32                                          	 3067027	       368.7 ns/op	     175 B/op	       1 allocs/op
+BenchmarkAudit-32                                          	 3150904	       384.8 ns/op	     190 B/op	       1 allocs/op
+BenchmarkAuditDisabledCategory-32                          	 3874150	       301.0 ns/op	     150 B/op	       1 allocs/op
+BenchmarkAuditDisabledCategory-32                          	 4272796	       294.6 ns/op	     142 B/op	       1 allocs/op
+BenchmarkAuditDisabledCategory-32                          	 4054315	       292.9 ns/op	     146 B/op	       1 allocs/op
+BenchmarkAuditDisabledCategory-32                          	 4082082	       311.9 ns/op	     148 B/op	       1 allocs/op
+BenchmarkAuditDisabledCategory-32                          	 4016108	       316.2 ns/op	     166 B/op	       1 allocs/op
+BenchmarkAuditDisabledAuditor-32                           	55232443	        19.24 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAuditDisabledAuditor-32                           	64245640	        18.26 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAuditDisabledAuditor-32                           	60438925	        20.72 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAuditDisabledAuditor-32                           	66625273	        18.28 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAuditDisabledAuditor-32                           	67437158	        18.81 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/NewEvent-32           	 3095424	       386.9 ns/op	      25 B/op	       1 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/NewEvent-32           	 3098546	       385.3 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/NewEvent-32           	 2657527	       440.3 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/NewEvent-32           	 3078436	       385.7 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/NewEvent-32           	 2748646	       416.8 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/EventHandle-32        	 3439356	       356.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/EventHandle-32        	 3019077	       438.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/EventHandle-32        	 3217000	       373.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/EventHandle-32        	 3284618	       369.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAudit_ViaHandle_vs_NewEvent/EventHandle-32        	 3472008	       364.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkAudit_RealisticFields-32                          	 1408359	       907.0 ns/op	     300 B/op	       1 allocs/op
+BenchmarkAudit_RealisticFields-32                          	 1323675	       801.4 ns/op	     299 B/op	       1 allocs/op
+BenchmarkAudit_RealisticFields-32                          	 1414776	       835.1 ns/op	     316 B/op	       1 allocs/op
+BenchmarkAudit_RealisticFields-32                          	 1384738	       805.9 ns/op	     323 B/op	       1 allocs/op
+BenchmarkAudit_RealisticFields-32                          	 1503228	       813.8 ns/op	     321 B/op	       1 allocs/op
+BenchmarkAudit_Parallel-32                                 	16328480	        65.26 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAudit_Parallel-32                                 	19697252	        60.75 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAudit_Parallel-32                                 	19751136	        63.27 ns/op	      25 B/op	       1 allocs/op
+BenchmarkAudit_Parallel-32                                 	18775030	        63.64 ns/op	      25 B/op	       1 allocs/op
+BenchmarkAudit_Parallel-32                                 	17811172	        64.28 ns/op	      24 B/op	       1 allocs/op
+BenchmarkAudit_PoolAmortised-32                            	 2895978	       410.5 ns/op	     184 B/op	       1 allocs/op
+BenchmarkAudit_PoolAmortised-32                            	 3028500	       416.1 ns/op	     172 B/op	       1 allocs/op
+BenchmarkAudit_PoolAmortised-32                            	 2953870	       371.1 ns/op	     172 B/op	       1 allocs/op
+BenchmarkAudit_PoolAmortised-32                            	 2821815	       380.2 ns/op	     178 B/op	       1 allocs/op
+BenchmarkAudit_PoolAmortised-32                            	=== bench file ===
 goos: linux
 goarch: amd64
 pkg: github.com/axonops/audit/file
 cpu: AMD Ryzen 9 7950X 16-Core Processor            
-BenchmarkFileOutput_Write-32             	19163791	        60.99 ns/op	2525.13 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write-32             	21004252	        60.71 ns/op	2536.52 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write-32             	18775450	        63.29 ns/op	2433.35 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write-32             	19239188	        61.30 ns/op	2512.23 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write-32             	20741199	        59.79 ns/op	2575.47 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write_Parallel-32    	14040064	        81.73 ns/op	1884.31 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write_Parallel-32    	13547336	        82.54 ns/op	1865.67 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write_Parallel-32    	13165737	        81.51 ns/op	1889.25 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write_Parallel-32    	13231131	        82.13 ns/op	1875.08 MB/s	     160 B/op	       1 allocs/op
-BenchmarkFileOutput_Write_Parallel-32    	13933154	        81.59 ns/op	1887.55 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write-32             	18825394	        63.28 ns/op	2433.54 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write-32             	19639994	        62.50 ns/op	2464.19 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write-32             	20022508	        62.49 ns/op	2464.58 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write-32             	22114996	        60.93 ns/op	2527.52 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write-32             	20352901	        59.68 ns/op	2580.46 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write_Parallel-32    	14168713	        79.58 ns/op	1935.24 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write_Parallel-32    	13767740	        80.81 ns/op	1905.77 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write_Parallel-32    	13200098	        88.88 ns/op	1732.75 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write_Parallel-32    	13233912	        86.31 ns/op	1784.30 MB/s	     160 B/op	       1 allocs/op
+BenchmarkFileOutput_Write_Parallel-32    	13918984	        79.16 ns/op	1945.47 MB/s	     160 B/op	       1 allocs/op
 PASS
-ok  	github.com/axonops/audit/file	12.426s
+ok  	github.com/axonops/audit/file	12.718s
 PASS
 ok  	github.com/axonops/audit/file/internal/rotate	0.004s
 === bench syslog ===
@@ -395,18 +66,18 @@ goos: linux
 goarch: amd64
 pkg: github.com/axonops/audit/syslog
 cpu: AMD Ryzen 9 7950X 16-Core Processor            
-BenchmarkSyslogOutput_Write-32             	12280488	        81.91 ns/op	1880.18 MB/s	     175 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write-32             	19207364	        78.72 ns/op	1956.20 MB/s	     174 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write-32             	17515053	        80.01 ns/op	1924.66 MB/s	     174 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write-32             	19232953	        81.13 ns/op	1898.22 MB/s	     175 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write-32             	19900209	        83.62 ns/op	1841.64 MB/s	     175 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write_Parallel-32    	 7799526	       141.8 ns/op	1086.00 MB/s	     181 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write_Parallel-32    	 6393717	       158.8 ns/op	 969.74 MB/s	     186 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write_Parallel-32    	 6503020	       158.5 ns/op	 971.54 MB/s	     186 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write_Parallel-32    	 6774262	       151.9 ns/op	1013.60 MB/s	     185 B/op	       1 allocs/op
-BenchmarkSyslogOutput_Write_Parallel-32    	 6674468	       150.6 ns/op	1022.88 MB/s	     182 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write-32             	16007250	        78.77 ns/op	1955.07 MB/s	     174 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write-32             	19574671	        76.76 ns/op	2006.21 MB/s	     174 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write-32             	19713217	        77.63 ns/op	1983.81 MB/s	     174 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write-32             	20528595	        77.31 ns/op	1992.07 MB/s	     174 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write-32             	20002818	        78.20 ns/op	1969.19 MB/s	     174 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write_Parallel-32    	 7205552	       139.5 ns/op	1103.96 MB/s	     182 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write_Parallel-32    	 6694854	       151.5 ns/op	1016.46 MB/s	     185 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write_Parallel-32    	 8080198	       131.5 ns/op	1171.31 MB/s	     179 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write_Parallel-32    	 7089184	       141.4 ns/op	1089.09 MB/s	     181 B/op	       1 allocs/op
+BenchmarkSyslogOutput_Write_Parallel-32    	 6953730	       144.6 ns/op	1064.78 MB/s	     183 B/op	       1 allocs/op
 PASS
-ok  	github.com/axonops/audit/syslog	42.473s
+ok  	github.com/axonops/audit/syslog	42.470s
 === bench webhook ===
 PASS
 ok  	github.com/axonops/audit/webhook	0.005s
@@ -415,52 +86,52 @@ goos: linux
 goarch: amd64
 pkg: github.com/axonops/audit/loki
 cpu: AMD Ryzen 9 7950X 16-Core Processor            
-BenchmarkWriteWithMetadata-32                        	19482666	        61.06 ns/op	      74 B/op	       1 allocs/op
-BenchmarkWriteWithMetadata-32                        	19892068	        62.33 ns/op	      74 B/op	       1 allocs/op
-BenchmarkWriteWithMetadata-32                        	22148150	        60.64 ns/op	      74 B/op	       1 allocs/op
-BenchmarkWriteWithMetadata-32                        	22626332	        62.69 ns/op	      74 B/op	       1 allocs/op
-BenchmarkWriteWithMetadata-32                        	24061504	        60.19 ns/op	      73 B/op	       1 allocs/op
-BenchmarkLokiOutput_BatchBuild-32                    	   35227	     34393 ns/op	   11843 B/op	      35 allocs/op
-BenchmarkLokiOutput_BatchBuild-32                    	   35317	     34547 ns/op	   11843 B/op	      35 allocs/op
-BenchmarkLokiOutput_BatchBuild-32                    	   34867	     34634 ns/op	   11843 B/op	      35 allocs/op
-BenchmarkLokiOutput_BatchBuild-32                    	   33655	     35358 ns/op	   11843 B/op	      35 allocs/op
-BenchmarkLokiOutput_BatchBuild-32                    	   34875	     33909 ns/op	   11843 B/op	      35 allocs/op
-BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   13036	     95207 ns/op	   70413 B/op	     500 allocs/op
-BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   12046	     98370 ns/op	   70414 B/op	     500 allocs/op
-BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   12945	     92605 ns/op	   70413 B/op	     500 allocs/op
-BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   10000	    100864 ns/op	   70417 B/op	     500 allocs/op
-BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   12837	     94130 ns/op	   70413 B/op	     500 allocs/op
-BenchmarkLokiOutput_Gzip-32                          	    5648	    213640 ns/op	 1053463 B/op	      84 allocs/op
-BenchmarkLokiOutput_Gzip-32                          	    5652	    228933 ns/op	 1053457 B/op	      84 allocs/op
-BenchmarkLokiOutput_Gzip-32                          	    5682	    211403 ns/op	 1053450 B/op	      84 allocs/op
-BenchmarkLokiOutput_Gzip-32                          	    5275	    229131 ns/op	 1053460 B/op	      84 allocs/op
-BenchmarkLokiOutput_Gzip-32                          	    6484	    224271 ns/op	 1053453 B/op	      84 allocs/op
-BenchmarkLokiOutput_MetadataWriter-32                	14231899	        85.67 ns/op	     167 B/op	       1 allocs/op
-BenchmarkLokiOutput_MetadataWriter-32                	12716210	        82.68 ns/op	     167 B/op	       1 allocs/op
-BenchmarkLokiOutput_MetadataWriter-32                	16375857	        77.21 ns/op	     167 B/op	       1 allocs/op
-BenchmarkLokiOutput_MetadataWriter-32                	13630766	        82.68 ns/op	     167 B/op	       1 allocs/op
-BenchmarkLokiOutput_MetadataWriter-32                	15451377	        77.43 ns/op	     167 B/op	       1 allocs/op
-BenchmarkLokiBackoff-32                              	44602357	        25.76 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLokiBackoff-32                              	44607895	        26.01 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLokiBackoff-32                              	46421300	        25.55 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLokiBackoff-32                              	46025840	        25.75 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLokiBackoff-32                              	46275745	        25.72 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParseRetryAfter-32                          	327526353	         3.676 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParseRetryAfter-32                          	320540095	         3.764 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParseRetryAfter-32                          	336736136	         3.689 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParseRetryAfter-32                          	326883487	         3.658 ns/op	       0 B/op	       0 allocs/op
-BenchmarkParseRetryAfter-32                          	334488339	         3.668 ns/op	       0 B/op	       0 allocs/op
+BenchmarkWriteWithMetadata-32                        	16662862	        61.13 ns/op	      74 B/op	       1 allocs/op
+BenchmarkWriteWithMetadata-32                        	20901236	        60.91 ns/op	      74 B/op	       1 allocs/op
+BenchmarkWriteWithMetadata-32                        	23026405	        63.87 ns/op	      74 B/op	       1 allocs/op
+BenchmarkWriteWithMetadata-32                        	22240704	        60.52 ns/op	      74 B/op	       1 allocs/op
+BenchmarkWriteWithMetadata-32                        	23991679	        62.01 ns/op	      73 B/op	       1 allocs/op
+BenchmarkLokiOutput_BatchBuild-32                    	   35360	     33499 ns/op	   11843 B/op	      35 allocs/op
+BenchmarkLokiOutput_BatchBuild-32                    	   36294	     33756 ns/op	   11843 B/op	      35 allocs/op
+BenchmarkLokiOutput_BatchBuild-32                    	   34605	     34193 ns/op	   11843 B/op	      35 allocs/op
+BenchmarkLokiOutput_BatchBuild-32                    	   35892	     33334 ns/op	   11843 B/op	      35 allocs/op
+BenchmarkLokiOutput_BatchBuild-32                    	   33992	     34544 ns/op	   11843 B/op	      35 allocs/op
+BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   12108	     98403 ns/op	   70414 B/op	     500 allocs/op
+BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   12697	     94979 ns/op	   70406 B/op	     500 allocs/op
+BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   12804	     94837 ns/op	   70413 B/op	     500 allocs/op
+BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   12774	     95500 ns/op	   70413 B/op	     500 allocs/op
+BenchmarkLokiOutput_BatchBuild_HighCardinality-32    	   12019	     98628 ns/op	   70414 B/op	     500 allocs/op
+BenchmarkLokiOutput_Gzip-32                          	    6332	    208795 ns/op	 1053460 B/op	      84 allocs/op
+BenchmarkLokiOutput_Gzip-32                          	    6596	    226473 ns/op	 1053460 B/op	      84 allocs/op
+BenchmarkLokiOutput_Gzip-32                          	    5607	    210502 ns/op	 1053457 B/op	      84 allocs/op
+BenchmarkLokiOutput_Gzip-32                          	    5968	    222111 ns/op	 1053456 B/op	      84 allocs/op
+BenchmarkLokiOutput_Gzip-32                          	    5451	    215867 ns/op	 1053454 B/op	      84 allocs/op
+BenchmarkLokiOutput_MetadataWriter-32                	13789117	        83.66 ns/op	     167 B/op	       1 allocs/op
+BenchmarkLokiOutput_MetadataWriter-32                	13296300	        82.81 ns/op	     167 B/op	       1 allocs/op
+BenchmarkLokiOutput_MetadataWriter-32                	15124094	        81.82 ns/op	     167 B/op	       1 allocs/op
+BenchmarkLokiOutput_MetadataWriter-32                	13825784	        85.67 ns/op	     167 B/op	       1 allocs/op
+BenchmarkLokiOutput_MetadataWriter-32                	16028554	        73.36 ns/op	     167 B/op	       1 allocs/op
+BenchmarkLokiBackoff-32                              	47061740	        25.71 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLokiBackoff-32                              	44323126	        25.60 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLokiBackoff-32                              	45485618	        25.54 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLokiBackoff-32                              	46811862	        25.60 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLokiBackoff-32                              	47188324	        25.48 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseRetryAfter-32                          	321206545	         3.739 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseRetryAfter-32                          	332847525	         3.698 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseRetryAfter-32                          	331253540	         3.710 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseRetryAfter-32                          	337694174	         3.642 ns/op	       0 B/op	       0 allocs/op
+BenchmarkParseRetryAfter-32                          	331315465	         3.705 ns/op	       0 B/op	       0 allocs/op
 PASS
-ok  	github.com/axonops/audit/loki	43.647s
+ok  	github.com/axonops/audit/loki	43.951s
 === bench outputconfig ===
 PASS
-ok  	github.com/axonops/audit/outputconfig	0.005s
+ok  	github.com/axonops/audit/outputconfig	0.004s
 PASS
 ok  	github.com/axonops/audit/outputconfig/tests/bdd	0.007s
 ?   	github.com/axonops/audit/outputconfig/tests/bdd/steps	[no test files]
 === bench outputs ===
 PASS
-ok  	github.com/axonops/audit/outputs	0.005s
+ok  	github.com/axonops/audit/outputs	0.004s
 === bench cmd/audit-gen ===
 PASS
 ok  	github.com/axonops/audit/cmd/audit-gen	0.004s

--- a/drain.go
+++ b/drain.go
@@ -227,23 +227,60 @@ func (a *Auditor) deliverToOutput(oe *outputEntry, entry *auditEntry, category s
 // returned slice aliases the scratch buffer and is valid only until
 // the next assemblePostFields call on the same fc.
 //
-// HMAC ordering: _hmac_v is appended before computeHMACFast so it is
-// part of the authenticated region; _hmac is appended last and never
-// covers itself.
+// # Append ordering and the HMAC authenticated region
+//
+// The HMAC tag (_hmac) is the LAST field on the wire and MUST NOT
+// cover itself. Every other post-field — currently event_category
+// and _hmac_v — MUST be inside the authenticated region so an
+// attacker cannot swap a salt version or inject a category label
+// without invalidating the HMAC. See issue #473 for the regression
+// class this invariant defends against.
+//
+// Concretely:
+//
+//  1. Collect every "inside the authenticated region" post-field
+//     into preHMAC (currently event_category and _hmac_v; order
+//     within the batch matches the intended wire order).
+//  2. Append them in ONE batch call ([appendPostFieldsInto] for
+//     n == 2, [appendPostFieldInto] for n == 1) — saves one
+//     terminator rewind / restore cycle vs two sequential calls.
+//  3. Compute the HMAC over everything written so far
+//     (oe.hmac.computeHMACFast(data)).
+//  4. Append _hmac as a SEPARATE [appendPostFieldInto] call. This
+//     call runs AFTER computeHMACFast and the value it writes is
+//     outside the authenticated region, as required.
+//
+// Any future post-field that must be authenticated MUST be added
+// to the preHMAC batch in step 1. Appending it after step 3 would
+// leave it outside the authenticated region — the same regression
+// class as #473.
 func (a *Auditor) assemblePostFields(fc *formatCache, base []byte, fmtr Formatter, category string, oe *outputEntry, needsCategory, needsHMAC bool) []byte {
 	pb := fc.borrowPostBuf()
 	pb.Write(base)
 	data := pb.Bytes()
 
+	// preHMAC holds every post-field that must fall inside the
+	// authenticated region. Stack-allocated: no per-event alloc.
+	// See #508 for the consolidation rationale and #473 for the
+	// ordering invariant this batch enforces.
+	var preHMAC [2]PostField
+	n := 0
 	if needsCategory {
-		data = appendEventCategoryInto(pb, fmtr, category)
+		preHMAC[n] = PostField{JSONKey: "event_category", CEFKey: "cat", Value: category}
+		n++
 	}
 	if needsHMAC {
-		// _hmac_v (salt version identifier) FIRST so it is in the
-		// authenticated region (issue #473).
-		data = appendPostFieldInto(pb, fmtr, PostField{
-			JSONKey: "_hmac_v", CEFKey: "_hmacVersion", Value: oe.hmacConfig.SaltVersion,
-		})
+		preHMAC[n] = PostField{JSONKey: "_hmac_v", CEFKey: "_hmacVersion", Value: oe.hmacConfig.SaltVersion}
+		n++
+	}
+	switch n {
+	case 1:
+		data = appendPostFieldInto(pb, fmtr, preHMAC[0])
+	case 2:
+		data = appendPostFieldsInto(pb, fmtr, preHMAC[:2])
+	}
+
+	if needsHMAC {
 		hmacHex := oe.hmac.computeHMACFast(data)
 		data = appendPostFieldInto(pb, fmtr, PostField{
 			JSONKey: "_hmac", CEFKey: "_hmac", Value: string(hmacHex),

--- a/postfield.go
+++ b/postfield.go
@@ -135,17 +135,6 @@ func appendPostFieldsJSON(data []byte, fields []PostField) []byte {
 	return result
 }
 
-// appendEventCategoryInto appends the event_category field to a
-// *bytes.Buffer that already contains the base serialised bytes. The
-// buffer is mutated in place: the trailing terminator is rewound, the
-// field is appended, and the terminator is restored. Returns
-// buf.Bytes().
-func appendEventCategoryInto(buf *bytes.Buffer, formatter Formatter, category string) []byte {
-	return appendPostFieldInto(buf, formatter, PostField{
-		JSONKey: "event_category", CEFKey: "cat", Value: category,
-	})
-}
-
 // appendPostFieldInto appends a single post-serialisation field by
 // mutating buf in place. This is the zero-allocation drain-pipeline
 // counterpart to [AppendPostField]. The buffer must already contain
@@ -190,6 +179,81 @@ func appendPostFieldCEFInto(buf *bytes.Buffer, f PostField) []byte {
 	buf.WriteString(f.CEFKey)
 	buf.WriteByte('=')
 	buf.WriteString(cefEscapeExtValue(f.Value))
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+// appendPostFieldsInto is the batch in-place counterpart to
+// [appendPostFieldInto]. It rewinds the buffer terminator once,
+// appends every field in fields, and restores the terminator once —
+// saving one rewind / restore cycle per additional field over
+// N sequential [appendPostFieldInto] calls. Used by the drain
+// pipeline to emit the pre-HMAC batch (event_category + _hmac_v)
+// in a single buffer mutation; see [Auditor.assemblePostFields]
+// in drain.go.
+//
+// Contract mirrors [appendPostFieldInto]:
+//
+//   - Returns buf.Bytes() unchanged if fields is empty or the buffer
+//     lacks the expected terminator (}\n for JSON, \n for CEF). The
+//     format cache always produces well-terminated input, so the
+//     guard is defensive against future invariant violations.
+//   - All-or-none: if the terminator guard fails the function returns
+//     without appending any field. It never leaves the buffer in a
+//     partially-appended state.
+//   - Silent on unknown formatter (matches the single-field variant).
+//
+// The returned slice aliases buf.Bytes() and is valid until the next
+// mutation of buf.
+func appendPostFieldsInto(buf *bytes.Buffer, formatter Formatter, fields []PostField) []byte {
+	if len(fields) == 0 {
+		return buf.Bytes()
+	}
+	switch formatter.(type) {
+	case *JSONFormatter:
+		return appendPostFieldsJSONInto(buf, fields)
+	case *CEFFormatter:
+		return appendPostFieldsCEFInto(buf, fields)
+	default:
+		return buf.Bytes()
+	}
+}
+
+// appendPostFieldsJSONInto rewinds the trailing }\n, appends
+// ,"k1":"v1",...,"kN":"vN", and restores the }\n. Returns
+// buf.Bytes(). See [appendPostFieldsInto] for the contract.
+func appendPostFieldsJSONInto(buf *bytes.Buffer, fields []PostField) []byte {
+	b := buf.Bytes()
+	if len(b) < 2 || b[len(b)-1] != '\n' || b[len(b)-2] != '}' {
+		return b
+	}
+	buf.Truncate(buf.Len() - 2)
+	for i := range fields {
+		buf.WriteByte(',')
+		WriteJSONString(buf, fields[i].JSONKey)
+		buf.WriteByte(':')
+		WriteJSONString(buf, fields[i].Value)
+	}
+	buf.WriteByte('}')
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+// appendPostFieldsCEFInto rewinds the trailing \n, appends
+// " k1=v1 k2=v2 ... kN=vN", and restores the \n. Returns
+// buf.Bytes(). See [appendPostFieldsInto] for the contract.
+func appendPostFieldsCEFInto(buf *bytes.Buffer, fields []PostField) []byte {
+	b := buf.Bytes()
+	if len(b) < 1 || b[len(b)-1] != '\n' {
+		return b
+	}
+	buf.Truncate(buf.Len() - 1)
+	for i := range fields {
+		buf.WriteByte(' ')
+		buf.WriteString(fields[i].CEFKey)
+		buf.WriteByte('=')
+		buf.WriteString(cefEscapeExtValue(fields[i].Value))
+	}
 	buf.WriteByte('\n')
 	return buf.Bytes()
 }

--- a/postfield_property_test.go
+++ b/postfield_property_test.go
@@ -64,6 +64,183 @@ func TestAppendPostFieldJSONInto_PropertyEqualsAppendPostFields(t *testing.T) {
 	})
 }
 
+// TestAppendPostField_PublicAPI covers the exported single-field
+// fast path so the public contract stays wired. The drain pipeline
+// uses the unexported *Into variants; this test protects the
+// published allocating path used by consumers who implement custom
+// formatters.
+func TestAppendPostField_PublicAPI(t *testing.T) {
+	field := PostField{JSONKey: "event_category", CEFKey: "cat", Value: "write"}
+
+	t.Run("json", func(t *testing.T) {
+		base := []byte(`{"outcome":"success"}` + "\n")
+		got := AppendPostField(base, &JSONFormatter{}, field)
+		want := []byte(`{"outcome":"success","event_category":"write"}` + "\n")
+		if !bytes.Equal(want, got) {
+			t.Fatalf("AppendPostField JSON:\nwant=%q\ngot =%q", want, got)
+		}
+	})
+
+	t.Run("cef", func(t *testing.T) {
+		base := []byte("CEF:0|v|p|1|evt|name|0|\n")
+		got := AppendPostField(base, &CEFFormatter{}, field)
+		want := []byte("CEF:0|v|p|1|evt|name|0| cat=write\n")
+		if !bytes.Equal(want, got) {
+			t.Fatalf("AppendPostField CEF:\nwant=%q\ngot =%q", want, got)
+		}
+	})
+
+	t.Run("unknown_formatter_returns_unchanged", func(t *testing.T) {
+		base := []byte(`{"outcome":"success"}` + "\n")
+		got := AppendPostField(base, noopFormatter{}, field)
+		if !bytes.Equal(base, got) {
+			t.Fatalf("unknown formatter must return data unchanged\nbase=%q\ngot =%q", base, got)
+		}
+	})
+
+	t.Run("short_input_returns_unchanged", func(t *testing.T) {
+		base := []byte("x")
+		got := AppendPostField(base, &JSONFormatter{}, field)
+		if !bytes.Equal(base, got) {
+			t.Fatalf("short input must return data unchanged\nbase=%q\ngot =%q", base, got)
+		}
+	})
+}
+
+// noopFormatter is an Event formatter that is neither *JSONFormatter
+// nor *CEFFormatter, used to exercise the AppendPostField default
+// arm that returns input unchanged.
+type noopFormatter struct{}
+
+func (noopFormatter) Format(ts time.Time, eventType string, fields Fields, def *EventDef, opts *FormatOptions) ([]byte, error) {
+	return nil, nil
+}
+
+// TestAppendPostFieldsJSONInto_PropertyEqualsSequentialInPlace is
+// the byte-equality proof for the #508 batch in-place JSON path.
+// Rapid generates random JSON-formatted bases and random PostField
+// sequences; the property asserts the batched single-call output
+// matches the sequential N-call in-place output exactly.
+//
+// Failure mode if regressed: the batch truncate/append-N/restore
+// sequence diverges from the N-call loop (e.g., wrong terminator
+// position, field reordering, or missing separator), producing
+// output that fails HMAC verification or JSON parsing.
+func TestAppendPostFieldsJSONInto_PropertyEqualsSequentialInPlace(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		base := generateValidJSONBase(t)
+		fields := generatePostFields(t)
+
+		// Reference: N sequential appendPostFieldJSONInto calls.
+		refBuf := new(bytes.Buffer)
+		refBuf.Write(base)
+		for _, f := range fields {
+			appendPostFieldJSONInto(refBuf, f)
+		}
+		want := append([]byte(nil), refBuf.Bytes()...)
+
+		// Subject: one appendPostFieldsJSONInto batch call.
+		gotBuf := new(bytes.Buffer)
+		gotBuf.Write(base)
+		got := appendPostFieldsJSONInto(gotBuf, fields)
+
+		if !bytes.Equal(want, got) {
+			t.Fatalf("batch JSON in-place output diverges from sequential in-place output\nbase  = %q\nfields= %#v\nwant  = %q\ngot   = %q",
+				base, fields, want, got)
+		}
+	})
+}
+
+// TestAppendPostFieldsCEFInto_PropertyEqualsSequentialInPlace is
+// the CEF analogue of the JSON batch property. Guards against
+// wire-format drift between the batch path and the existing
+// sequential single-field path — #508.
+func TestAppendPostFieldsCEFInto_PropertyEqualsSequentialInPlace(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		base := generateValidCEFBase(t)
+		fields := generatePostFields(t)
+
+		refBuf := new(bytes.Buffer)
+		refBuf.Write(base)
+		for _, f := range fields {
+			appendPostFieldCEFInto(refBuf, f)
+		}
+		want := append([]byte(nil), refBuf.Bytes()...)
+
+		gotBuf := new(bytes.Buffer)
+		gotBuf.Write(base)
+		got := appendPostFieldsCEFInto(gotBuf, fields)
+
+		if !bytes.Equal(want, got) {
+			t.Fatalf("batch CEF in-place output diverges from sequential in-place output\nbase  = %q\nfields= %#v\nwant  = %q\ngot   = %q",
+				base, fields, want, got)
+		}
+	})
+}
+
+// TestAppendPostFieldsInto_MalformedBase pins the all-or-none
+// guard behaviour: when the buffer lacks the expected terminator
+// (}\n for JSON, \n for CEF), the function MUST return without
+// appending any field. A partial append would produce malformed
+// wire bytes that downstream HMAC verification or parsers would
+// reject — #508 security-reviewer note on the all-or-none contract.
+func TestAppendPostFieldsInto_MalformedBase(t *testing.T) {
+	fields := []PostField{
+		{JSONKey: "event_category", CEFKey: "cat", Value: "write"},
+		{JSONKey: "_hmac_v", CEFKey: "_hmacVersion", Value: "v1"},
+	}
+
+	cases := []struct {
+		name      string
+		formatter Formatter
+		base      string
+	}{
+		{"json_empty", &JSONFormatter{}, ""},
+		{"json_one_byte", &JSONFormatter{}, "x"},
+		{"json_missing_newline", &JSONFormatter{}, "{}"},
+		{"json_missing_brace", &JSONFormatter{}, "]\n"},
+		{"cef_empty", &CEFFormatter{}, ""},
+		{"cef_missing_newline", &CEFFormatter{}, "CEF:0|v|p|1|e|n|0|"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			buf.WriteString(tc.base)
+			before := append([]byte(nil), buf.Bytes()...)
+
+			got := appendPostFieldsInto(buf, tc.formatter, fields)
+
+			if !bytes.Equal(before, got) {
+				t.Fatalf("malformed base must be returned unchanged\nbefore=%q\nafter =%q",
+					before, got)
+			}
+			if !bytes.Equal(before, buf.Bytes()) {
+				t.Fatalf("buffer must not be partially mutated on malformed base\nbefore=%q\nbuffer=%q",
+					before, buf.Bytes())
+			}
+		})
+	}
+}
+
+// TestAppendPostFieldsInto_EmptyFields pins the documented contract
+// that an empty fields slice returns buf.Bytes() unchanged and does
+// not touch the buffer. Defensive regression guard for #508.
+func TestAppendPostFieldsInto_EmptyFields(t *testing.T) {
+	base := []byte(`{"outcome":"success"}` + "\n")
+	buf := new(bytes.Buffer)
+	buf.Write(base)
+
+	got := appendPostFieldsInto(buf, &JSONFormatter{}, nil)
+
+	if !bytes.Equal(base, got) {
+		t.Fatalf("empty fields must return base unchanged\nwant=%q\ngot =%q", base, got)
+	}
+	if !bytes.Equal(base, buf.Bytes()) {
+		t.Fatalf("empty fields must not touch buffer\nwant=%q\nbuf =%q", base, buf.Bytes())
+	}
+}
+
 // TestAppendPostFieldCEFInto_PropertyEqualsAppendPostFields is the
 // CEF analogue of the JSON property. CEF terminates with \n only (no
 // brace), so the truncate-and-restore semantics differ — both

--- a/tests/bdd/features/hmac_integrity.feature
+++ b/tests/bdd/features/hmac_integrity.feature
@@ -116,6 +116,37 @@ Feature: HMAC Integrity Verification
     And I tamper with the "actor_id" field in the captured output setting it to "bobby-user01"
     Then independently recomputing HMAC-SHA-256 over the tampered payload with salt "tamper-f-salt-16-byt" does NOT match the "_hmac" value
 
+  # --- Consolidated pre-HMAC batch regression guard (issue #508) ---
+  #
+  # When both event_category and _hmac_v are present they are written
+  # in a single pre-HMAC batch (drain.go assemblePostFields). This
+  # scenario pins two invariants:
+  #
+  #   1. Both fields appear on the wire alongside _hmac.
+  #   2. event_category is INSIDE the authenticated region — tampering
+  #      with it after production breaks HMAC verification, same as
+  #      tampering with _hmac_v (#473) or any consumer field.
+  #
+  # A future refactor that accidentally emits event_category AFTER
+  # computeHMACFast would leave it unauthenticated; this scenario
+  # would fail the "tampered payload does NOT verify" check.
+
+  Scenario: HMAC authenticated region covers event_category (consolidated pre-HMAC batch)
+    Given an auditor with stdout output and HMAC enabled using salt "batch-guard-salt-16b" version "v1" and hash "HMAC-SHA-256"
+    When I audit event "user_create" with required fields
+    And I close the auditor
+    Then the captured output should contain field "event_category" with value "write"
+    And the output should contain "_hmac_v" field with value "v1"
+    And the output should contain "_hmac" field
+    And independently recomputing HMAC-SHA-256 over the payload with salt "batch-guard-salt-16b" matches the "_hmac" value
+
+  Scenario: Tampering event_category breaks HMAC verification
+    Given an auditor with stdout output and HMAC enabled using salt "batch-tamp-salt-16by" version "v1" and hash "HMAC-SHA-256"
+    When I audit event "user_create" with required fields
+    And I close the auditor
+    And I tamper with the "event_category" field in the captured output setting it to "other"
+    Then independently recomputing HMAC-SHA-256 over the tampered payload with salt "batch-tamp-salt-16by" does NOT match the "_hmac" value
+
   # --- Reserved field name collision (issue #473 security-reviewer finding 6b) ---
 
   Scenario Outline: Reserved library field name rejected at runtime

--- a/tests/bdd/steps/hmac_steps.go
+++ b/tests/bdd/steps/hmac_steps.go
@@ -85,6 +85,28 @@ func registerHMACPresenceSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 	ctx.Step(`^the output should contain "_hmac_v" field with value "([^"]*)"$`, func(want string) error { return assertCapturedHMACVersion(tc, want) })
 	ctx.Step(`^the output should not contain "_hmac" field$`, func() error { return assertNoHMACField(tc) })
 	ctx.Step(`^the output should not contain "_hmac_v" field$`, func() error { return assertNoHMACVersionField(tc) })
+	ctx.Step(`^the captured output should contain field "([^"]*)" with value "([^"]*)"$`,
+		func(field, want string) error { return assertCapturedFieldValue(tc, field, want) })
+}
+
+// assertCapturedFieldValue asserts every captured event contains a
+// JSON field with the given name and string value. Companion to the
+// HMAC-specific assertions that also read from CaptureOutput.
+// Added for the #508 "consolidated pre-HMAC batch" regression
+// scenarios that need to pin event_category presence in captured
+// output.
+func assertCapturedFieldValue(tc *AuditTestContext, field, want string) error {
+	events := tc.CaptureOutput.Events()
+	if len(events) == 0 {
+		return fmt.Errorf("no events captured")
+	}
+	needle := fmt.Sprintf(`%q:%q`, field, want)
+	for i, raw := range events {
+		if !strings.Contains(string(raw), needle) {
+			return fmt.Errorf("captured event %d does not contain %s (raw=%s)", i, needle, string(raw))
+		}
+	}
+	return nil
 }
 
 func assertCapturedContainsHMAC(tc *AuditTestContext) error {


### PR DESCRIPTION
## Summary

Consolidates the pre-HMAC post-field appends in `drain.go::assemblePostFields` so `event_category` and `_hmac_v` land in a single batch append rather than two sequential in-place calls. `_hmac` still goes through a separate call after `computeHMACFast` — outside the authenticated region as required (#473).

The drain hot path was already zero-alloc after #497's W2 work, so this change is **call-count consolidation for clarity and a small constant-factor win**, not an allocation-reduction. AC #2 in the issue ("one fewer alloc per event") is already satisfied by #497.

Closes #508.

## What Changed

### `drain.go` — `assemblePostFields`

```go
var preHMAC [2]PostField
n := 0
if needsCategory { preHMAC[n] = PostField{...event_category...}; n++ }
if needsHMAC     { preHMAC[n] = PostField{..._hmac_v...};        n++ }
switch n {
case 1: data = appendPostFieldInto(pb, fmtr, preHMAC[0])
case 2: data = appendPostFieldsInto(pb, fmtr, preHMAC[:2])
}
if needsHMAC {
    hmacHex := oe.hmac.computeHMACFast(data)
    data = appendPostFieldInto(pb, fmtr, PostField{..._hmac...})
}
```

- `preHMAC [2]PostField` is stack-allocated (confirmed by `go build -gcflags='-m=2'`).
- Per performance-reviewer: `n==1` keeps the single-field fast path (lower overhead); batch fires only at `n==2` where it pays off.
- Godoc expanded to document the HMAC-boundary invariant and the consolidation rationale.

### `postfield.go` — new batch helpers

- `appendPostFieldsInto(buf, formatter, fields)` — batch in-place counterpart to `appendPostFieldInto`. Rewinds terminator once, writes N fields, restores once. **All-or-none** guard: malformed input returns `buf.Bytes()` unchanged without partial mutation (security-reviewer invariant).
- `appendPostFieldsJSONInto` / `appendPostFieldsCEFInto` — format-specific helpers.
- Removed unused `appendEventCategoryInto` (inlined as a `PostField` literal in `assemblePostFields`).

## Performance Evidence

Scoped benchstat, count=10, same machine:

```
                                │  pre.txt  │        post.txt        │
                                │  sec/op   │  sec/op   vs base      │
Audit_WithHMAC-32                 368.1n ± 2%  363.8n ± 4%  ~ (p=0.280 n=10)
Audit_FastPath_WithHMAC_Noop-32   251.0n ± 2%  250.2n ± 2%  ~ (p=0.579 n=10)

                                │   B/op    │        post            │
Audit_WithHMAC-32                 172.5 ± 1%  169.5 ± 3%   ~ (p=0.098 n=10)
Audit_FastPath_WithHMAC_Noop-32   16.00 ± 6%  15.00 ± 7%   ~ (p=0.370 n=10)

                                │ allocs/op │        post            │
Audit_WithHMAC-32                 1.000       1.000       ~
Audit_FastPath_WithHMAC_Noop-32   0.000       0.000       ~
```

No statistically significant sec/op regression. No allocation change. Small directional B/op improvement consistent with one fewer terminator-rewind per `category+HMAC` event. Matches the pre-coding performance-reviewer's "~5 ns realistic" prediction.

Escape analysis verified: zero `moved to heap` additions in `drain.go`. `preHMAC` stays on the stack.

## Tests

- **`TestAppendPostFieldsJSONInto_PropertyEqualsSequentialInPlace`** — rapid property test, 100 cases, asserts N sequential `appendPostFieldJSONInto` calls == 1 `appendPostFieldsJSONInto` batch call byte-for-byte on random bases and field slices.
- **`TestAppendPostFieldsCEFInto_PropertyEqualsSequentialInPlace`** — CEF analogue, 100 cases.
- **`TestAppendPostFieldsInto_MalformedBase`** — 6 table subcases covering empty, one-byte, missing terminator, wrong terminator on both formatters.
- **`TestAppendPostFieldsInto_EmptyFields`** — pins the empty-slice contract.
- **`TestAppendPostField_PublicAPI`** — lifts the public copy-out `AppendPostField` path off 0% coverage (JSON / CEF / unknown-formatter / short-input). Addresses the pre-existing go-quality finding.
- **BDD scenarios** in `hmac_integrity.feature`:
  - "HMAC authenticated region covers event_category (consolidated pre-HMAC batch)" — positive-path guard.
  - "Tampering event_category breaks HMAC verification" — regression guard: if a future refactor moved `event_category` outside the authenticated region, this scenario would fail.
- **BDD step** `the captured output should contain field "X" with value "Y"` — new generic assertion for captured outputs.

## Agent Gates

| Gate | Result |
|------|--------|
| performance-reviewer (pre-coding) | Applied: keep `n==1` single-field path, stack `[2]PostField`, verify escape analysis |
| security-reviewer (pre-coding) | Applied: all-or-none guard, `_hmac_v` stays in preHMAC batch (#473), add BDD wire-byte scenario |
| test-analyst (pre-coding) | Applied: rapid property tests + table + BDD pinning (see test list above) |
| code-reviewer (pre-coding) | Applied: switch on `n`, silent-return on malformed, match `*Into` naming |
| test-analyst (post-coding) | PASS |
| code-reviewer (post-coding) | PASS (3 nits — optional, not applied in this PR) |
| security-reviewer (post-coding) | PASS — HMAC authenticated region preserved byte-for-byte |
| performance-reviewer (post-coding) | PASS — 0 allocs/op hot path preserved; escape analysis clean |
| go-quality (post-coding) | PASS after adding `TestAppendPostField_PublicAPI` |
| commit-message-reviewer | PASS |

## Acceptance Criteria (#508)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `drain.go` has at most two `AppendPostField(s)` invocations per event when HMAC enabled | ✅ one batch call pre-HMAC, one single call post-HMAC |
| 2 | `BenchmarkAudit_WithHMAC` / `_WithEventCategory` show one fewer alloc | ⚠️ already satisfied by #497 W2 — benchmarks at 1 (slow path, basicEvent escape) and 0 (fast path); cannot go lower |
| 3 | Output bytes unchanged — BDD passes | ✅ BDD green; property tests pin byte-for-byte equivalence |
| 4 | A-01 correctness preserved (HMAC covers `_hmac_v`) | ✅ `_hmac_v` still in preHMAC batch; existing scenario "HMAC authentication covers salt version identifier" unchanged and passes |

## Test Plan

- [x] `make check` green locally
- [x] `make test-bdd-core` green (including 2 new scenarios)
- [x] Scoped benchstat count=10, pre-vs-post
- [x] Escape analysis verification (0 new heap escapes in `drain.go`)
- [x] `bench-baseline.txt` regenerated on the branch
- [ ] CI green (watching)