### PR TITLE
docs: blank-import outputs in examples; fix runtime (#585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 > **Deviations from #566 AC (accepted):** (1) `audittest.PermissiveTaxonomy()` NOT added — `audittest.QuickTaxonomy()` already exists and fills the same role; adding a second name violates the "one obvious way" principle. (2) `WithExcludedLabels` renamed to `WithExcludeLabels` to match core `audit.WithExcludeLabels` exactly (no "d"). (3) AC named `RecordedEvents.WaitForN` (a type name from the original issue draft that was never implemented in the codebase) — the actual type is `*audittest.Recorder`, so `WaitForN` is a method on `*Recorder`. All three deviations confirmed with api-ergonomics-reviewer.
 
+### Changed
+
+- All examples (`examples/02-code-generation` through `examples/17-capstone`) now blank-import the `outputs` convenience package in place of individual output-module imports (#585). README + `docs/output-configuration.md` now lead with `import _ "github.com/axonops/audit/outputs"` as the default registration path, with individual sub-module imports documented as a binary-size optimisation. No API change; consumers who already use either pattern are unaffected.
+
+### Fixed
+
+- Examples `02-code-generation`, `04-testing`, `06-middleware`, `13-standard-fields`, and `15-tls-policy` failed at runtime with `unknown output type "stdout"` because they declared `type: stdout` in `outputs.yaml` without blank-importing anything that registered the stdout factory (stdout auto-registration was removed in #578). The new `_ "github.com/axonops/audit/outputs"` blank import registers stdout alongside the other built-ins (#585).
+
 ### Breaking Changes
 
 - HMAC configuration and wire format aligned for v1.0 API lock-in (#582). Three coordinated renames, detailed in [ADR-0004](docs/adr/0004-hmac-wire-field-naming.md):

--- a/README.md
+++ b/README.md
@@ -261,15 +261,31 @@ go get github.com/axonops/audit/outputconfig # YAML-based output configuration
 | `github.com/axonops/audit/webhook` | Batched HTTP webhook with retry and SSRF protection |
 | `github.com/axonops/audit/loki` | Grafana Loki output with stream labels, gzip, multi-tenancy |
 | `github.com/axonops/audit/outputconfig` | YAML-based output configuration with env var substitution |
-| `github.com/axonops/audit/outputs` | Convenience: single blank import registers all output factories |
+| `github.com/axonops/audit/outputs` | **Recommended default** — single blank import registers all output factories |
 | `github.com/axonops/audit/secrets` | Secret provider interface for `ref+` URI resolution in YAML config |
 | `github.com/axonops/audit/secrets/openbao` | OpenBao KV v2 secret provider |
 | `github.com/axonops/audit/secrets/vault` | HashiCorp Vault KV v2 secret provider |
 | `github.com/axonops/audit/cmd/audit-gen` | Code generator: YAML taxonomy to typed Go builders |
 
 Outputs are isolated in separate modules so the core library carries
-minimal third-party dependencies. Import only the outputs you use —
-or `import _ "github.com/axonops/audit/outputs"` to register all of them.
+minimal third-party dependencies. The default path is the
+convenience package — one blank import registers every built-in
+output:
+
+```go
+import _ "github.com/axonops/audit/outputs"
+```
+
+Production services typically import only the outputs they use —
+shaving a few MB of transitive dependencies (`goccy/go-yaml`,
+`srslog`, HTTP stacks) per unused output — and the convenience
+package is ideal for demos, examples, and apps that use most output
+types:
+
+```go
+import _ "github.com/axonops/audit/file"   // only if you use type: file
+import _ "github.com/axonops/audit/syslog" // only if you use type: syslog
+```
 
 ---
 

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -115,7 +115,7 @@ Every issue follows this sequence. Do not skip steps.
 - [x] **#582** refactor: align HMAC Go and YAML field names; unify _hmac_version / _hmacVersion.
 - [x] **#583** refactor: rename syslog.app_name YAML to procid or syslog_app_name; default APP-NAME from top-level app_name.
 - [x] **#584** refactor: align Loki gzip YAML key and Go Compress field.
-- [ ] **#585** refactor: examples use outputs convenience package instead of individual blank imports.
+- [x] **#585** refactor: examples use outputs convenience package instead of individual blank imports.
 - [ ] **#586** refactor: replace Metrics.RecordEvent stringly-typed status with EventStatus enum.
 - [ ] **#587** perf: WrapOutput conditionally implements MetadataWriter based on inner capability.
 - [ ] **#588** refactor: inline rgooding/go-syncmap; drop third-party dependency on filter hot path.

--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -613,26 +613,30 @@ setup, caching, security model, and error reference.
 ## 🏭 Factory Registry
 
 Output types must be registered before `Load` can create them.
-Registration happens via blank imports in your application:
-
-```go
-import (
-    _ "github.com/axonops/audit/file"
-    _ "github.com/axonops/audit/syslog"
-    _ "github.com/axonops/audit/webhook"
-    _ "github.com/axonops/audit/loki"
-)
-```
-
-Or register all output types with a single import:
+Registration happens via a blank import in your application. The
+default — and recommended — path is the convenience package, which
+registers every built-in output (including stdout) in a single line:
 
 ```go
 import _ "github.com/axonops/audit/outputs"
 ```
 
-If an output type's module is not imported, `Load` returns an error
-— no output is silently dropped. The `stdout` type is always
-available (built into core).
+This is the pattern every example in this repository uses.
+
+If you are optimising for binary size and know exactly which output
+types your YAML references, import only those sub-modules:
+
+```go
+import (
+    _ "github.com/axonops/audit/file"
+    _ "github.com/axonops/audit/syslog"
+)
+```
+
+Note that `stdout` is also a separate module; if you use
+`type: stdout` without importing `outputs` (or calling
+`audit.MustRegisterOutputFactory("stdout", audit.StdoutFactory())`),
+`Load` returns an error — no output is silently dropped.
 
 ## 📦 Loading Output Configuration
 

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -27,6 +27,7 @@ import (
 	"log"
 
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/03-file-output/README.md
+++ b/examples/03-file-output/README.md
@@ -75,19 +75,28 @@ misconfiguration.
 
 ### Enabling the File Output Type
 
-The file output lives in its own Go module. A blank import registers it
-with the output factory:
+The file output lives in its own Go module. The easiest way to
+register it (along with every other built-in output) is to blank-
+import the convenience package:
 
 ```go
 import (
-    _ "github.com/axonops/audit/file"
     "github.com/axonops/audit/outputconfig"
+    _ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 ```
 
-If you reference `type: file` in YAML without this import,
+If you prefer to register only the outputs you use (smaller binary
+for constrained deployments), import the individual sub-module
+instead:
+
+```go
+import _ "github.com/axonops/audit/file"
+```
+
+If `type: file` appears in YAML without either import,
 `outputconfig.Load` returns an error like:
-`output "audit_log": unknown output type "file" (registered: [stdout]); did you import _ "github.com/axonops/audit/file"?`
+`output "audit_log": unknown output type "file" (registered: []); add import _ "github.com/axonops/audit/outputs" for all built-in types (or import _ "github.com/axonops/audit/file" for only this one)`
 
 ### Close Flushes to Disk
 

--- a/examples/03-file-output/main.go
+++ b/examples/03-file-output/main.go
@@ -24,8 +24,8 @@ import (
 	"log"
 	"os"
 
-	_ "github.com/axonops/audit/file"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/04-testing/main.go
+++ b/examples/04-testing/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/axonops/audit"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/05-formatters/main.go
+++ b/examples/05-formatters/main.go
@@ -24,8 +24,8 @@ import (
 	"log"
 	"os"
 
-	_ "github.com/axonops/audit/file"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/06-middleware/main.go
+++ b/examples/06-middleware/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/axonops/audit"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/07-syslog-output/README.md
+++ b/examples/07-syslog-output/README.md
@@ -202,7 +202,7 @@ is retried once on the new connection.
 ```yaml
 outputs:
   siem:
-    type: syslog               # Register with: import _ "github.com/axonops/audit/syslog"
+    type: syslog               # Register with: import _ "github.com/axonops/audit/outputs" (all types) or _ "github.com/axonops/audit/syslog" (this type only)
     syslog:
       network: "tcp"           # Transport: "tcp" (default), "udp", or "tcp+tls"
       address: "localhost:1514" # Required: host:port of the syslog server
@@ -237,18 +237,25 @@ comparison.
 
 ## Blank Import Required
 
-Unlike stdout (which is built-in), syslog requires a blank import to
-register its factory:
+Every output (including stdout) lives in a separate Go module and
+requires a blank import to register its factory. The easiest path is
+the convenience package that registers all built-in outputs:
+
+```go
+import _ "github.com/axonops/audit/outputs"
+```
+
+If you prefer to register only this example's output (smaller binary
+for constrained deployments), import the syslog sub-module directly:
 
 ```go
 import _ "github.com/axonops/audit/syslog"
 ```
 
-This is needed because the syslog output lives in a separate module
-(`github.com/axonops/audit/syslog`) that depends on the
-`github.com/axonops/srslog` library for RFC 5424 formatting. The blank
-import triggers the `init()` function that registers the `"syslog"`
-output factory.
+Syslog itself lives in `github.com/axonops/audit/syslog`, which
+depends on the `github.com/axonops/srslog` library for RFC 5424
+formatting. The blank import triggers the `init()` function that
+registers the `"syslog"` output factory.
 
 ## Further Reading
 

--- a/examples/07-syslog-output/main.go
+++ b/examples/07-syslog-output/main.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/axonops/audit"
 	"github.com/axonops/audit/outputconfig"
-	_ "github.com/axonops/audit/syslog"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/08-webhook-output/README.md
+++ b/examples/08-webhook-output/README.md
@@ -173,7 +173,7 @@ webhook:
 ```yaml
 outputs:
   alerts:
-    type: webhook              # Register with: import _ "github.com/axonops/audit/webhook"
+    type: webhook              # Register with: import _ "github.com/axonops/audit/outputs" (all types) or _ "github.com/axonops/audit/webhook" (this type only)
     webhook:
       url: "http://localhost:9090/audit"  # Required. Must be https:// in production
       batch_size: 10           # Events per batch (default: 100, max: 10,000)
@@ -189,15 +189,23 @@ outputs:
 
 ## Blank Import Required
 
-Like syslog and loki, the webhook output requires a blank import:
+Every output (including stdout) requires a blank import to register
+its factory. The easiest path is the convenience package that
+registers all built-in outputs:
+
+```go
+import _ "github.com/axonops/audit/outputs"
+```
+
+If you prefer to register only webhook (smaller binary for
+constrained deployments), import the sub-module directly:
 
 ```go
 import _ "github.com/axonops/audit/webhook"
 ```
 
-This registers the `"webhook"` output factory. Without it,
-`outputconfig.Load` returns an error when it encounters `type: webhook`
-in the YAML.
+Without either, `outputconfig.Load` returns an error when it
+encounters `type: webhook` in the YAML.
 
 ## Further Reading
 

--- a/examples/08-webhook-output/main.go
+++ b/examples/08-webhook-output/main.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/axonops/audit"
 	"github.com/axonops/audit/outputconfig"
-	_ "github.com/axonops/audit/webhook"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/09-multi-output/main.go
+++ b/examples/09-multi-output/main.go
@@ -25,8 +25,8 @@ import (
 	"os"
 
 	"github.com/axonops/audit"
-	_ "github.com/axonops/audit/file"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/10-event-routing/main.go
+++ b/examples/10-event-routing/main.go
@@ -24,8 +24,8 @@ import (
 	"log"
 	"os"
 
-	_ "github.com/axonops/audit/file"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/11-sensitivity-labels/main.go
+++ b/examples/11-sensitivity-labels/main.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 
 	"github.com/axonops/audit"
-	_ "github.com/axonops/audit/file"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/12-hmac-integrity/main.go
+++ b/examples/12-hmac-integrity/main.go
@@ -24,8 +24,8 @@ import (
 	"log"
 	"os"
 
-	_ "github.com/axonops/audit/file"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/13-standard-fields/main.go
+++ b/examples/13-standard-fields/main.go
@@ -27,6 +27,7 @@ import (
 	"log"
 
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/14-loki-output/README.md
+++ b/examples/14-loki-output/README.md
@@ -379,7 +379,7 @@ host: "dev-machine"          # → stream label host="dev-machine"
 
 outputs:
   loki_audit:
-    type: loki               # Registers via: import _ "github.com/axonops/audit/loki"
+    type: loki               # Register with: import _ "github.com/axonops/audit/outputs" (all types) or _ "github.com/axonops/audit/loki" (this type only)
     loki:
       url: "http://localhost:3100/loki/api/v1/push"  # Full path required
       tenant_id: "example"   # Sets X-Scope-OrgID header for multi-tenant Loki
@@ -402,6 +402,27 @@ outputs:
           pid: false         # Exclude PID (high cardinality in dev)
           # To exclude other labels: severity: false, host: false, etc.
 ```
+
+## Blank Import Required
+
+Every output (including stdout) lives in a separate Go module and
+requires a blank import to register its factory. The easiest path is
+the convenience package that registers all built-in outputs:
+
+```go
+import _ "github.com/axonops/audit/outputs"
+```
+
+If you prefer to register only Loki (smaller binary for constrained
+deployments — Loki pulls in the full HTTP + gzip stack), import the
+sub-module directly:
+
+```go
+import _ "github.com/axonops/audit/loki"
+```
+
+Without either, `outputconfig.Load` returns an error when it
+encounters `type: loki` in the YAML.
 
 ## What the Event JSON Looks Like
 

--- a/examples/14-loki-output/main.go
+++ b/examples/14-loki-output/main.go
@@ -38,8 +38,8 @@ import (
 	"log"
 	"time"
 
-	_ "github.com/axonops/audit/loki" // register "loki" output type
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/15-tls-policy/main.go
+++ b/examples/15-tls-policy/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/axonops/audit"
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/16-buffering/main.go
+++ b/examples/16-buffering/main.go
@@ -38,9 +38,8 @@ import (
 	"time"
 
 	"github.com/axonops/audit"
-	_ "github.com/axonops/audit/file" // register "file" output type
 	"github.com/axonops/audit/outputconfig"
-	_ "github.com/axonops/audit/webhook" // register "webhook" output type
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 //go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main

--- a/examples/17-capstone/audit_setup.go
+++ b/examples/17-capstone/audit_setup.go
@@ -18,9 +18,8 @@ import (
 	"context"
 
 	"github.com/axonops/audit"
-	_ "github.com/axonops/audit/file" // register "file" output type
-	_ "github.com/axonops/audit/loki" // register "loki" output type
 	"github.com/axonops/audit/outputconfig"
+	_ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki
 )
 
 // setupAuditor creates an auditor using the outputconfig.New facade.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/axonops/audit/file v0.1.11
 	github.com/axonops/audit/loki v0.1.11
 	github.com/axonops/audit/outputconfig v0.1.11
+	github.com/axonops/audit/outputs v0.1.9
 	github.com/axonops/audit/syslog v0.1.11
 	github.com/axonops/audit/webhook v0.1.11
 	github.com/cucumber/godog v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/axonops/audit/loki v0.1.11 h1:jYewrKwhuml6KBsN2rS/4nejqTGQgv0X3GGV7Gp
 github.com/axonops/audit/loki v0.1.11/go.mod h1:7MZcSDpT4likpw/RqsroAimsjtxe+HGjzCkC7ds/6OY=
 github.com/axonops/audit/outputconfig v0.1.11 h1:RArErBa0X18R3QEEAQAYS5yY5VjoyQojnCezYMNuduw=
 github.com/axonops/audit/outputconfig v0.1.11/go.mod h1:gTzEFOubwmnvfLxTms+Y/3NjsQN+Rsd98IVKQhO9GVA=
+github.com/axonops/audit/outputs v0.1.9 h1:mH3EeoA1U5ahEQkNMvutOyWGfAbcSH0DCEeLrtM/HEA=
+github.com/axonops/audit/outputs v0.1.9/go.mod h1:x8jFor5DmgYOcRYTwSVwixqC+Xo8vNfCggL/YvX17uk=
 github.com/axonops/audit/secrets v0.1.11 h1:ilszR93wSDYRCVNK37LUJsrHUcHXyPOMjx5Lax29t9M=
 github.com/axonops/audit/secrets v0.1.11/go.mod h1:gAQX3co4e/23wOe4vkylrJ6smNicyITP+UEcx/gypak=
 github.com/axonops/audit/secrets/openbao v0.1.11 h1:pIRUVAFg117K48btcK4USV/1yaTa6p1gyLv1rWRNNqc=

--- a/outputconfig/output.go
+++ b/outputconfig/output.go
@@ -252,8 +252,8 @@ func invokeFactory(name string, f *outputFields, globalAppName, globalHost strin
 	if factory == nil {
 		registered := audit.RegisteredOutputTypes()
 		return nil, fmt.Errorf("output %q: unknown output type %q (registered: [%s]); "+
-			"add import _ \"github.com/axonops/audit/%s\" "+
-			"or import _ \"github.com/axonops/audit/outputs\" for all types",
+			"add import _ \"github.com/axonops/audit/outputs\" for all built-in types "+
+			"(or import _ \"github.com/axonops/audit/%s\" for only this one)",
 			name, f.typeName, strings.Join(registered, ", "), f.typeName)
 	}
 	// Inject global app_name and hostname into syslog config if not already set.

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -514,7 +514,7 @@ func TestLoad_UnknownType(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown output type \"kafka\"")
 	assert.Contains(t, err.Error(), "add import")
 	assert.Contains(t, err.Error(), "audit/outputs")
-	assert.Contains(t, err.Error(), "for all types")
+	assert.Contains(t, err.Error(), "for all built-in types")
 }
 
 func TestLoad_DuplicateOutputName(t *testing.T) {


### PR DESCRIPTION
## Summary

All 16 non-01 examples (02-17 incl. capstone) now use `_ "github.com/axonops/audit/outputs"` instead of individual output sub-module imports. README + `docs/output-configuration.md` now lead with the convenience package as the default registration path. Closes #585.

**Bonus**: fixes 5 examples (02, 04, 06, 13, 15) that were broken at runtime with `unknown output type "stdout"` — they declared `type: stdout` without any blank import that registered the factory (post-#578 stdout auto-registration removal). The new outputs import registers stdout alongside file/syslog/webhook/loki.

## What changed

- **Example imports**: 13 files swapped individual blank imports for `_ "github.com/axonops/audit/outputs"`; 5 files added the missing import; capstone `audit_setup.go` collapsed two imports into one.
- **README lines 264, 270-293**: module table marks `outputs` as "Recommended default"; registration section leads with the convenience path, frames individual imports as a binary-size optimisation ("shaving a few MB of transitive deps per unused output") suitable for production services.
- **docs/output-configuration.md §Factory Registry**: same narrative; calls out that stdout is also a separate module post-#578.
- **Example READMEs (03, 07, 08, 14)**: each now shows both paths and explains the trade-off; stale error-message quotes updated.
- **outputconfig/output.go:254**: error now leads with `audit/outputs` as the recommended fix, with sub-module import as the alternative.
- `TestLoad_UnknownType` updated to match new error-message wording.
- CHANGELOG + V1-RELEASE-PLAN updated.

## Agent gates

- [x] **api-ergonomics-reviewer** — 3 actionable items addressed:
  - README table description upgraded to "**Recommended default**".
  - Registration framing reworded: "Production services typically import only the outputs they use" (positive) rather than "optimising for binary size" (negative).
  - Error-message ordering flipped to lead with `audit/outputs` and offer the sub-module as secondary.
- [x] **user-guide-reviewer** — 2 findings addressed:
  - Stale error-message quote in `examples/03-file-output/README.md:99` corrected to match current source.
  - Added "Blank Import Required" section to `examples/14-loki-output/README.md` matching the pattern in 07/08.
- [x] **go-quality** (lint + tests) — clean.
- [x] **commit-message-reviewer** — PASS after subject shortened.

## Test plan

- [x] `go build ./...` clean.
- [x] `make lint` 0 issues across all modules.
- [x] `make test` passes with `-race`.
- [x] `make test-examples` all 17 compile.
- [x] Runtime smoke: `go run .` in examples 02, 04, 06, 13, 15 all succeed (pre-PR: all failed with unknown output type).
- [ ] CI pending.

## Files touched

26 files.