### PR TITLE
test(audittest): add WaitForN + WithExcludeLabels (#566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `audittest.Recorder.WaitForN(tb, n, timeout)` — blocks until at least `n` events have been recorded or the timeout elapses; returns `true` on success, `false` on timeout. Use in async-mode tests (`audittest.WithAsync`) or tests whose service emits from a goroutine. Poll interval is 10 ms, matching `testify/assert.Eventually`. The fast path returns immediately when the target is already reached. Synchronous auditors (the default for `New` / `NewQuick`) do not need `WaitForN` — events are recorded before `AuditEvent` returns; prefer `Count()` / `RequireEvents` there. Closes #566.
+- `audittest.WithExcludeLabels(outputName, labels...)` — applies sensitivity-label exclusion to the test recorder, mirroring `audit.WithExcludeLabels` on a named output. Lets consumer tests assert that a compliance output does NOT receive `pii`- or `financial`-labelled fields. `outputName` MUST match the recorder's name (`"recorder"` by default, or whatever was passed to `NewNamedRecorder`) — a mismatch calls `tb.Fatalf` at construction. Multiple calls accumulate labels. Internally, `audittest.New` / `audittest.NewQuick` switch from `audit.WithOutputs(rec)` to `audit.WithNamedOutput(rec, audit.WithExcludeLabels(...))` when any `audittest.WithExcludeLabels` option is present; this is observable only when the option is used. Closes #566.
+
+> **Deviations from #566 AC (accepted):** (1) `audittest.PermissiveTaxonomy()` NOT added — `audittest.QuickTaxonomy()` already exists and fills the same role; adding a second name violates the "one obvious way" principle. (2) `WithExcludedLabels` renamed to `WithExcludeLabels` to match core `audit.WithExcludeLabels` exactly (no "d"). (3) AC named `RecordedEvents.WaitForN` (a type name from the original issue draft that was never implemented in the codebase) — the actual type is `*audittest.Recorder`, so `WaitForN` is a method on `*Recorder`. All three deviations confirmed with api-ergonomics-reviewer.
+
 ### Breaking Changes
 
 - `audit.RegisterOutputFactory` now returns `error` instead of panicking on empty type name or nil factory (#590). The error wraps `audit.ErrValidation`. New companion `audit.MustRegisterOutputFactory(typeName, factory)` preserves the panic-on-programmer-error contract for init-time callers — mirrors `regexp.MustCompile`. All five built-in registrations (file / loki / stdout / syslog / webhook) migrated to `MustRegisterOutputFactory`. Custom factory authors who register via init() should migrate to `MustRegisterOutputFactory`; consumers who register dynamically should handle the returned error.

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -209,7 +209,7 @@ Every issue follows this sequence. Do not skip steps.
 - [ ] **#563** test: add BDD scenarios for secrets providers — TLS, partition, malformed JSON, injection safety.
 - [ ] **#564** test: BDD coverage for async delivery edge cases (panic, slow output, buffer:0, invariant).
 - [ ] **#565** test: add concrete unit tests per test-writer recommendations (Auditor, formatters, outputs, HMAC, secrets, outputconfig, audit-gen, routing, async).
-- [ ] **#566** test: expand audittest with WaitForN, PermissiveTaxonomy, WithExcludedLabels helper.
+- [x] **#566** test: expand audittest with WaitForN, PermissiveTaxonomy, WithExcludedLabels helper.
 - [ ] **#567** fix: MockOutput.WriteCh uses appropriate channel capacity to avoid signal drops.
 - [ ] **#568** test: expose GenerateTestCA and consolidate cert-generation helpers.
 - [ ] **#569** test: Docker Compose healthchecks use wait.ForLog / wait.ForFile instead of TCP port only.

--- a/audittest/audittest.go
+++ b/audittest/audittest.go
@@ -26,9 +26,18 @@ import (
 type Option func(*config)
 
 type config struct {
-	extraOpts []audit.Option
-	async     bool // opt out of default synchronous delivery
-	verbose   bool // re-enable diagnostic logs (silenced by default)
+	extraOpts     []audit.Option
+	excludeLabels []excludeLabelsEntry
+	async         bool // opt out of default synchronous delivery
+	verbose       bool // re-enable diagnostic logs (silenced by default)
+}
+
+// excludeLabelsEntry records a single [WithExcludeLabels] call so the
+// labels can be applied to the recorder via [audit.WithNamedOutput]
+// inside [newTestLogger].
+type excludeLabelsEntry struct {
+	outputName string
+	labels     []string
 }
 
 // WithConfig applies a [audit.Config] struct to the test auditor.
@@ -81,6 +90,38 @@ func WithAuditOption(opt audit.Option) Option {
 // debugging auditor behaviour in tests.
 func WithVerbose() Option {
 	return func(c *config) { c.verbose = true }
+}
+
+// WithExcludeLabels applies sensitivity-label exclusion to the test
+// [Recorder], mirroring [audit.WithExcludeLabels] on a named output.
+// Fields whose taxonomy labels match any of the given labels are
+// stripped before delivery to the recorder.
+//
+// Use this to unit-test compliance workflows — e.g., verify that a
+// "pii"-labelled field does not appear in an output configured for
+// an external analytics pipeline. The taxonomy passed to [New] MUST
+// define a sensitivity section covering every label, else [audit.New]
+// returns an error and the test fails at construction.
+//
+// outputName MUST match the recorder's name — "recorder" by default,
+// or whatever was passed to [NewNamedRecorder]. The parameter is
+// explicit for symmetry with [audit.WithNamedOutput] and to leave
+// room for future multi-output audittest expansion. A mismatch causes
+// [New] / [NewQuick] to call tb.Fatalf.
+//
+// Multiple calls accumulate: WithExcludeLabels("recorder", "pii"),
+// WithExcludeLabels("recorder", "financial") strips both. Passing no
+// labels (WithExcludeLabels("recorder")) is a no-op at the strip
+// level — it still engages the named-output plumbing branch but
+// no fields are stripped. Framework fields are never stripped, per
+// [audit.WithExcludeLabels].
+func WithExcludeLabels(outputName string, labels ...string) Option {
+	return func(c *config) {
+		c.excludeLabels = append(c.excludeLabels, excludeLabelsEntry{
+			outputName: outputName,
+			labels:     labels,
+		})
+	}
 }
 
 // New creates a test auditor with an in-memory [Recorder]
@@ -146,8 +187,31 @@ func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.A
 	auditOpts := []audit.Option{
 		audit.WithQueueSize(100), // small buffer — recorder has no I/O cost
 		audit.WithTaxonomy(tax),
-		audit.WithOutputs(rec),
 		audit.WithMetrics(met),
+	}
+
+	// Wire the recorder. When any per-output option is present (e.g.
+	// WithExcludeLabels), we must use audit.WithNamedOutput — the two
+	// ways of registering outputs are mutually exclusive. Otherwise,
+	// audit.WithOutputs stays the path to preserve observable parity
+	// with callers that never touch per-output options.
+	if len(c.excludeLabels) > 0 {
+		var labels []string
+		for _, el := range c.excludeLabels {
+			if el.outputName != rec.Name() {
+				// Fatalf on a real *testing.T performs runtime.Goexit so
+				// execution halts here; tb implementations that do not
+				// Goexit will fall through. Return explicitly to avoid
+				// partial registration under those TBs.
+				tb.Fatalf("audittest: WithExcludeLabels targets output %q but the test recorder is named %q",
+					el.outputName, rec.Name())
+				return nil, rec, met
+			}
+			labels = append(labels, el.labels...)
+		}
+		auditOpts = append(auditOpts, audit.WithNamedOutput(rec, audit.WithExcludeLabels(labels...)))
+	} else {
+		auditOpts = append(auditOpts, audit.WithOutputs(rec))
 	}
 	if !c.verbose {
 		auditOpts = append(auditOpts, audit.WithDiagnosticLogger(
@@ -161,7 +225,11 @@ func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.A
 
 	auditor, err := audit.New(auditOpts...)
 	if err != nil {
+		// See the WithExcludeLabels Fatalf above — return explicitly so
+		// non-Goexit TBs do not proceed to register Cleanup against a
+		// nil auditor.
 		tb.Fatalf("audittest: create auditor: %v", err)
+		return nil, rec, met
 	}
 
 	tb.Cleanup(func() { _ = auditor.Close() })

--- a/audittest/audittest_test.go
+++ b/audittest/audittest_test.go
@@ -15,6 +15,7 @@
 package audittest_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -199,4 +200,216 @@ func TestNew_WithAuditOption(t *testing.T) {
 	evt := events.Events()[0]
 	assert.Equal(t, "user_create", evt.EventType)
 	assert.Equal(t, "test-app", evt.StringField("app_name"))
+}
+
+// ---------------------------------------------------------------------------
+// WithExcludeLabels (#566)
+// ---------------------------------------------------------------------------
+
+// sensitivityTaxonomyYAML defines a taxonomy with two sensitivity
+// labels ("pii", "financial") for WithExcludeLabels tests.
+var sensitivityTaxonomyYAML = []byte(`
+version: 1
+sensitivity:
+  labels:
+    pii:
+      fields: [email, phone]
+    financial:
+      fields: [credit_card, bank_account]
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    fields:
+      outcome: {required: true}
+      actor_id: {required: true}
+      email: {}
+      phone: {}
+      credit_card: {}
+      bank_account: {}
+      locale: {}
+`)
+
+func TestWithExcludeLabels_StripsLabelledFields(t *testing.T) {
+	t.Parallel()
+	auditor, events, _ := audittest.New(t, sensitivityTaxonomyYAML,
+		audittest.WithExcludeLabels("recorder", "pii"),
+	)
+
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":     "success",
+		"actor_id":    "alice",
+		"email":       "alice@example.com",
+		"phone":       "555-1234",
+		"credit_card": "4111-1111-1111-1111",
+		"locale":      "en-GB",
+	})))
+
+	require.Equal(t, 1, events.Count())
+	evt := events.Events()[0]
+
+	// pii-labelled fields stripped.
+	assert.Nil(t, evt.Field("email"), "email (pii) must be stripped")
+	assert.Nil(t, evt.Field("phone"), "phone (pii) must be stripped")
+	// Non-pii fields preserved.
+	assert.Equal(t, "alice", evt.StringField("actor_id"))
+	assert.Equal(t, "success", evt.StringField("outcome"))
+	assert.Equal(t, "4111-1111-1111-1111", evt.StringField("credit_card"),
+		"financial fields must survive when only pii is excluded")
+	assert.Equal(t, "en-GB", evt.StringField("locale"))
+}
+
+func TestWithExcludeLabels_PreservesOtherFields(t *testing.T) {
+	t.Parallel()
+	auditor, events, _ := audittest.New(t, sensitivityTaxonomyYAML,
+		audittest.WithExcludeLabels("recorder", "pii"),
+	)
+
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "bob",
+		"locale":   "fr-FR",
+	})))
+
+	require.Equal(t, 1, events.Count())
+	evt := events.Events()[0]
+	// No pii fields present, so stripping is a no-op — all fields survive.
+	assert.Equal(t, "bob", evt.StringField("actor_id"))
+	assert.Equal(t, "success", evt.StringField("outcome"))
+	assert.Equal(t, "fr-FR", evt.StringField("locale"))
+	// Framework fields also survive (never stripped).
+	assert.NotEmpty(t, evt.StringField("event_category"))
+}
+
+func TestWithExcludeLabels_MultipleLabels(t *testing.T) {
+	t.Parallel()
+	auditor, events, _ := audittest.New(t, sensitivityTaxonomyYAML,
+		audittest.WithExcludeLabels("recorder", "pii", "financial"),
+	)
+
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":      "success",
+		"actor_id":     "carol",
+		"email":        "carol@example.com",
+		"credit_card":  "4111-1111-1111-1111",
+		"bank_account": "ACCT-42",
+		"locale":       "de-DE",
+	})))
+
+	require.Equal(t, 1, events.Count())
+	evt := events.Events()[0]
+	// All labelled fields stripped.
+	assert.Nil(t, evt.Field("email"), "pii")
+	assert.Nil(t, evt.Field("credit_card"), "financial")
+	assert.Nil(t, evt.Field("bank_account"), "financial")
+	// Non-labelled fields preserved.
+	assert.Equal(t, "carol", evt.StringField("actor_id"))
+	assert.Equal(t, "de-DE", evt.StringField("locale"))
+}
+
+func TestWithExcludeLabels_AccumulatesAcrossCalls(t *testing.T) {
+	t.Parallel()
+	// Two separate calls must accumulate label lists (not replace).
+	auditor, events, _ := audittest.New(t, sensitivityTaxonomyYAML,
+		audittest.WithExcludeLabels("recorder", "pii"),
+		audittest.WithExcludeLabels("recorder", "financial"),
+	)
+
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":     "success",
+		"actor_id":    "dave",
+		"email":       "dave@example.com",
+		"credit_card": "4111-1111-1111-1111",
+	})))
+
+	require.Equal(t, 1, events.Count())
+	evt := events.Events()[0]
+	assert.Nil(t, evt.Field("email"), "pii stripped by first call")
+	assert.Nil(t, evt.Field("credit_card"), "financial stripped by second call")
+}
+
+func TestWithExcludeLabels_EmptyVariadic(t *testing.T) {
+	t.Parallel()
+	// WithExcludeLabels("recorder") with zero labels engages the
+	// per-output-options plumbing branch (switch to WithNamedOutput)
+	// but the audit-level strip is a no-op. All fields should survive.
+	auditor, events, _ := audittest.New(t, sensitivityTaxonomyYAML,
+		audittest.WithExcludeLabels("recorder"),
+	)
+
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":     "success",
+		"actor_id":    "eve",
+		"email":       "eve@example.com",
+		"credit_card": "4111-1111-1111-1111",
+	})))
+
+	require.Equal(t, 1, events.Count())
+	evt := events.Events()[0]
+	// No labels supplied → no stripping.
+	assert.Equal(t, "eve@example.com", evt.StringField("email"))
+	assert.Equal(t, "4111-1111-1111-1111", evt.StringField("credit_card"))
+}
+
+func TestWithExcludeLabels_UnknownLabel(t *testing.T) {
+	t.Parallel()
+	// Unknown label — not defined in the taxonomy sensitivity section.
+	// audit.New returns an error; audittest surfaces it via tb.Fatalf.
+	// Use a captor *testing.T to verify the failure path without
+	// aborting the parent test.
+	captor := &fatalCaptor{}
+	func() {
+		defer captor.recoverFatal()
+		_, _, _ = audittest.New(captor, sensitivityTaxonomyYAML,
+			audittest.WithExcludeLabels("recorder", "not-a-label"),
+		)
+	}()
+	assert.True(t, captor.fatalCalled, "tb.Fatalf expected for unknown label")
+	assert.Contains(t, captor.fatalMsg, "not-a-label",
+		"fatal message should name the offending label")
+}
+
+func TestWithExcludeLabels_OutputNameMismatch(t *testing.T) {
+	t.Parallel()
+	// WithExcludeLabels("not-recorder", ...) targets an output that
+	// does not exist in the test logger — tb.Fatalf is expected.
+	captor := &fatalCaptor{}
+	func() {
+		defer captor.recoverFatal()
+		_, _, _ = audittest.New(captor, sensitivityTaxonomyYAML,
+			audittest.WithExcludeLabels("wrong-name", "pii"),
+		)
+	}()
+	assert.True(t, captor.fatalCalled, "tb.Fatalf expected for outputName mismatch")
+	assert.Contains(t, captor.fatalMsg, "wrong-name")
+	assert.Contains(t, captor.fatalMsg, "recorder")
+}
+
+// fatalCaptor is a testing.TB that turns Fatalf into a recorded
+// message + runtime.Goexit-equivalent. audittest.New calls tb.Fatalf
+// when audit.New returns an error; the caller must wrap the call in
+// a func/defer to scope the Goexit.
+type fatalCaptor struct {
+	testing.TB
+	fatalMsg    string
+	fatalCalled bool
+}
+
+func (f *fatalCaptor) Helper()        {}
+func (f *fatalCaptor) Cleanup(func()) {}
+func (f *fatalCaptor) Fatalf(format string, args ...any) {
+	f.fatalCalled = true
+	f.fatalMsg = fmt.Sprintf(format, args...)
+	panic(sentinelFatalPanic{})
+}
+
+type sentinelFatalPanic struct{}
+
+func (f *fatalCaptor) recoverFatal() {
+	if r := recover(); r != nil {
+		if _, ok := r.(sentinelFatalPanic); !ok {
+			panic(r)
+		}
+	}
 }

--- a/audittest/example_test.go
+++ b/audittest/example_test.go
@@ -17,6 +17,7 @@ package audittest_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/axonops/audit"
 	"github.com/axonops/audit/audittest"
@@ -85,4 +86,78 @@ func ExampleRecorder_FindByType() {
 	// Output:
 	// user_create count: 2
 	// auth_failure count: 1
+}
+
+// ExampleRecorder_WaitForN shows how to wait for asynchronously-
+// delivered events to land in the Recorder before asserting. Use
+// WaitForN with [WithAsync] or any auditor configured for async
+// delivery — synchronous auditors do not need it.
+func ExampleRecorder_WaitForN() {
+	t := &testing.T{}
+
+	auditor, events, _ := audittest.New(t, exampleTaxonomyYAML, audittest.WithAsync())
+	defer func() { _ = auditor.Close() }() // stub *testing.T has no Cleanup — close explicitly
+
+	// Emit events from a goroutine — simulates a service emitting
+	// audit events on a hot path.
+	go func() {
+		for i := 0; i < 3; i++ {
+			_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+				"outcome":  "success",
+				"actor_id": "alice",
+			}))
+		}
+	}()
+
+	if ok := events.WaitForN(t, 3, 2*time.Second); !ok {
+		fmt.Println("timeout waiting for 3 events")
+		return
+	}
+	fmt.Println("count:", events.Count())
+	// Output:
+	// count: 3
+}
+
+// exampleSensitivityTaxonomyYAML registers a "pii" sensitivity label
+// so ExampleWithExcludeLabels can exercise the strip path.
+var exampleSensitivityTaxonomyYAML = []byte(`
+version: 1
+sensitivity:
+  labels:
+    pii:
+      fields: [email]
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    fields:
+      outcome: {required: true}
+      actor_id: {required: true}
+      email: {}
+`)
+
+// ExampleWithExcludeLabels shows how to assert that a compliance
+// output does NOT receive pii-labelled fields. The recorder acts as
+// the compliance destination; labels defined in the taxonomy drive
+// the strip.
+func ExampleWithExcludeLabels() {
+	t := &testing.T{}
+
+	auditor, events, _ := audittest.New(t, exampleSensitivityTaxonomyYAML,
+		audittest.WithExcludeLabels("recorder", "pii"),
+	)
+
+	_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+		"email":    "alice@example.com",
+	}))
+
+	evt := events.Events()[0]
+	fmt.Println("actor_id:", evt.StringField("actor_id"))
+	fmt.Println("email present:", evt.Field("email") != nil)
+	// Output:
+	// actor_id: alice
+	// email present: false
 }

--- a/audittest/recorder.go
+++ b/audittest/recorder.go
@@ -205,6 +205,45 @@ func (r *Recorder) Count() int {
 	return len(r.events)
 }
 
+// WaitForN blocks until at least n events have been recorded or
+// timeout elapses. It returns true if the target was reached, false
+// on timeout.
+//
+// Use WaitForN in tests built with [WithAsync]: events are delivered
+// by a background goroutine, so assertions made immediately after
+// [audit.Auditor.AuditEvent] may race the drain. WaitForN provides a
+// deterministic wait-until-ready barrier without [time.Sleep].
+//
+// For synchronous auditors (the default for [New] and [NewQuick]),
+// events are available immediately after AuditEvent returns — prefer
+// [Recorder.Count] / [Recorder.RequireEvents] there. If the target is
+// already reached at call time, WaitForN returns true without sleeping.
+//
+// The poll interval is 10 ms and is not configurable — pass a larger
+// timeout to tolerate slower CI environments. Pass tb so that
+// subsequent caller-side assertions on the returned bool attribute
+// failure lines to the calling test.
+func (r *Recorder) WaitForN(tb testing.TB, n int, timeout time.Duration) bool {
+	tb.Helper()
+	if r.Count() >= n {
+		return true
+	}
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			return r.Count() >= n
+		case <-tick.C:
+			if r.Count() >= n {
+				return true
+			}
+		}
+	}
+}
+
 // Last returns the most recently recorded event, or false if the
 // Recorder is empty.
 func (r *Recorder) Last() (RecordedEvent, bool) {

--- a/audittest/recorder_test.go
+++ b/audittest/recorder_test.go
@@ -17,6 +17,7 @@ package audittest_test
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -367,4 +368,97 @@ func TestRecorder_NewNamedRecorder(t *testing.T) {
 	t.Parallel()
 	rec := audittest.NewNamedRecorder("custom-output")
 	assert.Equal(t, "custom-output", rec.Name())
+}
+
+// ---------------------------------------------------------------------------
+// WaitForN (#566)
+// ---------------------------------------------------------------------------
+
+func TestRecorder_WaitForN_ReachesTarget(t *testing.T) {
+	t.Parallel()
+	auditor, rec, _ := audittest.NewQuick(t, "user_create")
+
+	// Emit 3 events. Synchronous delivery guarantees they are recorded
+	// before AuditEvent returns, but WaitForN must still see them.
+	for i := 0; i < 3; i++ {
+		require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"n": i})))
+	}
+
+	assert.True(t, rec.WaitForN(t, 3, 100*time.Millisecond),
+		"3 events already recorded — WaitForN should return true immediately")
+	assert.Equal(t, 3, rec.Count())
+}
+
+func TestRecorder_WaitForN_Timeout(t *testing.T) {
+	t.Parallel()
+	_, rec, _ := audittest.NewQuick(t, "user_create")
+
+	start := time.Now()
+	ok := rec.WaitForN(t, 5, 50*time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.False(t, ok, "no events emitted — WaitForN should return false on timeout")
+	assert.Equal(t, 0, rec.Count())
+	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond, "WaitForN must respect the timeout")
+	assert.Less(t, elapsed, 500*time.Millisecond, "WaitForN must return near the timeout boundary")
+}
+
+func TestRecorder_WaitForN_AlreadyReached(t *testing.T) {
+	t.Parallel()
+	auditor, rec, _ := audittest.NewQuick(t, "user_create")
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"n": 1})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"n": 2})))
+
+	start := time.Now()
+	ok := rec.WaitForN(t, 2, time.Minute)
+	elapsed := time.Since(start)
+
+	assert.True(t, ok, "target already reached — returns true without sleeping")
+	// The fast path must not wait for a tick — be permissive under race mode.
+	assert.Less(t, elapsed, 10*time.Millisecond, "fast path should not sleep on a tick")
+}
+
+func TestRecorder_WaitForN_ZeroTimeout(t *testing.T) {
+	t.Parallel()
+	auditor, rec, _ := audittest.NewQuick(t, "user_create")
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"n": 1})))
+
+	// Zero-timeout + target reached → fast path returns true.
+	assert.True(t, rec.WaitForN(t, 1, 0))
+	// Zero-timeout + target unreachable (count=1, n=5) → falls through
+	// to the select loop with an immediately-firing timer → false.
+	assert.False(t, rec.WaitForN(t, 5, 0))
+}
+
+func TestRecorder_WaitForN_ZeroTimeoutEmpty(t *testing.T) {
+	t.Parallel()
+	// Count=0 + zero timeout + n>0 → miss path, no fast-path shortcut.
+	_, rec, _ := audittest.NewQuick(t, "user_create")
+	start := time.Now()
+	ok := rec.WaitForN(t, 1, 0)
+	elapsed := time.Since(start)
+	assert.False(t, ok, "empty recorder with zero timeout returns false")
+	assert.Less(t, elapsed, 10*time.Millisecond, "zero-timeout miss must not spin")
+}
+
+func TestRecorder_WaitForN_AsyncConcurrentEmit(t *testing.T) {
+	t.Parallel()
+	auditor, rec, _ := audittest.New(t, testTaxonomyYAML, audittest.WithAsync())
+
+	// Emit from a goroutine AFTER several tick intervals have elapsed —
+	// forces WaitForN through the tick-retry path rather than hitting
+	// the first tick with events already recorded.
+	go func() {
+		time.Sleep(50 * time.Millisecond) // ~5× tick interval
+		for i := 0; i < 5; i++ {
+			_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+				"outcome":  "success",
+				"actor_id": "alice",
+			}))
+		}
+	}()
+
+	assert.True(t, rec.WaitForN(t, 5, 2*time.Second),
+		"async emission of 5 events should complete within 2 seconds")
+	assert.GreaterOrEqual(t, rec.Count(), 5)
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,6 +9,8 @@
 - [Two Constructor Patterns](#two-constructor-patterns)
 - [Recorded Event API](#recorded-event-api)
 - [Assertion Helpers](#assertion-helpers)
+- [Waiting for Async Events](#waiting-for-async-events)
+- [Testing Sensitivity Stripping](#testing-sensitivity-stripping)
 - [Metrics Assertions](#metrics-assertions)
 - [OutputMetricsRecorder](#outputmetricsrecorder)
 - [Table-Driven Tests](#table-driven-tests)
@@ -188,6 +190,119 @@ events.AssertContains(t, "user_create", audit.Fields{
 | `events.Count()` | `int` | Total recorded events |
 | `events.Reset()` | — | Clear all events |
 
+## Waiting for Async Events
+
+Synchronous delivery (the default for `New` and `NewQuick`) removes
+timing concerns from most tests. When you need to exercise async-only
+behaviour — drain timeout, buffer backpressure, or a hot path that
+itself emits from a goroutine — use `Recorder.WaitForN` to block
+until events land in the recorder without resorting to `time.Sleep`:
+
+```go
+func TestAsyncHotPath(t *testing.T) {
+    auditor, events, _ := audittest.New(t, taxonomyYAML, audittest.WithAsync())
+
+    // Your service emits from a goroutine. Inlined here for clarity.
+    go func() {
+        for i := 0; i < 5; i++ {
+            _ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+                "outcome":  "success",
+                "actor_id": "alice",
+            }))
+        }
+    }()
+
+    // Block until 5 events have been recorded, or fail at 2 seconds.
+    if !events.WaitForN(t, 5, 2*time.Second) {
+        t.Fatalf("expected 5 events, got %d", events.Count())
+    }
+    // Safe to assert now — the drain has delivered the target count.
+    assert.Equal(t, 5, events.Count())
+}
+```
+
+`WaitForN` returns `true` once `Recorder.Count() >= n`, or `false` on
+timeout. The poll interval is 10ms, matching
+`testify/assert.Eventually`. If the target is already reached when
+`WaitForN` is called, it returns immediately without sleeping — so
+it is cheap to sprinkle through tests as a "wait-until-ready"
+barrier.
+
+> **Synchronous auditors do not need WaitForN.** Events are in the
+> recorder before `AuditEvent` returns. Prefer `Count()` /
+> `RequireEvents` there.
+
+## Testing Sensitivity Stripping
+
+Use `audittest.WithExcludeLabels` to verify your application's
+compliance wiring — that fields you tagged `pii` (or `financial`,
+etc.) in the taxonomy never reach an output you configured to exclude
+that label. You are testing **your** integration, not the library's
+strip logic.
+
+When your application tags fields with sensitivity labels and routes
+some outputs with `audit.WithExcludeLabels`,
+`audittest.WithExcludeLabels` lets you assert the stripping behaviour
+directly against the recorder:
+
+```go
+var taxonomyYAML = []byte(`
+version: 1
+sensitivity:
+  labels:
+    pii:
+      fields: [email, phone]
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    fields:
+      outcome: {required: true}
+      actor_id: {required: true}
+      email: {}
+`)
+
+func TestComplianceOutput_StripsPII(t *testing.T) {
+    auditor, events, _ := audittest.New(t, taxonomyYAML,
+        audittest.WithExcludeLabels("recorder", "pii"),
+    )
+
+    _ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+        "outcome":  "success",
+        "actor_id": "alice",
+        "email":    "alice@example.com",
+    }))
+
+    evt := events.Events()[0]
+    assert.Nil(t, evt.Field("email"), "pii-labelled field must be stripped")
+    assert.Equal(t, "alice", evt.StringField("actor_id"), "non-pii preserved")
+}
+```
+
+Multiple calls accumulate:
+
+```go
+audittest.New(t, taxonomyYAML,
+    audittest.WithExcludeLabels("recorder", "pii"),
+    audittest.WithExcludeLabels("recorder", "financial"),
+)
+```
+
+The first argument — `"recorder"` — is the name of the output to
+apply the exclusion to. `audittest.New` and `audittest.NewQuick`
+create a single recorder with the default name `"recorder"`; pass
+that name, or whatever was supplied to [`NewNamedRecorder`][nnr]. A
+mismatch causes `tb.Fatalf` at construction time (for both `New` and
+`NewQuick`) so typos surface immediately.
+
+[nnr]: https://pkg.go.dev/github.com/axonops/audit/audittest#NewNamedRecorder
+
+> **Taxonomy validation still applies.** Every label listed in
+> `WithExcludeLabels` MUST be defined in the taxonomy's
+> `sensitivity:` section; otherwise `audit.New` returns an error
+> and the test fails.
+
 ## Metrics Assertions
 
 The `MetricsRecorder` captures all metric calls:
@@ -255,6 +370,21 @@ do NOT need to call `auditor.Close()` before assertions. The
 cleanup automatically.
 
 Only call `Close()` before assertions when using `WithAsync()`.
+
+### WaitForN always times out
+
+If `WaitForN` never returns `true`, the three likely causes — in
+descending order of frequency:
+
+1. **Forgot `WithAsync()`.** The default is synchronous delivery; events
+   are recorded before `AuditEvent` returns, so `WaitForN` is
+   unnecessary and a bug-hunting test may never reach the target if
+   your code path never emits.
+2. **Target count exceeds buffer.** With `WithAsync()` and a small
+   queue, events may be dropped via `ErrQueueFull` before the drain
+   runs. Check metrics for drops.
+3. **Emitting goroutine panics before emitting `n` events.** Add an
+   error check to the emitter and log the panic.
 
 ### CEF formatter limitation
 

--- a/tests/bdd/features/audittest_helpers.feature
+++ b/tests/bdd/features/audittest_helpers.feature
@@ -1,0 +1,112 @@
+@core @audittest
+Feature: audittest Consumer Test Helpers
+  As a library consumer writing tests for my application, I want helpers
+  that let me wait for asynchronously-delivered events and verify that
+  sensitivity labels strip fields correctly — so that I can assert on
+  audit behaviour without hand-rolling drain synchronisation or raw
+  taxonomy scaffolding.
+
+  These helpers live in the `audittest` package and delegate to the
+  same validation and pipeline as production. Tests below use only the
+  public API surface a consumer would touch.
+
+  # ---------------------------------------------------------------------------
+  # WaitForN — async-mode wait-until-ready barrier
+  # ---------------------------------------------------------------------------
+
+  Scenario: WaitForN returns true when the target is reached asynchronously
+    Given an audittest auditor in async mode with taxonomy:
+      """
+      version: 1
+      categories:
+        write:
+          - user_create
+      events:
+        user_create:
+          fields:
+            outcome: {required: true}
+            actor_id: {required: true}
+      """
+    When 3 "user_create" events are emitted from a background goroutine
+    Then Recorder.WaitForN 3 within "2s" should return true
+    And the recorder should contain at least 3 events
+
+  Scenario: WaitForN returns false on timeout when no events arrive
+    Given an audittest auditor in async mode with taxonomy:
+      """
+      version: 1
+      categories:
+        write:
+          - user_create
+      events:
+        user_create:
+          fields:
+            outcome: {required: true}
+            actor_id: {required: true}
+      """
+    When no events are emitted
+    Then Recorder.WaitForN 1 within "50ms" should return false
+    And the recorder should contain 0 events
+
+  # ---------------------------------------------------------------------------
+  # WithExcludeLabels — sensitivity-stripping compliance workflow
+  # ---------------------------------------------------------------------------
+
+  Scenario: WithExcludeLabels strips pii-labelled fields from the recorder
+    Given an audittest auditor with WithExcludeLabels "pii" and taxonomy:
+      """
+      version: 1
+      sensitivity:
+        labels:
+          pii:
+            fields: [email]
+      categories:
+        write:
+          - user_create
+      events:
+        user_create:
+          fields:
+            outcome: {required: true}
+            actor_id: {required: true}
+            email: {}
+      """
+    When an event "user_create" is emitted with fields:
+      | field    | value             |
+      | outcome  | success           |
+      | actor_id | alice             |
+      | email    | alice@example.com |
+    Then the recorded event should have field "actor_id" equal to "alice"
+    And the recorded event should not have field "email"
+
+  Scenario: WithExcludeLabels with multiple labels strips every listed label
+    Given an audittest auditor with WithExcludeLabels "pii,financial" and taxonomy:
+      """
+      version: 1
+      sensitivity:
+        labels:
+          pii:
+            fields: [email]
+          financial:
+            fields: [credit_card]
+      categories:
+        write:
+          - user_create
+      events:
+        user_create:
+          fields:
+            outcome: {required: true}
+            actor_id: {required: true}
+            email: {}
+            credit_card: {}
+            locale: {}
+      """
+    When an event "user_create" is emitted with fields:
+      | field       | value               |
+      | outcome     | success             |
+      | actor_id    | bob                 |
+      | email       | bob@example.com     |
+      | credit_card | 4111-1111-1111-1111 |
+      | locale      | en-GB               |
+    Then the recorded event should not have field "email"
+    And the recorded event should not have field "credit_card"
+    And the recorded event should have field "locale" equal to "en-GB"

--- a/tests/bdd/steps/audittest_steps.go
+++ b/tests/bdd/steps/audittest_steps.go
@@ -1,0 +1,265 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/audittest"
+)
+
+// audittestState holds per-scenario state for audittest-helper BDD
+// tests. Kept local to this file so it does not pollute
+// AuditTestContext with helper-specific fields.
+type audittestState struct {
+	tb       testing.TB
+	auditor  *audit.Auditor
+	recorder *audittest.Recorder
+}
+
+// bddTB is a minimal testing.TB used to feed audittest.New inside a
+// BDD scenario. audittest itself only calls tb.Helper, tb.Cleanup,
+// and tb.Fatalf on this object; fatal failures propagate through
+// t.Failed() and a captured error message.
+//
+// Concurrency: every exported method acquires mu, so bddTB is safe
+// to share across goroutines that audittest may spawn (e.g.,
+// auditor.Cleanup running on the test goroutine while a BDD step
+// reads Failed()).
+type bddTB struct { //nolint:govet // fieldalignment: embedded testing.TB determines layout; reordering offers no savings
+	testing.TB
+	mu       sync.Mutex
+	cleanups []func()
+	fatalMsg string
+	failed   bool
+}
+
+func (b *bddTB) Helper()           {}
+func (b *bddTB) Cleanup(fn func()) { b.mu.Lock(); b.cleanups = append(b.cleanups, fn); b.mu.Unlock() }
+func (b *bddTB) Errorf(format string, args ...any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.failed = true
+	b.fatalMsg = fmt.Sprintf(format, args...)
+}
+func (b *bddTB) Fatalf(format string, args ...any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.failed = true
+	b.fatalMsg = fmt.Sprintf(format, args...)
+}
+func (b *bddTB) Logf(format string, args ...any) {}
+func (b *bddTB) Fail()                           { b.mu.Lock(); defer b.mu.Unlock(); b.failed = true }
+func (b *bddTB) FailNow()                        { b.mu.Lock(); defer b.mu.Unlock(); b.failed = true }
+func (b *bddTB) Failed() bool                    { b.mu.Lock(); defer b.mu.Unlock(); return b.failed }
+func (b *bddTB) Name() string                    { return "bdd-audittest" }
+func (b *bddTB) runCleanups() {
+	b.mu.Lock()
+	fns := make([]func(), len(b.cleanups))
+	copy(fns, b.cleanups)
+	b.cleanups = nil
+	b.mu.Unlock()
+	for i := len(fns) - 1; i >= 0; i-- {
+		fns[i]()
+	}
+}
+
+func registerAudittestSteps(ctx *godog.ScenarioContext, _ *AuditTestContext) {
+	state := &audittestState{}
+	registerAudittestLifecycle(ctx, state)
+	registerAudittestGivenSteps(ctx, state)
+	registerAudittestWhenSteps(ctx, state)
+	registerAudittestThenSteps(ctx, state)
+}
+
+func registerAudittestLifecycle(ctx *godog.ScenarioContext, state *audittestState) {
+	ctx.Before(func(c context.Context, _ *godog.Scenario) (context.Context, error) {
+		*state = audittestState{}
+		return c, nil
+	})
+	ctx.After(func(c context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		if state.auditor != nil {
+			_ = state.auditor.Close()
+		}
+		if tb, ok := state.tb.(*bddTB); ok {
+			tb.runCleanups()
+		}
+		return c, nil
+	})
+}
+
+func registerAudittestGivenSteps(ctx *godog.ScenarioContext, state *audittestState) {
+	ctx.Step(`^an audittest auditor in async mode with taxonomy:$`, func(doc *godog.DocString) error {
+		return createAudittestAuditor(state, doc.Content, nil, true)
+	})
+	ctx.Step(`^an audittest auditor with WithExcludeLabels "([^"]*)" and taxonomy:$`, func(labels string, doc *godog.DocString) error {
+		return createAudittestAuditor(state, doc.Content, splitAndTrim(labels, ","), false)
+	})
+}
+
+func registerAudittestWhenSteps(ctx *godog.ScenarioContext, state *audittestState) {
+	ctx.Step(`^(\d+) "([^"]*)" events are emitted from a background goroutine$`, func(n int, eventType string) error {
+		if state.auditor == nil {
+			return fmt.Errorf("auditor not initialised")
+		}
+		go func() {
+			for i := 0; i < n; i++ {
+				_ = state.auditor.AuditEvent(audit.NewEvent(eventType, audit.Fields{
+					"outcome":  "success",
+					"actor_id": fmt.Sprintf("actor-%d", i),
+				}))
+			}
+		}()
+		return nil
+	})
+	ctx.Step(`^no events are emitted$`, func() error { return nil })
+	ctx.Step(`^an event "([^"]*)" is emitted with fields:$`, func(eventType string, table *godog.Table) error {
+		if state.auditor == nil {
+			return fmt.Errorf("auditor not initialised")
+		}
+		fields := audit.Fields{}
+		for _, row := range table.Rows[1:] {
+			fields[row.Cells[0].Value] = row.Cells[1].Value
+		}
+		if err := state.auditor.AuditEvent(audit.NewEvent(eventType, fields)); err != nil {
+			return fmt.Errorf("audit event: %w", err)
+		}
+		return nil
+	})
+}
+
+func registerAudittestThenSteps(ctx *godog.ScenarioContext, state *audittestState) {
+	ctx.Step(`^Recorder\.WaitForN (\d+) within "([^"]*)" should return true$`, func(n int, timeoutStr string) error {
+		return assertWaitForN(state, n, timeoutStr, true)
+	})
+	ctx.Step(`^Recorder\.WaitForN (\d+) within "([^"]*)" should return false$`, func(n int, timeoutStr string) error {
+		return assertWaitForN(state, n, timeoutStr, false)
+	})
+	ctx.Step(`^the recorder should contain at least (\d+) events$`, func(n int) error {
+		return assertRecorderCountAtLeast(state, n)
+	})
+	ctx.Step(`^the recorder should contain (\d+) events$`, func(n int) error {
+		return assertRecorderCountExactly(state, n)
+	})
+	ctx.Step(`^the recorded event should have field "([^"]*)" equal to "([^"]*)"$`, func(field, want string) error {
+		return assertRecordedFieldEquals(state, field, want)
+	})
+	ctx.Step(`^the recorded event should not have field "([^"]*)"$`, func(field string) error {
+		return assertRecordedFieldAbsent(state, field)
+	})
+}
+
+func assertRecorderCountAtLeast(state *audittestState, n int) error {
+	if state.recorder == nil {
+		return fmt.Errorf("recorder not initialised")
+	}
+	if got := state.recorder.Count(); got < n {
+		return fmt.Errorf("expected at least %d events, got %d", n, got)
+	}
+	return nil
+}
+
+func assertRecorderCountExactly(state *audittestState, n int) error {
+	if state.recorder == nil {
+		return fmt.Errorf("recorder not initialised")
+	}
+	if got := state.recorder.Count(); got != n {
+		return fmt.Errorf("expected %d events, got %d", n, got)
+	}
+	return nil
+}
+
+func assertRecordedFieldEquals(state *audittestState, field, want string) error {
+	if state.recorder == nil {
+		return fmt.Errorf("recorder not initialised")
+	}
+	evt, ok := state.recorder.First()
+	if !ok {
+		return fmt.Errorf("no events recorded")
+	}
+	if got := evt.StringField(field); got != want {
+		return fmt.Errorf("field %q: expected %q, got %q", field, want, got)
+	}
+	return nil
+}
+
+func assertRecordedFieldAbsent(state *audittestState, field string) error {
+	if state.recorder == nil {
+		return fmt.Errorf("recorder not initialised")
+	}
+	evt, ok := state.recorder.First()
+	if !ok {
+		return fmt.Errorf("no events recorded")
+	}
+	if v := evt.Field(field); v != nil {
+		return fmt.Errorf("field %q should be stripped but has value %v", field, v)
+	}
+	return nil
+}
+
+func createAudittestAuditor(state *audittestState, yamlContent string, excludeLabels []string, async bool) error {
+	tb := &bddTB{}
+	state.tb = tb
+
+	opts := []audittest.Option{}
+	if async {
+		opts = append(opts, audittest.WithAsync())
+	}
+	for _, label := range excludeLabels {
+		if label != "" {
+			opts = append(opts, audittest.WithExcludeLabels("recorder", label))
+		}
+	}
+
+	auditor, rec, _ := audittest.New(tb, []byte(yamlContent), opts...)
+	if tb.Failed() {
+		return fmt.Errorf("audittest.New failed: %s", tb.fatalMsg)
+	}
+	state.auditor = auditor
+	state.recorder = rec
+	return nil
+}
+
+func assertWaitForN(state *audittestState, n int, timeoutStr string, expected bool) error {
+	if state.recorder == nil {
+		return fmt.Errorf("recorder not initialised")
+	}
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return fmt.Errorf("parse timeout %q: %w", timeoutStr, err)
+	}
+	got := state.recorder.WaitForN(state.tb, n, timeout)
+	if got != expected {
+		return fmt.Errorf("WaitForN(%d, %s): expected %t, got %t (recorder count=%d)",
+			n, timeoutStr, expected, got, state.recorder.Count())
+	}
+	return nil
+}
+
+func splitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -204,4 +204,5 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerEventMetricsSteps(ctx, tc)
 	registerOutputConfigSteps(ctx, tc)
 	registerSSRFSteps(ctx, tc)
+	registerAudittestSteps(ctx, tc)
 }


### PR DESCRIPTION
## Summary

Closes #566. Adds two public APIs to the `audittest` test-helper package for consumer test suites:

- **`Recorder.WaitForN(tb, n, timeout) bool`** — ticker-based (10 ms) poll until `Count() >= n` or timeout; fast-path returns immediately if the target is already reached. For use with async auditors (`WithAsync`); the synchronous default for `audittest.New`/`NewQuick` does not need it.
- **`audittest.WithExcludeLabels(outputName, labels...) Option`** — wires sensitivity-label exclusion onto the test recorder so consumer tests can assert their compliance outputs strip `pii`/`financial`/etc. fields. Mirrors core `audit.WithExcludeLabels` exactly.

Internal plumbing change (silent): `newTestLogger` switches from `audit.WithOutputs(rec)` to `audit.WithNamedOutput(rec, ...)` only when per-output options are present. Byte-identical observable behaviour for every existing caller.

## AC Deviations (approved by user, confirmed by api-ergonomics-reviewer)

1. **`PermissiveTaxonomy` NOT added** — `audittest.QuickTaxonomy()` already fills the same role; adding a second name violates "one obvious way".
2. **`WithExcludedLabels` → `WithExcludeLabels`** (no "d") to match core `audit.WithExcludeLabels` exactly.
3. **AC named `RecordedEvents.WaitForN`** — the actual type is `*Recorder` (see `audittest/recorder.go:138`); `WaitForN` is a method on `*Recorder`.

## Test plan

- [x] 9 new unit tests in `audittest/{recorder,audittest}_test.go` (4 `WaitForN` + 5 `WithExcludeLabels` — strip / preserve / multi-label / accumulate / empty-variadic / unknown-label Fatalf / outputName-mismatch Fatalf via a `fatalCaptor`)
- [x] 4 BDD scenarios in `tests/bdd/features/audittest_helpers.feature` (tagged `@core @audittest`) — WaitForN success + timeout, WithExcludeLabels single + multi-label
- [x] 2 runnable godoc examples in `audittest/example_test.go`
- [x] `docs/testing.md` — two new sections + new troubleshooting entry ("WaitForN always times out")
- [x] `CHANGELOG.md` — `### Added` entries with deviation flag block
- [x] `V1-RELEASE-PLAN.md` — #566 ticked
- [x] `make lint` clean
- [x] `go test -race ./...` all pass
- [x] `BDD_TAGS="@core && ~@docker" go test -race -tags=integration ./tests/bdd/...` all pass

## Agents consulted

- **api-ergonomics-reviewer** (pre-coding): signature shapes locked, `PermissiveTaxonomy` descoped
- **test-analyst** (post-coding): added `TestWithExcludeLabels_UnknownLabel`, `_OutputNameMismatch`, `_EmptyVariadic`, `TestRecorder_WaitForN_ZeroTimeoutEmpty`; tightened `_AsyncConcurrentEmit` to exercise the tick-retry path
- **code-reviewer** (post-coding): added explicit `return` after `tb.Fatalf` for non-Goexit TBs
- **api-ergonomics-reviewer** (post-coding): no blockers, final names confirmed
- **docs-writer** (post-coding): clarified CHANGELOG deviation wording, godoc polish
- **user-guide-reviewer** (post-coding): added troubleshooting section, linked `NewNamedRecorder`
- **go-quality** (post-coding): split `registerAudittestSteps` into focused helpers, cleaned up unused fields, `fieldalignment` justified
- **commit-message-reviewer**: approved