### PR TITLE
docs(readme): correct file-output fast-path description (#510)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,14 @@ go get github.com/axonops/audit/outputconfig # YAML-based output configuration
 > 💡 The core module includes `StdoutOutput` (no additional dependency)
 > and the `audittest` package for [testing](docs/testing.md).
 
-> 🚀 On Linux 5.5+ the file output automatically uses [io_uring][iouring]
-> to amortise the per-event `write(2)` syscall across batched vectored
-> writes; on other Unix platforms it falls back transparently to
-> `writev(2)`. No configuration needed. See [ADR 0002][adr-0002].
+> 🚀 On Unix the file output uses `writev(2)` via the
+> [iouring][iouring] submodule to collapse batched events into a
+> single syscall — measured faster than `io_uring` at every batch
+> size for our submit-and-wait pattern (see [ADR 0002][adr-0002]).
+> On Windows it falls back transparently to buffered writes.
+> No configuration needed. The `io_uring` primitive ships in the
+> submodule and is available for post-v1.0 async workloads (WAL,
+> O_DIRECT) that genuinely benefit.
 
 [iouring]: https://pkg.go.dev/github.com/axonops/audit/iouring
 [adr-0002]: docs/adr/0002-file-output-io-uring-approach.md


### PR DESCRIPTION
## Summary

Post-merge issue-closer gate on #510 caught a factual drift. Commit 0b2a798 on PR #675 flipped the file output's default to `StrategyWritev` based on measured evidence (io_uring slower than writev at every batch size on both tmpfs and ext4/NVMe), but the README note added earlier in that same branch at commit 5af25e7 still claimed "On Linux 5.5+ the file output automatically uses io_uring."

This PR corrects the one-paragraph note to match what the shipped code does.

## Test plan
- [x] README renders correctly (syntax check via markdown preview).
- [x] Claim aligns with `file/internal/rotate/writer.go:174` (`iouring.WithStrategy(iouring.StrategyWritev)`).
- [x] Cross-link to ADR 0002 preserved and correct.
- [x] issue-closer can now PASS on #510.

Closes out the last pending gate on #510.