### PR TITLE
refactor: rename OutputOption constructors to WithX convention (#576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Breaking Changes
 
+- Per-output `OutputOption` constructors renamed to follow the package's `WithX` convention (#576). `OutputRoute` → `WithRoute`, `OutputFormatter` → `WithOutputFormatter` (kept `Output` prefix because the auditor-level `WithFormatter` already exists), `OutputExcludeLabels` → `WithExcludeLabels`, `OutputHMAC` → `WithHMAC`. Call-site update is mechanical: `audit.WithNamedOutput(out, audit.OutputRoute(r), audit.OutputHMAC(h))` becomes `audit.WithNamedOutput(out, audit.WithRoute(r), audit.WithHMAC(h))`. No aliases kept.
 - `New` signature changed from `New(Config, ...Option)` to `New(...Option)` — Config fields expressed as Options (#388)
 - `Config.Version` unexported, `Config.Enabled` removed — use `WithDisabled()` (#388)
 - `Fields` changed from type alias to defined type `type Fields map[string]any` with `Has()`, `String()`, `Int()` methods (#388)

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -106,7 +106,7 @@ Every issue follows this sequence. Do not skip steps.
 ## Track B — API Shape (27 issues)
 
 - [ ] **#575** feat: code generator — typed custom fields, auditIntPtr prefix, explicit setter flag, Fields() contract doc.
-- [ ] **#576** refactor: rename OutputRoute/OutputFormatter/OutputExcludeLabels/OutputHMAC to WithX convention.
+- [x] **#576** refactor: rename OutputRoute/OutputFormatter/OutputExcludeLabels/OutputHMAC to WithX convention.
 - [ ] **#577** refactor: collapse outputconfig.LoadResult, fix outputconfig.New variadic, fix outputconfig/doc.go stale example.
 - [ ] **#578** refactor: rename Stdout to Writer-based output with Stdout/Stderr/Writer constructors, drop core init() registration.
 - [ ] **#579** refactor: pick one config pattern (Config struct vs functional options); export Version; bound fieldsPool.

--- a/audit_test.go
+++ b/audit_test.go
@@ -1232,7 +1232,7 @@ func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})),
 	)
@@ -1264,7 +1264,7 @@ func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			ExcludeCategories: []string{"security"},
 		})),
 	)
@@ -2031,7 +2031,7 @@ func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
@@ -2061,7 +2061,7 @@ func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
@@ -2776,9 +2776,9 @@ func BenchmarkAudit_FanOut_MixedFormatters(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out1),                                // default JSON
-		audit.WithNamedOutput(out2, audit.OutputFormatter(cefFmt)), // CEF
-		audit.WithNamedOutput(out3),                                // default JSON (shared)
+		audit.WithNamedOutput(out1),                                    // default JSON
+		audit.WithNamedOutput(out2, audit.WithOutputFormatter(cefFmt)), // CEF
+		audit.WithNamedOutput(out3),                                    // default JSON (shared)
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -2811,10 +2811,10 @@ func BenchmarkAudit_FanOut_FilteredOutputs(b *testing.B) {
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out1), // receives all events
-		audit.WithNamedOutput(out2, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out2, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
 		})), // receives only write events
-		audit.WithNamedOutput(out3, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out3, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})), // receives only security events — filters schema_register
 	)
@@ -3006,7 +3006,7 @@ func BenchmarkAudit_WithHMAC(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   []byte("benchmark-salt-value-32-bytes!!!"),
@@ -3722,7 +3722,7 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   []byte("test-salt-sixteen-bytes!"),
@@ -3777,7 +3777,7 @@ func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "2026-Q1",
 			SaltValue:   []byte("version-test-salt-16b!"),
@@ -3866,9 +3866,9 @@ events:
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// "full" output: no label exclusions — gets all fields including email.
-		audit.WithNamedOutput(fullOut, audit.OutputHMAC(fullHMACCfg)),
+		audit.WithNamedOutput(fullOut, audit.WithHMAC(fullHMACCfg)),
 		// "stripped" output: excludes PII — email is removed before HMAC.
-		audit.WithNamedOutput(strippedOut, audit.OutputExcludeLabels("pii"), audit.OutputHMAC(strippedHMACCfg)),
+		audit.WithNamedOutput(strippedOut, audit.WithExcludeLabels("pii"), audit.WithHMAC(strippedHMACCfg)),
 	)
 	require.NoError(t, err)
 
@@ -3932,7 +3932,7 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(hmacOut, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(hmacOut, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   salt,
@@ -4011,13 +4011,13 @@ events:
 		audit.WithTaxonomy(tax),
 		// Both outputs exclude PII. baseOut is a sanity check that
 		// stripping happened; verification uses hmacOut's own bytes.
-		audit.WithNamedOutput(hmacOut, audit.OutputExcludeLabels("pii"), audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(hmacOut, audit.WithExcludeLabels("pii"), audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   salt,
 			Algorithm:   "HMAC-SHA-256",
 		})),
-		audit.WithNamedOutput(baseOut, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(baseOut, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -4442,7 +4442,7 @@ func TestMetadataWriter_DeliveryReporter_SkipsMetrics(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
@@ -4485,7 +4485,7 @@ func TestMetadataWriter_WithHMAC_ReceivesHMACData(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   []byte("hmac-test-salt-value!"),
@@ -4546,7 +4546,7 @@ events:
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// Exclude PII — email must not appear in the data received by WriteWithMetadata.
-		audit.WithNamedOutput(out, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(out, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -4836,7 +4836,7 @@ events:
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// Excluding "pii" triggers formatWithExclusion (FormatOptions non-nil).
-		audit.WithNamedOutput(out, audit.OutputFormatter(&exclusionErrorFormatter{}), audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(out, audit.WithOutputFormatter(&exclusionErrorFormatter{}), audit.WithExcludeLabels("pii")),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)
@@ -5268,7 +5268,7 @@ func BenchmarkAudit_FastPath_WithHMAC_Noop(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputHMAC(hmacCfg)),
+		audit.WithNamedOutput(out, audit.WithHMAC(hmacCfg)),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -5315,7 +5315,7 @@ func newMultiFormatterAuditor(tb testing.TB, formatters []audit.Formatter) *audi
 	}
 	for i, f := range formatters {
 		out := testhelper.NewNoopOutput(fmt.Sprintf("noop-%d", i))
-		opts = append(opts, audit.WithNamedOutput(out, audit.OutputFormatter(f)))
+		opts = append(opts, audit.WithNamedOutput(out, audit.WithOutputFormatter(f)))
 	}
 	auditor, err := audit.New(opts...)
 	if err != nil {

--- a/bench_comparison_test.go
+++ b/bench_comparison_test.go
@@ -292,7 +292,7 @@ func benchAudit10FieldsSyncWithHMAC(b *testing.B) {
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(benchComparisonTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputHMAC(hmacCfg)),
+		audit.WithNamedOutput(out, audit.WithHMAC(hmacCfg)),
 		audit.WithSynchronousDelivery(),
 	)
 	require.NoError(b, err)

--- a/doc.go
+++ b/doc.go
@@ -187,7 +187,7 @@
 //   - [ComputeHMAC] — computes HMAC over a payload, returns lowercase hex
 //   - [VerifyHMAC] — verifies an HMAC value matches a payload
 //   - [ValidateHMACConfig] — validates HMAC configuration at startup
-//   - [OutputOption] — per-output configuration for [WithNamedOutput]: [OutputRoute], [OutputFormatter], [OutputExcludeLabels], [OutputHMAC]
+//   - [OutputOption] — per-output configuration for [WithNamedOutput]: [WithRoute], [WithOutputFormatter], [WithExcludeLabels], [WithHMAC]
 //   - [MigrateTaxonomy] — applies version migration to a [Taxonomy]
 //
 // # How Taxonomy Validation Works

--- a/example_test.go
+++ b/example_test.go
@@ -283,7 +283,7 @@ func ExampleAuditor_SetOutputRoute() {
 				"auth_failure": {Required: []string{"outcome"}},
 			},
 		}),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -133,7 +133,7 @@ func TestFanout_RouteFiltering(t *testing.T) {
 			auditor, err := audit.New(
 				audit.WithValidationMode(audit.ValidationPermissive),
 				audit.WithTaxonomy(testhelper.TestTaxonomy()),
-				audit.WithNamedOutput(out, audit.OutputRoute(&tt.route)),
+				audit.WithNamedOutput(out, audit.WithRoute(&tt.route)),
 			)
 			require.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestFanout_WithOutputs_AfterWithNamedOutput_Error(t *testing.T) {
 	out2 := testhelper.NewMockOutput("plain")
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out1, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out1, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithOutputs(out2), // should error
 	)
 	require.Error(t, err)
@@ -176,7 +176,7 @@ func TestFanout_WithNamedOutput_AfterWithOutputs_Error(t *testing.T) {
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithOutputs(out1),
-		audit.WithNamedOutput(out2, audit.OutputRoute(&audit.EventRoute{})), // should error
+		audit.WithNamedOutput(out2, audit.WithRoute(&audit.EventRoute{})), // should error
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be used with WithOutputs")
@@ -186,7 +186,7 @@ func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
 		})),
 	)
@@ -198,7 +198,7 @@ func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
 			ExcludeCategories: []string{"read"},
 		})),
@@ -212,7 +212,7 @@ func TestFanout_SetOutputRoute(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 
@@ -239,8 +239,8 @@ func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(outA, audit.OutputRoute(&audit.EventRoute{})),
-		audit.WithNamedOutput(outB, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(outA, audit.WithRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(outB, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 
@@ -273,7 +273,7 @@ func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -290,7 +290,7 @@ func TestFanout_ClearOutputRoute(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})),
 	)
@@ -322,7 +322,7 @@ func TestFanout_OutputRoute(t *testing.T) {
 	route := audit.EventRoute{IncludeCategories: []string{"security"}}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&route)),
+		audit.WithNamedOutput(out, audit.WithRoute(&route)),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -354,7 +354,7 @@ func TestFanout_OutputRoute_ReflectsSetAndClear(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -378,7 +378,7 @@ func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 
@@ -426,7 +426,7 @@ func TestFanout_GlobalFilterTakesPrecedence(t *testing.T) {
 				"auth_failure": {Required: []string{"outcome"}},
 			},
 		}),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})),
 	)
@@ -454,8 +454,8 @@ func TestFanout_PerOutputFormatter(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(jsonOut, audit.OutputRoute(&audit.EventRoute{})),
-		audit.WithNamedOutput(cefOut, audit.OutputRoute(&audit.EventRoute{}), audit.OutputFormatter(cefFmt)),
+		audit.WithNamedOutput(jsonOut, audit.WithRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(cefOut, audit.WithRoute(&audit.EventRoute{}), audit.WithOutputFormatter(cefFmt)),
 	)
 	require.NoError(t, err)
 
@@ -477,7 +477,7 @@ func TestFanout_PanicInFormatter_DrainLoopSurvives(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{}), audit.OutputFormatter(&panicFormatter{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{}), audit.WithOutputFormatter(&panicFormatter{})),
 	)
 	require.NoError(t, err)
 
@@ -559,7 +559,7 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithMetrics(metrics),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})),
 	)
@@ -579,7 +579,7 @@ func TestFanout_ExcludeEventType_EndToEnd(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			ExcludeEventTypes: []string{"config_get"},
 		})),
 	)
@@ -607,8 +607,8 @@ func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
-		audit.WithNamedOutput(goodOut, audit.OutputRoute(&audit.EventRoute{})),
-		audit.WithNamedOutput(badOut, audit.OutputRoute(&audit.EventRoute{}), audit.OutputFormatter(&errorFormatter{})),
+		audit.WithNamedOutput(goodOut, audit.WithRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(badOut, audit.WithRoute(&audit.EventRoute{}), audit.WithOutputFormatter(&errorFormatter{})),
 	)
 	require.NoError(t, err)
 

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -534,7 +534,7 @@ func newHMACPipelineTestAuditor(t *testing.T, name, saltVersion string, salt []b
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: saltVersion,
 			SaltValue:   salt,
@@ -792,7 +792,7 @@ func TestVerifyHMAC_CEF_TamperingHmacVersion_Detected(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithFormatter(cefFormatter),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   salt,
@@ -966,7 +966,7 @@ func TestVerifyHMAC_CEF_TamperingActorId_Detected(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithFormatter(cefFormatter),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   salt,
@@ -1025,7 +1025,7 @@ func TestHMAC_CEF_OnWireBytesMatchHashedBytes(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithFormatter(cefFormatter),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v1",
 			SaltValue:   salt,

--- a/options.go
+++ b/options.go
@@ -212,8 +212,8 @@ func WithOutputs(outputs ...Output) Option {
 }
 
 // OutputOption configures a single output registered via
-// [WithNamedOutput]. Use [OutputRoute], [OutputFormatter],
-// [OutputExcludeLabels], and [OutputHMAC] to customise per-output
+// [WithNamedOutput]. Use [WithRoute], [WithOutputFormatter],
+// [WithExcludeLabels], and [WithHMAC] to customise per-output
 // behaviour.
 type OutputOption func(*outputEntryBuilder)
 
@@ -226,48 +226,52 @@ type outputEntryBuilder struct {
 	excludeLabels []string
 }
 
-// OutputRoute sets the per-output event route. The route restricts
+// WithRoute sets the per-output event route. The route restricts
 // which events are delivered to this output. Nil means all
 // globally-enabled events are delivered.
-func OutputRoute(r *EventRoute) OutputOption {
+func WithRoute(r *EventRoute) OutputOption {
 	return func(b *outputEntryBuilder) {
 		b.route = r
 	}
 }
 
-// OutputFormatter overrides the auditor's default formatter for this
-// output. Nil means the auditor's default formatter is used.
-func OutputFormatter(f Formatter) OutputOption {
+// WithOutputFormatter overrides the auditor's default formatter for
+// this output. Nil means the auditor's default formatter is used.
+//
+// The "Output" prefix disambiguates from the auditor-level
+// [WithFormatter] option; the two options set different defaults
+// (auditor-wide vs per-output).
+func WithOutputFormatter(f Formatter) OutputOption {
 	return func(b *outputEntryBuilder) {
 		b.formatter = f
 	}
 }
 
-// OutputExcludeLabels specifies sensitivity labels whose fields should
+// WithExcludeLabels specifies sensitivity labels whose fields should
 // be stripped from events before delivery to this output. When
 // non-empty, the taxonomy MUST define a [SensitivityConfig] and every
 // label MUST be defined within it; [New] returns an error if
 // either condition is violated. An empty call means no field stripping.
 // Framework fields are never stripped.
-func OutputExcludeLabels(labels ...string) OutputOption {
+func WithExcludeLabels(labels ...string) OutputOption {
 	return func(b *outputEntryBuilder) {
 		b.excludeLabels = labels
 	}
 }
 
-// OutputHMAC configures per-output HMAC integrity. The config is
+// WithHMAC configures per-output HMAC integrity. The config is
 // validated eagerly during [New] option application — invalid
 // configs (short salt, unknown algorithm) cause [New] to return
 // an error. Nil means no HMAC for this output.
-func OutputHMAC(cfg *HMACConfig) OutputOption {
+func WithHMAC(cfg *HMACConfig) OutputOption {
 	return func(b *outputEntryBuilder) {
 		b.hmacConfig = cfg
 	}
 }
 
 // WithNamedOutput adds a single named output with optional per-output
-// configuration. Use [OutputRoute], [OutputFormatter],
-// [OutputExcludeLabels], and [OutputHMAC] to customise behaviour.
+// configuration. Use [WithRoute], [WithOutputFormatter],
+// [WithExcludeLabels], and [WithHMAC] to customise behaviour.
 //
 // WithNamedOutput MUST NOT be combined with [WithOutputs]; if
 // [WithOutputs] was already applied, WithNamedOutput returns an error.

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -359,16 +359,16 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 	for i := range outputs {
 		var outOpts []audit.OutputOption
 		if outputs[i].Route != nil {
-			outOpts = append(outOpts, audit.OutputRoute(outputs[i].Route))
+			outOpts = append(outOpts, audit.WithRoute(outputs[i].Route))
 		}
 		if outputs[i].Formatter != nil {
-			outOpts = append(outOpts, audit.OutputFormatter(outputs[i].Formatter))
+			outOpts = append(outOpts, audit.WithOutputFormatter(outputs[i].Formatter))
 		}
 		if len(outputs[i].ExcludeLabels) > 0 {
-			outOpts = append(outOpts, audit.OutputExcludeLabels(outputs[i].ExcludeLabels...))
+			outOpts = append(outOpts, audit.WithExcludeLabels(outputs[i].ExcludeLabels...))
 		}
 		if outputs[i].HMACConfig != nil && outputs[i].HMACConfig.Enabled {
-			outOpts = append(outOpts, audit.OutputHMAC(outputs[i].HMACConfig))
+			outOpts = append(outOpts, audit.WithHMAC(outputs[i].HMACConfig))
 		}
 		result.Options = append(result.Options, audit.WithNamedOutput(outputs[i].Output, outOpts...))
 	}

--- a/processentry_zero_copy_test.go
+++ b/processentry_zero_copy_test.go
@@ -377,8 +377,8 @@ func TestProcessEntry_MultiCategory_BufferReuseAcrossPasses(t *testing.T) {
 	cefOut := testhelper.NewMockOutput("cef")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(jsonOut, audit.OutputFormatter(&audit.JSONFormatter{})),
-		audit.WithNamedOutput(cefOut, audit.OutputFormatter(&audit.CEFFormatter{
+		audit.WithNamedOutput(jsonOut, audit.WithOutputFormatter(&audit.JSONFormatter{})),
+		audit.WithNamedOutput(cefOut, audit.WithOutputFormatter(&audit.CEFFormatter{
 			Vendor: "axonops", Product: "audit", Version: "1.0",
 		})),
 		audit.WithSynchronousDelivery(),
@@ -495,8 +495,8 @@ func TestProcessEntry_FormatError_CacheNilEntry_NoDoublePut(t *testing.T) {
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
 		audit.WithMetrics(metrics),
-		audit.WithNamedOutput(out1, audit.OutputFormatter(shared), audit.OutputRoute(&audit.EventRoute{})),
-		audit.WithNamedOutput(out2, audit.OutputFormatter(shared), audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out1, audit.WithOutputFormatter(shared), audit.WithRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out2, audit.WithOutputFormatter(shared), audit.WithRoute(&audit.EventRoute{})),
 		audit.WithSynchronousDelivery(),
 	)
 	require.NoError(t, err)

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -507,7 +507,7 @@ func TestFieldStripping_SingleLabel(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -555,7 +555,7 @@ func TestFieldStripping_MultiLabel_AnyOverlap(t *testing.T) {
 	// Exclude financial only — card_number is stripped.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("financial")),
+		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("financial")),
 	)
 	require.NoError(t, err)
 
@@ -588,8 +588,8 @@ func TestFieldStripping_DifferentOutputs(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(outAll), // no exclusions
-		audit.WithNamedOutput(outNoPII, audit.OutputExcludeLabels("pii")), // exclude PII
+		audit.WithNamedOutput(outAll),                                   // no exclusions
+		audit.WithNamedOutput(outNoPII, audit.WithExcludeLabels("pii")), // exclude PII
 	)
 	require.NoError(t, err)
 
@@ -673,7 +673,7 @@ events:
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -719,7 +719,7 @@ events:
 
 	_, err = audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no sensitivity config")
@@ -749,7 +749,7 @@ events:
 
 	_, err = audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("nonexistent")),
+		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("nonexistent")),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "undefined sensitivity label")
@@ -788,7 +788,7 @@ events:
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -828,7 +828,7 @@ func TestFormatWithExclusion_ExclusionPath(t *testing.T) {
 	// Output with exclusions — formatOpts should be pre-allocated.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -895,8 +895,8 @@ func TestFormatWithExclusion_MultipleOutputsDifferentExclusions(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(outAll),
-		audit.WithNamedOutput(outNoPII, audit.OutputExcludeLabels("pii")),
-		audit.WithNamedOutput(outNoFinancial, audit.OutputExcludeLabels("financial")),
+		audit.WithNamedOutput(outNoPII, audit.WithExcludeLabels("pii")),
+		audit.WithNamedOutput(outNoFinancial, audit.WithExcludeLabels("financial")),
 	)
 	require.NoError(t, err)
 
@@ -943,7 +943,7 @@ func TestFieldStripping_Concurrent(t *testing.T) {
 	out := testhelper.NewMockOutput("concurrent")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(out, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
 
@@ -1116,7 +1116,7 @@ func BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(outAll),
-		audit.WithNamedOutput(outFiltered, audit.OutputExcludeLabels("pii")),
+		audit.WithNamedOutput(outFiltered, audit.WithExcludeLabels("pii")),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -1145,7 +1145,7 @@ func benchAuditWithExclusions(b *testing.B, taxonomyYAML string, excludeLabels [
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputExcludeLabels(excludeLabels...)),
+		audit.WithNamedOutput(out, audit.WithExcludeLabels(excludeLabels...)),
 	)
 	if err != nil {
 		b.Fatal(err)

--- a/severity_routing_test.go
+++ b/severity_routing_test.go
@@ -369,7 +369,7 @@ func TestSetRoute_CopiesMinSeverityPointer(t *testing.T) {
 	out := testhelper.NewMockOutput("copy-min")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -401,7 +401,7 @@ func TestSetRoute_CopiesMaxSeverityPointer(t *testing.T) {
 	out := testhelper.NewMockOutput("copy-max")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -432,7 +432,7 @@ func TestGetRoute_ReturnsIndependentSeverityPointers(t *testing.T) {
 	out := testhelper.NewMockOutput("get-copy")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(4)})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{MinSeverity: intPtr(4)})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -463,7 +463,7 @@ func TestSetRoute_NilSeverityPointersPreserved(t *testing.T) {
 	out := testhelper.NewMockOutput("nil-sev")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -679,7 +679,7 @@ func TestAudit_SeverityRouteFiltersInDrainLoop(t *testing.T) {
 	out := testhelper.NewMockOutput("sev-filter")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(7)})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{MinSeverity: intPtr(7)})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -735,7 +735,7 @@ events:
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		// Output route: MinSeverity 5 — only events with severity >= 5 delivered.
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{MinSeverity: intPtr(5)})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{MinSeverity: intPtr(5)})),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -878,7 +878,7 @@ func TestConcurrentSetRouteWithSeverity(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
-		audit.WithNamedOutput(out, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
 

--- a/tests/bdd/steps/fanout_steps.go
+++ b/tests/bdd/steps/fanout_steps.go
@@ -390,7 +390,7 @@ func tryMixedRoute(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = f.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(f, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
 			ExcludeCategories: []string{"read"},
 		})),
@@ -411,7 +411,7 @@ func tryUnknownCategoryRoute(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = f.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(f, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
 		})),
 	)
@@ -473,7 +473,7 @@ func tryUnknownEventTypeRoute(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = f.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(f, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(f, audit.WithRoute(&audit.EventRoute{
 			IncludeEventTypes: []string{"nonexistent_event"},
 		})),
 	)
@@ -539,7 +539,7 @@ func createFanoutAuditor(tc *AuditTestContext, useFile, useSyslog, useWebhook bo
 			return fmt.Errorf("create webhook output: %w", err)
 		}
 		tc.AddCleanup(func() { _ = w.Close() })
-		opts = append(opts, audit.WithNamedOutput(w, audit.OutputFormatter(webhookFmt)))
+		opts = append(opts, audit.WithNamedOutput(w, audit.WithOutputFormatter(webhookFmt)))
 	}
 
 	auditor, err := audit.New(opts...)
@@ -662,7 +662,7 @@ func createPanicFormatterAuditor(tc *AuditTestContext) error {
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(fileOut), // normal file
-		audit.WithNamedOutput(&devNullOutput{}, audit.OutputFormatter(&panicFormatter{})), // panicking formatter
+		audit.WithNamedOutput(&devNullOutput{}, audit.WithOutputFormatter(&panicFormatter{})), // panicking formatter
 	}
 
 	auditor, err := audit.New(opts...)
@@ -697,8 +697,8 @@ func createDualFileRoutedAuditor(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(secOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"security"}})),
-		audit.WithNamedOutput(writeOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),
+		audit.WithNamedOutput(secOut, audit.WithRoute(&audit.EventRoute{IncludeCategories: []string{"security"}})),
+		audit.WithNamedOutput(writeOut, audit.WithRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),
 	}
 
 	auditor, err := audit.New(opts...)
@@ -744,8 +744,8 @@ func createTripleRoutedAuditor(tc *AuditTestContext) error {
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(fileOut), // all events
-		audit.WithNamedOutput(syslogOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"security"}})), // security only
-		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),   // write only
+		audit.WithNamedOutput(syslogOut, audit.WithRoute(&audit.EventRoute{IncludeCategories: []string{"security"}})), // security only
+		audit.WithNamedOutput(webhookOut, audit.WithRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),   // write only
 	}
 
 	auditor, err := audit.New(opts...)
@@ -783,7 +783,7 @@ func createRoutedAuditor(tc *AuditTestContext, webhookRoute *audit.EventRoute) e
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(f),
-		audit.WithNamedOutput(w, audit.OutputRoute(webhookRoute)),
+		audit.WithNamedOutput(w, audit.WithRoute(webhookRoute)),
 	}
 
 	auditor, err := audit.New(opts...)

--- a/tests/bdd/steps/formatter_steps.go
+++ b/tests/bdd/steps/formatter_steps.go
@@ -109,7 +109,7 @@ func registerFormatterGivenCEFSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
+			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 		opts = append(opts, tc.Options...)
 
@@ -151,8 +151,8 @@ func registerFormatterGivenMultiSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(jsonOut),                               // default JSON
-			audit.WithNamedOutput(cefOut, audit.OutputFormatter(cefFmt)), // CEF
+			audit.WithNamedOutput(jsonOut),                                   // default JSON
+			audit.WithNamedOutput(cefOut, audit.WithOutputFormatter(cefFmt)), // CEF
 		}
 
 		auditor, err := audit.New(opts...)
@@ -192,7 +192,7 @@ func registerFormatterGivenCustomSeveritySteps(ctx *godog.ScenarioContext, tc *A
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
+			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 
 		auditor, err := audit.New(opts...)
@@ -229,7 +229,7 @@ func registerFormatterGivenInvalidKeySteps(ctx *godog.ScenarioContext, tc *Audit
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
+			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 
 		auditor, err := audit.New(opts...)
@@ -264,7 +264,7 @@ func registerFormatterGivenSeveritySteps(ctx *godog.ScenarioContext, tc *AuditTe
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
+			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 
 		auditor, err := audit.New(opts...)
@@ -303,7 +303,7 @@ func registerFormatterGivenExtraSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
-			audit.WithNamedOutput(fileOut, audit.OutputFormatter(cefFmt)),
+			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 
 		auditor, err := audit.New(opts...)

--- a/tests/bdd/steps/hmac_steps.go
+++ b/tests/bdd/steps/hmac_steps.go
@@ -41,7 +41,7 @@ func registerHMACGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 			auditor, err := audit.New(
 				audit.WithTaxonomy(tc.Taxonomy),
-				audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+				audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 					Enabled:     true,
 					SaltVersion: version,
 					SaltValue:   []byte(salt),
@@ -63,7 +63,7 @@ func registerHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 			_, err := audit.New(
 				audit.WithTaxonomy(tc.Taxonomy),
-				audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+				audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 					Enabled:     true,
 					SaltVersion: version,
 					SaltValue:   []byte(salt),
@@ -515,8 +515,8 @@ func createDualHMACAuditor(tc *AuditTestContext, strippedName, label, fullSalt, 
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(fullOut, audit.OutputHMAC(fullHMACCfg)),
-		audit.WithNamedOutput(strippedOut, audit.OutputExcludeLabels(label), audit.OutputHMAC(strippedHMACCfg)),
+		audit.WithNamedOutput(fullOut, audit.WithHMAC(fullHMACCfg)),
+		audit.WithNamedOutput(strippedOut, audit.WithExcludeLabels(label), audit.WithHMAC(strippedHMACCfg)),
 	)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)

--- a/tests/bdd/steps/loki_fanout_steps.go
+++ b/tests/bdd/steps/loki_fanout_steps.go
@@ -235,10 +235,10 @@ func createFileAndLokiAuditor(tc *AuditTestContext, hmacCfg *audit.HMACConfig, l
 	}
 
 	var fileOpts, lokiOpts []audit.OutputOption
-	lokiOpts = append(lokiOpts, audit.OutputRoute(lokiRoute))
+	lokiOpts = append(lokiOpts, audit.WithRoute(lokiRoute))
 	if hmacCfg != nil {
-		fileOpts = append(fileOpts, audit.OutputHMAC(hmacCfg))
-		lokiOpts = append(lokiOpts, audit.OutputHMAC(hmacCfg))
+		fileOpts = append(fileOpts, audit.WithHMAC(hmacCfg))
+		lokiOpts = append(lokiOpts, audit.WithHMAC(hmacCfg))
 	}
 	opts = append(opts,
 		audit.WithNamedOutput(fileOut, fileOpts...),
@@ -285,8 +285,8 @@ func createFileAndLokiAuditorWithExclusion(tc *AuditTestContext, excludeLabel st
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
-		audit.WithNamedOutput(fileOut),                                          // no exclusions
-		audit.WithNamedOutput(lokiOut, audit.OutputExcludeLabels(excludeLabel)), // strip PII
+		audit.WithNamedOutput(fileOut),                                        // no exclusions
+		audit.WithNamedOutput(lokiOut, audit.WithExcludeLabels(excludeLabel)), // strip PII
 	)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)

--- a/tests/bdd/steps/loki_hmac_steps.go
+++ b/tests/bdd/steps/loki_hmac_steps.go
@@ -261,13 +261,13 @@ func createLokiAuditorWithHMAC(tc *AuditTestContext, salt, version, hash string,
 		audit.WithHost("bdd-host"),
 	}
 
-	lokiOpts := []audit.OutputOption{audit.OutputHMAC(hmacCfg)}
+	lokiOpts := []audit.OutputOption{audit.WithHMAC(hmacCfg)}
 	if excludeLabels != nil {
-		lokiOpts = append(lokiOpts, audit.OutputExcludeLabels(excludeLabels...))
+		lokiOpts = append(lokiOpts, audit.WithExcludeLabels(excludeLabels...))
 		// Also add a capture output with no exclusions for comparison.
 		capture := newCaptureOutput("capture-full")
 		tc.CaptureOutput = capture
-		opts = append(opts, audit.WithNamedOutput(capture, audit.OutputHMAC(&audit.HMACConfig{
+		opts = append(opts, audit.WithNamedOutput(capture, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v-capture",
 			SaltValue:   []byte("capture-comparison16"),
@@ -304,13 +304,13 @@ func createLokiAuditorWithHMACAndCapture(tc *AuditTestContext, lokiSalt, lokiVer
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: lokiVersion,
 			SaltValue:   []byte(lokiSalt),
 			Algorithm:   "HMAC-SHA-256",
 		})),
-		audit.WithNamedOutput(capture, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(capture, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: "v-capture",
 			SaltValue:   []byte("capture-salt-beta16!"),

--- a/tests/bdd/steps/metrics_steps.go
+++ b/tests/bdd/steps/metrics_steps.go
@@ -236,7 +236,7 @@ func registerMetricsGivenFilterSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 			audit.WithTaxonomy(tc.Taxonomy),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithNamedOutput(fileOut),
-			audit.WithNamedOutput(whOut, audit.OutputRoute(&audit.EventRoute{ExcludeCategories: []string{excludeCat}})),
+			audit.WithNamedOutput(whOut, audit.WithRoute(&audit.EventRoute{ExcludeCategories: []string{excludeCat}})),
 		}
 
 		auditor, err := audit.New(opts...)

--- a/tests/bdd/steps/multicat_steps.go
+++ b/tests/bdd/steps/multicat_steps.go
@@ -134,7 +134,7 @@ func createMultiCatAuditor(tc *AuditTestContext, route *audit.EventRoute, format
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(stdout, audit.OutputRoute(route), audit.OutputFormatter(formatter)),
+		audit.WithNamedOutput(stdout, audit.WithRoute(route), audit.WithOutputFormatter(formatter)),
 	)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)

--- a/tests/bdd/steps/sensitivity_steps.go
+++ b/tests/bdd/steps/sensitivity_steps.go
@@ -72,7 +72,7 @@ func createSensitivityAuditor(tc *AuditTestContext, excludeLabels []string) erro
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(stdout, audit.OutputExcludeLabels(excludeLabels...)),
+		audit.WithNamedOutput(stdout, audit.WithExcludeLabels(excludeLabels...)),
 	)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)

--- a/tests/bdd/steps/severity_routing_steps.go
+++ b/tests/bdd/steps/severity_routing_steps.go
@@ -159,7 +159,7 @@ func createSeverityRoutedAuditor(tc *AuditTestContext, minSev, maxSev *int, incl
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(stdout, audit.OutputRoute(route)),
+		audit.WithNamedOutput(stdout, audit.WithRoute(route)),
 	)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -204,7 +204,7 @@ func trySeverityLoggerCreation(tc *AuditTestContext, minSev, maxSev *int) error 
 	}
 	auditor, lErr := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(stdout, audit.OutputRoute(route)),
+		audit.WithNamedOutput(stdout, audit.WithRoute(route)),
 	)
 	tc.LastErr = lErr
 	if auditor != nil {

--- a/tests/bdd/steps/syslog_severity_steps.go
+++ b/tests/bdd/steps/syslog_severity_steps.go
@@ -345,7 +345,7 @@ func createSyslogAuditorWithFormatter(tc *AuditTestContext, cfg *syslog.Config, 
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(out, audit.OutputFormatter(formatter)),
+		audit.WithNamedOutput(out, audit.WithOutputFormatter(formatter)),
 	}
 	opts = append(opts, tc.Options...)
 
@@ -373,7 +373,7 @@ func createSyslogAuditorWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt,
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(out, audit.OutputHMAC(&audit.HMACConfig{
+		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled:     true,
 			SaltVersion: version,
 			SaltValue:   []byte(salt),
@@ -406,7 +406,7 @@ func createSyslogAuditorWithExcludeLabels(tc *AuditTestContext, cfg *syslog.Conf
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(out, audit.OutputExcludeLabels(excludeLabels...)),
+		audit.WithNamedOutput(out, audit.WithExcludeLabels(excludeLabels...)),
 	}
 	opts = append(opts, tc.Options...)
 
@@ -449,7 +449,7 @@ func createSyslogAuditorWithRoute(tc *AuditTestContext, cfg *syslog.Config, rout
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
-		audit.WithNamedOutput(out, audit.OutputRoute(route)),
+		audit.WithNamedOutput(out, audit.WithRoute(route)),
 	}
 	opts = append(opts, tc.Options...)
 

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -239,7 +239,7 @@ func TestFanOut_EventRouting(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
 		audit.WithNamedOutput(fileOut), // all events
-		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{
+		audit.WithNamedOutput(webhookOut, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})), // security only
 	)
@@ -378,8 +378,8 @@ func TestFanOut_MixedFormatters(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
-		audit.WithNamedOutput(fileOut),                                   // JSON (default)
-		audit.WithNamedOutput(webhookOut, audit.OutputFormatter(cefFmt)), // CEF
+		audit.WithNamedOutput(fileOut),                                       // JSON (default)
+		audit.WithNamedOutput(webhookOut, audit.WithOutputFormatter(cefFmt)), // CEF
 	)
 	require.NoError(t, err)
 

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1394,7 +1394,7 @@ func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testTaxonomy()),
-		audit.WithNamedOutput(webhookOut, audit.OutputRoute(&audit.EventRoute{})),
+		audit.WithNamedOutput(webhookOut, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Closes #576. Pre-v1.0 API naming lock-in — the four per-output `OutputOption` constructors break the package's `WithX` convention used by every other Option.

| Current | New |
|---|---|
| `OutputRoute` | `WithRoute` |
| `OutputFormatter` | `WithOutputFormatter` (kept `Output` prefix — auditor-level `WithFormatter` already exists) |
| `OutputExcludeLabels` | `WithExcludeLabels` |
| `OutputHMAC` | `WithHMAC` |

Pattern matches gRPC (`WithBlock`, `WithTransportCredentials`), AWS SDK v2 (`WithRegion`, `WithCredentialsProvider`), zap. The enclosing `audit.WithNamedOutput(...)` already says "output", so dropping the redundant prefix eliminates stuttering at call sites.

No backwards-compat aliases kept — consumers update mechanically.

## Out of scope

Auditor runtime methods `SetOutputRoute`, `ClearOutputRoute`, `(*Auditor).OutputRoute(name)` — they are a different API surface (runtime mutators on a constructed `*Auditor`, not construction-time Option constructors). Untouched.

## Test plan

- [x] `go test -race -count=1 ./...` (all pass)
- [x] `make lint` (0 issues)
- [x] `make test-bdd-core` (pass)
- [x] `make test-bdd-syslog` (pass)
- [x] `make test-bdd-webhook` (pass)
- [x] `make test-bdd-loki` (pass)
- [x] `make check` (full gate: fmt + vet + lint + test + build + tidy + verify + security + release-check)

## Agent reviews

- **api-ergonomics-reviewer** pre-coding: rejected issue's verbatim `WithOutputX` as stuttering; recommended dropping prefix where safe — applied.
- **api-ergonomics-reviewer** post-coding: approved final state, godoc rationale for `WithOutputFormatter` retention confirmed.
- **code-reviewer**: 0 blocking, 0 important, 0 nits.
- **go-quality**: READY TO COMMIT.
- **commit-message-reviewer**: PASS.

## Verification

```
make check   # All checks passed.
```