### PR TITLE
docs: add accepted performance trade-off comments (#509)

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -106,6 +106,15 @@ type Auditor struct {
 	// syncMu guards processEntry calls in synchronous delivery mode.
 	// processEntry reuses per-output state (formatOpts, HMAC) that is
 	// only safe under single-goroutine access.
+	//
+	// Accepted trade-off (#509, master-tracker C-31): synchronous
+	// delivery serialises every AuditEvent call through this mutex.
+	// That is the intended behaviour — WithSynchronousDelivery exists
+	// precisely to give tests and CLI tools a deterministic "audit
+	// returned so the write completed" contract, which requires
+	// serialisation. Production consumers use the default async
+	// path where syncMu is not held and the drain goroutine owns
+	// the single-writer invariant.
 	syncMu sync.Mutex
 	// Framework fields set via WithAppName, WithHost, WithTimezone.
 	// PID is captured once at construction via os.Getpid().
@@ -540,6 +549,16 @@ func (a *Auditor) validateExcludeLabels(oe *outputEntry) error {
 	}
 	return nil
 }
+
+// Accepted trade-off (#509, master-tracker C-23): EnableCategory,
+// DisableCategory, EnableEvent, and DisableEvent all use fmt.Errorf
+// on the validation-miss path, which allocates. These are admin /
+// control-plane operations invoked during startup and occasional
+// runtime reconfiguration — not the hot path. The allocation rate
+// is negligible compared to Audit() and optimising it would obscure
+// the error-message semantics. Hot-path filter state reads
+// (filterState.isEnabled) are separately optimised and do not
+// allocate; see filter.go.
 
 // EnableCategory enables all events in the named category. The
 // category MUST exist in the registered taxonomy. Per-event overrides

--- a/droplimit.go
+++ b/droplimit.go
@@ -67,6 +67,16 @@ type dropLimiter struct {
 func (d *dropLimiter) record(interval time.Duration, warnFn func(dropped int64)) {
 	d.count.Add(1)
 
+	// Accepted trade-off (#509, master-tracker C-30): time.Now() is
+	// a syscall on some kernels and adds a handful of nanoseconds per
+	// call. record() runs only on the drop path — reaching this
+	// function at all means the buffer is full and the producer is
+	// outpacing the drain, i.e. the system is already in a degraded
+	// state. Adding any optimisation here (cached clock, TSC rdtsc)
+	// would introduce cross-platform portability risk without any
+	// observable improvement on a path that runs orders of magnitude
+	// less frequently than Audit() itself.
+
 	// UnixNano uses wall clock; NTP adjustments may shift the interval
 	// by the step size, which is acceptable for a 10s diagnostic window.
 	now := time.Now().UnixNano()

--- a/filter.go
+++ b/filter.go
@@ -336,6 +336,15 @@ func (f *filterState) isEnabled(eventType string, taxonomy *Taxonomy) bool {
 	}
 
 	// Enabled if ANY category is enabled.
+	//
+	// Accepted trade-off (#509, master-tracker C-29): linear scan
+	// over def.Categories. An event_type typically belongs to 1–3
+	// categories; `BenchmarkFilterCheck` runs at ~16 ns/op and 0
+	// allocs/op which includes this loop. A map-based early-exit
+	// would regress the common single-category case by adding a
+	// map allocation at registration time without reducing the
+	// steady-state ns/op. Re-evaluate only if production taxonomies
+	// emerge with >10 categories per event.
 	for _, cat := range def.Categories {
 		if enabled, _ := f.enabledCategories.Load(cat); enabled {
 			return true

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -444,6 +444,17 @@ func (s *Output) writeEntry(entry syslogEntry) { //nolint:gocyclo,cyclop // even
 
 	// Attempt write. If the writer is nil (previous reconnect failed),
 	// treat as a write failure.
+	//
+	// Accepted trade-off (#509, master-tracker C-28): srslog.Writer
+	// takes an internal mutex on every WriteWithPriority call. That
+	// mutex is uncontended in our topology — only writeLoop (one
+	// goroutine per syslog Output) ever invokes it — so acquisition
+	// adds minimal CAS overhead per event. Benchmarks
+	// (BenchmarkSyslogOutput_Write in bench-baseline.txt) report the
+	// end-to-end enqueue cost at ~75–78 ns/op dominated by channel
+	// send, not the mutex. Forking srslog to strip the mutex would
+	// gain single-digit nanoseconds per event on a single hot path,
+	// at the cost of maintaining a divergent fork. Accepted as-is.
 	var writeErr error
 	if s.writer == nil {
 		writeErr = errSyslogNotConnected


### PR DESCRIPTION
## Summary

Closes #509. Adds five in-code comments documenting the rationale for performance decisions that the reviewer concluded acceptable, so future maintainers understand why they weren't optimised.

## Changes

Pure comment additions. Zero code change. 4 files, 49 insertions.

| Site | Master tracker | Rationale |
|------|----------------|-----------|
| `audit.go` — `EnableCategory`/`DisableCategory`/`EnableEvent`/`DisableEvent` | C-23 | `fmt.Errorf` on validation-miss is admin path, not hot path |
| `audit.go` — `syncMu` field | C-31 | `WithSynchronousDelivery` is opt-in; serialisation is its intended contract |
| `filter.go` — `isEnabled` category scan | C-29 | Events have 1–3 categories typically; `BenchmarkFilterCheck` ~16 ns/op 0 allocs covers it |
| `droplimit.go` — `record` `time.Now()` | C-30 | Drop path only — system already degraded |
| `syslog/syslog.go` — `attemptWrite` srslog mutex | C-28 | Single-writer topology; `BenchmarkSyslogOutput_Write` ~75–78 ns/op dominated by channel send |

## Acceptance Criteria

- [x] 1. Comment present at each of the five locations
- [x] 2. Each comment cites the relevant benchmark (or absence of contention) justifying the decision
- [x] 3. `go-quality` lint passes

## Test plan

- [x] `make fmt-check` clean
- [x] `make lint` clean
- [x] `go test -race -count=1` passes
- [x] Post-coding docs-writer review: 0 blockers, 1 non-blocker, 3 nitpicks (syslog ns/op range tightened from "79" to "~75–78" per the most material accuracy nit)