### PR TITLE
refactor: rename loki.Config.Compress to Gzip for alignment (#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Breaking Changes
 
+- `loki.Config.Compress` Go field renamed to `loki.Config.Gzip` to align with the YAML key `gzip` (#584). YAML key unchanged — operator configs are unaffected. Programmatic consumers constructing `loki.Config` in Go must rename the field: `loki.Config{Compress: true}` becomes `loki.Config{Gzip: true}`. Rationale: Loki's server only accepts gzip (`Content-Encoding: gzip`), so the bool is algorithm-specific, not a generic toggle; naming the algorithm matches the Vector / Fluent Bit / promtail idiom. No aliases kept.
 - Per-output `OutputOption` constructors renamed to follow the package's `WithX` convention (#576). `OutputRoute` → `WithRoute`, `OutputFormatter` → `WithOutputFormatter` (kept `Output` prefix because the auditor-level `WithFormatter` already exists), `OutputExcludeLabels` → `WithExcludeLabels`, `OutputHMAC` → `WithHMAC`. Call-site update is mechanical: `audit.WithNamedOutput(out, audit.OutputRoute(r), audit.OutputHMAC(h))` becomes `audit.WithNamedOutput(out, audit.WithRoute(r), audit.WithHMAC(h))`. No aliases kept.
 - `New` signature changed from `New(Config, ...Option)` to `New(...Option)` — Config fields expressed as Options (#388)
 - `Config.Version` unexported, `Config.Enabled` removed — use `WithDisabled()` (#388)

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -114,7 +114,7 @@ Every issue follows this sequence. Do not skip steps.
 - [ ] **#581** refactor: unified OutputMetricsFactory pattern across file/syslog/webhook/loki.
 - [ ] **#582** refactor: align HMAC Go and YAML field names; unify _hmac_v / _hmacVersion.
 - [ ] **#583** refactor: rename syslog.app_name YAML to procid or syslog_app_name; default APP-NAME from top-level app_name.
-- [ ] **#584** refactor: align Loki gzip YAML key and Go Compress field.
+- [x] **#584** refactor: align Loki gzip YAML key and Go Compress field.
 - [ ] **#585** refactor: examples use outputs convenience package instead of individual blank imports.
 - [ ] **#586** refactor: replace Metrics.RecordEvent stringly-typed status with EventStatus enum.
 - [ ] **#587** perf: WrapOutput conditionally implements MetadataWriter based on inner capability.

--- a/loki/bench_test.go
+++ b/loki/bench_test.go
@@ -163,11 +163,11 @@ func BenchmarkLokiOutput_Gzip(b *testing.B) {
 	}
 
 	input := loki.TestPayloadInput{
-		Events:   events,
-		Compress: true,
-		AppName:  "bench-app",
-		Host:     "bench-host",
-		PID:      12345,
+		Events:  events,
+		Gzip:    true,
+		AppName: "bench-app",
+		Host:    "bench-host",
+		PID:     12345,
 	}
 
 	b.ReportAllocs()

--- a/loki/config.go
+++ b/loki/config.go
@@ -233,10 +233,12 @@ type Config struct { //nolint:govet // fieldalignment: readability preferred
 	// Zero defaults to [DefaultMaxRetries] (3).
 	MaxRetries int
 
-	// Compress enables gzip compression of push requests. The YAML
-	// factory defaults to true when the gzip key is omitted; the Go
-	// zero value is false for programmatic construction.
-	Compress bool
+	// Gzip enables gzip compression of push requests (the only
+	// compression algorithm Loki accepts). The YAML key is
+	// `gzip`. The YAML factory defaults to true when the key is
+	// omitted; the Go zero value is false for programmatic
+	// construction.
+	Gzip bool
 
 	// AllowInsecureHTTP permits http:// URLs. MUST NOT be true in
 	// production.
@@ -262,8 +264,8 @@ func (c Config) String() string {
 	} else if c.BearerToken != "" {
 		auth = "bearer_token"
 	}
-	return fmt.Sprintf("LokiConfig{url=%q, auth=%s, compress=%t, batch_size=%d}",
-		sanitizeURLForLog(c.URL), auth, c.Compress, c.BatchSize)
+	return fmt.Sprintf("LokiConfig{url=%q, auth=%s, gzip=%t, batch_size=%d}",
+		sanitizeURLForLog(c.URL), auth, c.Gzip, c.BatchSize)
 }
 
 // sanitizeURLForLog returns the scheme+host portion of a URL, dropping

--- a/loki/example_test.go
+++ b/loki/example_test.go
@@ -33,7 +33,7 @@ func ExampleNew() {
 		Timeout:            10 * time.Second,
 		MaxRetries:         3,
 		BufferSize:         10000,
-		Compress:           true,
+		Gzip:               true,
 		Labels: loki.LabelConfig{
 			Static: map[string]string{
 				"job":         "audit",

--- a/loki/export_test.go
+++ b/loki/export_test.go
@@ -57,7 +57,7 @@ type TestPayloadInput struct { //nolint:govet // fieldalignment: readability pre
 	AppName          string
 	Host             string
 	PID              int
-	Compress         bool
+	Gzip             bool
 	ExcludeEventType bool
 	ExcludeSeverity  bool
 }
@@ -73,7 +73,7 @@ func buildTestConfig(input TestPayloadInput) *Config { //nolint:gocritic // huge
 		Timeout:            5 * time.Second,
 		MaxRetries:         1,
 		BufferSize:         1000,
-		Compress:           input.Compress,
+		Gzip:               input.Gzip,
 	}
 	if input.StaticLabels != nil {
 		cfg.Labels.Static = input.StaticLabels

--- a/loki/http_test.go
+++ b/loki/http_test.go
@@ -310,7 +310,7 @@ func TestHTTP_ContentType_JSON(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	cfg := validConfigWithURL(srv.URL)
-	cfg.Compress = false
+	cfg.Gzip = false
 
 	out, err := loki.New(cfg, nil)
 	require.NoError(t, err)
@@ -333,7 +333,7 @@ func TestHTTP_ContentEncoding_Gzip(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	cfg := validConfigWithURL(srv.URL)
-	cfg.Compress = true
+	cfg.Gzip = true
 
 	out, err := loki.New(cfg, nil)
 	require.NoError(t, err)
@@ -355,7 +355,7 @@ func TestHTTP_CompressedBody_ValidJSON(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	cfg := validConfigWithURL(srv.URL)
-	cfg.Compress = true
+	cfg.Gzip = true
 
 	out, err := loki.New(cfg, nil)
 	require.NoError(t, err)

--- a/loki/loki_test.go
+++ b/loki/loki_test.go
@@ -60,7 +60,7 @@ func validConfigWithURL(url string) *loki.Config {
 		Timeout:            5 * time.Second,
 		MaxRetries:         1,
 		BufferSize:         1000,
-		Compress:           true,
+		Gzip:               true,
 	}
 }
 

--- a/loki/push.go
+++ b/loki/push.go
@@ -291,7 +291,7 @@ func (o *Output) writeLabelsJSON(buf *bytes.Buffer, labels map[string]string) {
 	}
 }
 
-// maybeCompress applies gzip compression if cfg.Compress is true.
+// maybeCompress applies gzip compression if cfg.Gzip is true.
 // Returns the payload bytes, whether they are compressed, and any
 // compression error. On error the caller should fall back to the
 // uncompressed payload in payloadBuf.
@@ -300,7 +300,7 @@ func (o *Output) writeLabelsJSON(buf *bytes.Buffer, labels map[string]string) {
 // (bytes.Buffer.Write always returns nil error). The error handling
 // is defensive — a safety net for correctness.
 func (o *Output) maybeCompress() (body []byte, compressed bool, err error) {
-	if !o.cfg.Compress {
+	if !o.cfg.Gzip {
 		return o.payloadBuf.Bytes(), false, nil
 	}
 	o.compressBuf.Reset()

--- a/loki/push_test.go
+++ b/loki/push_test.go
@@ -465,10 +465,10 @@ func TestCompressDecompress_RoundTrip(t *testing.T) {
 		Events: []loki.TestEvent{
 			{Data: []byte(`{"test":"roundtrip"}`), Meta: audit.EventMetadata{EventType: "test", Severity: 1, Timestamp: time.Now()}},
 		},
-		Compress: true,
-		AppName:  "app",
-		Host:     "h1",
-		PID:      1,
+		Gzip:    true,
+		AppName: "app",
+		Host:    "h1",
+		PID:     1,
 	})
 
 	// Decompress and verify valid JSON.
@@ -560,7 +560,7 @@ func TestMaybeCompress_GzipError_ReturnsError(t *testing.T) {
 		StaticLabels: map[string]string{"env": "test"},
 		AppName:      "test",
 		Host:         "localhost",
-		Compress:     true,
+		Gzip:         true,
 	}
 	o := loki.PreparePayloadForTest(t, input)
 	defer func() { _ = o.Close() }()

--- a/loki/register.go
+++ b/loki/register.go
@@ -56,7 +56,7 @@ type yamlLokiConfig struct { //nolint:govet // fieldalignment: readability prefe
 	BufferSize *int              `yaml:"buffer_size"`
 	Timeout    yamlDuration      `yaml:"timeout"`
 	MaxRetries *int              `yaml:"max_retries"`
-	Compress   *bool             `yaml:"gzip"` // YAML key is "gzip" for user clarity; maps to Compress
+	Gzip       *bool             `yaml:"gzip"`
 	AllowHTTP  bool              `yaml:"allow_insecure_http"`
 	AllowPriv  bool              `yaml:"allow_private_ranges"`
 }
@@ -155,10 +155,10 @@ func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics, logge
 	}
 
 	// Gzip: default true, explicit false overrides.
-	if yc.Compress != nil {
-		cfg.Compress = *yc.Compress
+	if yc.Gzip != nil {
+		cfg.Gzip = *yc.Gzip
 	} else {
-		cfg.Compress = true
+		cfg.Gzip = true
 	}
 
 	// Labels.

--- a/loki/register_test.go
+++ b/loki/register_test.go
@@ -177,7 +177,7 @@ bearer_token: tok-should-not-coexist
 
 // TestLokiFactory_GzipDefaultTrue verifies that omitting the "gzip" field
 // from the YAML config results in compression being enabled. This is the
-// documented default (Compress: true) and must be preserved by the factory.
+// documented default (Gzip: true) and must be preserved by the factory.
 // The config passes validation and reaches the "not yet implemented" gate.
 func TestLokiFactory_GzipDefaultTrue(t *testing.T) {
 	t.Parallel()

--- a/loki/tests/integration/loki_test.go
+++ b/loki/tests/integration/loki_test.go
@@ -83,7 +83,7 @@ func newLokiOutput(t *testing.T, opts ...func(*loki.Config)) *loki.Output {
 		Timeout:            10 * time.Second,
 		MaxRetries:         3,
 		BufferSize:         1000,
-		Compress:           true,
+		Gzip:               true,
 		TenantID:           testTenant,
 	}
 	for _, opt := range opts {
@@ -494,7 +494,7 @@ func TestLoki_GzipCompression(t *testing.T) {
 	// Gzip enabled (default in newLokiOutput).
 	out := newLokiOutput(t, func(c *loki.Config) {
 		c.Labels.Static = map[string]string{"job": "gzip_test"}
-		c.Compress = true
+		c.Gzip = true
 	})
 	out.SetFrameworkFields("gzapp", "gz-host", "UTC", 1)
 
@@ -517,7 +517,7 @@ func TestLoki_GzipCompression(t *testing.T) {
 func TestLoki_UncompressedDelivery(t *testing.T) {
 	out := newLokiOutput(t, func(c *loki.Config) {
 		c.Labels.Static = map[string]string{"job": "nogzip_test"}
-		c.Compress = false
+		c.Gzip = false
 	})
 	out.SetFrameworkFields("noapp", "no-host", "UTC", 1)
 

--- a/tests/bdd/steps/event_metrics_steps.go
+++ b/tests/bdd/steps/event_metrics_steps.go
@@ -252,7 +252,7 @@ func registerEventMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 			AllowPrivateRanges: true,
 			BatchSize:          1,
 			FlushInterval:      200 * time.Millisecond,
-			Compress:           true,
+			Gzip:               true,
 			BufferSize:         bufSize,
 		}, nil)
 		if err != nil {

--- a/tests/bdd/steps/loki_fanout_steps.go
+++ b/tests/bdd/steps/loki_fanout_steps.go
@@ -324,7 +324,7 @@ func createFileAndLokiAuditorUnreachable(tc *AuditTestContext) error {
 		Timeout:            1e9, // 1 second timeout
 		MaxRetries:         1,
 		BufferSize:         100,
-		Compress:           false,
+		Gzip:               false,
 	}
 
 	lokiOut, err := loki.New(lokiCfg, nil)

--- a/tests/bdd/steps/loki_hmac_steps.go
+++ b/tests/bdd/steps/loki_hmac_steps.go
@@ -374,7 +374,7 @@ func defaultLokiTestConfig(tc *AuditTestContext) *loki.Config {
 		Timeout:            5e9,
 		MaxRetries:         1,
 		BufferSize:         1000,
-		Compress:           true,
+		Gzip:               true,
 		Labels: loki.LabelConfig{
 			Static: map[string]string{"test_suite": "bdd"},
 		},

--- a/tests/bdd/steps/loki_receiver_steps.go
+++ b/tests/bdd/steps/loki_receiver_steps.go
@@ -165,7 +165,7 @@ func registerLokiReceiverSetupSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			BatchSize:  1,
 			MaxRetries: 1,
-			Compress:   true,
+			Gzip:       true,
 		})
 	})
 
@@ -216,7 +216,7 @@ func registerLokiReceiverLoggerRetrySteps(ctx *godog.ScenarioContext, tc *AuditT
 		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			MaxRetries: retries,
 			BatchSize:  1,
-			Compress:   true,
+			Gzip:       true,
 		})
 	})
 
@@ -228,7 +228,7 @@ func registerLokiReceiverLoggerRetrySteps(ctx *godog.ScenarioContext, tc *AuditT
 		cfg := &loki.Config{
 			MaxRetries: retries,
 			BatchSize:  1,
-			Compress:   true,
+			Gzip:       true,
 		}
 		cfg.URL = r.server.URL + "/loki/api/v1/push"
 		cfg.AllowInsecureHTTP = true
@@ -265,7 +265,7 @@ func registerLokiReceiverLoggerRetrySteps(ctx *godog.ScenarioContext, tc *AuditT
 			AllowPrivateRanges: true,
 			BatchSize:          1,
 			MaxRetries:         1,
-			Compress:           true,
+			Gzip:               true,
 		}
 		return createLokiAuditorFromConfig(tc, cfg)
 	})
@@ -286,7 +286,7 @@ func registerLokiReceiverLoggerSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTe
 			FlushInterval:      200 * time.Millisecond,
 			Timeout:            5 * time.Second,
 			BufferSize:         100,
-			Compress:           true,
+			Gzip:               true,
 		}
 		return createLokiAuditorFromConfig(tc, cfg)
 	})
@@ -298,7 +298,7 @@ func registerLokiReceiverLoggerSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTe
 		}
 		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			BatchSize: 1,
-			Compress:  true,
+			Gzip:      true,
 		})
 	})
 
@@ -309,7 +309,7 @@ func registerLokiReceiverLoggerSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTe
 		}
 		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			BatchSize: 1,
-			Compress:  true,
+			Gzip:      true,
 		})
 	})
 
@@ -321,7 +321,7 @@ func registerLokiReceiverLoggerSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTe
 		return createLokiAuditorWithReceiver(tc, r, &loki.Config{
 			BatchSize:  1,
 			MaxRetries: 1,
-			Compress:   true,
+			Gzip:       true,
 		})
 	})
 }

--- a/tests/bdd/steps/loki_steps.go
+++ b/tests/bdd/steps/loki_steps.go
@@ -55,22 +55,22 @@ func registerLokiGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 func registerLokiGivenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 	ctx.Step(`^an auditor with loki output$`, func() error {
-		return createLokiAuditor(tc, &loki.Config{Compress: true})
+		return createLokiAuditor(tc, &loki.Config{Gzip: true})
 	})
 
 	ctx.Step(`^an auditor with loki output to tenant "([^"]*)"$`, func(tenant string) error {
-		return createLokiAuditor(tc, &loki.Config{TenantID: tenant, Compress: true})
+		return createLokiAuditor(tc, &loki.Config{TenantID: tenant, Gzip: true})
 	})
 
 	ctx.Step(`^an auditor with loki output with static label "([^"]*)" = "([^"]*)"$`, func(name, value string) error {
 		return createLokiAuditor(tc, &loki.Config{
-			Compress: true,
-			Labels:   loki.LabelConfig{Static: map[string]string{name: value}},
+			Gzip:   true,
+			Labels: loki.LabelConfig{Static: map[string]string{name: value}},
 		})
 	})
 
 	ctx.Step(`^an auditor with loki output with batch size (\d+)$`, func(size int) error {
-		return createLokiAuditor(tc, &loki.Config{BatchSize: size, Compress: true})
+		return createLokiAuditor(tc, &loki.Config{BatchSize: size, Gzip: true})
 	})
 
 	// Max event size (#688).
@@ -80,7 +80,7 @@ func registerLokiGivenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditTes
 				BatchSize:     1,
 				FlushInterval: 100 * time.Millisecond,
 				MaxEventBytes: maxEventBytes,
-				Compress:      true,
+				Gzip:          true,
 			})
 		})
 
@@ -88,7 +88,7 @@ func registerLokiGivenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditTes
 		return createLokiAuditor(tc, &loki.Config{
 			BatchSize:     size,
 			FlushInterval: time.Duration(ms) * time.Millisecond,
-			Compress:      true,
+			Gzip:          true,
 		})
 	})
 
@@ -96,12 +96,12 @@ func registerLokiGivenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditTes
 		return createLokiAuditor(tc, &loki.Config{
 			BatchSize:     size,
 			FlushInterval: time.Duration(s) * time.Second,
-			Compress:      true,
+			Gzip:          true,
 		})
 	})
 
 	ctx.Step(`^an auditor with loki output excluding dynamic label "([^"]*)"$`, func(label string) error {
-		cfg := &loki.Config{Compress: true}
+		cfg := &loki.Config{Gzip: true}
 		switch label {
 		case "severity":
 			cfg.Labels.Dynamic.ExcludeSeverity = true
@@ -122,12 +122,12 @@ func registerLokiGivenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditTes
 	})
 
 	ctx.Step(`^an auditor with loki output with gzip enabled$`, func() error {
-		return createLokiAuditor(tc, &loki.Config{Compress: true})
+		return createLokiAuditor(tc, &loki.Config{Gzip: true})
 	})
 
 	ctx.Step(`^an auditor with loki output with gzip disabled$`, func() error {
 		cfg := &loki.Config{}
-		cfg.Compress = false
+		cfg.Gzip = false
 		return createLokiAuditor(tc, cfg)
 	})
 }
@@ -476,7 +476,7 @@ func applyLokiTestDefaults(tc *AuditTestContext, cfg *loki.Config) {
 	if cfg.TenantID == "" {
 		cfg.TenantID = defaultLokiTenant
 	}
-	// Do NOT set cfg.Compress here — let each step control it.
+	// Do NOT set cfg.Gzip here — let each step control it.
 	// The default zero value (false) is overridden by individual steps.
 
 	if cfg.Labels.Static == nil {


### PR DESCRIPTION
## Summary

Closes #584. Pre-v1.0 API naming lock-in — the Loki YAML key `gzip` diverged from the Go field `Compress`.

**Decision** (api-ergonomics consult): rename Go field `Compress` → `Gzip`, keep YAML key `gzip` unchanged.

**Why**:
- Loki's server only accepts gzip (`Content-Encoding: gzip`); the bool is algorithm-specific, not a generic toggle.
- Matches the promtail / grafana-agent / loki-client-go idiom (algorithm naming).
- Future-proof: adding a zstd toggle later becomes a sibling `Zstd bool` / `zstd: true` — no rename needed.

**Consumer impact**:
- **YAML users**: zero change. YAML key was and remains `gzip`.
- **Programmatic Go users**: mechanical field rename `loki.Config{Compress: true}` → `loki.Config{Gzip: true}`. No aliases kept.

## Out of scope

`file.Config.Compress` — separate module, separate field. Not part of this issue. Untouched.

## Test plan

- [x] `go test -race -count=1 ./...` (all pass)
- [x] `make lint` (0 issues)
- [x] `make test-bdd-loki` (all scenarios pass)
- [x] `make check` (full gate: fmt + vet + lint + test + build + tidy + verify + security + release-check)

## Agent reviews

- **api-ergonomics-reviewer** pre-coding: approved rename direction + cited comparable library evidence
- **code-reviewer**: 0 blocking, 0 important, 0 nits
- **go-quality**: READY TO COMMIT
- **commit-message-reviewer**: PASS

## Verification

```
make check   # All checks passed.
```