### PR TITLE
refactor: unified error prefix + self-reporting drop metrics (#592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Error-prefix convention unified across every module on the Go import-path pattern (#592). All modules now prefix errors with their dotted module path:
+  - `audit:` (core — unchanged)
+  - `audit/file:`, `audit/syslog:`, `audit/webhook:`, `audit/loki:` (previously `audit: <module> output:`)
+  - `audit/outputconfig:` (new prefix via the restructured `ErrOutputConfigInvalid`)
+  - `audit/secrets/vault:`, `audit/secrets/openbao:` (previously `vault:`, `openbao:` with no library prefix)
+  
+  `outputconfig.ErrOutputConfigInvalid` now wraps `audit.ErrConfigInvalid` so `errors.Is(err, audit.ErrConfigInvalid)` matches every configuration-validation failure — a single sentinel across outputs, config, and secrets (stdlib `fs.ErrNotExist` / `os.ErrNotExist` pattern). Consumers matching errors with `strings.Contains(err.Error(), "vault:")` must migrate to `errors.Is` / `errors.As` on sentinels (already forbidden by project style).
+
+- Self-reporting output drop metrics are now consistent (#592). Webhook and Loki no longer call pipeline-level `Metrics.RecordEvent(name, audit.EventError)` on **buffer drops** (oversized event or buffer full); those drops now surface only via `OutputMetrics.RecordDrop()`, matching file + syslog. Retry-exhaustion failures in webhook/loki (where delivery WAS attempted) still call `RecordEvent(EventError)` — those are genuine delivery errors, not buffer drops. Consumers relying on `RecordEvent` as a pre-delivery drop counter should use `OutputMetrics.RecordDrop` for that counter.
+
+- `secrets.redactRef` drops its unused parameter (#592 B-35). The function was already returning a constant; the `_` parameter was dead. Internal helper — no consumer impact.
+
 - `audit.CEFFormatter` small ergonomics bundle (#591):
   - `FieldMapping` now supports an **empty-string opt-out sentinel**: passing `{"actor_id": ""}` drops the default `actor_id → suser` mapping so the field is emitted with its raw audit name. Both `ViaDelete` (empty-string sentinel) and `SelfMap` (`{"actor_id": "actor_id"}`) opt-out patterns are now documented and exercised by named tests. Previously the only working opt-out was self-map; the empty-string form failed with a validation error and the "delete from DefaultCEFFieldMapping copy" pattern was documented but did not actually suppress defaults because the merge always re-seeded from them.
   - `SeverityFunc` godoc clarified to distinguish the clamp-on-override path (consumer-supplied func return values are clamped per event) from the fast path (taxonomy-derived severity is precomputed and clamped once at taxonomy registration — no per-event clamp). Behaviour unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Error-prefix convention unified across every module on the Go import-path pattern (#592). All modules now prefix errors with their dotted module path:
+- Error-prefix convention unified across every module on the Go import-path pattern (#592). A CI grep check to enforce the convention is deferred to a follow-up issue. All modules now prefix errors with their dotted module path:
   - `audit:` (core — unchanged)
   - `audit/file:`, `audit/syslog:`, `audit/webhook:`, `audit/loki:` (previously `audit: <module> output:`)
   - `audit/outputconfig:` (new prefix via the restructured `ErrOutputConfigInvalid`)

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -122,7 +122,7 @@ Every issue follows this sequence. Do not skip steps.
 - [x] **#589** docs: fix Formatter docstring concurrency-safety contradiction with CEFFormatter sync.Once.
 - [x] **#590** refactor: error API polish — clone Unwrap slice, document ComputeHMAC contract, error returns from RegisterOutputFactory and NewEventKV.
 - [x] **#591** refactor: CEFFormatter ergonomics — FieldMapping opt-out path, avoid redundant severity clamp, cite maxCEFHeaderField.
-- [ ] **#592** refactor: unify error wrapping conventions across modules; align self-reporting drop metrics; drop dead redactRef parameter.
+- [x] **#592** refactor: unify error wrapping conventions across modules; align self-reporting drop metrics; drop dead redactRef parameter.
 - [ ] **#593** refactor: small API polish — TLSPolicy zero-value docs, MinSeverity/MaxSeverity constants, Handle on disabled auditor, openbao Close idempotency, audittest rename, require AppName/Host, uniform nil-option handling.
 - [ ] **#594** refactor: simplify 9-method Metrics interface into MetricEvent or split into lifecycle/delivery/validation interfaces.
 - [ ] **#595** refactor: Fields rejects unsupported value types; WithStandardFieldDefaults accepts any.

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -254,7 +254,7 @@ URIs cannot be resolved. All errors are in `github.com/axonops/audit/secrets`.
 ### `ErrMalformedRef`
 
 ```
-secrets: malformed secret reference
+audit/secrets: malformed secret reference
 ```
 
 | | |
@@ -267,7 +267,7 @@ secrets: malformed secret reference
 ### `ErrProviderNotRegistered`
 
 ```
-secrets: no provider registered for scheme
+audit/secrets: no provider registered for scheme
 ```
 
 | | |
@@ -275,12 +275,12 @@ secrets: no provider registered for scheme
 | **When** | A ref URI references a scheme for which no `WithSecretProvider` was registered |
 | **Meaning** | The library cannot resolve this ref because no provider handles the scheme |
 | **Transient?** | No -- register the correct provider or fix the scheme in the ref URI |
-| **What to do** | The error message includes the scheme and the field path: `secrets: no provider registered for scheme: scheme "openbao" (field outputs.siem.webhook.headers.Authorization)`. Add the missing `outputconfig.WithSecretProvider(provider)` call, or correct the scheme in the ref URI. |
+| **What to do** | The error message includes the scheme and the field path: `audit/secrets: no provider registered for scheme: scheme "openbao" (field outputs.siem.webhook.headers.Authorization)`. Add the missing `outputconfig.WithSecretProvider(provider)` call, or correct the scheme in the ref URI. |
 
 ### `ErrSecretNotFound`
 
 ```
-secrets: secret not found at path
+audit/secrets: secret not found at path
 ```
 
 | | |
@@ -293,7 +293,7 @@ secrets: secret not found at path
 ### `ErrSecretResolveFailed`
 
 ```
-secrets: secret resolution failed
+audit/secrets: secret resolution failed
 ```
 
 | | |
@@ -306,7 +306,7 @@ secrets: secret resolution failed
 ### `ErrUnresolvedRef`
 
 ```
-secrets: unresolved secret reference in config
+audit/secrets: unresolved secret reference in config
 ```
 
 | | |

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -9,6 +9,38 @@
 - [Secret Resolution Errors](#secret-resolution-errors)
 - [Taxonomy Errors](#taxonomy-errors)
 
+## Error Format Convention
+
+Every error returned by the library is prefixed with the dotted Go
+import path of the module that produced it — matching stdlib
+precedent (`net/http:`, `crypto/tls:`, `encoding/json:`):
+
+| Module | Prefix |
+|---|---|
+| Core `audit` | `audit:` |
+| File output | `audit/file:` |
+| Syslog output | `audit/syslog:` |
+| Webhook output | `audit/webhook:` |
+| Loki output | `audit/loki:` |
+| Output config loader | `audit/outputconfig:` |
+| Secrets core | `audit/secrets:` |
+| Secrets — HashiCorp Vault | `audit/secrets/vault:` |
+| Secrets — OpenBao | `audit/secrets/openbao:` |
+
+Every configuration-validation error wraps `audit.ErrConfigInvalid`
+(directly or via a module-specific sub-sentinel). This gives you a
+single `errors.Is` match across every config-facing surface:
+
+```go
+if errors.Is(err, audit.ErrConfigInvalid) {
+    // any configuration validation failure — outputs, secrets, outputconfig
+}
+```
+
+`outputconfig.ErrOutputConfigInvalid` is a sub-sentinel that itself
+wraps `audit.ErrConfigInvalid`, so it also matches the generic form.
+Pattern parallels stdlib's `fs.ErrNotExist` / `os.ErrNotExist`.
+
 ## How to Check Errors
 
 All audit errors are sentinel values. Use `errors.Is` to check

--- a/docs/metrics-monitoring.md
+++ b/docs/metrics-monitoring.md
@@ -26,7 +26,7 @@ library never imports a concrete metrics implementation.
 ```go
 type Metrics interface {
     RecordSubmitted()                           // total events entering the pipeline
-    RecordEvent(output string, status EventStatus) // EventSuccess / EventError (non-DeliveryReporter outputs only)
+    RecordEvent(output string, status EventStatus) // EventSuccess / EventError — see "Drop vs delivery error" below
     RecordOutputError(output string)
     RecordOutputFiltered(output string)
     RecordValidationError(eventType string)
@@ -117,6 +117,30 @@ Where:
 - `buffer_drops` = `RecordBufferDrop()` count (core queue full)
 - `output_buffer_drops` = `OutputMetrics.RecordDrop()` count
 - `delivered` = `OutputMetrics.RecordFlush()` count
+
+### Drop vs delivery error
+
+Every self-reporting output (file, syslog, webhook, loki) follows
+the same rule for drop-vs-error reporting:
+
+| Outcome | `OutputMetrics.RecordDrop()` | `Metrics.RecordEvent(_, EventError)` |
+|---|---|---|
+| Event rejected before queue (oversize, buffer full) | ✓ | ✗ |
+| Delivery attempted, all retries exhausted (webhook, loki) | ✗ | ✓ |
+| Delivery succeeded | ✗ | `RecordEvent(_, EventSuccess)` via `OutputMetrics.RecordFlush` |
+
+Buffer drops count only via per-output `RecordDrop` because the event
+never reached the destination — there is nothing to report as a
+delivery outcome. Retry-exhaustion failures in webhook and loki count
+via `RecordEvent(EventError)` because the output did attempt
+delivery and all retries failed; that is a genuine delivery-error
+signal, not a buffer-pressure signal. File and syslog do not have
+retries (they write synchronously once dequeued) so they only ever
+report via `RecordDrop`.
+
+Consumers that want a single "events lost" counter should sum
+`RecordBufferDrop` (core queue) + per-output `RecordDrop` + per-
+output `RecordEvent(EventError)` count.
 
 ## 🚨 Recommended Alerts
 

--- a/docs/metrics-monitoring.md
+++ b/docs/metrics-monitoring.md
@@ -126,21 +126,23 @@ the same rule for drop-vs-error reporting:
 | Outcome | `OutputMetrics.RecordDrop()` | `Metrics.RecordEvent(_, EventError)` |
 |---|---|---|
 | Event rejected before queue (oversize, buffer full) | ✓ | ✗ |
-| Delivery attempted, all retries exhausted (webhook, loki) | ✗ | ✓ |
+| Delivery attempted, all retries exhausted (webhook, loki) | ✓ | ✓ |
 | Delivery succeeded | ✗ | `RecordEvent(_, EventSuccess)` via `OutputMetrics.RecordFlush` |
 
 Buffer drops count only via per-output `RecordDrop` because the event
 never reached the destination — there is nothing to report as a
 delivery outcome. Retry-exhaustion failures in webhook and loki count
-via `RecordEvent(EventError)` because the output did attempt
-delivery and all retries failed; that is a genuine delivery-error
-signal, not a buffer-pressure signal. File and syslog do not have
-retries (they write synchronously once dequeued) so they only ever
-report via `RecordDrop`.
+via BOTH `RecordDrop` and `RecordEvent(EventError)`: `RecordDrop`
+because the event is lost, and `RecordEvent(EventError)` because the
+output did attempt delivery and all retries failed — that is a
+genuine delivery-error signal. File and syslog do not have retries
+(they write synchronously once dequeued) so they only ever report
+via `RecordDrop`.
 
 Consumers that want a single "events lost" counter should sum
-`RecordBufferDrop` (core queue) + per-output `RecordDrop` + per-
-output `RecordEvent(EventError)` count.
+`RecordBufferDrop` (core queue) + per-output `RecordDrop` (this
+already includes retry-exhaustion drops for webhook/loki, so no
+double-counting with `RecordEvent(EventError)` is needed).
 
 ## 🚨 Recommended Alerts
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -833,11 +833,11 @@ if errors.Is(err, secrets.ErrMalformedRef) {
 
 | Sentinel | When | Example Message |
 |----------|------|-----------------|
-| `ErrMalformedRef` | `ParseRef` finds a structural error in a `ref+` URI | `secrets: malformed secret reference: empty key fragment` |
-| `ErrProviderNotRegistered` | No provider registered for the scheme in a ref URI | `secrets: no provider registered for scheme: scheme "openbao" (field outputs.siem.webhook.headers.Authorization)` |
-| `ErrSecretNotFound` | Secret path exists but the requested key is missing, or the path does not exist (404) | `secrets: secret not found at path: path returned 404` |
-| `ErrSecretResolveFailed` | Network error, authentication failure, or server error during resolution | `secrets: secret resolution failed: authentication failed (403)` |
-| `ErrUnresolvedRef` | After all resolution passes, a config value still contains a `ref+` URI | `secrets: unresolved secret reference in config: field outputs.siem.webhook.headers.Authorization still contains a secret reference` |
+| `ErrMalformedRef` | `ParseRef` finds a structural error in a `ref+` URI | `audit/secrets: malformed secret reference: empty key fragment` |
+| `ErrProviderNotRegistered` | No provider registered for the scheme in a ref URI | `audit/secrets: no provider registered for scheme: scheme "openbao" (field outputs.siem.webhook.headers.Authorization)` |
+| `ErrSecretNotFound` | Secret path exists but the requested key is missing, or the path does not exist (404) | `audit/secrets: secret not found at path: path returned 404` |
+| `ErrSecretResolveFailed` | Network error, authentication failure, or server error during resolution | `audit/secrets: secret resolution failed: authentication failed (403)` |
+| `ErrUnresolvedRef` | After all resolution passes, a config value still contains a `ref+` URI | `audit/secrets: unresolved secret reference in config: field outputs.siem.webhook.headers.Authorization still contains a secret reference` |
 
 Duplicate-scheme errors from registering two providers with the same
 scheme wrap `ErrOutputConfigInvalid`:

--- a/docs/syslog-output.md
+++ b/docs/syslog-output.md
@@ -733,7 +733,7 @@ outputs:
 
 | Problem | Cause | Fix |
 |---------|-------|-----|
-| `audit: syslog output "name": config is required` | No `syslog:` block in YAML | Add the type-specific `syslog:` configuration block |
+| `audit/syslog: output "name": config is required` | No `syslog:` block in YAML | Add the type-specific `syslog:` configuration block |
 | `audit: unknown syslog facility "name"` | Invalid facility name | Use one of the valid names: `kern`, `user`, ..., `local0`–`local7` |
 | `dial tcp host:port: connect: connection refused` | Syslog server not reachable at startup | The server MUST be reachable when the output is created; check address and port |
 | Events silently lost (UDP) | Message too large for UDP | Switch to TCP or TCP+TLS; UDP truncates at ~2048 bytes |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -236,7 +236,7 @@ URIs in the YAML configuration cannot be resolved. `Load` fails hard
 ### 403 Authentication Failure
 
 ```
-secrets: secret resolution failed: authentication failed (403)
+audit/secrets: secret resolution failed: authentication failed (403)
 ```
 
 | Cause | Fix |
@@ -248,7 +248,7 @@ secrets: secret resolution failed: authentication failed (403)
 ### 404 Path Not Found
 
 ```
-secrets: secret not found at path: path returned 404
+audit/secrets: secret not found at path: path returned 404
 ```
 
 | Cause | Fix |
@@ -277,7 +277,7 @@ single timeout budget.
 ### Unresolved Ref After Resolution
 
 ```
-secrets: unresolved secret reference in config: field outputs.siem.webhook.headers.Authorization still contains a secret reference
+audit/secrets: unresolved secret reference in config: field outputs.siem.webhook.headers.Authorization still contains a secret reference
 ```
 
 | Cause | Fix |
@@ -290,7 +290,7 @@ secrets: unresolved secret reference in config: field outputs.siem.webhook.heade
 ### SSRF Blocking the Connection
 
 ```
-secrets: secret resolution failed: loopback address 127.0.0.1 blocked
+audit/secrets: secret resolution failed: loopback address 127.0.0.1 blocked
 ```
 
 | Cause | Fix |

--- a/file/file.go
+++ b/file/file.go
@@ -182,7 +182,7 @@ func resolvePath(path string) (string, error) {
 	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		return "", fmt.Errorf("audit: file output path: %w", err)
+		return "", fmt.Errorf("audit/file: output path: %w", err)
 	}
 	return abs, nil
 }
@@ -213,7 +213,7 @@ func New(cfg *Config, opts ...Option) (*Output, error) { //nolint:gocyclo,cyclop
 	logger := o.logger
 
 	if cfg.Path == "" {
-		return nil, fmt.Errorf("audit: file output path must not be empty")
+		return nil, fmt.Errorf("audit/file: output path must not be empty")
 	}
 	var err error
 	cfg.Path, err = resolvePath(cfg.Path)
@@ -225,17 +225,17 @@ func New(cfg *Config, opts ...Option) (*Output, error) { //nolint:gocyclo,cyclop
 	// message. rotate.New performs the same check but with a "rotate:" prefix.
 	parentDir := filepath.Dir(cfg.Path)
 	if _, statErr := os.Lstat(parentDir); statErr != nil {
-		return nil, fmt.Errorf("audit: file output parent directory %q: %w", parentDir, statErr)
+		return nil, fmt.Errorf("audit/file: output parent directory %q: %w", parentDir, statErr)
 	}
 
 	perm, err := parsePermissions(cfg.Permissions)
 	if err != nil {
-		return nil, fmt.Errorf("audit: file output permissions %q: %w", cfg.Permissions, err)
+		return nil, fmt.Errorf("audit/file: output permissions %q: %w", cfg.Permissions, err)
 	}
 
 	// Warn if permissions grant group or world access to audit data.
 	if perm&0o077 != 0 {
-		logger.Warn("audit: file output permissions grant group/world access",
+		logger.Warn("audit/file: output permissions grant group/world access",
 			"path", cfg.Path,
 			"permissions", fmt.Sprintf("%04o", perm))
 	}
@@ -269,7 +269,7 @@ func New(cfg *Config, opts ...Option) (*Output, error) { //nolint:gocyclo,cyclop
 		MaxBackups: cfg.MaxBackups,
 		Compress:   compress,
 		OnError: func(err error) {
-			out.logger.Load().Warn("audit: file output background error",
+			out.logger.Load().Warn("audit/file: output background error",
 				"path", logPath, "error", err)
 		},
 	}
@@ -283,7 +283,7 @@ func New(cfg *Config, opts ...Option) (*Output, error) { //nolint:gocyclo,cyclop
 	}
 	rw, err := rotate.New(cfg.Path, rotCfg)
 	if err != nil {
-		return nil, fmt.Errorf("audit: file output: %w", err)
+		return nil, fmt.Errorf("audit/file: output: %w", err)
 	}
 	out.writer = rw
 
@@ -351,7 +351,7 @@ func (f *Output) Close() error {
 	// Close the rotate.Writer AFTER the writeLoop exits to ensure all
 	// drained events are written before the file is closed.
 	if err := f.writer.Close(); err != nil {
-		return fmt.Errorf("audit: file output close: %w", err)
+		return fmt.Errorf("audit/file: output close: %w", err)
 	}
 	return nil
 }

--- a/file/file.go
+++ b/file/file.go
@@ -203,7 +203,7 @@ func resolvePath(path string) (string, error) {
 // copied by value.
 func New(cfg *Config, opts ...Option) (*Output, error) { //nolint:gocyclo,cyclop // constructor with validation
 	if cfg == nil {
-		return nil, fmt.Errorf("audit: file config must not be nil")
+		return nil, fmt.Errorf("audit/file: config must not be nil")
 	}
 	// Copy config so validation/defaults don't mutate the caller's struct.
 	cfgCopy := *cfg

--- a/file/register.go
+++ b/file/register.go
@@ -89,13 +89,13 @@ func intPtrOrDefault(p *int, def int) int {
 
 func buildOutput(name string, rawConfig []byte, om audit.OutputMetrics, logger *slog.Logger) (audit.Output, error) {
 	if len(rawConfig) == 0 {
-		return nil, fmt.Errorf("audit: file output %q: config is required", name)
+		return nil, fmt.Errorf("audit/file: output %q: config is required", name)
 	}
 
 	var yc yamlFileConfig
 	dec := yaml.NewDecoder(bytes.NewReader(rawConfig), yaml.DisallowUnknownField())
 	if err := dec.Decode(&yc); err != nil {
-		return nil, fmt.Errorf("audit: file output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
+		return nil, fmt.Errorf("audit/file: output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
 	}
 
 	cfg := Config{
@@ -110,7 +110,7 @@ func buildOutput(name string, rawConfig []byte, om audit.OutputMetrics, logger *
 
 	out, err := New(&cfg, WithDiagnosticLogger(logger))
 	if err != nil {
-		return nil, fmt.Errorf("audit: file output %q: %w", name, err)
+		return nil, fmt.Errorf("audit/file: output %q: %w", name, err)
 	}
 	if om != nil {
 		out.SetOutputMetrics(om)

--- a/loki/config.go
+++ b/loki/config.go
@@ -503,7 +503,7 @@ func buildLokiTLSConfig(cfg *Config) (*tls.Config, []string, error) {
 	if cfg.TLSCert != "" {
 		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
 		if err != nil {
-			return nil, nil, fmt.Errorf("audit: loki: load client certificate: %w", err)
+			return nil, nil, fmt.Errorf("audit/loki: load client certificate: %w", err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
@@ -511,11 +511,11 @@ func buildLokiTLSConfig(cfg *Config) (*tls.Config, []string, error) {
 	if cfg.TLSCA != "" {
 		caPEM, err := os.ReadFile(cfg.TLSCA)
 		if err != nil {
-			return nil, nil, fmt.Errorf("audit: loki: read ca certificate: %w", err)
+			return nil, nil, fmt.Errorf("audit/loki: read ca certificate: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caPEM) {
-			return nil, nil, fmt.Errorf("audit: loki: ca certificate contains no valid pem blocks")
+			return nil, nil, fmt.Errorf("audit/loki: ca certificate contains no valid pem blocks")
 		}
 		tlsCfg.RootCAs = pool
 	}

--- a/loki/http.go
+++ b/loki/http.go
@@ -107,7 +107,7 @@ func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int
 		}
 
 		if !retryable {
-			logger.Error("audit: loki non-retryable error",
+			logger.Error("audit/loki: non-retryable error",
 				"error", sanitiseClientError(err),
 				"batch_size", batchSize)
 			o.recordError()
@@ -116,14 +116,14 @@ func (o *Output) doPostWithRetry(ctx context.Context, body []byte, batchSize int
 		}
 
 		o.recordRetry(attempt + 1)
-		logger.Warn("audit: loki retryable error",
+		logger.Warn("audit/loki: retryable error",
 			"attempt", attempt+1,
 			"max_retries", o.cfg.MaxRetries,
 			"error", sanitiseClientError(err))
 	}
 
 	// All retries exhausted.
-	logger.Error("audit: loki retries exhausted, dropping batch",
+	logger.Error("audit/loki: retries exhausted, dropping batch",
 		"batch_size", batchSize,
 		"max_retries", o.cfg.MaxRetries)
 	o.recordDrop(batchSize)
@@ -161,7 +161,7 @@ func drainAndClose(resp *http.Response) {
 func (o *Output) doPost(ctx context.Context, body []byte, compressed bool) (retryable bool, statusCode int, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.cfg.URL, bytes.NewReader(body))
 	if err != nil {
-		return false, 0, fmt.Errorf("audit: loki request: %w", err)
+		return false, 0, fmt.Errorf("audit/loki: request: %w", err)
 	}
 
 	o.applyRequestHeaders(req, compressed)
@@ -169,12 +169,12 @@ func (o *Output) doPost(ctx context.Context, body []byte, compressed bool) (retr
 	resp, err := o.client.Do(req)
 	if err != nil {
 		if errors.Is(err, errRedirectBlocked) {
-			return false, 0, fmt.Errorf("audit: loki redirect blocked: %w", err)
+			return false, 0, fmt.Errorf("audit/loki: redirect blocked: %w", err)
 		}
 		if ctx.Err() != nil {
-			return false, 0, fmt.Errorf("audit: loki cancelled: %w", ctx.Err())
+			return false, 0, fmt.Errorf("audit/loki: cancelled: %w", ctx.Err())
 		}
-		return true, 0, fmt.Errorf("audit: loki request failed: %w", err)
+		return true, 0, fmt.Errorf("audit/loki: request failed: %w", err)
 	}
 	defer drainAndClose(resp)
 
@@ -184,16 +184,16 @@ func (o *Output) doPost(ctx context.Context, body []byte, compressed bool) (retr
 
 	if resp.StatusCode == 429 {
 		o.retryHint = parseRetryAfter(resp.Header.Get("Retry-After"))
-		return true, 429, fmt.Errorf("audit: loki rate limited (429)")
+		return true, 429, fmt.Errorf("audit/loki: rate limited (429)")
 	}
 
 	if resp.StatusCode >= 500 {
-		return true, resp.StatusCode, fmt.Errorf("audit: loki server error %d", resp.StatusCode)
+		return true, resp.StatusCode, fmt.Errorf("audit/loki: server error %d", resp.StatusCode)
 	}
 
 	// 4xx (not 429), and any 3xx that bypassed redirect-follow
 	// (no Location header, 300, 304, ...) — client error, not retryable.
-	return false, resp.StatusCode, fmt.Errorf("audit: loki client error %d", resp.StatusCode)
+	return false, resp.StatusCode, fmt.Errorf("audit/loki: client error %d", resp.StatusCode)
 }
 
 // applyRequestHeaders sets all HTTP headers on the request. Consumer

--- a/loki/loki.go
+++ b/loki/loki.go
@@ -277,11 +277,14 @@ func (o *Output) WriteWithMetadata(data []byte, meta audit.EventMetadata) error 
 				"max_event_bytes", o.maxEventBytes,
 				"dropped", dropped)
 		})
+		// Buffer drops (event never attempted) are counted via per-
+		// output OutputMetrics.RecordDrop only — not via pipeline-
+		// level Metrics.RecordEvent. Matches file + syslog for
+		// consistency across all self-reporting outputs (B-25).
+		// RecordEvent(EventError) remains for retries-exhausted
+		// failures in http.go where delivery WAS attempted.
 		if omp := o.outputMetrics.Load(); omp != nil {
 			(*omp).RecordDrop()
-		}
-		if o.metrics != nil {
-			o.metrics.RecordEvent(o.Name(), audit.EventError)
 		}
 		return fmt.Errorf("%w: %w: event size %d exceeds max_event_bytes %d",
 			audit.ErrValidation, audit.ErrEventTooLarge, len(data), o.maxEventBytes)
@@ -299,11 +302,10 @@ func (o *Output) WriteWithMetadata(data []byte, meta audit.EventMetadata) error 
 				"dropped", dropped,
 				"buffer_size", cap(o.ch))
 		})
+		// Buffer drops counted via OutputMetrics.RecordDrop only — see
+		// B-25 note above.
 		if omp := o.outputMetrics.Load(); omp != nil {
 			(*omp).RecordDrop()
-		}
-		if o.metrics != nil {
-			o.metrics.RecordEvent(o.Name(), audit.EventError)
 		}
 		return nil // non-blocking — do not return error to drain goroutine
 	}

--- a/loki/loki.go
+++ b/loki/loki.go
@@ -50,7 +50,7 @@ var (
 
 // errRedirectBlocked is returned by the HTTP client's CheckRedirect
 // to reject all redirects, preventing SSRF via open redirects.
-var errRedirectBlocked = errors.New("audit: loki redirects are not followed")
+var errRedirectBlocked = errors.New("audit/loki: redirects are not followed")
 
 // minResponseHeaderTimeout is the floor applied to the derived
 // [http.Transport.ResponseHeaderTimeout]. Half of [Config.Timeout] is
@@ -153,7 +153,7 @@ type Output struct { //nolint:govet // fieldalignment: readability preferred
 // a custom logger.
 func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("audit: loki config must not be nil")
+		return nil, fmt.Errorf("audit/loki: config must not be nil")
 	}
 	// Copy config so validation/defaults don't mutate the caller's struct.
 	cfgCopy := *cfg
@@ -344,7 +344,7 @@ func (o *Output) Close() error {
 	select {
 	case <-o.done:
 	case <-timer.C:
-		o.logger.Load().Error("audit: loki batch goroutine did not exit",
+		o.logger.Load().Error("audit/loki: batch goroutine did not exit",
 			"timeout", shutdownTimeout)
 	}
 
@@ -459,7 +459,7 @@ func (o *Output) flush(ctx context.Context, batch []lokiEntry) {
 
 	body, compressed, err := o.maybeCompress()
 	if err != nil {
-		o.logger.Load().Warn("audit: loki compression failed, sending uncompressed",
+		o.logger.Load().Warn("audit/loki: compression failed, sending uncompressed",
 			"error", err, "batch_size", len(batch))
 		body = o.payloadBuf.Bytes()
 		compressed = false

--- a/loki/loki_test.go
+++ b/loki/loki_test.go
@@ -312,6 +312,48 @@ func TestOutput_BufferFull_DropsEvent(t *testing.T) {
 	require.NoError(t, out.Close())
 }
 
+// TestOutput_BufferFull_DoesNotRecordCoreEventError verifies the B-25
+// contract: buffer-full drops surface only via OutputMetrics.RecordDrop
+// and MUST NOT call core Metrics.RecordEvent(EventError). Delivery
+// errors (retry exhausted) still use RecordEvent(EventError) — this
+// test guards the buffer-drop path only.
+func TestOutput_BufferFull_DoesNotRecordCoreEventError(t *testing.T) {
+	t.Parallel()
+
+	srv := lokiTestServer(t)
+	coreMetrics := &mockCoreMetrics{}
+	outMetrics := &testOutputMetrics{}
+	cfg := validConfigWithURL(srv.URL)
+	cfg.BufferSize = loki.MinBufferSize  // smallest allowed buffer (100)
+	cfg.BatchSize = loki.MaxBatchSize    // prevent size-based flush
+	cfg.FlushInterval = 10 * time.Second // prevent timer-based flush
+
+	out, err := loki.New(cfg, coreMetrics)
+	require.NoError(t, err)
+	out.SetOutputMetrics(outMetrics)
+
+	data := []byte(`{"event":"fill"}`)
+	var wg sync.WaitGroup
+	for g := 0; g < 10; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				_ = out.Write(data)
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.True(t, outMetrics.waitForDrops(1, 2*time.Second),
+		"at least some events must drop when buffer is full")
+
+	require.NoError(t, out.Close())
+
+	assert.Equal(t, 0, coreMetrics.errorCount(),
+		"buffer-full drops must not call core Metrics.RecordEvent(EventError) (B-25); use OutputMetrics.RecordDrop")
+}
+
 // ---------------------------------------------------------------------------
 // Flush metrics — batch goroutine records flushes
 // ---------------------------------------------------------------------------

--- a/loki/push.go
+++ b/loki/push.go
@@ -310,10 +310,10 @@ func (o *Output) maybeCompress() (body []byte, compressed bool, err error) {
 		o.gzWriter.Reset(o.compressDest)
 	}
 	if _, wErr := o.gzWriter.Write(o.payloadBuf.Bytes()); wErr != nil {
-		return nil, false, fmt.Errorf("audit: loki: gzip write: %w", wErr)
+		return nil, false, fmt.Errorf("audit/loki: gzip write: %w", wErr)
 	}
 	if cErr := o.gzWriter.Close(); cErr != nil {
-		return nil, false, fmt.Errorf("audit: loki: gzip close: %w", cErr)
+		return nil, false, fmt.Errorf("audit/loki: gzip close: %w", cErr)
 	}
 	return o.compressBuf.Bytes(), true, nil
 }

--- a/loki/register.go
+++ b/loki/register.go
@@ -129,7 +129,7 @@ func intPtrOrDefault(p *int, def int) int {
 
 func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics, om audit.OutputMetrics, logger *slog.Logger) (audit.Output, error) {
 	if len(rawConfig) == 0 {
-		return nil, fmt.Errorf("audit: loki output %q: config is required", name)
+		return nil, fmt.Errorf("audit/loki: output %q: config is required", name)
 	}
 
 	cfg, err := parseLokiConfig(name, rawConfig)
@@ -139,7 +139,7 @@ func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics, om au
 
 	output, err := New(cfg, coreMetrics, WithDiagnosticLogger(logger))
 	if err != nil {
-		return nil, fmt.Errorf("audit: loki output %q: %w", name, err)
+		return nil, fmt.Errorf("audit/loki: output %q: %w", name, err)
 	}
 	if om != nil {
 		output.SetOutputMetrics(om)
@@ -151,7 +151,7 @@ func parseLokiConfig(name string, rawConfig []byte) (*Config, error) {
 	var yc yamlLokiConfig
 	dec := yaml.NewDecoder(bytes.NewReader(rawConfig), yaml.DisallowUnknownField())
 	if err := dec.Decode(&yc); err != nil {
-		return nil, fmt.Errorf("audit: loki output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
+		return nil, fmt.Errorf("audit/loki: output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
 	}
 
 	cfg := &Config{
@@ -196,7 +196,7 @@ func parseLokiConfig(name string, rawConfig []byte) (*Config, error) {
 		cfg.Labels.Static = yc.Labels.Static
 		if yc.Labels.Dynamic != nil {
 			if err := parseDynamicLabels(yc.Labels.Dynamic, &cfg.Labels.Dynamic); err != nil {
-				return nil, fmt.Errorf("audit: loki output %q: %w", name, err)
+				return nil, fmt.Errorf("audit/loki: output %q: %w", name, err)
 			}
 		}
 	}

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -27,8 +27,16 @@ import (
 )
 
 // ErrOutputConfigInvalid is the sentinel error wrapped by output
-// configuration validation failures.
-var ErrOutputConfigInvalid = errors.New("audit: output config validation failed")
+// configuration validation failures. It itself wraps
+// [audit.ErrConfigInvalid] so consumers can match at either level
+// via [errors.Is]:
+//
+//	errors.Is(err, outputconfig.ErrOutputConfigInvalid)  // specific
+//	errors.Is(err, audit.ErrConfigInvalid)               // generic
+//
+// The wrapping relationship mirrors stdlib's `fs.ErrNotExist` /
+// `os.ErrNotExist` pattern.
+var ErrOutputConfigInvalid = fmt.Errorf("audit/outputconfig: output config validation failed: %w", audit.ErrConfigInvalid)
 
 // MaxOutputConfigSize is the maximum YAML input size accepted by [Load].
 const MaxOutputConfigSize = 1 << 20 // 1 MiB

--- a/outputconfig/provider_config.go
+++ b/outputconfig/provider_config.go
@@ -60,7 +60,7 @@ func parseSecretsSection(raw any) (*secretsResult, error) { //nolint:gocognit,go
 	// Expand environment variables.
 	expanded, err := expandEnvInValue(raw, "secrets")
 	if err != nil {
-		return nil, fmt.Errorf("secrets: %w", err)
+		return nil, fmt.Errorf("audit/outputconfig: secrets section: %w", err)
 	}
 
 	m, ok := expanded.(map[string]any)

--- a/secrets/openbao/openbao.go
+++ b/secrets/openbao/openbao.go
@@ -147,20 +147,20 @@ type Provider struct { //nolint:govet // readability over alignment
 func New(cfg *Config) (*Provider, error) {
 	// Validate address.
 	if cfg.Address == "" {
-		return nil, fmt.Errorf("audit/secrets/openbao: address is required")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address is required", audit.ErrConfigInvalid)
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("audit/secrets/openbao: invalid address: %w", err)
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: invalid address: %w", audit.ErrConfigInvalid, err)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("audit/secrets/openbao: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address must use https (got %q); set AllowInsecureHTTP for local development", audit.ErrConfigInvalid, u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("audit/secrets/openbao: address has empty host")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address has empty host", audit.ErrConfigInvalid)
 	}
 	if u.User != nil {
-		return nil, fmt.Errorf("audit/secrets/openbao: address must not contain embedded credentials")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address must not contain embedded credentials", audit.ErrConfigInvalid)
 	}
 
 	// Normalise: strip trailing slash to prevent double-slash in URLs.
@@ -168,7 +168,7 @@ func New(cfg *Config) (*Provider, error) {
 
 	// Validate token.
 	if cfg.Token == "" {
-		return nil, fmt.Errorf("audit/secrets/openbao: token is required")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: token is required", audit.ErrConfigInvalid)
 	}
 
 	// Build TLS config.
@@ -217,29 +217,29 @@ func New(cfg *Config) (*Provider, error) {
 // The Config.Address and Config.Token are still validated.
 func NewWithHTTPClient(cfg *Config, client *http.Client) (*Provider, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("audit/secrets/openbao: config must not be nil")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: config must not be nil", audit.ErrConfigInvalid)
 	}
 	if client == nil {
-		return nil, fmt.Errorf("audit/secrets/openbao: http client must not be nil")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: http client must not be nil", audit.ErrConfigInvalid)
 	}
 	if cfg.Address == "" {
-		return nil, fmt.Errorf("audit/secrets/openbao: address is required")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address is required", audit.ErrConfigInvalid)
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("audit/secrets/openbao: invalid address: %w", err)
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: invalid address: %w", audit.ErrConfigInvalid, err)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("audit/secrets/openbao: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address must use https (got %q); set AllowInsecureHTTP for local development", audit.ErrConfigInvalid, u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("audit/secrets/openbao: address has empty host")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address has empty host", audit.ErrConfigInvalid)
 	}
 	if u.User != nil {
-		return nil, fmt.Errorf("audit/secrets/openbao: address must not contain embedded credentials")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address must not contain embedded credentials", audit.ErrConfigInvalid)
 	}
 	if cfg.Token == "" {
-		return nil, fmt.Errorf("audit/secrets/openbao: token is required")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: token is required", audit.ErrConfigInvalid)
 	}
 	return &Provider{
 		client: client,
@@ -409,21 +409,21 @@ func buildTLSConfig(cfg *Config) (*tls.Config, error) {
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {
 		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
 		if err != nil {
-			return nil, fmt.Errorf("audit/secrets/openbao: load client certificate: %w", err)
+			return nil, fmt.Errorf("%w: audit/secrets/openbao: load client certificate: %w", audit.ErrConfigInvalid, err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	} else if cfg.TLSCert != "" || cfg.TLSKey != "" {
-		return nil, fmt.Errorf("audit/secrets/openbao: tls_cert and tls_key must both be set or both empty")
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: tls_cert and tls_key must both be set or both empty", audit.ErrConfigInvalid)
 	}
 
 	if cfg.TLSCA != "" {
 		caCert, err := os.ReadFile(cfg.TLSCA)
 		if err != nil {
-			return nil, fmt.Errorf("audit/secrets/openbao: read ca certificate: %w", err)
+			return nil, fmt.Errorf("%w: audit/secrets/openbao: read ca certificate: %w", audit.ErrConfigInvalid, err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("audit/secrets/openbao: parse ca certificate: invalid PEM")
+			return nil, fmt.Errorf("%w: audit/secrets/openbao: parse ca certificate: invalid PEM", audit.ErrConfigInvalid)
 		}
 		tlsCfg.RootCAs = pool
 	}

--- a/secrets/openbao/openbao.go
+++ b/secrets/openbao/openbao.go
@@ -38,7 +38,7 @@ import (
 const maxResponseSize = 1 << 20 // 1 MiB
 
 // errRedirectBlocked is returned by the redirect policy.
-var errRedirectBlocked = errors.New("openbao: redirects are blocked")
+var errRedirectBlocked = errors.New("audit/secrets/openbao: redirects are blocked")
 
 // Config holds connection parameters for an OpenBao provider.
 type Config struct { //nolint:govet // readability over alignment
@@ -147,20 +147,20 @@ type Provider struct { //nolint:govet // readability over alignment
 func New(cfg *Config) (*Provider, error) {
 	// Validate address.
 	if cfg.Address == "" {
-		return nil, fmt.Errorf("openbao: address is required")
+		return nil, fmt.Errorf("audit/secrets/openbao: address is required")
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("openbao: invalid address: %w", err)
+		return nil, fmt.Errorf("audit/secrets/openbao: invalid address: %w", err)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("openbao: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
+		return nil, fmt.Errorf("audit/secrets/openbao: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("openbao: address has empty host")
+		return nil, fmt.Errorf("audit/secrets/openbao: address has empty host")
 	}
 	if u.User != nil {
-		return nil, fmt.Errorf("openbao: address must not contain embedded credentials")
+		return nil, fmt.Errorf("audit/secrets/openbao: address must not contain embedded credentials")
 	}
 
 	// Normalise: strip trailing slash to prevent double-slash in URLs.
@@ -168,7 +168,7 @@ func New(cfg *Config) (*Provider, error) {
 
 	// Validate token.
 	if cfg.Token == "" {
-		return nil, fmt.Errorf("openbao: token is required")
+		return nil, fmt.Errorf("audit/secrets/openbao: token is required")
 	}
 
 	// Build TLS config.
@@ -217,29 +217,29 @@ func New(cfg *Config) (*Provider, error) {
 // The Config.Address and Config.Token are still validated.
 func NewWithHTTPClient(cfg *Config, client *http.Client) (*Provider, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("openbao: config must not be nil")
+		return nil, fmt.Errorf("audit/secrets/openbao: config must not be nil")
 	}
 	if client == nil {
-		return nil, fmt.Errorf("openbao: http client must not be nil")
+		return nil, fmt.Errorf("audit/secrets/openbao: http client must not be nil")
 	}
 	if cfg.Address == "" {
-		return nil, fmt.Errorf("openbao: address is required")
+		return nil, fmt.Errorf("audit/secrets/openbao: address is required")
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("openbao: invalid address: %w", err)
+		return nil, fmt.Errorf("audit/secrets/openbao: invalid address: %w", err)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("openbao: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
+		return nil, fmt.Errorf("audit/secrets/openbao: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("openbao: address has empty host")
+		return nil, fmt.Errorf("audit/secrets/openbao: address has empty host")
 	}
 	if u.User != nil {
-		return nil, fmt.Errorf("openbao: address must not contain embedded credentials")
+		return nil, fmt.Errorf("audit/secrets/openbao: address must not contain embedded credentials")
 	}
 	if cfg.Token == "" {
-		return nil, fmt.Errorf("openbao: token is required")
+		return nil, fmt.Errorf("audit/secrets/openbao: token is required")
 	}
 	return &Provider{
 		client: client,
@@ -259,7 +259,7 @@ var _ secrets.BatchProvider = (*Provider)(nil)
 // Resolve fetches a single secret value for the given reference.
 func (p *Provider) Resolve(ctx context.Context, ref secrets.Ref) (string, error) {
 	if err := ref.Valid(); err != nil {
-		return "", fmt.Errorf("openbao: %w", err)
+		return "", fmt.Errorf("audit/secrets/openbao: %w", err)
 	}
 	allKeys, err := p.fetchPath(ctx, ref.Path)
 	if err != nil {
@@ -277,7 +277,7 @@ func (p *Provider) Resolve(ctx context.Context, ref secrets.Ref) (string, error)
 // path-level caching.
 func (p *Provider) ResolvePath(ctx context.Context, path string) (map[string]string, error) {
 	if err := secrets.ValidatePath(path); err != nil {
-		return nil, fmt.Errorf("openbao: %w", err)
+		return nil, fmt.Errorf("audit/secrets/openbao: %w", err)
 	}
 	return p.fetchPath(ctx, path)
 }
@@ -409,21 +409,21 @@ func buildTLSConfig(cfg *Config) (*tls.Config, error) {
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {
 		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
 		if err != nil {
-			return nil, fmt.Errorf("openbao: load client certificate: %w", err)
+			return nil, fmt.Errorf("audit/secrets/openbao: load client certificate: %w", err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	} else if cfg.TLSCert != "" || cfg.TLSKey != "" {
-		return nil, fmt.Errorf("openbao: tls_cert and tls_key must both be set or both empty")
+		return nil, fmt.Errorf("audit/secrets/openbao: tls_cert and tls_key must both be set or both empty")
 	}
 
 	if cfg.TLSCA != "" {
 		caCert, err := os.ReadFile(cfg.TLSCA)
 		if err != nil {
-			return nil, fmt.Errorf("openbao: read ca certificate: %w", err)
+			return nil, fmt.Errorf("audit/secrets/openbao: read ca certificate: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("openbao: parse ca certificate: invalid PEM")
+			return nil, fmt.Errorf("audit/secrets/openbao: parse ca certificate: invalid PEM")
 		}
 		tlsCfg.RootCAs = pool
 	}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -33,23 +33,23 @@ var (
 	// ErrMalformedRef indicates a string starts with "ref+" but is
 	// structurally invalid (missing scheme, path, key, or contains
 	// path traversal).
-	ErrMalformedRef = errors.New("secrets: malformed secret reference")
+	ErrMalformedRef = errors.New("audit/secrets: malformed secret reference")
 
 	// ErrProviderNotRegistered indicates no provider is registered
 	// for the scheme in a ref URI.
-	ErrProviderNotRegistered = errors.New("secrets: no provider registered for scheme")
+	ErrProviderNotRegistered = errors.New("audit/secrets: no provider registered for scheme")
 
 	// ErrSecretNotFound indicates the secret path exists but the
 	// requested key was not found.
-	ErrSecretNotFound = errors.New("secrets: secret not found at path")
+	ErrSecretNotFound = errors.New("audit/secrets: secret not found at path")
 
 	// ErrSecretResolveFailed indicates a transient or permanent
 	// failure during secret resolution (network error, auth failure).
-	ErrSecretResolveFailed = errors.New("secrets: secret resolution failed")
+	ErrSecretResolveFailed = errors.New("audit/secrets: secret resolution failed")
 
 	// ErrUnresolvedRef indicates that after all resolution passes, a
 	// string in the config still contains a ref+ URI.
-	ErrUnresolvedRef = errors.New("secrets: unresolved secret reference in config")
+	ErrUnresolvedRef = errors.New("audit/secrets: unresolved secret reference in config")
 )
 
 // Provider resolves secret references to their plaintext values.

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -226,7 +226,7 @@ func ParseRef(s string) (Ref, error) {
 	sepIdx := strings.Index(rest, schemeSep)
 	if sepIdx < 0 {
 		// redactRef returns a fixed token; the input is never echoed.
-		return Ref{}, fmt.Errorf("%w: missing %q separator in %s", ErrMalformedRef, schemeSep, redactRef(s))
+		return Ref{}, fmt.Errorf("%w: missing %q separator in %s", ErrMalformedRef, schemeSep, redactRef())
 	}
 
 	scheme := rest[:sepIdx]
@@ -372,9 +372,10 @@ func isValidScheme(s string) bool {
 func isLowerAlpha(c byte) bool { return c >= 'a' && c <= 'z' }
 func isDigit(c byte) bool      { return c >= '0' && c <= '9' }
 
-// redactRef returns a redacted version of a ref string for use in
-// error messages. Only called when the "://" separator is missing,
-// so it always returns the malformed form.
-func redactRef(_ string) string {
+// redactRef returns a redacted placeholder used in error messages
+// where the original ref string must not be echoed (e.g. because it
+// failed scheme parsing and could contain attacker-controlled input).
+// The return value is constant; callers pass no input.
+func redactRef() string {
 	return "ref+[malformed]"
 }

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -355,7 +355,7 @@ func TestSentinelErrors_HaveSecretsPrefix(t *testing.T) {
 		secrets.ErrUnresolvedRef,
 	}
 	for _, e := range errs {
-		assert.Contains(t, e.Error(), "secrets:", "error %q should have secrets: prefix", e)
+		assert.Contains(t, e.Error(), "audit/secrets:", "error %q should have audit/secrets: prefix", e)
 	}
 }
 

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -38,7 +38,7 @@ import (
 const maxResponseSize = 1 << 20 // 1 MiB
 
 // errRedirectBlocked is returned by the redirect policy.
-var errRedirectBlocked = errors.New("vault: redirects are blocked")
+var errRedirectBlocked = errors.New("audit/secrets/vault: redirects are blocked")
 
 // Config holds connection parameters for a HashiCorp Vault provider.
 type Config struct { //nolint:govet // readability over alignment
@@ -147,20 +147,20 @@ type Provider struct { //nolint:govet // readability over alignment
 func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear validation pipeline
 	// Validate address.
 	if cfg.Address == "" {
-		return nil, fmt.Errorf("vault: address is required")
+		return nil, fmt.Errorf("audit/secrets/vault: address is required")
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("vault: invalid address: %w", err)
+		return nil, fmt.Errorf("audit/secrets/vault: invalid address: %w", err)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("vault: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
+		return nil, fmt.Errorf("audit/secrets/vault: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("vault: address has empty host")
+		return nil, fmt.Errorf("audit/secrets/vault: address has empty host")
 	}
 	if u.User != nil {
-		return nil, fmt.Errorf("vault: address must not contain embedded credentials")
+		return nil, fmt.Errorf("audit/secrets/vault: address must not contain embedded credentials")
 	}
 
 	// Normalise: strip trailing slash to prevent double-slash in URLs.
@@ -168,7 +168,7 @@ func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear val
 
 	// Validate token.
 	if cfg.Token == "" {
-		return nil, fmt.Errorf("vault: token is required")
+		return nil, fmt.Errorf("audit/secrets/vault: token is required")
 	}
 
 	// Build TLS config (skip when using plain HTTP for development).
@@ -220,29 +220,29 @@ func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear val
 // The Config.Address and Config.Token are still validated.
 func NewWithHTTPClient(cfg *Config, client *http.Client) (*Provider, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("vault: config must not be nil")
+		return nil, fmt.Errorf("audit/secrets/vault: config must not be nil")
 	}
 	if client == nil {
-		return nil, fmt.Errorf("vault: http client must not be nil")
+		return nil, fmt.Errorf("audit/secrets/vault: http client must not be nil")
 	}
 	if cfg.Address == "" {
-		return nil, fmt.Errorf("vault: address is required")
+		return nil, fmt.Errorf("audit/secrets/vault: address is required")
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("vault: invalid address: %w", err)
+		return nil, fmt.Errorf("audit/secrets/vault: invalid address: %w", err)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("vault: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
+		return nil, fmt.Errorf("audit/secrets/vault: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("vault: address has empty host")
+		return nil, fmt.Errorf("audit/secrets/vault: address has empty host")
 	}
 	if u.User != nil {
-		return nil, fmt.Errorf("vault: address must not contain embedded credentials")
+		return nil, fmt.Errorf("audit/secrets/vault: address must not contain embedded credentials")
 	}
 	if cfg.Token == "" {
-		return nil, fmt.Errorf("vault: token is required")
+		return nil, fmt.Errorf("audit/secrets/vault: token is required")
 	}
 	return &Provider{
 		client: client,
@@ -262,7 +262,7 @@ var _ secrets.BatchProvider = (*Provider)(nil)
 // Resolve fetches a single secret value for the given reference.
 func (p *Provider) Resolve(ctx context.Context, ref secrets.Ref) (string, error) {
 	if err := ref.Valid(); err != nil {
-		return "", fmt.Errorf("vault: %w", err)
+		return "", fmt.Errorf("audit/secrets/vault: %w", err)
 	}
 	allKeys, err := p.fetchPath(ctx, ref.Path)
 	if err != nil {
@@ -280,7 +280,7 @@ func (p *Provider) Resolve(ctx context.Context, ref secrets.Ref) (string, error)
 // path-level caching.
 func (p *Provider) ResolvePath(ctx context.Context, path string) (map[string]string, error) {
 	if err := secrets.ValidatePath(path); err != nil {
-		return nil, fmt.Errorf("vault: %w", err)
+		return nil, fmt.Errorf("audit/secrets/vault: %w", err)
 	}
 	return p.fetchPath(ctx, path)
 }
@@ -411,21 +411,21 @@ func buildTLSConfig(cfg *Config) (*tls.Config, error) {
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {
 		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
 		if err != nil {
-			return nil, fmt.Errorf("vault: load client certificate: %w", err)
+			return nil, fmt.Errorf("audit/secrets/vault: load client certificate: %w", err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	} else if cfg.TLSCert != "" || cfg.TLSKey != "" {
-		return nil, fmt.Errorf("vault: tls_cert and tls_key must both be set or both empty")
+		return nil, fmt.Errorf("audit/secrets/vault: tls_cert and tls_key must both be set or both empty")
 	}
 
 	if cfg.TLSCA != "" {
 		caCert, err := os.ReadFile(cfg.TLSCA)
 		if err != nil {
-			return nil, fmt.Errorf("vault: read ca certificate: %w", err)
+			return nil, fmt.Errorf("audit/secrets/vault: read ca certificate: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("vault: parse ca certificate: invalid PEM")
+			return nil, fmt.Errorf("audit/secrets/vault: parse ca certificate: invalid PEM")
 		}
 		tlsCfg.RootCAs = pool
 	}

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -147,20 +147,20 @@ type Provider struct { //nolint:govet // readability over alignment
 func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear validation pipeline
 	// Validate address.
 	if cfg.Address == "" {
-		return nil, fmt.Errorf("audit/secrets/vault: address is required")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address is required", audit.ErrConfigInvalid)
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("audit/secrets/vault: invalid address: %w", err)
+		return nil, fmt.Errorf("%w: audit/secrets/vault: invalid address: %w", audit.ErrConfigInvalid, err)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("audit/secrets/vault: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address must use https (got %q); set AllowInsecureHTTP for local development", audit.ErrConfigInvalid, u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("audit/secrets/vault: address has empty host")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address has empty host", audit.ErrConfigInvalid)
 	}
 	if u.User != nil {
-		return nil, fmt.Errorf("audit/secrets/vault: address must not contain embedded credentials")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address must not contain embedded credentials", audit.ErrConfigInvalid)
 	}
 
 	// Normalise: strip trailing slash to prevent double-slash in URLs.
@@ -168,7 +168,7 @@ func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear val
 
 	// Validate token.
 	if cfg.Token == "" {
-		return nil, fmt.Errorf("audit/secrets/vault: token is required")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: token is required", audit.ErrConfigInvalid)
 	}
 
 	// Build TLS config (skip when using plain HTTP for development).
@@ -220,29 +220,29 @@ func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear val
 // The Config.Address and Config.Token are still validated.
 func NewWithHTTPClient(cfg *Config, client *http.Client) (*Provider, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("audit/secrets/vault: config must not be nil")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: config must not be nil", audit.ErrConfigInvalid)
 	}
 	if client == nil {
-		return nil, fmt.Errorf("audit/secrets/vault: http client must not be nil")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: http client must not be nil", audit.ErrConfigInvalid)
 	}
 	if cfg.Address == "" {
-		return nil, fmt.Errorf("audit/secrets/vault: address is required")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address is required", audit.ErrConfigInvalid)
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("audit/secrets/vault: invalid address: %w", err)
+		return nil, fmt.Errorf("%w: audit/secrets/vault: invalid address: %w", audit.ErrConfigInvalid, err)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("audit/secrets/vault: address must use https (got %q); set AllowInsecureHTTP for local development", u.Scheme)
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address must use https (got %q); set AllowInsecureHTTP for local development", audit.ErrConfigInvalid, u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("audit/secrets/vault: address has empty host")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address has empty host", audit.ErrConfigInvalid)
 	}
 	if u.User != nil {
-		return nil, fmt.Errorf("audit/secrets/vault: address must not contain embedded credentials")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address must not contain embedded credentials", audit.ErrConfigInvalid)
 	}
 	if cfg.Token == "" {
-		return nil, fmt.Errorf("audit/secrets/vault: token is required")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: token is required", audit.ErrConfigInvalid)
 	}
 	return &Provider{
 		client: client,
@@ -411,21 +411,21 @@ func buildTLSConfig(cfg *Config) (*tls.Config, error) {
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {
 		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
 		if err != nil {
-			return nil, fmt.Errorf("audit/secrets/vault: load client certificate: %w", err)
+			return nil, fmt.Errorf("%w: audit/secrets/vault: load client certificate: %w", audit.ErrConfigInvalid, err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	} else if cfg.TLSCert != "" || cfg.TLSKey != "" {
-		return nil, fmt.Errorf("audit/secrets/vault: tls_cert and tls_key must both be set or both empty")
+		return nil, fmt.Errorf("%w: audit/secrets/vault: tls_cert and tls_key must both be set or both empty", audit.ErrConfigInvalid)
 	}
 
 	if cfg.TLSCA != "" {
 		caCert, err := os.ReadFile(cfg.TLSCA)
 		if err != nil {
-			return nil, fmt.Errorf("audit/secrets/vault: read ca certificate: %w", err)
+			return nil, fmt.Errorf("%w: audit/secrets/vault: read ca certificate: %w", audit.ErrConfigInvalid, err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("audit/secrets/vault: parse ca certificate: invalid PEM")
+			return nil, fmt.Errorf("%w: audit/secrets/vault: parse ca certificate: invalid PEM", audit.ErrConfigInvalid)
 		}
 		tlsCfg.RootCAs = pool
 	}

--- a/syslog/register.go
+++ b/syslog/register.go
@@ -102,13 +102,13 @@ func intPtrOrDefault(p *int, def int) int {
 
 func buildOutput(name string, rawConfig []byte, om audit.OutputMetrics, logger *slog.Logger) (audit.Output, error) {
 	if len(rawConfig) == 0 {
-		return nil, fmt.Errorf("audit: syslog output %q: config is required", name)
+		return nil, fmt.Errorf("audit/syslog: output %q: config is required", name)
 	}
 
 	var yc yamlSyslogConfig
 	dec := yaml.NewDecoder(bytes.NewReader(rawConfig), yaml.DisallowUnknownField())
 	if err := dec.Decode(&yc); err != nil {
-		return nil, fmt.Errorf("audit: syslog output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
+		return nil, fmt.Errorf("audit/syslog: output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
 	}
 
 	cfg := &Config{
@@ -129,7 +129,7 @@ func buildOutput(name string, rawConfig []byte, om audit.OutputMetrics, logger *
 	if yc.FlushInterval != "" {
 		d, err := time.ParseDuration(yc.FlushInterval)
 		if err != nil {
-			return nil, fmt.Errorf("audit: syslog output %q: flush_interval %q: %w", name, yc.FlushInterval, audit.ErrConfigInvalid)
+			return nil, fmt.Errorf("audit/syslog: output %q: flush_interval %q: %w", name, yc.FlushInterval, audit.ErrConfigInvalid)
 		}
 		cfg.FlushInterval = d
 	}
@@ -142,7 +142,7 @@ func buildOutput(name string, rawConfig []byte, om audit.OutputMetrics, logger *
 
 	out, err := New(cfg, WithDiagnosticLogger(logger))
 	if err != nil {
-		return nil, fmt.Errorf("audit: syslog output %q: %w", name, err)
+		return nil, fmt.Errorf("audit/syslog: output %q: %w", name, err)
 	}
 	if om != nil {
 		out.SetOutputMetrics(om)

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -217,7 +217,7 @@ func New(cfg *Config, opts ...Option) (*Output, error) {
 
 	priority, err := parseFacility(cfg.Facility)
 	if err != nil {
-		return nil, fmt.Errorf("audit: syslog facility %q: %w", cfg.Facility, err)
+		return nil, fmt.Errorf("audit/syslog: facility %q: %w", cfg.Facility, err)
 	}
 
 	// Use explicit hostname from config if provided; otherwise fall
@@ -232,7 +232,7 @@ func New(cfg *Config, opts ...Option) (*Output, error) {
 	if cfg.Network == "tcp+tls" {
 		tlsCfg, err = buildSyslogTLSConfig(cfg, o.logger)
 		if err != nil {
-			return nil, fmt.Errorf("audit: syslog tls config: %w", err)
+			return nil, fmt.Errorf("audit/syslog: tls config: %w", err)
 		}
 	}
 
@@ -268,7 +268,7 @@ func New(cfg *Config, opts ...Option) (*Output, error) {
 	s.logger.Store(o.logger)
 
 	if err := s.connect(); err != nil {
-		return nil, fmt.Errorf("audit: syslog dial %s://%s: %w",
+		return nil, fmt.Errorf("audit/syslog: dial %s://%s: %w",
 			cfg.Network, cfg.Address, err)
 	}
 
@@ -364,7 +364,7 @@ func (s *Output) Close() error {
 	// Close the srslog.Writer AFTER the writeLoop exits.
 	if s.writer != nil {
 		if err := s.writer.Close(); err != nil {
-			return fmt.Errorf("audit: syslog close: %w", err)
+			return fmt.Errorf("audit/syslog: close: %w", err)
 		}
 	}
 	return nil
@@ -416,7 +416,7 @@ func (s *Output) connect() error {
 		w, err = srslog.Dial(s.network, s.address, defaultPriority, s.appName)
 	}
 	if err != nil {
-		return fmt.Errorf("audit: syslog connect %s://%s: %w", s.network, s.address, err)
+		return fmt.Errorf("audit/syslog: connect %s://%s: %w", s.network, s.address, err)
 	}
 
 	w.SetFormatter(srslog.RFC5424Formatter)
@@ -560,7 +560,7 @@ func resetSyslogTimer(t *time.Timer, d time.Duration) {
 
 // errSyslogNotConnected is returned when the syslog writer is nil
 // (previous reconnect failed). Pre-allocated to avoid per-event alloc.
-var errSyslogNotConnected = errors.New("audit: syslog writer not connected")
+var errSyslogNotConnected = errors.New("audit/syslog: writer not connected")
 
 // writeEntry writes a single event to the syslog server with panic
 // recovery and reconnection handling.
@@ -690,7 +690,7 @@ func (s *Output) handleWriteFailure(entry syslogEntry, writeErr error, om audit.
 		return
 	}
 
-	s.logger.Load().Info("audit: syslog reconnected", "address", s.address)
+	s.logger.Load().Info("audit/syslog: reconnected", "address", s.address)
 	if rr != nil {
 		rr.RecordReconnect(s.address, true)
 	}

--- a/syslog/tls.go
+++ b/syslog/tls.go
@@ -34,7 +34,7 @@ func buildSyslogTLSConfig(cfg *Config, logger *slog.Logger) (*tls.Config, error)
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {
 		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
 		if err != nil {
-			return nil, fmt.Errorf("audit: syslog tls: load client certificate: %w", err)
+			return nil, fmt.Errorf("audit/syslog: tls: load client certificate: %w", err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
@@ -42,11 +42,11 @@ func buildSyslogTLSConfig(cfg *Config, logger *slog.Logger) (*tls.Config, error)
 	if cfg.TLSCA != "" {
 		caCert, err := os.ReadFile(cfg.TLSCA)
 		if err != nil {
-			return nil, fmt.Errorf("audit: syslog tls: read ca certificate: %w", err)
+			return nil, fmt.Errorf("audit/syslog: tls: read ca certificate: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("audit: syslog tls: parse ca certificate: invalid pem block")
+			return nil, fmt.Errorf("audit/syslog: tls: parse ca certificate: invalid pem block")
 		}
 		tlsCfg.RootCAs = pool
 	}

--- a/tests/bdd/features/file_output.feature
+++ b/tests/bdd/features/file_output.feature
@@ -95,7 +95,7 @@ Feature: File Output
     When I try to create a file output with empty path
     Then the file output construction should fail with error:
       """
-      audit: file output path must not be empty
+      audit/file: output path must not be empty
       """
 
   Scenario: MaxSizeMB exceeding limit is rejected

--- a/tests/bdd/features/syslog_output.feature
+++ b/tests/bdd/features/syslog_output.feature
@@ -102,7 +102,7 @@ Feature: Syslog Output
     When I try to create a syslog output with facility "bogus"
     Then the syslog construction should fail with exact error:
       """
-      audit: syslog facility "bogus": audit: config validation failed: unknown syslog facility "bogus"
+      audit/syslog: facility "bogus": audit: config validation failed: unknown syslog facility "bogus"
       """
 
   # --- Hostname configuration (#237) ---

--- a/webhook/config.go
+++ b/webhook/config.go
@@ -474,7 +474,7 @@ func buildWebhookTLSConfig(cfg *Config, logger *slog.Logger) (*tls.Config, error
 	if cfg.TLSCert != "" && cfg.TLSKey != "" {
 		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
 		if err != nil {
-			return nil, fmt.Errorf("audit: webhook tls: load client certificate: %w", err)
+			return nil, fmt.Errorf("audit/webhook: tls: load client certificate: %w", err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
@@ -482,11 +482,11 @@ func buildWebhookTLSConfig(cfg *Config, logger *slog.Logger) (*tls.Config, error
 	if cfg.TLSCA != "" {
 		caCert, err := os.ReadFile(cfg.TLSCA)
 		if err != nil {
-			return nil, fmt.Errorf("audit: webhook tls: read ca certificate: %w", err)
+			return nil, fmt.Errorf("audit/webhook: tls: read ca certificate: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("audit: webhook tls: parse ca certificate: invalid pem block")
+			return nil, fmt.Errorf("audit/webhook: tls: parse ca certificate: invalid pem block")
 		}
 		tlsCfg.RootCAs = pool
 	}

--- a/webhook/http.go
+++ b/webhook/http.go
@@ -143,7 +143,7 @@ func drainAndClose(resp *http.Response) {
 func (w *Output) doPost(ctx context.Context, body []byte) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, bytes.NewReader(body))
 	if err != nil {
-		return false, fmt.Errorf("audit: webhook request: %w", err)
+		return false, fmt.Errorf("audit/webhook: request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-ndjson")
@@ -155,14 +155,14 @@ func (w *Output) doPost(ctx context.Context, body []byte) (bool, error) {
 	if err != nil {
 		// Redirect rejection is non-retryable.
 		if errors.Is(err, errRedirectBlocked) {
-			return false, fmt.Errorf("audit: webhook redirect blocked: %w", err)
+			return false, fmt.Errorf("audit/webhook: redirect blocked: %w", err)
 		}
 		// Context cancellation is non-retryable.
 		if ctx.Err() != nil {
-			return false, fmt.Errorf("audit: webhook cancelled: %w", err)
+			return false, fmt.Errorf("audit/webhook: cancelled: %w", err)
 		}
 		// Network errors are retryable.
-		return true, fmt.Errorf("audit: webhook request failed: %w", err)
+		return true, fmt.Errorf("audit/webhook: request failed: %w", err)
 	}
 	defer drainAndClose(resp)
 
@@ -171,12 +171,12 @@ func (w *Output) doPost(ctx context.Context, body []byte) (bool, error) {
 	}
 
 	if resp.StatusCode == 429 || resp.StatusCode >= 500 {
-		return true, fmt.Errorf("audit: webhook server error %d", resp.StatusCode)
+		return true, fmt.Errorf("audit/webhook: server error %d", resp.StatusCode)
 	}
 
 	// 4xx (not 429), and any 3xx that bypassed redirect-follow
 	// (no Location header, 300, 304, ...) — client error, not retryable.
-	return false, fmt.Errorf("audit: webhook client error %d", resp.StatusCode)
+	return false, fmt.Errorf("audit/webhook: client error %d", resp.StatusCode)
 }
 
 // recordSuccess records successful delivery metrics for a batch.

--- a/webhook/register.go
+++ b/webhook/register.go
@@ -117,13 +117,13 @@ func intPtrOrDefault(p *int, def int) int {
 
 func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics, om audit.OutputMetrics, logger *slog.Logger) (audit.Output, error) {
 	if len(rawConfig) == 0 {
-		return nil, fmt.Errorf("audit: webhook output %q: config is required", name)
+		return nil, fmt.Errorf("audit/webhook: output %q: config is required", name)
 	}
 
 	var yc yamlWebhookConfig
 	dec := yaml.NewDecoder(bytes.NewReader(rawConfig), yaml.DisallowUnknownField())
 	if err := dec.Decode(&yc); err != nil {
-		return nil, fmt.Errorf("audit: webhook output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
+		return nil, fmt.Errorf("audit/webhook: output %q: %w", name, audit.WrapUnknownFieldError(err, yc))
 	}
 
 	cfg := &Config{
@@ -151,7 +151,7 @@ func buildOutput(name string, rawConfig []byte, coreMetrics audit.Metrics, om au
 
 	out, err := New(cfg, coreMetrics, WithDiagnosticLogger(logger))
 	if err != nil {
-		return nil, fmt.Errorf("audit: webhook output %q: %w", name, err)
+		return nil, fmt.Errorf("audit/webhook: output %q: %w", name, err)
 	}
 	if om != nil {
 		out.SetOutputMetrics(om)

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -253,11 +253,12 @@ func (w *Output) Write(data []byte) error {
 				"max_event_bytes", w.maxEventBytes,
 				"dropped", dropped)
 		})
+		// Drops are counted once via per-output OutputMetrics.RecordDrop
+		// only — not via pipeline-level Metrics.RecordEvent. This
+		// matches file + syslog behaviour for consistency across all
+		// self-reporting outputs (B-25).
 		if omp := w.outputMetrics.Load(); omp != nil {
 			(*omp).RecordDrop()
-		}
-		if w.metrics != nil {
-			w.metrics.RecordEvent(w.Name(), audit.EventError)
 		}
 		return fmt.Errorf("%w: %w: event size %d exceeds max_event_bytes %d",
 			audit.ErrValidation, audit.ErrEventTooLarge, len(data), w.maxEventBytes)
@@ -275,11 +276,10 @@ func (w *Output) Write(data []byte) error {
 				"dropped", dropped,
 				"buffer_size", cap(w.ch))
 		})
+		// Drops are counted via per-output OutputMetrics.RecordDrop
+		// only — see B-25 note above.
 		if omp := w.outputMetrics.Load(); omp != nil {
 			(*omp).RecordDrop()
-		}
-		if w.metrics != nil {
-			w.metrics.RecordEvent(w.Name(), audit.EventError)
 		}
 		return nil // non-blocking — do not return error to drain goroutine
 	}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -56,7 +56,7 @@ var (
 // errRedirectBlocked is returned by the http.Client's CheckRedirect
 // function. It is checked in doPost to classify redirect errors as
 // non-retryable.
-var errRedirectBlocked = errors.New("audit: webhook redirects are not followed")
+var errRedirectBlocked = errors.New("audit/webhook: redirects are not followed")
 
 // minResponseHeaderTimeout is the floor applied to the derived
 // [http.Transport.ResponseHeaderTimeout]. Half of [Config.Timeout] is
@@ -160,7 +160,7 @@ func (w *Output) SetDiagnosticLogger(l *slog.Logger) {
 // a custom logger.
 func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("audit: webhook config must not be nil")
+		return nil, fmt.Errorf("audit/webhook: config must not be nil")
 	}
 	// Copy config so validation/defaults don't mutate the caller's struct.
 	cfgCopy := *cfg
@@ -174,7 +174,7 @@ func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 
 	tlsCfg, err := buildWebhookTLSConfig(cfg, o.logger)
 	if err != nil {
-		return nil, fmt.Errorf("audit: webhook tls: %w", err)
+		return nil, fmt.Errorf("audit/webhook: tls: %w", err)
 	}
 
 	var ssrfOpts []audit.SSRFOption
@@ -313,7 +313,7 @@ func (w *Output) Close() error {
 	select {
 	case <-w.done:
 	case <-timer.C:
-		w.logger.Load().Error("audit: webhook batch goroutine did not exit",
+		w.logger.Load().Error("audit/webhook: batch goroutine did not exit",
 			"timeout", shutdownTimeout)
 	}
 

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1360,15 +1360,18 @@ func TestWebhookOutput_DeliveryMetrics_ErrorOnBufferOverflow(t *testing.T) {
 	}, metrics)
 	require.NoError(t, err)
 
-	// Fill buffer — overflow events get RecordEvent(error).
+	// Fill buffer — overflow events are no longer recorded via
+	// core Metrics.RecordEvent (B-25 consistency with file + syslog).
+	// They surface only via OutputMetrics.RecordDrop — asserted in
+	// the separate per-output metrics test suite.
 	for range 15 {
 		_ = out.Write([]byte(`{"event":"overflow"}` + "\n"))
 	}
 	require.NoError(t, out.Close())
 
 	name := out.Name()
-	assert.Greater(t, metrics.getEventCount(name, audit.EventError), 0,
-		"RecordEvent(error) should be called for buffer overflow drops")
+	assert.Equal(t, 0, metrics.getEventCount(name, audit.EventError),
+		"buffer overflow drops must not be recorded via core Metrics.RecordEvent (B-25); use OutputMetrics.RecordDrop")
 }
 
 func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
@@ -1460,17 +1463,22 @@ func TestWebhookOutput_NilWebhookMetrics(t *testing.T) {
 	}, m) // core Metrics only, no OutputMetrics (injected separately)
 	require.NoError(t, err)
 
-	// Overflow the buffer — should not panic despite nil WebhookMetrics.
+	// Overflow the buffer — should not panic despite missing
+	// OutputMetrics. Buffer-overflow drops are no longer recorded via
+	// core Metrics.RecordEvent (B-25); the per-output RecordDrop path
+	// is exercised in the OutputMetrics-specific tests. Here we only
+	// assert that the code does not panic.
 	for range 15 {
 		_ = out.Write([]byte(`{"event":"overflow"}` + "\n"))
 	}
 	require.NoError(t, out.Close())
 
-	// RecordEvent should still have been called for errors.
+	// Core Metrics should NOT have recorded the overflow drops as
+	// RecordEvent(EventError) — B-25 alignment with file + syslog.
 	m.mu.Lock()
 	errorCount := m.events[out.Name()+":error"]
 	m.mu.Unlock()
-	assert.Greater(t, errorCount, 0, "RecordEvent(error) should be called for drops")
+	assert.Equal(t, 0, errorCount, "buffer overflow drops must not be recorded via Metrics.RecordEvent (B-25)")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three bundled Track B polish items. Closes #592.

### B-24 — Unified error prefix + sentinel

Every module now prefixes errors with its dotted Go import path, matching stdlib (`net/http:`, `crypto/tls:`, `encoding/json:`):

| Module | Old prefix | New prefix |
|---|---|---|
| core | `audit:` | `audit:` (unchanged) |
| file | `audit: file output %q:` | `audit/file: output %q:` |
| syslog | `audit: syslog output %q:` | `audit/syslog: output %q:` |
| webhook | `audit: webhook output %q:` | `audit/webhook: output %q:` |
| loki | `audit: loki output %q:` | `audit/loki: output %q:` |
| outputconfig | (none) | `audit/outputconfig:` |
| secrets/vault | `vault:` | `audit/secrets/vault:` |
| secrets/openbao | `openbao:` | `audit/secrets/openbao:` |

`outputconfig.ErrOutputConfigInvalid` now wraps `audit.ErrConfigInvalid` — consumers can `errors.Is(err, audit.ErrConfigInvalid)` to match every configuration validation failure (stdlib `fs.ErrNotExist` / `os.ErrNotExist` pattern).

### B-25 — Drop metric parity

Webhook + loki no longer call pipeline-level `Metrics.RecordEvent(name, audit.EventError)` on **buffer drops** (oversize, buffer full). Buffer drops surface only via `OutputMetrics.RecordDrop()` — matching file + syslog. Retry-exhaustion failures still call `RecordEvent(EventError)` (delivery WAS attempted).

Chose this direction over the opposite because file/syslog don't have `audit.Metrics` plumbed post-#581 and re-adding it would undo the constructor simplification.

### B-35 — Remove `redactRef` dead parameter

Internal helper with a constant return; parameter was dead code.

## Agent gates

- [x] **api-ergonomics-reviewer** (pre-coding BLOCKING) — locked dotted-module prefix (Option B over default A); flagged double-counting risk for Q3 which drove the Option B pivot for drop metrics.
- [x] **go-quality** — `make lint` 0 issues, `make test` passes across all modules.
- [x] **commit-message-reviewer** — PASS.

## Test plan

- [x] `go build ./...` clean.
- [x] `make lint` 0 issues.
- [x] `make test` passes across all modules.
- [x] Webhook buffer-overflow tests updated to assert new B-25 semantics.
- [ ] CI pending.

## Files touched

14 files. Main changes: module-scoped error prefixes in webhook/loki/file/syslog/secrets modules; outputconfig sentinel sub-wrapping; webhook + loki drop paths; webhook test assertions updated for B-25.