### PR TITLE
docs: Formatter MUST be concurrent-safe (#589)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `audit.Formatter` godoc now declares that `Format` MUST be safe for concurrent use (#589). Previous godoc stated the method was called from a single goroutine, but the library's own `CEFFormatter` used `sync.Once` + `noCopy` for exactly the opposite reason — a shared formatter instance across multiple Auditors calls Format concurrently. The contract is updated to match the built-in implementation and the stdlib precedent (`log/slog.Handler`, `net/http.Handler`, `encoding/json.Marshaler`). Godoc on `JSONFormatter` + `CEFFormatter` adds a "Concurrency" section describing the `sync.Once` / `sync.Pool` pattern used internally. No behavioural change to the built-in formatters — the implementation has been concurrency-safe since inception. Consumer-side `Formatter` implementations that relied on the old single-goroutine wording must guard any mutable state (field caches, compiled templates) with `sync.Once` / `sync.RWMutex` / `sync/atomic`. A new `TestCEFFormatter_ConcurrentFormat` + `TestJSONFormatter_ConcurrentFormat` in `format_test.go` locks the contract at test time — run with `-race`, a future regression will fail loudly.
+
 - All examples (`examples/02-code-generation` through `examples/17-capstone`) now blank-import the `outputs` convenience package in place of individual output-module imports (#585). README + `docs/output-configuration.md` now lead with `import _ "github.com/axonops/audit/outputs"` as the default registration path, with individual sub-module imports documented as a binary-size optimisation. No API change; consumers who already use either pattern are unaffected.
 
 ### Fixed

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -119,7 +119,7 @@ Every issue follows this sequence. Do not skip steps.
 - [x] **#586** refactor: replace Metrics.RecordEvent stringly-typed status with EventStatus enum.
 - [ ] **#587** perf: WrapOutput conditionally implements MetadataWriter based on inner capability.
 - [ ] **#588** refactor: inline rgooding/go-syncmap; drop third-party dependency on filter hot path.
-- [ ] **#589** docs: fix Formatter docstring concurrency-safety contradiction with CEFFormatter sync.Once.
+- [x] **#589** docs: fix Formatter docstring concurrency-safety contradiction with CEFFormatter sync.Once.
 - [x] **#590** refactor: error API polish — clone Unwrap slice, document ComputeHMAC contract, error returns from RegisterOutputFactory and NewEventKV.
 - [ ] **#591** refactor: CEFFormatter ergonomics — FieldMapping opt-out path, avoid redundant severity clamp, cite maxCEFHeaderField.
 - [ ] **#592** refactor: unify error wrapping conventions across modules; align self-reporting drop metrics; drop dead redactRef parameter.

--- a/format.go
+++ b/format.go
@@ -113,8 +113,26 @@ func (o *FormatOptions) IsExcluded(fieldName string) bool {
 // Implementations MUST append a newline terminator. The library
 // provides [JSONFormatter] and [CEFFormatter].
 //
-// Format is called from a single goroutine (the drain loop);
-// implementations do not need to be safe for concurrent use.
+// # Concurrency
+//
+// A single Auditor's drain loop calls Format from one goroutine at a
+// time, but a formatter instance MAY be shared across multiple
+// Auditors via [WithFormatter] (multi-tenant or multi-pipeline
+// deployments) and MAY be called from caller goroutines in
+// synchronous delivery mode. Implementations MUST be safe for
+// concurrent use.
+//
+// Stateless formatters satisfy this trivially. Formatters that cache
+// derived state (resolved field mappings, compiled templates, metric
+// handles) SHOULD guard the state with [sync.Once] for one-shot
+// initialisation or [sync.RWMutex] / [sync/atomic] for mutable
+// caches. The package-level [sync.Pool] pattern used by the built-in
+// [JSONFormatter] and [CEFFormatter] is the recommended shape for
+// per-call buffer reuse.
+//
+// Precedent: [log/slog.Handler.Handle], [net/http.Handler.ServeHTTP],
+// and [encoding/json.Marshaler] all require concurrent-safe
+// implementations by the same reasoning.
 type Formatter interface {
 	// Format serialises a single audit event into a wire-format byte
 	// slice. Implementations MUST append a newline terminator; the

--- a/format_cef.go
+++ b/format_cef.go
@@ -132,6 +132,14 @@ func DefaultCEFFieldMapping() map[string]string {
 // the taxonomy-defined severity is used via [EventDef.ResolvedSeverity]:
 // event Severity (if non-nil) → first category Severity in alphabetical
 // order (if non-nil) → 5. Values are clamped to the valid CEF range 0-10.
+//
+// # Concurrency
+//
+// Safe for concurrent use by multiple goroutines, per the
+// [Formatter] contract. Lazy field-mapping resolution is guarded by
+// [sync.Once], and per-call buffers are leased from a package-level
+// [sync.Pool]. The noCopy marker prevents accidental copies that
+// would duplicate the sync.Once state.
 type CEFFormatter struct {
 	// SeverityFunc maps event types to CEF severity (0-10). If nil,
 	// taxonomy-defined severity is used via [EventDef.ResolvedSeverity].

--- a/format_json.go
+++ b/format_json.go
@@ -73,6 +73,13 @@ func putJSONBuf(buf *bytes.Buffer) {
 // [time.Duration] values are converted to int64 milliseconds.
 // Timestamps are rendered according to [JSONFormatter.Timestamp]
 // (default [TimestampRFC3339Nano]).
+//
+// # Concurrency
+//
+// Safe for concurrent use by multiple goroutines, per the
+// [Formatter] contract. All per-call buffers are leased from a
+// package-level [sync.Pool]; the struct itself holds only
+// write-once configuration set at construction.
 type JSONFormatter struct {
 	// Timestamp controls the timestamp format. Empty defaults to
 	// [TimestampRFC3339Nano].

--- a/format_test.go
+++ b/format_test.go
@@ -2209,3 +2209,113 @@ func TestCEFFormatter_AcceptsBoundaryVendor(t *testing.T) {
 	_, err := f.Format(testTime, "ev", audit.Fields{"outcome": "ok"}, &audit.EventDef{Required: []string{"outcome"}}, nil)
 	assert.NoError(t, err)
 }
+
+// TestCEFFormatter_ConcurrentFormat is the named contract test from
+// #589. It verifies the [audit.Formatter] interface's documented
+// concurrency contract: a single formatter instance MAY be shared
+// across goroutines and MUST be safe for concurrent use.
+//
+// The test runs Format from 64 goroutines against one *CEFFormatter
+// instance. Combined with `go test -race`, it locks the contract at
+// compile time — any future regression that introduces an unguarded
+// write to shared formatter state (e.g. removing the sync.Once
+// around fieldMapping) will fail here under the race detector.
+func TestCEFFormatter_ConcurrentFormat(t *testing.T) {
+	t.Parallel()
+	f := &audit.CEFFormatter{
+		Vendor:  "AxonOps",
+		Product: "Audit",
+		Version: "1.0",
+		FieldMapping: map[string]string{
+			"actor_id": "suser",
+			"outcome":  "outcome",
+		},
+	}
+	def := &audit.EventDef{
+		Required: []string{"outcome", "actor_id"},
+	}
+
+	const goroutines = 64
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errCh := make(chan error, goroutines*iterations)
+
+	for g := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				fields := audit.Fields{
+					"outcome":  "success",
+					"actor_id": fmt.Sprintf("goroutine-%d-iter-%d", id, i),
+				}
+				line, err := f.Format(testTime, "user_create", fields, def, nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				// Basic CEF header sanity — concurrent access must not
+				// corrupt the output.
+				if !bytes.HasPrefix(line, []byte("CEF:0|AxonOps|Audit|1.0|")) {
+					errCh <- fmt.Errorf("goroutine %d iter %d: malformed CEF header: %s", id, i, line)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("concurrent Format failure: %v", err)
+	}
+}
+
+// TestJSONFormatter_ConcurrentFormat mirrors
+// TestCEFFormatter_ConcurrentFormat for [audit.JSONFormatter]. Though
+// JSONFormatter holds only write-once configuration, the contract
+// test locks the concurrent-safety guarantee in place regardless of
+// future implementation drift.
+func TestJSONFormatter_ConcurrentFormat(t *testing.T) {
+	t.Parallel()
+	f := &audit.JSONFormatter{}
+	def := &audit.EventDef{Required: []string{"outcome", "actor_id"}}
+
+	const goroutines = 64
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errCh := make(chan error, goroutines*iterations)
+
+	for g := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				fields := audit.Fields{
+					"outcome":  "success",
+					"actor_id": fmt.Sprintf("g%d-i%d", id, i),
+				}
+				line, err := f.Format(testTime, "user_create", fields, def, nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				// Confirm the output is valid JSON; concurrent access
+				// must not interleave bytes from different goroutines.
+				var m map[string]any
+				if jerr := json.Unmarshal(bytes.TrimSuffix(line, []byte{'\n'}), &m); jerr != nil {
+					errCh <- fmt.Errorf("goroutine %d iter %d: invalid JSON: %w: %s", id, i, jerr, line)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("concurrent Format failure: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Resolves the contradiction between `audit.Formatter.Format` godoc ("single goroutine; implementations do not need to be safe for concurrent use") and `CEFFormatter`'s use of `sync.Once` + `noCopy`. Closes #589.

api-ergonomics pre-coding consult locked option (a) from the AC: **update the godoc to require concurrent-safe implementations**. Matches stdlib precedent (`log/slog.Handler`, `net/http.Handler`, `encoding/json.Marshaler`). `CEFFormatter`'s `sync.Once` stays; moving resolution to construction was out of scope.

## What changed

- **`format.go`**: `Formatter` interface godoc rewritten with a Concurrency section — implementations MUST be safe for concurrent use; recommends the `sync.Once` / `sync.Pool` pattern.
- **`format_cef.go`**: `CEFFormatter` godoc adds a Concurrency section.
- **`format_json.go`**: `JSONFormatter` godoc adds a Concurrency section.
- **`format_test.go`**: new `TestCEFFormatter_ConcurrentFormat` + `TestJSONFormatter_ConcurrentFormat` run Format from **64 goroutines × 100 iterations** against a single formatter instance. Under `go test -race`, any future regression (removed `sync.Once`, unguarded state) will fail loudly.
- **CHANGELOG**: Changed entry explaining the contract tightening + consumer migration (guard mutable formatter state with `sync.Once` / `sync.RWMutex` / `sync/atomic`).
- **V1-RELEASE-PLAN**: ticked #589.

## Agent gates

- [x] **api-ergonomics-reviewer** (pre-coding, BLOCKING) — picked option (a) with stdlib precedent. Also recommended: keep `sync.Once` lazy resolution.
- [x] **go-quality** — `make lint` 0 issues, `make test` passes with `-race` across all 12 modules (95.5% core coverage).
- [x] **commit-message-reviewer** — PASS.

## Test plan

- [x] `go build ./...` clean.
- [x] `make lint` 0 issues.
- [x] `TestCEFFormatter_ConcurrentFormat` / `TestJSONFormatter_ConcurrentFormat` pass under `-race`.
- [x] Full suite passes under `-race`.
- [ ] CI pending.

## Files touched

6 files, 148 insertions, 3 deletions. No runtime behaviour change — built-in formatters were already concurrency-safe.