### PR TITLE
refactor: align HMAC naming: Salt, algorithm, _hmac_version (#582)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -276,7 +276,7 @@ serialise to JSON; both sides discard the output (`slog` →
   not shown here for the reason documented in *Methodology*.
 - **HMAC costs ≈ 442 ns at 10 fields** (2178 − 1736). This is the
   cost of tamper-evidence (`HMAC-SHA-256` over the full
-  event bytes + authenticated `_hmac_v` salt version), amortised
+  event bytes + authenticated `_hmac_version` salt version), amortised
   via pre-allocated state. There is no `slog` equivalent to
   compare against.
 - **Fan-out to 4 outputs costs ≈ 63 ns per extra output**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Breaking Changes
 
+- HMAC configuration and wire format aligned for v1.0 API lock-in (#582). Three coordinated renames, detailed in [ADR-0004](docs/adr/0004-hmac-wire-field-naming.md):
+  - **Go struct restructured**. `HMACConfig.SaltVersion string` + `HMACConfig.SaltValue []byte` → `HMACConfig.Salt HMACSalt` (new exported type `audit.HMACSalt{Version string, Value []byte}`). Matches the nested YAML shape so godoc and YAML read the same structure in both places. Go-precedent: `tls.Config` → `tls.Certificate` (domain-prefixed nested type).
+  - **YAML key `hash` → `algorithm`**. `hmac.hash: HMAC-SHA-256` → `hmac.algorithm: HMAC-SHA-256`. The field holds an HMAC algorithm identifier, not a hash name; the Go API already called it `Algorithm`. No backward-compat alias — pre-v1.0, stale `hash:` configs fail loudly with a clear unknown-field error.
+  - **Wire key JSON `_hmac_v` → `_hmac_version`**. CEF stays `_hmacVersion`. The pair `_hmac_version` / `_hmacVersion` matches the snake/camel symmetry already used for `event_category` / `eventCategory`. `_hmac_v` was the only abbreviated wire key and its `_v` suffix read ambiguously as version / value / verify. Position inside the HMAC-authenticated region is preserved — immediately preceding the `_hmac` digest, as locked by #473.
+  
+  Migration:
+  ```go
+  // Before
+  cfg := audit.HMACConfig{
+      Enabled:     true,
+      SaltVersion: "2026-Q1",
+      SaltValue:   salt,
+      Algorithm:   "HMAC-SHA-256",
+  }
+  
+  // After
+  cfg := audit.HMACConfig{
+      Enabled: true,
+      Salt: audit.HMACSalt{
+          Version: "2026-Q1",
+          Value:   salt,
+      },
+      Algorithm: "HMAC-SHA-256",
+  }
+  ```
+  ```yaml
+  # Before
+  hmac:
+    enabled: true
+    salt:
+      version: "2026-Q1"
+      value: "${HMAC_SALT}"
+    hash: HMAC-SHA-256
+  
+  # After
+  hmac:
+    enabled: true
+    salt:
+      version: "2026-Q1"
+      value: "${HMAC_SALT}"
+    algorithm: HMAC-SHA-256
+  ```
+  External JSON verifiers: update the string constant from `_hmac_v` to `_hmac_version`. Continue to strip only `_hmac` (never `_hmac_version`) before recomputing the HMAC. CEF verifiers: no change.
+
 - All four output sub-modules (`file`, `syslog`, `webhook`, `loki`) now expose the identical `NewFactory` signature (#581):
   ```go
   func NewFactory(factory audit.OutputMetricsFactory) audit.OutputFactory

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -50,7 +50,7 @@ Every issue follows this sequence. Do not skip steps.
 
 [GitHub issue view](https://github.com/axonops/audit/issues?q=is%3Aissue+is%3Aopen+label%3Av1.0.0+%22security%22+OR+%22fix%22)
 
-- [x] **#473** security: include _hmac_v inside HMAC authenticated bytes — HMAC authenticity hole (code-reviewer C3, verified against `drain.go:183-192`). ✅ Merged in PR #623 (2026-04-17).
+- [x] **#473** security: include _hmac_version inside HMAC authenticated bytes — HMAC authenticity hole (code-reviewer C3, verified against `drain.go:183-192`). ✅ Merged in PR #623 (2026-04-17).
 - [x] **#474** fix: atomic.Pointer for diagnostic logger in async outputs — data race across webhook/file/syslog/loki. ✅ Merged in PR #629 (2026-04-18).
 - [ ] **#475** security: strip credentials from Webhook and Loki Config.String() output — token leakage via `%v` / `%+v` debug.
 - [ ] **#476** fix: apply global tls_policy to loki and secret providers — injection currently only covers syslog/webhook.
@@ -112,7 +112,7 @@ Every issue follows this sequence. Do not skip steps.
 - [x] **#579** refactor: pick one config pattern (Config struct vs functional options); export Version; bound fieldsPool.
 - [x] **#580** refactor: align file/syslog/webhook/loki New() constructors on pointer Config receiver.
 - [x] **#581** refactor: unified OutputMetricsFactory pattern across file/syslog/webhook/loki.
-- [ ] **#582** refactor: align HMAC Go and YAML field names; unify _hmac_v / _hmacVersion.
+- [x] **#582** refactor: align HMAC Go and YAML field names; unify _hmac_version / _hmacVersion.
 - [x] **#583** refactor: rename syslog.app_name YAML to procid or syslog_app_name; default APP-NAME from top-level app_name.
 - [x] **#584** refactor: align Loki gzip YAML key and Go Compress field.
 - [ ] **#585** refactor: examples use outputs convenience package instead of individual blank imports.

--- a/audit_test.go
+++ b/audit_test.go
@@ -3007,10 +3007,12 @@ func BenchmarkAudit_WithHMAC(b *testing.B) {
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v1",
-			SaltValue:   []byte("benchmark-salt-value-32-bytes!!!"),
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v1",
+				Value:   []byte("benchmark-salt-value-32-bytes!!!"),
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	if err != nil {
@@ -3723,10 +3725,12 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v1",
-			SaltValue:   []byte("test-salt-sixteen-bytes!"),
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v1",
+				Value:   []byte("test-salt-sixteen-bytes!"),
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	require.NoError(t, err)
@@ -3738,7 +3742,7 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 
 	ev := out.GetEvent(0)
 	assert.NotEmpty(t, ev["_hmac"], "HMAC should be present")
-	assert.Equal(t, "v1", ev["_hmac_v"], "salt version should be present")
+	assert.Equal(t, "v1", ev["_hmac_version"], "salt version should be present")
 }
 
 func TestHMAC_Disabled_NoFields(t *testing.T) {
@@ -3778,10 +3782,12 @@ func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "2026-Q1",
-			SaltValue:   []byte("version-test-salt-16b!"),
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "2026-Q1",
+				Value:   []byte("version-test-salt-16b!"),
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	require.NoError(t, err)
@@ -3792,12 +3798,12 @@ func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 	require.NoError(t, auditor.Close())
 
 	ev := out.GetEvent(0)
-	assert.Equal(t, "2026-Q1", ev["_hmac_v"])
+	assert.Equal(t, "2026-Q1", ev["_hmac_version"])
 }
 
 func TestHMAC_ReservedFieldNames(t *testing.T) {
 	t.Parallel()
-	for _, field := range []string{"_hmac", "_hmac_v"} {
+	for _, field := range []string{"_hmac", "_hmac_version"} {
 		t.Run(field, func(t *testing.T) {
 			t.Parallel()
 			tax := &audit.Taxonomy{
@@ -3848,16 +3854,20 @@ events:
 	// Different salts per output — proves each output uses its own
 	// HMAC config independently, not a shared singleton.
 	fullHMACCfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte("full-output-salt-value!"),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte("full-output-salt-value!"),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 	strippedHMACCfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v2",
-		SaltValue:   []byte("stripped-output-salt!!"),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v2",
+			Value:   []byte("stripped-output-salt!!"),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 
 	fullOut := testhelper.NewMockOutput("full")
@@ -3900,8 +3910,8 @@ events:
 	assert.False(t, hasEmail, "stripped output should not have email (PII excluded)")
 
 	// Salt versions should reflect per-output config.
-	assert.Equal(t, "v1", fullEvent["_hmac_v"], "full output should have salt version v1")
-	assert.Equal(t, "v2", strippedEvent["_hmac_v"], "stripped output should have salt version v2")
+	assert.Equal(t, "v1", fullEvent["_hmac_version"], "full output should have salt version v1")
+	assert.Equal(t, "v2", strippedEvent["_hmac_version"], "stripped output should have salt version v2")
 
 	// The HMACs MUST be different because the payloads differ
 	// (one has email, the other does not) AND the salts differ.
@@ -3913,7 +3923,7 @@ events:
 // by the drain loop can be verified against the on-wire bytes. Emits a
 // single event to an HMAC-enabled output, then reconstructs the
 // authenticated payload by stripping only the `_hmac` field (leaving
-// `_hmac_v` in place per issue #473), and confirms the HMAC verifies.
+// `_hmac_version` in place per issue #473), and confirms the HMAC verifies.
 // This is the canonical real-world verifier pattern.
 func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 	t.Parallel()
@@ -3933,10 +3943,12 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(hmacOut, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v1",
-			SaltValue:   salt,
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v1",
+				Value:   salt,
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	require.NoError(t, err)
@@ -3958,7 +3970,7 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 	require.NotEmpty(t, hmacHex)
 
 	// Reconstruct the authenticated payload: strip ONLY `_hmac` from
-	// the on-wire bytes, keeping `_hmac_v` in place because it is
+	// the on-wire bytes, keeping `_hmac_version` in place because it is
 	// inside the authenticated region (issue #473).
 	canonical := stripHMACJSONField(line)
 
@@ -4012,10 +4024,12 @@ events:
 		// Both outputs exclude PII. baseOut is a sanity check that
 		// stripping happened; verification uses hmacOut's own bytes.
 		audit.WithNamedOutput(hmacOut, audit.WithExcludeLabels("pii"), audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v1",
-			SaltValue:   salt,
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v1",
+				Value:   salt,
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 		audit.WithNamedOutput(baseOut, audit.WithExcludeLabels("pii")),
 	)
@@ -4044,7 +4058,7 @@ events:
 	}
 
 	// Verify the HMAC against hmacOut's own bytes with only `_hmac`
-	// stripped — _hmac_v remains because it is inside the authenticated
+	// stripped — _hmac_version remains because it is inside the authenticated
 	// region per issue #473.
 	hmacHex, ok := hmacEvent["_hmac"].(string)
 	require.True(t, ok, "HMAC output must contain _hmac field")
@@ -4486,10 +4500,12 @@ func TestMetadataWriter_WithHMAC_ReceivesHMACData(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v1",
-			SaltValue:   []byte("hmac-test-salt-value!"),
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v1",
+				Value:   []byte("hmac-test-salt-value!"),
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	require.NoError(t, err)
@@ -5243,7 +5259,7 @@ func BenchmarkAudit_FastPath_FanOut4_NoopOutputs(b *testing.B) {
 
 // BenchmarkAudit_FastPath_WithHMAC_Noop measures the in-place HMAC
 // post-field append cost. Pre-W2 this allocated 2 byte slices per
-// output (_hmac_v + _hmac); post-W2 these are appended in place into
+// output (_hmac_version + _hmac); post-W2 these are appended in place into
 // the per-event scratch buffer. Target: 0 allocs/op on the pipeline
 // side (HMAC compute contributes a small constant B/op from
 // hex.EncodeToString — pre-existing, not introduced by W2).
@@ -5260,10 +5276,12 @@ func BenchmarkAudit_FastPath_WithHMAC_Noop(b *testing.B) {
 	}
 	out := testhelper.NewNoopOutput("noop")
 	hmacCfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),

--- a/audittest/recorder.go
+++ b/audittest/recorder.go
@@ -98,7 +98,7 @@ func (e RecordedEvent) BoolField(key string) bool { //nolint:gocritic // value r
 
 // UserFields returns a copy of the event's fields with framework
 // fields removed (event_category, app_name, host, timezone, pid,
-// duration_ms, _hmac, _hmac_v). This is useful for count assertions
+// duration_ms, _hmac, _hmac_version). This is useful for count assertions
 // where framework fields would inflate the total.
 func (e RecordedEvent) UserFields() map[string]any { //nolint:gocritic // value receiver for consistency
 	out := make(map[string]any, len(e.Fields))
@@ -373,7 +373,7 @@ var frameworkFields = map[string]bool{
 	"pid":            true,
 	"duration_ms":    true,
 	"_hmac":          true,
-	"_hmac_v":        true,
+	"_hmac_version":  true,
 }
 
 func isFrameworkField(key string) bool {

--- a/audittest/recorder_test.go
+++ b/audittest/recorder_test.go
@@ -221,7 +221,7 @@ func TestRecordedEvent_UserFields(t *testing.T) {
 			"pid":            float64(1234),
 			"duration_ms":    float64(10),
 			"_hmac":          "abc",
-			"_hmac_v":        float64(1),
+			"_hmac_version":  float64(1),
 		},
 	}
 	userFields := evt.UserFields()
@@ -236,7 +236,7 @@ func TestRecordedEvent_UserFields(t *testing.T) {
 	assert.NotContains(t, userFields, "pid")
 	assert.NotContains(t, userFields, "duration_ms")
 	assert.NotContains(t, userFields, "_hmac")
-	assert.NotContains(t, userFields, "_hmac_v")
+	assert.NotContains(t, userFields, "_hmac_version")
 }
 
 func TestRecordedEvent_BoolField(t *testing.T) {

--- a/bench_comparison_test.go
+++ b/bench_comparison_test.go
@@ -285,10 +285,12 @@ func benchAudit10FieldsSyncWithHMAC(b *testing.B) {
 	silenceSlog(b)
 	out := testhelper.NewNoopOutput("bench-cmp-hmac")
 	hmacCfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(benchComparisonTaxonomy()),

--- a/benchmarks_internal_test.go
+++ b/benchmarks_internal_test.go
@@ -204,10 +204,12 @@ func itoa(n int) string {
 // No per-call allocation by construction (state pre-allocated).
 func BenchmarkComputeHMACFast(b *testing.B) {
 	cfg := &HMACConfig{
-		Enabled:     true,
-		Algorithm:   "HMAC-SHA-256",
-		SaltVersion: "v1",
-		SaltValue:   []byte("benchmark-salt-32-bytes-00000000"),
+		Enabled:   true,
+		Algorithm: "HMAC-SHA-256",
+		Salt: HMACSalt{
+			Version: "v1",
+			Value:   []byte("benchmark-salt-32-bytes-00000000"),
+		},
 	}
 	s := newHMACState(cfg)
 	payload := []byte(`{"event_type":"user_create","outcome":"success","actor_id":"alice","subject":"schema-topic"}`)

--- a/doc.go
+++ b/doc.go
@@ -244,8 +244,9 @@
 //     sentinel donateFields()), and the auditor takes ownership of the
 //     event's Fields map. The formatter writes into a pool-leased
 //     *bytes.Buffer that is shared across every output and category pass
-//     for the same event; per-output post-fields (event_category, _hmac_v,
-//     _hmac) are appended in place into a per-event scratch buffer.
+//     for the same event; per-output post-fields (event_category,
+//     _hmac_version, _hmac) are appended in place into a per-event
+//     scratch buffer.
 //     This path achieves zero allocations on the drain side after warm-up.
 //
 //   - Slow path: events constructed via [NewEvent] or [NewEventKV] do

--- a/docs/adr/0001-fields-ownership-contract.md
+++ b/docs/adr/0001-fields-ownership-contract.md
@@ -155,7 +155,7 @@ mechanism but contributed equally to per-event GC pressure:
 1. The formatter copy-out: `Format()` allocated a fresh `[]byte` to
    return because the format-cache entry had to outlive the leased
    buffer.
-2. The post-field append: `event_category`, `_hmac_v`, `_hmac` each
+2. The post-field append: `event_category`, `_hmac_version`, `_hmac` each
    allocated a fresh `[]byte` because they had to mutate the cache
    value without aliasing it.
 3. The sorted-keys slice in the formatter when `omitEmpty` or extra

--- a/docs/adr/0004-hmac-wire-field-naming.md
+++ b/docs/adr/0004-hmac-wire-field-naming.md
@@ -1,0 +1,126 @@
+# ADR-0004: HMAC Wire-Field Naming Convention
+
+## Status
+
+Accepted — 2026-04-23
+
+## Context
+
+The audit library emits HMAC metadata on every HMAC-enabled event in two
+wire formats: newline-delimited JSON and RFC-5424 CEF. Each record
+carries a salt-version identifier alongside the HMAC digest itself, so
+consumers can look up the correct salt during verification.
+
+Before this decision the JSON and CEF output used inconsistent keys for
+the salt-version identifier:
+
+- JSON emitted `_hmac_v` (abbreviated).
+- CEF emitted `_hmacVersion` (full word, camelCase).
+
+The divergence produced three consumer problems. First, the
+abbreviation `_v` was ambiguous: a reader of raw JSON could not
+tell whether it meant *version*, *value*, or *verify* without cross-
+referencing the library docs. Second, every other paired wire field
+uses a consistent snake/camel symmetry (`event_category` /
+`eventCategory`, `event_type` / `eventType`) — `_hmac_v` broke the
+convention. Third, external verifier implementations had to carry a
+named special case for the HMAC version key, where every other field
+could be handled uniformly by lowercasing and removing underscores.
+
+The `_hmac` key itself (the HMAC digest) already used the same literal
+string in both formats, so only the version-identifier key was
+inconsistent.
+
+#473 (merged 2026-04-17) canonicalised `_hmac_v` inside the
+authenticated region of each record to prevent salt-redirect attacks.
+Any rename must preserve that invariant: the version-identifier key
+must remain inside the HMAC-authenticated byte range, in the same
+position relative to the digest.
+
+## Decision
+
+**Rename the JSON key from `_hmac_v` to `_hmac_version`.** The CEF key
+remains `_hmacVersion`.
+
+The pair `_hmac_version` (JSON snake_case) / `_hmacVersion` (CEF
+camelCase) matches the convention already used for `event_category` /
+`eventCategory` and `event_type` / `eventType`. External verifiers
+that previously looked for `_hmac_v` in JSON must update to
+`_hmac_version`. CEF consumers see no change.
+
+The authenticated-region invariant from #473 is preserved: the
+renamed key occupies the identical byte position — immediately
+preceding the `_hmac` digest — and is part of the HMAC input byte
+range.
+
+## Consequences
+
+### Positive
+
+- Consumer code can handle the version key with the same uniform
+  field-name normalisation used for every other wire field.
+- Abbreviation ambiguity is eliminated. `_hmac_version` self-describes.
+- The wire-format audit log is internally consistent: every JSON key
+  is snake_case; every CEF key is camelCase; pairs are related by a
+  mechanical transformation.
+- The ecosystem precedent aligns: CloudTrail, GCP Audit Logs, and
+  Kubernetes audit logs emit snake_case JSON for operational
+  identifiers. No established audit-log format abbreviates to `_v`.
+
+### Negative
+
+- Seven additional bytes per event in JSON output. At 10,000
+  events/second this adds approximately 70 KB/s to JSON output
+  throughput. Measured against the 44+ base-64-encoded bytes of the
+  HMAC digest already present on every record the overhead is
+  negligible.
+- External JSON verifiers written against the v0.x `_hmac_v` key must
+  migrate. The library is pre-v1.0 (v0.x) so breaking changes are
+  acceptable; migration is a single string replacement and the
+  CHANGELOG entry for #582 carries the recipe.
+
+## Alternatives considered
+
+### Keep `_hmac_v` and document the abbreviation
+
+Rejected. The ambiguity of `_v` is a durable documentation cost on
+every consumer who reads raw JSON logs. The 7-byte saving is below
+the noise floor relative to the HMAC digest. Pre-v1.0 is the correct
+moment to fix the naming; post-v1.0 the migration cost compounds.
+
+### Rename both keys to `_hmac_version` (JSON + CEF)
+
+Rejected. CEF extension keys are camelCase per the ArcSight CEF
+specification. The library already uses `eventCategory` / `eventType`
+in CEF to match that convention; switching to snake_case for one
+key would create a new inconsistency inside the CEF format.
+
+### Rename CEF to `_hmac_v` instead of JSON to `_hmac_version`
+
+Rejected. Short keys in CEF go against ArcSight convention and make
+the CEF format harder to read for SIEM operators who already expect
+`deviceEventCategory`-style keys.
+
+## Coordination with #473
+
+#473 established that `_hmac_v` lives inside the authenticated byte
+range immediately before `_hmac`. This ADR preserves that order and
+position; only the literal key name changes. A consumer that verified
+against #473's authenticated-region contract must:
+
+1. Update the string constant from `_hmac_v` to `_hmac_version` in
+   the JSON verifier.
+2. Continue to strip only `_hmac` (never `_hmac_version`) before
+   recomputing the HMAC.
+3. Make no changes to CEF verification — the CEF key is unchanged.
+
+## References
+
+- Issue #582 — refactor: align HMAC Go and YAML field names; unify
+  `_hmac_v` / `_hmacVersion`.
+- Issue #473 — security: include `_hmac_v` inside HMAC authenticated
+  bytes (merged 2026-04-17).
+- [ArcSight CEF Implementation Standard](https://community.microfocus.com/cfs-file/__key/communityserver-wikis-components-files/00-00-00-00-22/3731.CommonEventFormatv23.pdf)
+  — CEF extension key conventions.
+- ADR-0001 — fields ownership contract (preceding ADR for formatter
+  wire-format invariants).

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -142,10 +142,10 @@ receives invalid HMAC parameters.
 
 | Error (contains) | When |
 |------------------|------|
-| `hmac salt version is required when hmac is enabled` | `hmac.salt.version` is empty or missing |
-| `hmac salt value is required when hmac is enabled` | `hmac.salt.value` is empty or missing |
-| `hmac hash algorithm is required when hmac is enabled` | `hmac.hash` is empty or missing |
-| `hmac salt must be at least` | Salt is shorter than `audit.MinSaltLength` (currently 16) bytes |
+| `hmac salt.version is required when hmac is enabled` | `hmac.salt.version` is empty or missing |
+| `hmac salt.value is required when hmac is enabled` | `hmac.salt.value` is empty or missing |
+| `hmac algorithm is required when hmac is enabled` | `hmac.algorithm` is empty or missing |
+| `hmac salt.value must be at least` | Salt is shorter than `audit.MinSaltLength` (currently 16) bytes |
 | `unknown hmac algorithm` | Algorithm is not in `audit.SupportedHMACAlgorithms()` (currently: HMAC-SHA-256, HMAC-SHA-384, HMAC-SHA-512, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512) |
 
 All HMAC configuration validation errors (from `ValidateHMACConfig`, `outputconfig.Load()`, and `New`) wrap `audit.ErrConfigInvalid`. Use `errors.Is(err, audit.ErrConfigInvalid)` to detect them programmatically. Errors returned by `ComputeHMAC` and `VerifyHMAC` do not wrap this sentinel and must be handled separately.

--- a/docs/file-output.md
+++ b/docs/file-output.md
@@ -335,7 +335,7 @@ outputs:
       salt:
         version: "2026-Q1"
         value: "${HMAC_SALT}"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 ```
 
 The [HMAC integrity](hmac-integrity.md) option adds a tamper-detection

--- a/docs/hmac-integrity.md
+++ b/docs/hmac-integrity.md
@@ -76,7 +76,7 @@ outputs:
       salt:
         version: "2026-Q1"
         value: "${HMAC_SALT}"           # env var — never hardcode salts
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
     file:
       path: "./secure-audit.log"
     route:
@@ -94,7 +94,7 @@ outputs:
 | `hmac.enabled` | No | Default: `false`. Must be explicitly `true`. |
 | `hmac.salt.version` | Yes (when enabled) | User-defined version identifier for the salt. Included in output for rotation support. |
 | `hmac.salt.value` | Yes (when enabled) | The salt value. Min 16 bytes (128 bits). Supports `${VAR}` env vars. |
-| `hmac.hash` | Yes (when enabled) | Hash algorithm. See [Supported Algorithms](#supported-algorithms). |
+| `hmac.algorithm` | Yes (when enabled) | HMAC algorithm. See [Supported Algorithms](#supported-algorithms). |
 
 ## 📋 Supported Algorithms
 
@@ -155,21 +155,21 @@ The HMAC covers the following bytes, in this exact order:
 
 1. All event fields that survived sensitivity-label stripping.
 2. The `event_category` field (when the taxonomy has an active category for the event).
-3. The `_hmac_v` field (the salt version identifier).
+3. The `_hmac_version` field (the salt version identifier).
 
 The HMAC tag itself (`_hmac`) is **not** inside the authenticated region —
 it is the authentication tag, and it is always appended last.
 
-**Why authenticate `_hmac_v`?** A verifier uses `_hmac_v` to select the
-salt. If `_hmac_v` were outside the HMAC scope, an in-transit attacker
+**Why authenticate `_hmac_version`?** A verifier uses `_hmac_version` to select the
+salt. If `_hmac_version` were outside the HMAC scope, an in-transit attacker
 could change `v1` to `v2` to redirect the verifier to a different salt
-without detection. Including `_hmac_v` inside the authenticated bytes
+without detection. Including `_hmac_version` inside the authenticated bytes
 invalidates the HMAC on any modification to the version identifier.
 
 The library enforces this contract in two ways:
 
-- **SaltVersion character set** is restricted to `[A-Za-z0-9._:-]` (up to 64 characters) at config-time validation. Control characters, spaces, CEF/JSON escape metacharacters, and quote characters are all rejected. This eliminates escape ambiguity between the bytes that are hashed and the bytes that appear on the wire.
-- **Reserved-field collision**: consumer-supplied event fields named `_hmac` or `_hmac_v` are rejected at runtime regardless of `ValidationMode`. This prevents accidentally-or-maliciously emitting a duplicate `_hmac_v` earlier in the payload, which would introduce canonicalisation ambiguity for verifiers.
+- **`HMACSalt.Version` character set** is restricted to `[A-Za-z0-9._:-]` (up to 64 characters) at config-time validation. Control characters, spaces, CEF/JSON escape metacharacters, and quote characters are all rejected. This eliminates escape ambiguity between the bytes that are hashed and the bytes that appear on the wire.
+- **Reserved-field collision**: consumer-supplied event fields named `_hmac` or `_hmac_version` are rejected at runtime regardless of `ValidationMode`. This prevents accidentally-or-maliciously emitting a duplicate `_hmac_version` earlier in the payload, which would introduce canonicalisation ambiguity for verifiers.
 
 ## ✅ Verification
 
@@ -178,9 +178,9 @@ The library provides exported functions for HMAC verification:
 ```go
 // Verify an event's HMAC
 ok, err := audit.VerifyHMAC(
-    payloadBytes,    // on-wire bytes with ONLY the `_hmac` field removed (leave `_hmac_v` in place)
+    payloadBytes,    // on-wire bytes with ONLY the `_hmac` field removed (leave `_hmac_version` in place)
     hmacValue,       // the _hmac field value (lowercase hex)
-    salt,            // the salt bytes (looked up by _hmac_v version)
+    salt,            // the salt bytes (looked up by _hmac_version version)
     "HMAC-SHA-256",  // the algorithm
 )
 ```
@@ -189,17 +189,17 @@ ok, err := audit.VerifyHMAC(
 
 - Operate on the **on-wire bytes** (the exact bytes written by the output).
 - Strip ONLY the trailing `_hmac` field (JSON: `,"_hmac":"<hex>"` before the closing `}`; CEF: ` _hmac=<hex>` before the trailing newline).
-- **Keep `_hmac_v` in place** — it is authenticated.
+- **Keep `_hmac_version` in place** — it is authenticated.
 - Do NOT re-parse and re-serialise the event. Escape representations in the bytes the HMAC was computed over MUST match the bytes on the wire exactly.
 - Do NOT un-escape CEF values before recomputing — the escaped bytes are what the HMAC authenticates.
-- Determine `_hmac_v` by **position** (the last field before `_hmac`), not by parsing. This defends against field-duplication attacks where a payload contains two `_hmac_v` fields.
+- Determine `_hmac_version` by **position** (the last field before `_hmac`), not by parsing. This defends against field-duplication attacks where a payload contains two `_hmac_version` fields.
 - Use a **JSON-aware or CEF-aware parser** to locate the `_hmac` field, not a naive substring search for `,"_hmac":"`. A malicious consumer-controlled field value elsewhere in the payload containing that literal would confuse a substring-based stripper. The library's own tests use a simple substring strip because the taxonomy rejects reserved field names at runtime, but production verifiers should parse structurally.
 
 ### Output Format
 
 **JSON:**
 ```json
-{"timestamp":"...","event_type":"auth_failure","severity":8,"app_name":"my-service","host":"prod-01","timezone":"UTC","pid":12345,"outcome":"failure","event_category":"security","_hmac_v":"2026-Q1","_hmac":"a1b2c3d4..."}
+{"timestamp":"...","event_type":"auth_failure","severity":8,"app_name":"my-service","host":"prod-01","timezone":"UTC","pid":12345,"outcome":"failure","event_category":"security","_hmac_version":"2026-Q1","_hmac":"a1b2c3d4..."}
 ```
 
 **CEF:**
@@ -207,11 +207,11 @@ ok, err := audit.VerifyHMAC(
 CEF:0|...|8|... outcome=failure cat=security _hmacVersion=2026-Q1 _hmac=a1b2c3d4...
 ```
 
-`_hmac_v` precedes `_hmac` on the wire so that `_hmac_v` is part of the
+`_hmac_version` precedes `_hmac` on the wire so that `_hmac_version` is part of the
 bytes the HMAC authenticates. `_hmac` is always the **last** field; no
 post-fields are appended after it.
 
-Note: JSON uses `_hmac_v`; CEF uses `_hmacVersion`. Verifiers parsing CEF
+Note: JSON uses `_hmac_version`; CEF uses `_hmacVersion`. Verifiers parsing CEF
 output must look for `_hmacVersion`.
 
 ### Interaction with Other Features
@@ -223,9 +223,9 @@ output must look for `_hmacVersion`.
 - **Framework fields:** HMAC covers `app_name`, `host`, `timezone`, and
   `pid` when present. These fields are part of the serialised payload
   before HMAC computation.
-- **Salt version:** `_hmac_v` is inside the authenticated region. See "What Is Authenticated" above.
+- **Salt version:** `_hmac_version` is inside the authenticated region. See "What Is Authenticated" above.
 - **Format cache:** The base serialised event is cached. HMAC is
-  computed per-delivery (after event_category + field stripping + `_hmac_v` append).
+  computed per-delivery (after event_category + field stripping + `_hmac_version` append).
 
 ## 🔄 Alternative Approaches
 

--- a/docs/loki-output.md
+++ b/docs/loki-output.md
@@ -393,7 +393,7 @@ outputs:
       enabled: true
       salt: "${HMAC_SALT}"
       version: "v1"
-      hash: "HMAC-SHA-256"
+      algorithm: "HMAC-SHA-256"
 ```
 
 ### Formatter Restriction
@@ -898,23 +898,23 @@ only): `labels.dynamic.timezone: false`.
 
 ## HMAC Integrity with Loki
 
-When HMAC is enabled on a Loki output, the `_hmac` and `_hmac_v`
+When HMAC is enabled on a Loki output, the `_hmac` and `_hmac_version`
 fields are appended to every event before delivery. These fields
 appear in the JSON log line stored in Loki and are queryable via
 LogQL:
 
 ```logql
-{app_name="my-app"} | json | _hmac_v="v1"
+{app_name="my-app"} | json | _hmac_version="v1"
 ```
 
 The HMAC is computed over the serialised payload **after** sensitivity
-label stripping and **after** `_hmac_v` is appended, but **before**
-`_hmac` is appended. `_hmac_v` is authenticated by the HMAC — see
+label stripping and **after** `_hmac_version` is appended, but **before**
+`_hmac` is appended. `_hmac_version` is authenticated by the HMAC — see
 [docs/hmac-integrity.md](hmac-integrity.md) for the full
 canonicalisation contract. This means:
 
 - Events stored in Loki can be independently verified by stripping
-  **only** the `_hmac` field (keeping `_hmac_v` in place), recomputing
+  **only** the `_hmac` field (keeping `_hmac_version` in place), recomputing
   the HMAC with the same salt, and comparing
 - If the Loki output strips PII fields (via `exclude_labels`), the
   HMAC covers the stripped payload — the HMAC will differ from a

--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -563,7 +563,7 @@ outputs:
       salt:
         version: "2026-Q1"
         value: "ref+openbao://secret/data/audit/hmac#salt"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
     file:
       path: "/var/log/audit/secure.log"
   alerts:

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -151,7 +151,7 @@ call), the W2 pipeline is identical for both paths:
 - No `make([]byte, …)` for the formatter output. Pre-W2: 1 alloc per
   event per unique formatter.
 - No `make([]byte, …)` per `AppendPostField` call (event_category +
-  HMAC's `_hmac_v` + HMAC's `_hmac`). Pre-W2: up to 3 allocs per output
+  HMAC's `_hmac_version` + HMAC's `_hmac`). Pre-W2: up to 3 allocs per output
   per HMAC-enabled fan-out.
 - No `make([]string, …)` for sorted field keys when no extras are
   present. Pre-W2: variable.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -237,7 +237,7 @@ outputs:
       salt:
         version: "2026-Q1"
         value: "ref+openbao://secret/data/audit/hmac#salt"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 ```
 
 ### Config Reference
@@ -430,7 +430,7 @@ outputs:
       salt:
         version: "2026-Q1"
         value: "ref+openbao://secret/data/audit/hmac#salt"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
     file:
       path: "/var/log/audit/secure.log"
 ```
@@ -483,7 +483,7 @@ outputs:
       salt:
         version: "${HMAC_SALT_VERSION:-2026-Q1}"
         value: "ref+openbao://${BAO_HMAC_PATH:-secret/data/audit/hmac}#salt"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
     file:
       path: "/var/log/audit/secure.log"
 ```

--- a/docs/taxonomy-validation.md
+++ b/docs/taxonomy-validation.md
@@ -317,7 +317,7 @@ used as required or optional fields in your taxonomy:
 | `timezone` | Timezone context (set via outputs YAML or `WithTimezone`) |
 | `pid` | Process ID (auto-captured at construction) |
 | `_hmac` | HMAC integrity signature (set by HMAC config) |
-| `_hmac_v` | HMAC salt version (set by HMAC config) |
+| `_hmac_version` | HMAC salt version (set by HMAC config) |
 
 If you try to define any of these as a required or optional field,
 taxonomy validation fails with:

--- a/drain.go
+++ b/drain.go
@@ -200,7 +200,7 @@ func (a *Auditor) deliverToOutput(oe *outputEntry, entry *auditEntry, category s
 
 	// HMAC ordering invariant: the HMAC tag (_hmac) is the LAST field
 	// on the wire and is computed over every byte that precedes it,
-	// including event_category and _hmac_v. Any future post-field
+	// including event_category and _hmac_version. Any future post-field
 	// MUST be appended before computeHMACFast; appending after _hmac
 	// would leave the new field outside the authenticated region —
 	// same class of bug as issue #473. The buffer holding `data` MUST
@@ -231,7 +231,8 @@ func (a *Auditor) deliverToOutput(oe *outputEntry, entry *auditEntry, category s
 //
 // The HMAC tag (_hmac) is the LAST field on the wire and MUST NOT
 // cover itself. Every other post-field — currently event_category
-// and _hmac_v — MUST be inside the authenticated region so an
+// and _hmac_version (JSON) / _hmacVersion (CEF) — MUST be inside the
+// authenticated region so an
 // attacker cannot swap a salt version or inject a category label
 // without invalidating the HMAC. See issue #473 for the regression
 // class this invariant defends against.
@@ -239,8 +240,8 @@ func (a *Auditor) deliverToOutput(oe *outputEntry, entry *auditEntry, category s
 // Concretely:
 //
 //  1. Collect every "inside the authenticated region" post-field
-//     into preHMAC (currently event_category and _hmac_v; order
-//     within the batch matches the intended wire order).
+//     into preHMAC (currently event_category and _hmac_version;
+//     order within the batch matches the intended wire order).
 //  2. Append them in ONE batch call ([appendPostFieldsInto] for
 //     n == 2, [appendPostFieldInto] for n == 1) — saves one
 //     terminator rewind / restore cycle vs two sequential calls.
@@ -270,7 +271,7 @@ func (a *Auditor) assemblePostFields(fc *formatCache, base []byte, fmtr Formatte
 		n++
 	}
 	if needsHMAC {
-		preHMAC[n] = PostField{JSONKey: "_hmac_v", CEFKey: "_hmacVersion", Value: oe.hmacConfig.SaltVersion}
+		preHMAC[n] = PostField{JSONKey: "_hmac_version", CEFKey: "_hmacVersion", Value: oe.hmacConfig.Salt.Version}
 		n++
 	}
 	switch n {

--- a/errors.go
+++ b/errors.go
@@ -162,7 +162,7 @@ var (
 
 	// ErrReservedFieldName is returned by [Auditor.AuditEvent] when
 	// the event's Fields map uses a name reserved for library-emitted
-	// fields (for example `_hmac`, `_hmac_v`). These names would
+	// fields (for example `_hmac`, `_hmac_version`). These names would
 	// collide with library output and could enable canonicalisation-
 	// ambiguity attacks on HMAC verifiers (issue #473). This check runs
 	// regardless of [ValidationMode]; permissive mode cannot opt out.

--- a/examples/12-hmac-integrity/README.md
+++ b/examples/12-hmac-integrity/README.md
@@ -15,7 +15,7 @@ patterns side by side: **selective** (only security events) and
 - Selective HMAC via category routing (only security events pay crypto cost)
 - Global HMAC without routing (every event gets tamper detection)
 - Comparing the same event across outputs with and without HMAC
-- Understanding `_hmac` and `_hmac_v` fields in the output
+- Understanding `_hmac` and `_hmac_version` fields in the output
 - How to verify event integrity
 
 ## Prerequisites
@@ -56,7 +56,7 @@ secure_log:
     salt:
       version: "2026-Q1"
       value: "${HMAC_SALT:-default-example-salt!}"
-    hash: HMAC-SHA-256
+    algorithm: HMAC-SHA-256
   file:
     path: "./secure-audit.log"
   route:
@@ -75,7 +75,7 @@ tamperproof_log:
     salt:
       version: "2026-Q1"
       value: "${HMAC_SALT:-default-example-salt!}"
-    hash: HMAC-SHA-256
+    algorithm: HMAC-SHA-256
   file:
     path: "./all-audit.log"
   # No route — all events are delivered with HMAC
@@ -120,7 +120,7 @@ Never hardcode salts in production — use `${ENV_VAR}` substitution.
 
 ### Salt Versioning
 
-The `version` field is included in every HMAC'd event as `_hmac_v`.
+The `version` field is included in every HMAC'd event as `_hmac_version`.
 When you rotate salts, change the version so verifiers know which
 salt to use for each event.
 
@@ -128,14 +128,14 @@ salt to use for each event.
 
 Use the exported `audit.VerifyHMAC` function. The canonicalisation rule
 is: strip **only** the `_hmac` field from the on-wire bytes; leave
-`_hmac_v` in place because it is authenticated by the HMAC (issue
+`_hmac_version` in place because it is authenticated by the HMAC (issue
 [#473](https://github.com/axonops/audit/issues/473)).
 
 ```go
 // payloadBytes is the raw JSON line with ONLY the _hmac field removed.
-// The _hmac_v field stays in place — it is inside the authenticated region.
+// The _hmac_version field stays in place — it is inside the authenticated region.
 // hmacValue is the string value of the _hmac field (lowercase hex).
-// salt is []byte loaded from your key store, looked up by _hmac_v.
+// salt is []byte loaded from your key store, looked up by _hmac_version.
 ok, err := audit.VerifyHMAC(payloadBytes, hmacValue, salt, "HMAC-SHA-256")
 if err != nil {
     log.Printf("hmac verify: %v", err)
@@ -145,7 +145,7 @@ if !ok {
 }
 ```
 
-Verifiers should determine `_hmac_v` by **position** (the last field
+Verifiers should determine `_hmac_version` by **position** (the last field
 before `_hmac`), not by parsing — this defends against field-duplication
 attacks. See [`docs/hmac-integrity.md`](../../docs/hmac-integrity.md)
 for the full canonicalisation contract.
@@ -184,11 +184,11 @@ INFO audit: shutdown started
 INFO audit: shutdown complete duration=...
 
 --- secure-audit.log ---
-{"timestamp":"...","event_type":"auth_failure",...,"_hmac_v":"2026-Q1","_hmac":"<hex-64-chars>"}
+{"timestamp":"...","event_type":"auth_failure",...,"_hmac_version":"2026-Q1","_hmac":"<hex-64-chars>"}
 
 --- all-audit.log ---
-{"timestamp":"...","event_type":"auth_failure",...,"_hmac_v":"2026-Q1","_hmac":"<same-hex>"}
-{"timestamp":"...","event_type":"user_create",...,"_hmac_v":"2026-Q1","_hmac":"<different-hex>"}
+{"timestamp":"...","event_type":"auth_failure",...,"_hmac_version":"2026-Q1","_hmac":"<same-hex>"}
+{"timestamp":"...","event_type":"user_create",...,"_hmac_version":"2026-Q1","_hmac":"<different-hex>"}
 ```
 
 Notice the three contrasts:

--- a/examples/12-hmac-integrity/outputs.yaml
+++ b/examples/12-hmac-integrity/outputs.yaml
@@ -12,7 +12,7 @@ outputs:
       salt:
         version: "2026-Q1"
         value: "${HMAC_SALT:-default-example-salt!}"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
     file:
       path: "./secure-audit.log"
     route:
@@ -28,7 +28,7 @@ outputs:
       salt:
         version: "2026-Q1"
         value: "${HMAC_SALT:-default-example-salt!}"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
     file:
       path: "./all-audit.log"
 

--- a/examples/17-capstone/outputs.yaml
+++ b/examples/17-capstone/outputs.yaml
@@ -55,7 +55,7 @@ outputs:
       salt:
         version: "ref+openbao://secret/data/audit/hmac-v1#version"
         value: "ref+openbao://secret/data/audit/hmac-v1#salt"
-      hash: "ref+openbao://secret/data/audit/hmac-v1#hash"
+      algorithm: "ref+openbao://secret/data/audit/hmac-v1#hash"
 
   # 3. Security team feed — JSON, security category only, severity >= 7.
   #    HMAC v2 (SHA-512) with a DIFFERENT salt to prove per-output
@@ -81,7 +81,7 @@ outputs:
       salt:
         version: "ref+openbao://secret/data/audit/hmac-v2#version"
         value: "ref+openbao://secret/data/audit/hmac-v2#salt"
-      hash: "ref+openbao://secret/data/audit/hmac-v2#hash"
+      algorithm: "ref+openbao://secret/data/audit/hmac-v2#hash"
 
   # 4. Operational monitoring — Loki with Grafana dashboards.
   #    PII fields (email, phone, address) are STRIPPED before delivery.

--- a/hmac.go
+++ b/hmac.go
@@ -26,14 +26,14 @@ import (
 	"regexp"
 )
 
-// hmacSaltVersionPattern constrains SaltVersion to a character set that
+// hmacSaltVersionPattern constrains HMACSalt.Version to a character set that
 // is safe across JSON, CEF, and syslog wire formats without any escape
 // ambiguity (issue #473). The allowed set covers typical operational
 // version identifiers ("v1", "2026-Q1", "salt_v2.1", "key-rotation-12")
 // while eliminating log-injection vectors via control characters.
 var hmacSaltVersionPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]+$`)
 
-// maxHMACSaltVersionLen bounds SaltVersion length. Longer values inflate
+// maxHMACSaltVersionLen bounds HMACSalt.Version length. Longer values inflate
 // every emitted event without operational benefit.
 const maxHMACSaltVersionLen = 64
 
@@ -45,19 +45,23 @@ const MinSaltLength = 16
 // true, every event delivered to the output has an HMAC appended.
 // The HMAC is computed over the final serialised payload (after
 // field stripping and event_category append).
+//
+// The Go shape mirrors the YAML shape under outputs.<name>.hmac:
+//
+//	hmac:
+//	  enabled: true
+//	  salt:
+//	    version: "2026-Q1"
+//	    value:   "${HMAC_SALT}"
+//	  algorithm: "HMAC-SHA-256"
 type HMACConfig struct { //nolint:govet // readability over alignment
 	// Enabled controls whether HMAC is computed for this output.
 	// Default: false. Must be explicitly true.
 	Enabled bool
 
-	// SaltVersion is a user-defined identifier for the salt, included
-	// in the output alongside the HMAC. Supports salt rotation —
-	// consumers use this to look up the correct salt for verification.
-	SaltVersion string
-
-	// SaltValue is the raw salt bytes. MUST be at least MinSaltLength
-	// (16 bytes / 128 bits). Never appears in logs or error messages.
-	SaltValue []byte
+	// Salt carries the salt identifier and the raw salt bytes. See
+	// [HMACSalt] for field-level documentation.
+	Salt HMACSalt
 
 	// Algorithm is the HMAC hash algorithm. Must be one of the
 	// NIST-approved values: HMAC-SHA-256, HMAC-SHA-384, HMAC-SHA-512,
@@ -65,13 +69,51 @@ type HMACConfig struct { //nolint:govet // readability over alignment
 	Algorithm string
 }
 
+// HMACSalt groups the salt identifier and salt bytes for an
+// [HMACConfig]. The grouping matches the nested YAML shape under
+// outputs.<name>.hmac.salt, so a consumer reading the library's
+// godoc and writing YAML sees the same structure in both places.
+//
+// HMACSalt implements [fmt.Stringer] and [fmt.GoStringer] to redact
+// the raw Value from %v, %+v, and %#v format verbs. Consumers
+// SHOULD still treat Value as secret and avoid passing it to any
+// unbounded writer.
+type HMACSalt struct {
+	// Version is a user-defined identifier for the salt, emitted in
+	// the output alongside the HMAC digest. Supports salt rotation —
+	// consumers use this to look up the correct salt for
+	// verification. Required when [HMACConfig.Enabled] is true. Must
+	// match `^[A-Za-z0-9._:-]+$` (for unambiguous authenticated-byte
+	// representation on the wire — see #473) and be at most 64
+	// characters.
+	Version string
+
+	// Value is the raw salt bytes. MUST be at least [MinSaltLength]
+	// (16 bytes / 128 bits). The built-in [HMACSalt.String] and
+	// [HMACSalt.GoString] methods redact this value; consumers
+	// implementing their own formatting MUST NOT log or include it in
+	// error messages.
+	Value []byte
+}
+
+// String returns a safe representation that never includes the salt
+// Value bytes.
+func (s HMACSalt) String() string {
+	return fmt.Sprintf("HMACSalt{Version: %q, ValueLen: %d}", s.Version, len(s.Value))
+}
+
+// GoString implements [fmt.GoStringer] to prevent salt leakage via %#v.
+func (s HMACSalt) GoString() string {
+	return s.String()
+}
+
 // String returns a safe representation that never includes the salt value.
 func (c HMACConfig) String() string {
 	if !c.Enabled {
 		return "HMACConfig{Enabled: false}"
 	}
-	return fmt.Sprintf("HMACConfig{Enabled: true, SaltVersion: %q, Algorithm: %q, SaltLen: %d}",
-		c.SaltVersion, c.Algorithm, len(c.SaltValue))
+	return fmt.Sprintf("HMACConfig{Enabled: true, Salt.Version: %q, Algorithm: %q, Salt.Len: %d}",
+		c.Salt.Version, c.Algorithm, len(c.Salt.Value))
 }
 
 // GoString implements [fmt.GoStringer] to prevent salt leakage via %#v.
@@ -118,25 +160,25 @@ func ValidateHMACConfig(cfg *HMACConfig) error {
 	if cfg == nil || !cfg.Enabled {
 		return nil
 	}
-	if cfg.SaltVersion == "" {
-		return fmt.Errorf("%w: hmac salt version is required when hmac is enabled", ErrConfigInvalid)
+	if cfg.Salt.Version == "" {
+		return fmt.Errorf("%w: hmac salt.version is required when hmac is enabled", ErrConfigInvalid)
 	}
-	if len(cfg.SaltVersion) > maxHMACSaltVersionLen {
-		return fmt.Errorf("%w: hmac salt version length %d exceeds maximum %d",
-			ErrConfigInvalid, len(cfg.SaltVersion), maxHMACSaltVersionLen)
+	if len(cfg.Salt.Version) > maxHMACSaltVersionLen {
+		return fmt.Errorf("%w: hmac salt.version length %d exceeds maximum %d",
+			ErrConfigInvalid, len(cfg.Salt.Version), maxHMACSaltVersionLen)
 	}
-	if !hmacSaltVersionPattern.MatchString(cfg.SaltVersion) {
-		return fmt.Errorf("%w: hmac salt version %q contains characters outside the allowed set [A-Za-z0-9._:-] (required so the version can be authenticated unambiguously on the wire — see issue #473)",
-			ErrConfigInvalid, cfg.SaltVersion)
+	if !hmacSaltVersionPattern.MatchString(cfg.Salt.Version) {
+		return fmt.Errorf("%w: hmac salt.version %q contains characters outside the allowed set [A-Za-z0-9._:-] (required so the version can be authenticated unambiguously on the wire — see issue #473)",
+			ErrConfigInvalid, cfg.Salt.Version)
 	}
-	if len(cfg.SaltValue) == 0 {
-		return fmt.Errorf("%w: hmac salt value is required when hmac is enabled", ErrConfigInvalid)
+	if len(cfg.Salt.Value) == 0 {
+		return fmt.Errorf("%w: hmac salt.value is required when hmac is enabled", ErrConfigInvalid)
 	}
-	if len(cfg.SaltValue) < MinSaltLength {
-		return fmt.Errorf("%w: hmac salt must be at least %d bytes", ErrConfigInvalid, MinSaltLength)
+	if len(cfg.Salt.Value) < MinSaltLength {
+		return fmt.Errorf("%w: hmac salt.value must be at least %d bytes", ErrConfigInvalid, MinSaltLength)
 	}
 	if cfg.Algorithm == "" {
-		return fmt.Errorf("%w: hmac hash algorithm is required when hmac is enabled", ErrConfigInvalid)
+		return fmt.Errorf("%w: hmac algorithm is required when hmac is enabled", ErrConfigInvalid)
 	}
 	if hmacHashFunc(cfg.Algorithm) == nil {
 		return fmt.Errorf("%w: unknown hmac algorithm %q (supported: %v)", ErrConfigInvalid, cfg.Algorithm, SupportedHMACAlgorithms())
@@ -151,7 +193,7 @@ func newHMACState(cfg *HMACConfig) *hmacState {
 	if hashFunc == nil {
 		return nil // unreachable: ValidateHMACConfig rejects unknown algorithms during New
 	}
-	mac := hmac.New(hashFunc, cfg.SaltValue)
+	mac := hmac.New(hashFunc, cfg.Salt.Value)
 	return &hmacState{
 		mac:     mac,
 		hashLen: mac.Size(),

--- a/hmac_internal_test.go
+++ b/hmac_internal_test.go
@@ -25,10 +25,12 @@ func TestComputeHMACFast_EquivalentToComputeHMAC(t *testing.T) {
 		t.Run(alg, func(t *testing.T) {
 			t.Parallel()
 			cfg := &HMACConfig{
-				Enabled:     true,
-				SaltVersion: "v1",
-				SaltValue:   salt,
-				Algorithm:   alg,
+				Enabled: true,
+				Salt: HMACSalt{
+					Version: "v1",
+					Value:   salt,
+				},
+				Algorithm: alg,
 			}
 			state := newHMACState(cfg)
 			if state == nil {

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -200,10 +200,12 @@ func TestComputeHMAC_UnknownAlgorithm(t *testing.T) {
 func TestValidateHMACConfig_Valid(t *testing.T) {
 	t.Parallel()
 	cfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte("sixteen-byte-key"),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte("sixteen-byte-key"),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 	assert.NoError(t, audit.ValidateHMACConfig(cfg))
 }
@@ -217,10 +219,12 @@ func TestValidateHMACConfig_Disabled(t *testing.T) {
 func TestValidateHMACConfig_SaltTooShort(t *testing.T) {
 	t.Parallel()
 	cfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte("short"),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte("short"),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 	err := audit.ValidateHMACConfig(cfg)
 	require.Error(t, err)
@@ -231,21 +235,21 @@ func TestValidateHMACConfig_SaltTooShort(t *testing.T) {
 func TestValidateHMACConfig_MissingSalt(t *testing.T) {
 	t.Parallel()
 	cfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		Algorithm:   "HMAC-SHA-256",
+		Enabled:   true,
+		Salt:      audit.HMACSalt{Version: "v1"},
+		Algorithm: "HMAC-SHA-256",
 	}
 	err := audit.ValidateHMACConfig(cfg)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
-	assert.Contains(t, err.Error(), "salt value")
+	assert.Contains(t, err.Error(), "salt.value")
 }
 
 func TestValidateHMACConfig_MissingVersion(t *testing.T) {
 	t.Parallel()
 	cfg := &audit.HMACConfig{
 		Enabled:   true,
-		SaltValue: []byte("sixteen-byte-key"),
+		Salt:      audit.HMACSalt{Value: []byte("sixteen-byte-key")},
 		Algorithm: "HMAC-SHA-256",
 	}
 	err := audit.ValidateHMACConfig(cfg)
@@ -257,9 +261,11 @@ func TestValidateHMACConfig_MissingVersion(t *testing.T) {
 func TestValidateHMACConfig_MissingAlgorithm(t *testing.T) {
 	t.Parallel()
 	cfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte("sixteen-byte-key"),
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte("sixteen-byte-key"),
+		},
 	}
 	err := audit.ValidateHMACConfig(cfg)
 	require.Error(t, err)
@@ -270,10 +276,12 @@ func TestValidateHMACConfig_MissingAlgorithm(t *testing.T) {
 func TestValidateHMACConfig_UnknownAlgorithm(t *testing.T) {
 	t.Parallel()
 	cfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte("sixteen-byte-key"),
-		Algorithm:   "SHA-1",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte("sixteen-byte-key"),
+		},
+		Algorithm: "SHA-1",
 	}
 	err := audit.ValidateHMACConfig(cfg)
 	require.Error(t, err)
@@ -296,10 +304,12 @@ func TestValidateHMACConfig_SaltVersionCharsetValid(t *testing.T) {
 		t.Run(v, func(t *testing.T) {
 			t.Parallel()
 			cfg := &audit.HMACConfig{
-				Enabled:     true,
-				SaltVersion: v,
-				SaltValue:   []byte("sixteen-byte-key"),
-				Algorithm:   "HMAC-SHA-256",
+				Enabled: true,
+				Salt: audit.HMACSalt{
+					Version: v,
+					Value:   []byte("sixteen-byte-key"),
+				},
+				Algorithm: "HMAC-SHA-256",
 			}
 			assert.NoError(t, audit.ValidateHMACConfig(cfg))
 		})
@@ -325,10 +335,12 @@ func TestValidateHMACConfig_SaltVersionCharsetInvalid(t *testing.T) {
 		t.Run(fmt.Sprintf("%q", v), func(t *testing.T) {
 			t.Parallel()
 			cfg := &audit.HMACConfig{
-				Enabled:     true,
-				SaltVersion: v,
-				SaltValue:   []byte("sixteen-byte-key"),
-				Algorithm:   "HMAC-SHA-256",
+				Enabled: true,
+				Salt: audit.HMACSalt{
+					Version: v,
+					Value:   []byte("sixteen-byte-key"),
+				},
+				Algorithm: "HMAC-SHA-256",
 			}
 			err := audit.ValidateHMACConfig(cfg)
 			require.Error(t, err)
@@ -342,10 +354,12 @@ func TestValidateHMACConfig_SaltVersionCharsetInvalid(t *testing.T) {
 func TestValidateHMACConfig_SaltVersionTooLong(t *testing.T) {
 	t.Parallel()
 	cfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: strings.Repeat("a", 65),
-		SaltValue:   []byte("sixteen-byte-key"),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: strings.Repeat("a", 65),
+			Value:   []byte("sixteen-byte-key"),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 	err := audit.ValidateHMACConfig(cfg)
 	require.Error(t, err)
@@ -354,7 +368,7 @@ func TestValidateHMACConfig_SaltVersionTooLong(t *testing.T) {
 }
 
 // TestReservedLibraryField_RejectedAtRuntime covers consumer-supplied
-// Fields map with `_hmac` or `_hmac_v`. The library emits these on
+// Fields map with `_hmac` or `_hmac_version`. The library emits these on
 // every HMAC-enabled event. Consumer-supplied collisions would
 // duplicate the field and enable canonicalisation-ambiguity attacks
 // on verifiers (issue #473 security-reviewer finding 6b). Rejection
@@ -364,7 +378,7 @@ func TestReservedLibraryField_RejectedAtRuntime(t *testing.T) {
 	for _, mode := range []audit.ValidationMode{
 		audit.ValidationStrict, audit.ValidationWarn, audit.ValidationPermissive,
 	} {
-		for _, fieldName := range []string{"_hmac", "_hmac_v"} {
+		for _, fieldName := range []string{"_hmac", "_hmac_version"} {
 			t.Run(fmt.Sprintf("%v/%s", mode, fieldName), func(t *testing.T) {
 				t.Parallel()
 				tax := &audit.Taxonomy{
@@ -447,10 +461,12 @@ func BenchmarkHMAC_SHA256_LargeEvent(b *testing.B) {
 func TestHMACConfig_String_HidesSalt(t *testing.T) {
 	t.Parallel()
 	cfg := audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte("super-secret-salt-value"),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte("super-secret-salt-value"),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 	s := cfg.String()
 	assert.NotContains(t, s, "super-secret-salt-value")
@@ -492,16 +508,16 @@ func BenchmarkHMAC_SHA512_SmallEvent(b *testing.B) {
 // ---------------------------------------------------------------------------
 // Salt version authentication tests (issue #473)
 //
-// These tests verify that `_hmac_v` (the salt version identifier) is
-// authenticated by the HMAC. Before the fix, `_hmac_v` was appended to
+// These tests verify that `_hmac_version` (the salt version identifier) is
+// authenticated by the HMAC. Before the fix, `_hmac_version` was appended to
 // the wire AFTER `computeHMACFast` ran, leaving it outside the
 // authenticated region — a MITM could flip v1 → v2 to redirect a
 // verifier's salt lookup without detection. The fix reorders
-// drain.go:183-192 to append `_hmac_v` BEFORE computing HMAC.
+// drain.go:183-192 to append `_hmac_version` BEFORE computing HMAC.
 // ---------------------------------------------------------------------------
 
 // stripHMACJSONField removes the `,"_hmac":"<hex>"` field from a JSON
-// event line, keeping `_hmac_v` in place. This is the canonicalisation
+// event line, keeping `_hmac_version` in place. This is the canonicalisation
 // rule: recompute HMAC over the remaining bytes. Called from the #473
 // tests. Mirrors the helper in tests/bdd/steps/hmac_steps.go.
 func stripHMACJSONField(line []byte) []byte {
@@ -535,10 +551,12 @@ func newHMACPipelineTestAuditor(t *testing.T, name, saltVersion string, salt []b
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: saltVersion,
-			SaltValue:   salt,
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: saltVersion,
+				Value:   salt,
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	require.NoError(t, err)
@@ -588,13 +606,13 @@ func TestComputeHMACFast_IncludesSaltVersionInPayload(t *testing.T) {
 	lineV1, hmacV1 := runOnce("v1")
 	lineV2, hmacV2 := runOnce("v2")
 
-	// Sanity: both lines contain the expected _hmac_v value.
-	assert.Contains(t, string(lineV1), `"_hmac_v":"v1"`,
+	// Sanity: both lines contain the expected _hmac_version value.
+	assert.Contains(t, string(lineV1), `"_hmac_version":"v1"`,
 		"line must embed the salt version on the wire")
-	assert.Contains(t, string(lineV2), `"_hmac_v":"v2"`)
+	assert.Contains(t, string(lineV2), `"_hmac_version":"v2"`)
 
 	// Primary assertion: changing only SaltVersion changes the HMAC.
-	// If the implementation regressed to appending _hmac_v AFTER the
+	// If the implementation regressed to appending _hmac_version AFTER the
 	// HMAC computation, both hashes would be identical.
 	assert.NotEqual(t, hmacV1, hmacV2,
 		"HMAC must differ when SaltVersion differs — proves salt version is an input to computeHMACFast (#473)")
@@ -602,17 +620,17 @@ func TestComputeHMACFast_IncludesSaltVersionInPayload(t *testing.T) {
 	// Secondary assertion: re-compute HMAC externally over the on-wire
 	// bytes minus the `_hmac` field. The result must match the
 	// embedded HMAC, proving the wire-visible payload (which contains
-	// _hmac_v) IS what was fed into the HMAC.
+	// _hmac_version) IS what was fed into the HMAC.
 	canonicalV1 := stripHMACJSONField(lineV1)
 	verifiedV1, err := audit.VerifyHMAC(canonicalV1, hmacV1, salt, "HMAC-SHA-256")
 	require.NoError(t, err)
 	assert.True(t, verifiedV1,
-		"HMAC over (wire bytes minus _hmac) must verify — proves the payload fed to computeHMACFast was the wire content including _hmac_v")
+		"HMAC over (wire bytes minus _hmac) must verify — proves the payload fed to computeHMACFast was the wire content including _hmac_version")
 }
 
 // TestHMACOutputOrdering_VBeforeHmac asserts that on-wire JSON places
-// `_hmac_v` BEFORE `_hmac`. Pre-fix the order was reversed, which left
-// `_hmac_v` outside the authenticated region. Post-fix `_hmac_v` is
+// `_hmac_version` BEFORE `_hmac`. Pre-fix the order was reversed, which left
+// `_hmac_version` outside the authenticated region. Post-fix `_hmac_version` is
 // appended first so it is part of the hashed bytes.
 func TestHMACOutputOrdering_VBeforeHmac(t *testing.T) {
 	t.Parallel()
@@ -626,12 +644,12 @@ func TestHMACOutputOrdering_VBeforeHmac(t *testing.T) {
 
 	line := out.GetEvents()[0]
 	s := string(line)
-	vIdx := strings.Index(s, `"_hmac_v"`)
+	vIdx := strings.Index(s, `"_hmac_version"`)
 	hIdx := strings.Index(s, `"_hmac"`)
-	require.GreaterOrEqual(t, vIdx, 0, "_hmac_v must appear in JSON output")
+	require.GreaterOrEqual(t, vIdx, 0, "_hmac_version must appear in JSON output")
 	require.GreaterOrEqual(t, hIdx, 0, "_hmac must appear in JSON output")
 	assert.Less(t, vIdx, hIdx,
-		"_hmac_v must appear BEFORE _hmac so it is inside the authenticated region (issue #473)")
+		"_hmac_version must appear BEFORE _hmac so it is inside the authenticated region (issue #473)")
 }
 
 // TestDrainPipeline_NoFieldsAppearAfterHMAC asserts that `_hmac` is the
@@ -693,7 +711,7 @@ func TestHMAC_OnWireBytesMatchHashedBytes(t *testing.T) {
 	require.NotEmpty(t, hmacHex)
 
 	// Canonicalise: strip only `_hmac` from the on-wire bytes, keeping
-	// `_hmac_v` in place because it is authenticated.
+	// `_hmac_version` in place because it is authenticated.
 	canonical := stripHMACJSONField(line)
 
 	verified, err := audit.VerifyHMAC(canonical, hmacHex, salt, "HMAC-SHA-256")
@@ -704,11 +722,11 @@ func TestHMAC_OnWireBytesMatchHashedBytes(t *testing.T) {
 }
 
 // TestVerifyHMAC_TamperingHmacVersion_Detected is the primary security
-// regression test for issue #473. It emits an event with _hmac_v="v1",
-// mutates the on-wire bytes to set _hmac_v="v2" (simulating a MITM),
+// regression test for issue #473. It emits an event with _hmac_version="v1",
+// mutates the on-wire bytes to set _hmac_version="v2" (simulating a MITM),
 // then verifies using the correct salt and the canonicalisation rule
 // (strip only _hmac). The verifier MUST reject the tampered bytes
-// because _hmac_v is now part of the authenticated region.
+// because _hmac_version is now part of the authenticated region.
 func TestVerifyHMAC_TamperingHmacVersion_Detected(t *testing.T) {
 	t.Parallel()
 	salt := []byte("tamper-v-salt-16-bytes!!!!!")
@@ -728,9 +746,9 @@ func TestVerifyHMAC_TamperingHmacVersion_Detected(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, unverifyPassed, "unmodified event must verify")
 
-	// Tamper: replace "_hmac_v":"v1" with "_hmac_v":"v2" in the on-wire
+	// Tamper: replace "_hmac_version":"v1" with "_hmac_version":"v2" in the on-wire
 	// bytes. Both strings are the same length so positions don't shift.
-	tampered := bytes.Replace(line, []byte(`"_hmac_v":"v1"`), []byte(`"_hmac_v":"v2"`), 1)
+	tampered := bytes.Replace(line, []byte(`"_hmac_version":"v1"`), []byte(`"_hmac_version":"v2"`), 1)
 	require.NotEqual(t, line, tampered, "tamper step must modify the line")
 
 	// Canonicalise and verify: strip only _hmac from the TAMPERED bytes.
@@ -738,14 +756,14 @@ func TestVerifyHMAC_TamperingHmacVersion_Detected(t *testing.T) {
 	verified, err := audit.VerifyHMAC(canonical, hmacHex, salt, "HMAC-SHA-256")
 	require.NoError(t, err)
 	assert.False(t, verified,
-		"HMAC verification must fail on a tampered _hmac_v — this is the core guarantee of issue #473")
+		"HMAC verification must fail on a tampered _hmac_version — this is the core guarantee of issue #473")
 }
 
 // TestVerifyHMAC_TamperingActorId_Detected is the sanity counterpart to
 // the #473 primary test. It tampers a non-HMAC field (actor_id) and
 // confirms verification still fails, proving the HMAC continues to
 // cover the rest of the payload. Guards against a regression where
-// the fix accidentally narrows HMAC scope to only _hmac_v.
+// the fix accidentally narrows HMAC scope to only _hmac_version.
 func TestVerifyHMAC_TamperingActorId_Detected(t *testing.T) {
 	t.Parallel()
 	salt := []byte("tamper-actor-salt-16-bytes!")
@@ -793,10 +811,12 @@ func TestVerifyHMAC_CEF_TamperingHmacVersion_Detected(t *testing.T) {
 		audit.WithTaxonomy(tax),
 		audit.WithFormatter(cefFormatter),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v1",
-			SaltValue:   salt,
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v1",
+				Value:   salt,
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	require.NoError(t, err)
@@ -883,11 +903,11 @@ func extractCEFExtensionValue(t *testing.T, line []byte, key string) string {
 }
 
 // TestVerifyHMAC_RemoveHmacVersion_Detected covers the "delete to
-// downgrade" attack where an attacker strips `_hmac_v` entirely from
+// downgrade" attack where an attacker strips `_hmac_version` entirely from
 // the on-wire bytes. A naive verifier that parses JSON and uses a
-// default salt when `_hmac_v` is missing would accept the event.
+// default salt when `_hmac_version` is missing would accept the event.
 // The strip-only-`_hmac` canonicalisation correctly rejects this: the
-// original `_hmac_v` was part of the hashed bytes, so removing it
+// original `_hmac_version` was part of the hashed bytes, so removing it
 // changes the canonical payload and the HMAC no longer matches.
 func TestVerifyHMAC_RemoveHmacVersion_Detected(t *testing.T) {
 	t.Parallel()
@@ -903,17 +923,17 @@ func TestVerifyHMAC_RemoveHmacVersion_Detected(t *testing.T) {
 	hmacHex := extractJSONStringField(t, line, "_hmac")
 	require.NotEmpty(t, hmacHex)
 
-	// Remove `,"_hmac_v":"v1"` from the on-wire bytes entirely.
-	// _hmac_v is inside the authenticated region, so removing it
+	// Remove `,"_hmac_version":"v1"` from the on-wire bytes entirely.
+	// _hmac_version is inside the authenticated region, so removing it
 	// changes the canonicalised bytes and verification must fail.
-	removed := bytes.ReplaceAll(line, []byte(`,"_hmac_v":"v1"`), []byte(``))
+	removed := bytes.ReplaceAll(line, []byte(`,"_hmac_version":"v1"`), []byte(``))
 	require.NotEqual(t, line, removed, "remove step must modify the line")
 
 	canonical := stripHMACJSONField(removed)
 	verified, err := audit.VerifyHMAC(canonical, hmacHex, salt, "HMAC-SHA-256")
 	require.NoError(t, err)
 	assert.False(t, verified,
-		"removing _hmac_v from the wire must fail HMAC verification (issue #473: delete-to-downgrade attack)")
+		"removing _hmac_version from the wire must fail HMAC verification (issue #473: delete-to-downgrade attack)")
 }
 
 // TestVerifyHMAC_TamperingSeverity_Detected covers tampering with a
@@ -967,10 +987,12 @@ func TestVerifyHMAC_CEF_TamperingActorId_Detected(t *testing.T) {
 		audit.WithTaxonomy(tax),
 		audit.WithFormatter(cefFormatter),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v1",
-			SaltValue:   salt,
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v1",
+				Value:   salt,
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	require.NoError(t, err)
@@ -1026,10 +1048,12 @@ func TestHMAC_CEF_OnWireBytesMatchHashedBytes(t *testing.T) {
 		audit.WithTaxonomy(tax),
 		audit.WithFormatter(cefFormatter),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v1",
-			SaltValue:   salt,
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v1",
+				Value:   salt,
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	require.NoError(t, err)
@@ -1060,7 +1084,7 @@ func TestHMAC_CEF_OnWireBytesMatchHashedBytes(t *testing.T) {
 
 // TestReservedLibraryField_RejectedEvenWhenDeclaredInTaxonomy proves
 // that the runtime reserved-field check fires even if the consumer
-// managed to declare `_hmac` or `_hmac_v` as a taxonomy event field
+// managed to declare `_hmac` or `_hmac_version` as a taxonomy event field
 // (and the taxonomy-level `reservedFieldNames` check was bypassed or
 // disabled). The runtime check is the defence-in-depth safety net.
 func TestReservedLibraryField_RejectedEvenWhenDeclaredInTaxonomy(t *testing.T) {
@@ -1092,9 +1116,9 @@ func TestReservedLibraryField_RejectedEvenWhenDeclaredInTaxonomy(t *testing.T) {
 	defer func() { _ = auditor.Close() }()
 
 	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
-		"outcome":  "failure",
-		"actor_id": "alice",
-		"_hmac_v":  "attacker-injected-version",
+		"outcome":       "failure",
+		"actor_id":      "alice",
+		"_hmac_version": "attacker-injected-version",
 	}))
 	require.Error(t, err, "reserved field injection at runtime must be rejected")
 	assert.ErrorIs(t, err, audit.ErrReservedFieldName)

--- a/outputconfig/doc.go
+++ b/outputconfig/doc.go
@@ -68,7 +68,7 @@
 //	      salt:
 //	        version: "v1"
 //	        value: "${HMAC_SALT}"
-//	      hash: HMAC-SHA-256
+//	      algorithm: HMAC-SHA-256
 //
 // # Environment Variables
 //

--- a/outputconfig/hmac.go
+++ b/outputconfig/hmac.go
@@ -24,9 +24,9 @@ import (
 )
 
 type yamlHMACConfig struct { //nolint:govet // readability over alignment
-	Enabled bool         `yaml:"enabled"`
-	Salt    yamlHMACSalt `yaml:"salt"`
-	Hash    string       `yaml:"hash"`
+	Enabled   bool         `yaml:"enabled"`
+	Salt      yamlHMACSalt `yaml:"salt"`
+	Algorithm string       `yaml:"algorithm"`
 }
 
 // yamlHMACSalt is the YAML representation of the hmac.salt section.
@@ -94,10 +94,12 @@ func buildHMACConfig(ctx context.Context, name string, raw any, r *resolver) (*a
 	}
 
 	cfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: yc.Salt.Version,
-		SaltValue:   []byte(yc.Salt.Value),
-		Algorithm:   yc.Hash,
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: yc.Salt.Version,
+			Value:   []byte(yc.Salt.Value),
+		},
+		Algorithm: yc.Algorithm,
 	}
 
 	if vErr := audit.ValidateHMACConfig(cfg); vErr != nil {

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -1594,7 +1594,7 @@ outputs:
       salt:
         version: "v1"
         value: "this-is-a-test-salt!"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
 	result, err := outputconfig.Load(context.Background(), data, tax)
@@ -1602,7 +1602,7 @@ outputs:
 	require.Len(t, result.OutputMetadata(), 1)
 	require.NotNil(t, result.OutputMetadata()[0].HMACConfig)
 	assert.True(t, result.OutputMetadata()[0].HMACConfig.Enabled)
-	assert.Equal(t, "v1", result.OutputMetadata()[0].HMACConfig.SaltVersion)
+	assert.Equal(t, "v1", result.OutputMetadata()[0].HMACConfig.Salt.Version)
 	assert.Equal(t, "HMAC-SHA-256", result.OutputMetadata()[0].HMACConfig.Algorithm)
 }
 
@@ -1656,7 +1656,7 @@ outputs:
       salt:
         version: "v1"
         value: "short"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), data, tax)
@@ -1678,7 +1678,7 @@ outputs:
       salt:
         version: "v1"
         value: "valid-salt-sixteen-b!"
-      hash: MD5
+      algorithm: MD5
 `)
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), data, tax)
@@ -1697,7 +1697,7 @@ outputs:
     type: stdout
     hmac:
       enabled: true
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), data, tax)
@@ -1741,13 +1741,13 @@ outputs:
       salt:
         version: "v1"
         value: "${TEST_HMAC_SALT}"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
 	result, err := outputconfig.Load(context.Background(), data, tax)
 	require.NoError(t, err)
 	require.NotNil(t, result.OutputMetadata()[0].HMACConfig)
-	assert.Equal(t, []byte("env-salt-value-sixteen!"), result.OutputMetadata()[0].HMACConfig.SaltValue)
+	assert.Equal(t, []byte("env-salt-value-sixteen!"), result.OutputMetadata()[0].HMACConfig.Salt.Value)
 }
 
 func TestLoad_HMAC_SaltNotInError(t *testing.T) {
@@ -1764,7 +1764,7 @@ outputs:
       salt:
         version: "v1"
         value: "short"
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), data, tax)

--- a/outputconfig/provider_config_test.go
+++ b/outputconfig/provider_config_test.go
@@ -73,7 +73,7 @@ outputs:
       salt:
         version: "ref+openbao://secret/data/hmac#version"
         value: "ref+openbao://secret/data/hmac#salt"
-      hash: "ref+openbao://secret/data/hmac#hash"
+      algorithm: "ref+openbao://secret/data/hmac#hash"
 `
 	tax := testTaxonomy(t)
 	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
@@ -81,8 +81,8 @@ outputs:
 	require.Len(t, result.OutputMetadata(), 1)
 	require.NotNil(t, result.OutputMetadata()[0].HMACConfig)
 	assert.True(t, result.OutputMetadata()[0].HMACConfig.Enabled)
-	assert.Equal(t, "this-is-a-test-salt-value-at-least-16-bytes", string(result.OutputMetadata()[0].HMACConfig.SaltValue))
-	assert.Equal(t, "v1", result.OutputMetadata()[0].HMACConfig.SaltVersion)
+	assert.Equal(t, "this-is-a-test-salt-value-at-least-16-bytes", string(result.OutputMetadata()[0].HMACConfig.Salt.Value))
+	assert.Equal(t, "v1", result.OutputMetadata()[0].HMACConfig.Salt.Version)
 }
 
 func TestLoad_SecretsSection_Vault(t *testing.T) {
@@ -118,7 +118,7 @@ outputs:
       salt:
         version: "ref+vault://secret/data/hmac#version"
         value: "ref+vault://secret/data/hmac#salt"
-      hash: "ref+vault://secret/data/hmac#hash"
+      algorithm: "ref+vault://secret/data/hmac#hash"
 `
 	tax := testTaxonomy(t)
 	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
@@ -126,8 +126,8 @@ outputs:
 	require.Len(t, result.OutputMetadata(), 1)
 	require.NotNil(t, result.OutputMetadata()[0].HMACConfig)
 	assert.True(t, result.OutputMetadata()[0].HMACConfig.Enabled)
-	assert.Equal(t, "vault-salt-value-at-least-sixteen-bytes-long", string(result.OutputMetadata()[0].HMACConfig.SaltValue))
-	assert.Equal(t, "v2", result.OutputMetadata()[0].HMACConfig.SaltVersion)
+	assert.Equal(t, "vault-salt-value-at-least-sixteen-bytes-long", string(result.OutputMetadata()[0].HMACConfig.Salt.Value))
+	assert.Equal(t, "v2", result.OutputMetadata()[0].HMACConfig.Salt.Version)
 }
 
 func TestLoad_SecretsSection_AllowInsecureHTTP(t *testing.T) {
@@ -161,14 +161,14 @@ outputs:
       salt:
         version: "ref+openbao://secret/data/hmac#version"
         value: "ref+openbao://secret/data/hmac#salt"
-      hash: "ref+openbao://secret/data/hmac#hash"
+      algorithm: "ref+openbao://secret/data/hmac#hash"
 `
 	tax := testTaxonomy(t)
 	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
 	require.NoError(t, err)
 	require.Len(t, result.OutputMetadata(), 1)
 	require.NotNil(t, result.OutputMetadata()[0].HMACConfig)
-	assert.Equal(t, "insecure-salt-value-at-least-sixteen-bytes", string(result.OutputMetadata()[0].HMACConfig.SaltValue))
+	assert.Equal(t, "insecure-salt-value-at-least-sixteen-bytes", string(result.OutputMetadata()[0].HMACConfig.Salt.Value))
 }
 
 func TestLoad_SecretsSection_UnknownProvider(t *testing.T) {
@@ -355,7 +355,7 @@ outputs:
       salt:
         version: "ref+openbao://secret/data/hmac#version"
         value: "ref+openbao://secret/data/hmac#salt"
-      hash: "ref+openbao://secret/data/hmac#hash"
+      algorithm: "ref+openbao://secret/data/hmac#hash"
 `
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax,
@@ -474,14 +474,14 @@ outputs:
       salt:
         version: "ref+vault://secret/data/hmac#version"
         value: "ref+vault://secret/data/hmac#salt"
-      hash: "ref+vault://secret/data/hmac#hash"
+      algorithm: "ref+vault://secret/data/hmac#hash"
 `
 	tax := testTaxonomy(t)
 	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
 	require.NoError(t, err)
 	require.Len(t, result.OutputMetadata(), 1)
 	require.NotNil(t, result.OutputMetadata()[0].HMACConfig)
-	assert.Equal(t, "vault-http-salt-value-at-least-sixteen-bytes", string(result.OutputMetadata()[0].HMACConfig.SaltValue))
+	assert.Equal(t, "vault-http-salt-value-at-least-sixteen-bytes", string(result.OutputMetadata()[0].HMACConfig.Salt.Value))
 }
 
 func TestLoad_SecretsSection_BothProviders(t *testing.T) {
@@ -534,7 +534,7 @@ outputs:
       salt:
         version: "ref+openbao://secret/data/hmac#version"
         value: "ref+openbao://secret/data/hmac#salt"
-      hash: "ref+openbao://secret/data/hmac#hash"
+      algorithm: "ref+openbao://secret/data/hmac#hash"
   vault_output:
     type: stdout
     hmac:
@@ -542,15 +542,15 @@ outputs:
       salt:
         version: "ref+vault://secret/data/hmac#version"
         value: "ref+vault://secret/data/hmac#salt"
-      hash: "ref+vault://secret/data/hmac#hash"
+      algorithm: "ref+vault://secret/data/hmac#hash"
 `
 	tax := testTaxonomy(t)
 	result, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
 	require.NoError(t, err)
 	require.Len(t, result.OutputMetadata(), 2)
 
-	assert.Equal(t, "bao-salt-value-at-least-sixteen-bytes-long", string(result.OutputMetadata()[0].HMACConfig.SaltValue))
-	assert.Equal(t, "vault-salt-value-at-least-sixteen-bytes-long", string(result.OutputMetadata()[1].HMACConfig.SaltValue))
+	assert.Equal(t, "bao-salt-value-at-least-sixteen-bytes-long", string(result.OutputMetadata()[0].HMACConfig.Salt.Value))
+	assert.Equal(t, "vault-salt-value-at-least-sixteen-bytes-long", string(result.OutputMetadata()[1].HMACConfig.Salt.Value))
 }
 
 // ---------------------------------------------------------------------------

--- a/outputconfig/secrets_test.go
+++ b/outputconfig/secrets_test.go
@@ -121,7 +121,7 @@ outputs:
       salt:
         version: %s
         value: %s
-      hash: %s
+      algorithm: %s
 `, enabledValue, versionRef, saltRef, hashRef))
 }
 
@@ -155,8 +155,8 @@ func TestLoad_WithSecretProvider_AllHMACFieldsResolved(t *testing.T) {
 	hmac := result.OutputMetadata()[0].HMACConfig
 	require.NotNil(t, hmac)
 	assert.True(t, hmac.Enabled)
-	assert.Equal(t, "v1", hmac.SaltVersion)
-	assert.Equal(t, []byte("my-secret-salt-value-32bytes!!!!"), hmac.SaltValue)
+	assert.Equal(t, "v1", hmac.Salt.Version)
+	assert.Equal(t, []byte("my-secret-salt-value-32bytes!!!!"), hmac.Salt.Value)
 	assert.Equal(t, "HMAC-SHA-256", hmac.Algorithm)
 	for _, o := range result.OutputMetadata() {
 		_ = o.Output.Close()
@@ -183,7 +183,7 @@ outputs:
       salt:
         version: v1
         value: ${TEST_HMAC_SALT_REF}
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -193,7 +193,7 @@ outputs:
 	require.Len(t, result.OutputMetadata(), 1)
 	hmac := result.OutputMetadata()[0].HMACConfig
 	require.NotNil(t, hmac)
-	assert.Equal(t, []byte("env-var-resolved-salt-32bytes!!!"), hmac.SaltValue)
+	assert.Equal(t, []byte("env-var-resolved-salt-32bytes!!!"), hmac.Salt.Value)
 	for _, o := range result.OutputMetadata() {
 		_ = o.Output.Close()
 	}
@@ -316,7 +316,7 @@ outputs:
       salt:
         version: v1
         value: ref+mock://path#key
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -438,8 +438,8 @@ func TestLoad_ClearsResolverCacheBeforeReturn(t *testing.T) {
 	hmac1, hmac2 := result1.OutputMetadata()[0].HMACConfig, result2.OutputMetadata()[0].HMACConfig
 	require.NotNil(t, hmac1)
 	require.NotNil(t, hmac2)
-	assert.Equal(t, hmac1.SaltValue, hmac2.SaltValue)
-	assert.Equal(t, hmac1.SaltVersion, hmac2.SaltVersion)
+	assert.Equal(t, hmac1.Salt.Value, hmac2.Salt.Value)
+	assert.Equal(t, hmac1.Salt.Version, hmac2.Salt.Version)
 
 	for _, o := range result1.OutputMetadata() {
 		_ = o.Output.Close()
@@ -481,8 +481,8 @@ func TestLoad_WithSecretProvider_PathLevelCache_OneCallForMultipleKeys(t *testin
 	require.Len(t, result.OutputMetadata(), 1)
 	hmac := result.OutputMetadata()[0].HMACConfig
 	require.NotNil(t, hmac)
-	assert.Equal(t, "v1", hmac.SaltVersion)
-	assert.Equal(t, []byte("cached-salt-value-32-bytes!!!!!!"), hmac.SaltValue)
+	assert.Equal(t, "v1", hmac.Salt.Version)
+	assert.Equal(t, []byte("cached-salt-value-32-bytes!!!!!!"), hmac.Salt.Value)
 	assert.Equal(t, "HMAC-SHA-256", hmac.Algorithm)
 	for _, o := range result.OutputMetadata() {
 		_ = o.Output.Close()
@@ -507,7 +507,7 @@ outputs:
       salt:
         version: ${TEST_HMAC_VERSION}
         value: ref+mock://secret/data/hmac#salt
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -516,9 +516,9 @@ outputs:
 	require.NoError(t, err)
 	hmac := result.OutputMetadata()[0].HMACConfig
 	require.NotNil(t, hmac)
-	assert.Equal(t, "v2", hmac.SaltVersion)                                     // from env var
-	assert.Equal(t, []byte("ref-resolved-salt-value-32bytes!"), hmac.SaltValue) // from ref
-	assert.Equal(t, "HMAC-SHA-256", hmac.Algorithm)                             // literal
+	assert.Equal(t, "v2", hmac.Salt.Version)                                     // from env var
+	assert.Equal(t, []byte("ref-resolved-salt-value-32bytes!"), hmac.Salt.Value) // from ref
+	assert.Equal(t, "HMAC-SHA-256", hmac.Algorithm)                              // literal
 	for _, o := range result.OutputMetadata() {
 		_ = o.Output.Close()
 	}
@@ -540,7 +540,7 @@ outputs:
       salt:
         version: v1
         value: ref+vault://secret/data/hmac#salt
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -672,7 +672,7 @@ outputs:
       salt:
         version: v1
         value: ${TEST_HMAC_SALT_LITERAL}
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -681,7 +681,7 @@ outputs:
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), mock.calls.Load())
 	require.NotNil(t, result.OutputMetadata()[0].HMACConfig)
-	assert.Equal(t, []byte("literal-salt-value-32-bytes!!!!!"), result.OutputMetadata()[0].HMACConfig.SaltValue)
+	assert.Equal(t, []byte("literal-salt-value-32-bytes!!!!!"), result.OutputMetadata()[0].HMACConfig.Salt.Value)
 	for _, o := range result.OutputMetadata() {
 		_ = o.Output.Close()
 	}
@@ -713,7 +713,7 @@ outputs:
       salt:
         version: v1
         value: ref+mock://secret/data/hmac#salt
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	// The resolved value contains "ref+mock://..." which the safety
 	// net should flag as an unresolved reference.
@@ -750,7 +750,7 @@ outputs:
       salt:
         version: v1
         value: ref+mock://secret/data/hmac#salt
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -788,7 +788,7 @@ outputs:
       salt:
         version: v1
         value: ref+mock://secret/data/hmac#salt
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -796,7 +796,7 @@ outputs:
 	)
 	require.NoError(t, err)
 	require.NotNil(t, result.OutputMetadata()[0].HMACConfig)
-	assert.Equal(t, []byte("env-enabled-ref-salt-32-bytes!!!"), result.OutputMetadata()[0].HMACConfig.SaltValue)
+	assert.Equal(t, []byte("env-enabled-ref-salt-32-bytes!!!"), result.OutputMetadata()[0].HMACConfig.Salt.Value)
 	for _, o := range result.OutputMetadata() {
 		_ = o.Output.Close()
 	}
@@ -907,7 +907,7 @@ outputs:
       salt:
         version: v1
         value: my-salt-value-32-bytes!!!!!!!!
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
@@ -1081,7 +1081,7 @@ outputs:
       salt:
         version: v1
         value: my-salt-value-that-is-32-bytes!
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -1177,7 +1177,7 @@ outputs:
       salt:
         version: ref+nbmock://secret/data/hmac#version
         value: ref+nbmock://secret/data/hmac#salt
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	result, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -1187,8 +1187,8 @@ outputs:
 	require.Len(t, result.OutputMetadata(), 1)
 	hmac := result.OutputMetadata()[0].HMACConfig
 	require.NotNil(t, hmac)
-	assert.Equal(t, "v1", hmac.SaltVersion)
-	assert.Equal(t, []byte("non-batch-salt-value-32bytes!!!"), hmac.SaltValue)
+	assert.Equal(t, "v1", hmac.Salt.Version)
+	assert.Equal(t, []byte("non-batch-salt-value-32bytes!!!"), hmac.Salt.Value)
 	// Two distinct refs → two Resolve calls (no batch path).
 	assert.Equal(t, int64(2), p.calls.Load())
 	for _, o := range result.OutputMetadata() {
@@ -1247,7 +1247,7 @@ outputs:
       salt:
         version: v1
         value: ref+nbmock://secret/data/hmac#salt
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -1338,7 +1338,7 @@ outputs:
       salt:
         version: v1
         value: ref+prova://secret/data/hmac#salt
-      hash: ref+provb://secret/data/hmac#algorithm
+      algorithm: ref+provb://secret/data/hmac#algorithm
 `)
 	result, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -1349,7 +1349,7 @@ outputs:
 	require.Len(t, result.OutputMetadata(), 1)
 	hmac := result.OutputMetadata()[0].HMACConfig
 	require.NotNil(t, hmac)
-	assert.Equal(t, []byte("salt-from-prov-a-32-bytes!!!!!!"), hmac.SaltValue)
+	assert.Equal(t, []byte("salt-from-prov-a-32-bytes!!!!!!"), hmac.Salt.Value)
 	assert.Equal(t, "HMAC-SHA-256", hmac.Algorithm)
 	assert.Equal(t, int64(1), provA.calls.Load())
 	assert.Equal(t, int64(1), provB.calls.Load())
@@ -1390,7 +1390,7 @@ outputs:
       salt:
         version: v1
         value: ref+mock://secret/data/config#salt
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
 		context.Background(), data, tax,
@@ -1526,7 +1526,7 @@ outputs:
       salt:
         version: v1
         value: some-salt-value-that-is-32-bytes
-      hash: HMAC-SHA-256
+      algorithm: HMAC-SHA-256
 `)
 	_, err := outputconfig.Load(
 		context.Background(), data, tax,

--- a/outputconfig/testdata/bench_config.yaml
+++ b/outputconfig/testdata/bench_config.yaml
@@ -40,7 +40,7 @@ outputs:
       salt:
         version: "v1"
         value: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-      hash: "HMAC-SHA-256"
+      algorithm: "HMAC-SHA-256"
 
   security_log:
     type: file

--- a/outputconfig/tests/bdd/features/secret_resolution.feature
+++ b/outputconfig/tests/bdd/features/secret_resolution.feature
@@ -31,7 +31,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: my-literal-salt-32-bytes!!!!!!!
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
 
@@ -53,7 +53,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: ${BDD_HMAC_SALT_LITERAL}
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
 
@@ -77,7 +77,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: ref+mock://secret/data/hmac#version
               value: ref+mock://secret/data/hmac#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
 
@@ -101,7 +101,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: ${BDD_HMAC_SALT_REF}
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
 
@@ -125,7 +125,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: ${BDD_HMAC_VERSION}
               value: ref+mock://secret/data/hmac#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
 
@@ -167,7 +167,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: ref+vault://secret/data/hmac#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should fail with an error containing "no provider registered for scheme"
 
@@ -189,7 +189,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: ref+mock://secret/data/hmac
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should fail with an error containing "malformed secret reference"
 
@@ -211,7 +211,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: ref+mock://secret/../data/hmac#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should fail with an error containing "malformed secret reference"
 
@@ -235,7 +235,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: ref+mock://secret/data/hmac#salt
-            hash: ref+mock://nonexistent/path#algorithm
+            algorithm: ref+mock://nonexistent/path#algorithm
       """
     Then the config load should fail
     And the error message should not contain "SUPER-SECRET-MUST-NOT-APPEAR-IN-ERRORS"
@@ -259,7 +259,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: ref+mock://nonexistent/path#version
               value: ref+mock://nonexistent/path#salt
-            hash: ref+mock://nonexistent/path#algorithm
+            algorithm: ref+mock://nonexistent/path#algorithm
       """
     Then the config load should succeed
     And the mock provider call count should be 1
@@ -283,7 +283,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: ref+mock://nonexistent/path#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should fail with an error containing "secret not found"
 
@@ -304,7 +304,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: ref+nonexistent://path/does/not/matter#version
               value: ref+nonexistent://path/does/not/matter#salt
-            hash: ref+nonexistent://path/does/not/matter#hash
+            algorithm: ref+nonexistent://path/does/not/matter#hash
       """
     Then the config load should succeed
 
@@ -353,7 +353,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: ref+mock://secret/data/hmac#version
               value: ref+mock://secret/data/hmac#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
     And the mock provider call count should be 2
@@ -378,7 +378,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: v1
               value: ref+slow://secret/data/hmac#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should fail with an error containing "context"
 
@@ -440,7 +440,7 @@ Feature: Secret reference resolution in output configuration
             salt:
               version: ref+mock://secret/data/hmac#version
               value: ref+mock://secret/data/hmac#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
 

--- a/outputconfig/tests/bdd/features/secret_resolution_docker.feature
+++ b/outputconfig/tests/bdd/features/secret_resolution_docker.feature
@@ -36,7 +36,7 @@ Feature: Secret provider resolution with real containers
             salt:
               version: ref+<scheme>://secret/data/bdd/hmac#version
               value: ref+<scheme>://secret/data/bdd/hmac#salt
-            hash: ref+<scheme>://secret/data/bdd/hmac#algorithm
+            algorithm: ref+<scheme>://secret/data/bdd/hmac#algorithm
       """
     Then the config load should succeed
     And the HMAC config should have salt "bdd-real-salt-value-32-bytes!!!!"
@@ -66,7 +66,7 @@ Feature: Secret provider resolution with real containers
             salt:
               version: v1
               value: ${BDD_HMAC_SALT}
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
     And the HMAC config should have salt "env-to-ref-salt-value-32-bytes!!"
@@ -95,7 +95,7 @@ Feature: Secret provider resolution with real containers
             salt:
               version: ${BDD_HMAC_VERSION}
               value: ref+<scheme>://secret/data/bdd/mixed#salt
-            hash: HMAC-SHA-256
+            algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
     And the HMAC config should have salt "mixed-real-salt-value-32-bytes!!"

--- a/outputconfig/tests/bdd/steps/real_secret_steps.go
+++ b/outputconfig/tests/bdd/steps/real_secret_steps.go
@@ -219,7 +219,7 @@ func (tc *TestContext) stepAssertHMACSalt(expected string) error {
 	if hmac == nil {
 		return fmt.Errorf("HMAC config is nil")
 	}
-	actual := string(hmac.SaltValue)
+	actual := string(hmac.Salt.Value)
 	if actual != expected {
 		return fmt.Errorf("HMAC salt: got %q, want %q", actual, expected)
 	}

--- a/postfield.go
+++ b/postfield.go
@@ -188,7 +188,7 @@ func appendPostFieldCEFInto(buf *bytes.Buffer, f PostField) []byte {
 // appends every field in fields, and restores the terminator once —
 // saving one rewind / restore cycle per additional field over
 // N sequential [appendPostFieldInto] calls. Used by the drain
-// pipeline to emit the pre-HMAC batch (event_category + _hmac_v)
+// pipeline to emit the pre-HMAC batch (event_category + _hmac_version)
 // in a single buffer mutation; see [Auditor.assemblePostFields]
 // in drain.go.
 //

--- a/postfield_property_test.go
+++ b/postfield_property_test.go
@@ -187,7 +187,7 @@ func TestAppendPostFieldsCEFInto_PropertyEqualsSequentialInPlace(t *testing.T) {
 func TestAppendPostFieldsInto_MalformedBase(t *testing.T) {
 	fields := []PostField{
 		{JSONKey: "event_category", CEFKey: "cat", Value: "write"},
-		{JSONKey: "_hmac_v", CEFKey: "_hmacVersion", Value: "v1"},
+		{JSONKey: "_hmac_version", CEFKey: "_hmacVersion", Value: "v1"},
 	}
 
 	cases := []struct {

--- a/tests/bdd/features/hmac_integrity.feature
+++ b/tests/bdd/features/hmac_integrity.feature
@@ -14,14 +14,14 @@ Feature: HMAC Integrity Verification
     When I audit event "user_create" with required fields
     And I close the auditor
     Then the output should contain "_hmac" field
-    And the output should contain "_hmac_v" field with value "v1"
+    And the output should contain "_hmac_version" field with value "v1"
 
   Scenario: HMAC fields absent when not configured
     Given an auditor with stdout output
     When I audit event "user_create" with required fields
     And I close the auditor
     Then the output should not contain "_hmac" field
-    And the output should not contain "_hmac_v" field
+    And the output should not contain "_hmac_version" field
 
   # --- Independent verification ---
 
@@ -37,7 +37,7 @@ Feature: HMAC Integrity Verification
     Given an auditor with stdout output and HMAC enabled using salt "version-test-salt-16" version "2026-Q1" and hash "HMAC-SHA-256"
     When I audit event "user_create" with required fields
     And I close the auditor
-    Then the output should contain "_hmac_v" field with value "2026-Q1"
+    Then the output should contain "_hmac_version" field with value "2026-Q1"
 
   # --- Field stripping changes the HMAC ---
 
@@ -94,7 +94,7 @@ Feature: HMAC Integrity Verification
 
   # --- Salt version authentication (issue #473) ---
   #
-  # These scenarios prove that `_hmac_v` (the salt version identifier)
+  # These scenarios prove that `_hmac_version` (the salt version identifier)
   # is authenticated by the HMAC. Before the fix, an in-transit attacker
   # could flip the version from v1 to v2 to mislead a verifier's salt
   # lookup without detection.
@@ -103,7 +103,7 @@ Feature: HMAC Integrity Verification
     Given an auditor with stdout output and HMAC enabled using salt "tamper-v-salt-16-byt" version "v1" and hash "HMAC-SHA-256"
     When I audit event "user_create" with required fields
     And I close the auditor
-    And I tamper with the "_hmac_v" field in the captured output setting it to "v2"
+    And I tamper with the "_hmac_version" field in the captured output setting it to "v2"
     Then independently recomputing HMAC-SHA-256 over the tampered payload with salt "tamper-v-salt-16-byt" does NOT match the "_hmac" value
 
   Scenario: HMAC authentication covers consumer event fields
@@ -118,14 +118,14 @@ Feature: HMAC Integrity Verification
 
   # --- Consolidated pre-HMAC batch regression guard (issue #508) ---
   #
-  # When both event_category and _hmac_v are present they are written
+  # When both event_category and _hmac_version are present they are written
   # in a single pre-HMAC batch (drain.go assemblePostFields). This
   # scenario pins two invariants:
   #
   #   1. Both fields appear on the wire alongside _hmac.
   #   2. event_category is INSIDE the authenticated region — tampering
   #      with it after production breaks HMAC verification, same as
-  #      tampering with _hmac_v (#473) or any consumer field.
+  #      tampering with _hmac_version (#473) or any consumer field.
   #
   # A future refactor that accidentally emits event_category AFTER
   # computeHMACFast would leave it unauthenticated; this scenario
@@ -136,7 +136,7 @@ Feature: HMAC Integrity Verification
     When I audit event "user_create" with required fields
     And I close the auditor
     Then the captured output should contain field "event_category" with value "write"
-    And the output should contain "_hmac_v" field with value "v1"
+    And the output should contain "_hmac_version" field with value "v1"
     And the output should contain "_hmac" field
     And independently recomputing HMAC-SHA-256 over the payload with salt "batch-guard-salt-16b" matches the "_hmac" value
 
@@ -163,7 +163,7 @@ Feature: HMAC Integrity Verification
     Examples:
       | field   |
       | _hmac   |
-      | _hmac_v |
+      | _hmac_version |
 
   Scenario Outline: Reserved library field name rejected even in permissive mode
     Given an auditor with stdout output and validation mode "permissive"
@@ -179,7 +179,7 @@ Feature: HMAC Integrity Verification
     Examples:
       | field   |
       | _hmac   |
-      | _hmac_v |
+      | _hmac_version |
 
   # --- SaltVersion charset validation (issue #473 security-reviewer finding 3) ---
 

--- a/tests/bdd/features/loki_hmac.feature
+++ b/tests/bdd/features/loki_hmac.feature
@@ -7,7 +7,7 @@ Feature: HMAC Integrity with Loki Output
 
   The HMAC is computed in the core pipeline over the serialised
   payload (after field stripping, after event_category append, before
-  _hmac/_hmac_v append). The complete event including HMAC fields is
+  _hmac/_hmac_version append). The complete event including HMAC fields is
   then delivered to Loki via WriteWithMetadata. These tests verify
   the end-to-end chain: audit call → HMAC computation → Loki
   delivery → Loki query → independent HMAC verification.
@@ -40,7 +40,7 @@ Feature: HMAC Integrity with Loki Output
     And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the loki event payload should contain field "_hmac"
-    And the loki event payload should contain field "_hmac_v" with value "v1"
+    And the loki event payload should contain field "_hmac_version" with value "v1"
     And the loki event payload should contain:
       | field          | value        |
       | event_type     | user_create  |
@@ -56,7 +56,7 @@ Feature: HMAC Integrity with Loki Output
     And I close the auditor
     Then the loki server should contain the marker within 10 seconds
     And the loki event payload should not contain field "_hmac"
-    And the loki event payload should not contain field "_hmac_v"
+    And the loki event payload should not contain field "_hmac_version"
 
   Scenario: HMAC stored in Loki is independently verifiable
     Given an auditor with loki output and HMAC enabled using salt "loki-verify-salt-16!" version "v1" and hash "HMAC-SHA-256"
@@ -79,7 +79,7 @@ Feature: HMAC Integrity with Loki Output
     When I audit a uniquely marked "user_create" event with actor "alice" and outcome "success"
     And I close the auditor
     Then the loki server should contain the marker within 10 seconds
-    And the loki event payload should contain field "_hmac_v" with value "2026-Q2"
+    And the loki event payload should contain field "_hmac_version" with value "2026-Q2"
 
   Scenario: Sensitivity label stripping changes HMAC between Loki and full output
     Given the following taxonomy:
@@ -127,4 +127,4 @@ Feature: HMAC Integrity with Loki Output
       | host           | bdd-host     |
       | event_category | write        |
     And the loki event payload should contain field "_hmac"
-    And the loki event payload should contain field "_hmac_v" with value "v1"
+    And the loki event payload should contain field "_hmac_version" with value "v1"

--- a/tests/bdd/features/syslog_severity.feature
+++ b/tests/bdd/features/syslog_severity.feature
@@ -151,7 +151,7 @@ Feature: Syslog Severity Mapping and Cross-Cutting Features
     And I close the auditor
     Then the syslog server should contain marker "hmac_present" within 10 seconds
     And the syslog line with marker "hmac_present" should contain "_hmac"
-    And the syslog line with marker "hmac_present" should contain "_hmac_v"
+    And the syslog line with marker "hmac_present" should contain "_hmac_version"
     And the syslog line with marker "hmac_present" should contain "v1"
 
   Scenario: HMAC fields absent in syslog output when not configured

--- a/tests/bdd/steps/hmac_steps.go
+++ b/tests/bdd/steps/hmac_steps.go
@@ -42,10 +42,12 @@ func registerHMACGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 			auditor, err := audit.New(
 				audit.WithTaxonomy(tc.Taxonomy),
 				audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-					Enabled:     true,
-					SaltVersion: version,
-					SaltValue:   []byte(salt),
-					Algorithm:   hash,
+					Enabled: true,
+					Salt: audit.HMACSalt{
+						Version: version,
+						Value:   []byte(salt),
+					},
+					Algorithm: hash,
 				})),
 			)
 			if err != nil {
@@ -64,10 +66,12 @@ func registerHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 			_, err := audit.New(
 				audit.WithTaxonomy(tc.Taxonomy),
 				audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-					Enabled:     true,
-					SaltVersion: version,
-					SaltValue:   []byte(salt),
-					Algorithm:   hash,
+					Enabled: true,
+					Salt: audit.HMACSalt{
+						Version: version,
+						Value:   []byte(salt),
+					},
+					Algorithm: hash,
 				})),
 			)
 			tc.LastErr = err
@@ -82,9 +86,9 @@ func registerHMACThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 func registerHMACPresenceSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^the output should contain "_hmac" field$`, func() error { return assertCapturedContainsHMAC(tc) })
-	ctx.Step(`^the output should contain "_hmac_v" field with value "([^"]*)"$`, func(want string) error { return assertCapturedHMACVersion(tc, want) })
+	ctx.Step(`^the output should contain "_hmac_version" field with value "([^"]*)"$`, func(want string) error { return assertCapturedHMACVersion(tc, want) })
 	ctx.Step(`^the output should not contain "_hmac" field$`, func() error { return assertNoHMACField(tc) })
-	ctx.Step(`^the output should not contain "_hmac_v" field$`, func() error { return assertNoHMACVersionField(tc) })
+	ctx.Step(`^the output should not contain "_hmac_version" field$`, func() error { return assertNoHMACVersionField(tc) })
 	ctx.Step(`^the captured output should contain field "([^"]*)" with value "([^"]*)"$`,
 		func(field, want string) error { return assertCapturedFieldValue(tc, field, want) })
 }
@@ -154,8 +158,8 @@ func assertNoHMACVersionField(tc *AuditTestContext) error {
 		return fmt.Errorf("no events captured")
 	}
 	for _, raw := range lines {
-		if strings.Contains(string(raw), `"_hmac_v"`) {
-			return fmt.Errorf("event unexpectedly contains _hmac_v field")
+		if strings.Contains(string(raw), `"_hmac_version"`) {
+			return fmt.Errorf("event unexpectedly contains _hmac_version field")
 		}
 	}
 	return nil
@@ -170,7 +174,7 @@ func registerHMACVerificationSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 
 	// Salt-version authentication tamper-detection steps (issue #473).
 	//
-	// Together these verify that the HMAC covers _hmac_v and the rest of
+	// Together these verify that the HMAC covers _hmac_version and the rest of
 	// the payload: tamper with a field, recompute the HMAC over the
 	// tampered bytes (stripping only _hmac), and assert the HMAC does
 	// NOT match.
@@ -256,7 +260,7 @@ func tamperCapturedField(tc *AuditTestContext, fieldName, newValue string) error
 }
 
 // assertTamperedHMACMismatches strips only _hmac from the tampered raw
-// bytes (leaving _hmac_v inside the authenticated region per issue
+// bytes (leaving _hmac_version inside the authenticated region per issue
 // #473), recomputes HMAC-SHA-256 with the given salt, and asserts it
 // does NOT match the original _hmac value. If verification succeeds
 // on tampered bytes, the HMAC has failed to cover the tampered field.
@@ -285,12 +289,12 @@ func assertHMACVersion(raw []byte, want string) error {
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return fmt.Errorf("parse event JSON: %w", err)
 	}
-	got, ok := m["_hmac_v"]
+	got, ok := m["_hmac_version"]
 	if !ok {
-		return fmt.Errorf("event does not contain _hmac_v field")
+		return fmt.Errorf("event does not contain _hmac_version field")
 	}
 	if fmt.Sprint(got) != want {
-		return fmt.Errorf("_hmac_v: want %q, got %q", want, got)
+		return fmt.Errorf("_hmac_version: want %q, got %q", want, got)
 	}
 	return nil
 }
@@ -306,7 +310,7 @@ func verifyEventHMAC(raw []byte, salt string) error {
 	}
 
 	// Reconstruct the authenticated payload: strip ONLY the `_hmac`
-	// field. `_hmac_v` (salt version) is inside the authenticated
+	// field. `_hmac_version` (salt version) is inside the authenticated
 	// region per issue #473 and must remain.
 	payload := stripHMACField(raw)
 
@@ -321,7 +325,7 @@ func verifyEventHMAC(raw []byte, salt string) error {
 }
 
 // stripHMACField removes the `,"_hmac":"..."` field from a JSON line,
-// returning the bytes the HMAC was computed over. `_hmac_v` is left
+// returning the bytes the HMAC was computed over. `_hmac_version` is left
 // intact because it is authenticated by the HMAC (issue #473).
 func stripHMACField(line []byte) []byte {
 	s := string(line)
@@ -501,16 +505,20 @@ func createDualHMACAuditor(tc *AuditTestContext, strippedName, label, fullSalt, 
 	// Different salts per output — proves each output applies its own
 	// HMAC config independently, not a shared singleton.
 	fullHMACCfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v1",
-		SaltValue:   []byte(fullSalt),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v1",
+			Value:   []byte(fullSalt),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 	strippedHMACCfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: "v2",
-		SaltValue:   []byte(strippedSalt),
-		Algorithm:   "HMAC-SHA-256",
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: "v2",
+			Value:   []byte(strippedSalt),
+		},
+		Algorithm: "HMAC-SHA-256",
 	}
 
 	auditor, err := audit.New(

--- a/tests/bdd/steps/loki_fanout_steps.go
+++ b/tests/bdd/steps/loki_fanout_steps.go
@@ -50,10 +50,12 @@ func registerLokiFanoutGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 	ctx.Step(`^an auditor with file and loki outputs both HMAC-enabled with salt "([^"]*)" version "([^"]*)"$`,
 		func(salt, version string) error {
 			hmacCfg := &audit.HMACConfig{
-				Enabled:     true,
-				SaltVersion: version,
-				SaltValue:   []byte(salt),
-				Algorithm:   "HMAC-SHA-256",
+				Enabled: true,
+				Salt: audit.HMACSalt{
+					Version: version,
+					Value:   []byte(salt),
+				},
+				Algorithm: "HMAC-SHA-256",
 			}
 			return createFileAndLokiAuditor(tc, hmacCfg, nil)
 		})

--- a/tests/bdd/steps/loki_hmac_steps.go
+++ b/tests/bdd/steps/loki_hmac_steps.go
@@ -249,10 +249,12 @@ func createLokiAuditorWithHMAC(tc *AuditTestContext, salt, version, hash string,
 	tc.LokiOutputName = out.Name()
 
 	hmacCfg := &audit.HMACConfig{
-		Enabled:     true,
-		SaltVersion: version,
-		SaltValue:   []byte(salt),
-		Algorithm:   hash,
+		Enabled: true,
+		Salt: audit.HMACSalt{
+			Version: version,
+			Value:   []byte(salt),
+		},
+		Algorithm: hash,
 	}
 
 	opts := []audit.Option{
@@ -268,10 +270,12 @@ func createLokiAuditorWithHMAC(tc *AuditTestContext, salt, version, hash string,
 		capture := newCaptureOutput("capture-full")
 		tc.CaptureOutput = capture
 		opts = append(opts, audit.WithNamedOutput(capture, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v-capture",
-			SaltValue:   []byte("capture-comparison16"),
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v-capture",
+				Value:   []byte("capture-comparison16"),
+			},
+			Algorithm: "HMAC-SHA-256",
 		})))
 	}
 	opts = append(opts, audit.WithNamedOutput(out, lokiOpts...))
@@ -305,16 +309,20 @@ func createLokiAuditorWithHMACAndCapture(tc *AuditTestContext, lokiSalt, lokiVer
 		audit.WithAppName("bdd-audit"),
 		audit.WithHost("bdd-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: lokiVersion,
-			SaltValue:   []byte(lokiSalt),
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: lokiVersion,
+				Value:   []byte(lokiSalt),
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 		audit.WithNamedOutput(capture, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: "v-capture",
-			SaltValue:   []byte("capture-salt-beta16!"),
-			Algorithm:   "HMAC-SHA-256",
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: "v-capture",
+				Value:   []byte("capture-salt-beta16!"),
+			},
+			Algorithm: "HMAC-SHA-256",
 		})),
 	)
 	if err != nil {

--- a/tests/bdd/steps/syslog_severity_steps.go
+++ b/tests/bdd/steps/syslog_severity_steps.go
@@ -374,10 +374,12 @@ func createSyslogAuditorWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt,
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
-			Enabled:     true,
-			SaltVersion: version,
-			SaltValue:   []byte(salt),
-			Algorithm:   hash,
+			Enabled: true,
+			Salt: audit.HMACSalt{
+				Version: version,
+				Value:   []byte(salt),
+			},
+			Algorithm: hash,
 		})),
 	}
 	opts = append(opts, tc.Options...)

--- a/validate_fields.go
+++ b/validate_fields.go
@@ -36,8 +36,8 @@ func (a *Auditor) validateFields(eventType string, def *EventDef, fields Fields)
 // regardless of ValidationMode — permissive mode cannot opt out of
 // this check.
 var libraryReservedFields = map[string]struct{}{
-	"_hmac":   {},
-	"_hmac_v": {},
+	"_hmac":         {},
+	"_hmac_version": {},
 }
 
 // checkLibraryReservedFields rejects events whose Fields map contains

--- a/validate_taxonomy.go
+++ b/validate_taxonomy.go
@@ -252,7 +252,7 @@ func reservedFieldNames() []string {
 	return []string{
 		"timestamp", "event_type", "severity", "event_category",
 		"app_name", "host", "timezone", "pid",
-		"_hmac", "_hmac_v",
+		"_hmac", "_hmac_version",
 	}
 }
 


### PR DESCRIPTION
## Summary

Aligns HMAC naming across Go struct, YAML schema, and wire format for v1.0 API lock-in. Closes #582 (B-08 + B-36).

Three coordinated breaking renames:

1. **Go struct restructured** — flat `HMACConfig.SaltVersion` + `.SaltValue` → nested `.Salt audit.HMACSalt{Version, Value}`. New exported type implements `fmt.Stringer` + `fmt.GoStringer` to redact `Value` from `%v` / `%+v` / `%#v`. Stdlib precedent: `tls.Config` → `tls.Certificate`.
2. **YAML key** — `hmac.hash` → `hmac.algorithm`. The field holds an HMAC algorithm identifier (e.g. `HMAC-SHA-256`), not a hash name. Go already called it `Algorithm`. No backward-compat alias — stale configs fail loudly with `DisallowUnknownField`.
3. **Wire key** — JSON `_hmac_v` → `_hmac_version`. CEF `_hmacVersion` unchanged. The snake/camel pair matches `event_category` / `eventCategory`. `_hmac_v` was ambiguous (version / value / verify). Position inside the HMAC-authenticated byte range is preserved (#473 invariant).

ADR: [`docs/adr/0004-hmac-wire-field-naming.md`](docs/adr/0004-hmac-wire-field-naming.md).

## Migration

```go
// Before
cfg := audit.HMACConfig{
    Enabled:     true,
    SaltVersion: "2026-Q1",
    SaltValue:   salt,
    Algorithm:   "HMAC-SHA-256",
}

// After
cfg := audit.HMACConfig{
    Enabled: true,
    Salt:    audit.HMACSalt{Version: "2026-Q1", Value: salt},
    Algorithm: "HMAC-SHA-256",
}
```

```yaml
# Before
hmac:
  enabled: true
  salt: { version: "2026-Q1", value: "${HMAC_SALT}" }
  hash: HMAC-SHA-256

# After
hmac:
  enabled: true
  salt: { version: "2026-Q1", value: "${HMAC_SALT}" }
  algorithm: HMAC-SHA-256
```

External JSON verifiers: update string constant `_hmac_v` → `_hmac_version`. Continue to strip only `_hmac` (never `_hmac_version`) before recomputing. CEF verifiers: no change.

## Agent gates

- [x] **api-ergonomics-reviewer** (pre-coding, blocking) — approved `HMACSalt` prefixed type + `_hmac_version` rename with stdlib precedent justifications.
- [x] **code-reviewer** — 1 IMPORTANT + 1 NIT addressed: stale error-reference.md table rewritten, comment strings in hmac_test.go/errors.go/postfield.go swept.
- [x] **security-reviewer** — APPROVED. Confirmed #473 authenticated-region invariant preserved; reserved-field guards updated; salt confidentiality intact; charset/length validation unchanged.
- [x] **docs-writer** — 2 addressed findings: `outputconfig/doc.go:71` `hash:` → `algorithm:`, `HMACSalt.String()` + `GoString()` added so the "redacted from %v" godoc claim is enforced. ADR date flagged by docs-writer was actually correct for today.
- [x] **go-quality** — all automated gates pass; godoc on all new exported symbols.
- [x] **commit-message-reviewer** — PASS (subject shortened to 66 chars).

## Test plan

- [x] `go build ./...` clean.
- [x] `make lint` 0 issues across all 12 modules.
- [x] `make test` passes with `-race` across all modules (95.5% core coverage preserved).
- [x] `make fmt-check`, `make vet`, `make tidy-check`, `go mod verify` clean.
- [ ] CI — pending.
- [ ] BDD — runs in CI; features updated.

## Files touched

47 files: `hmac.go`, `outputconfig/hmac.go`, `drain.go`, `validate_fields.go`, `validate_taxonomy.go`, `audittest/recorder.go`; 3 BDD feature files + step files; 5 example/capstone YAMLs + READMEs; 10 doc files; CHANGELOG + V1-RELEASE-PLAN; new ADR-0004.