### PR TITLE
refactor: API polish bundle — severity, required fields (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `audit.MinSeverity` / `audit.MaxSeverity` constants (#593 B-27) replace the magic-number `0` / `10` range checks in `filter.go:validateSeverityRange`, `taxonomy.go:clampSeverity`, and `validate_taxonomy.go:checkSeverityRanges`. Godoc on each constant documents the inclusive CEF range semantic. Consumers may use these in their own severity validation to stay aligned with the library's contract.
+- `audit.ErrTaxonomyRequired`, `audit.ErrAppNameRequired`, and `audit.ErrHostRequired` sentinel errors (#593 B-41) returned by `audit.New` when the corresponding `WithTaxonomy` / `WithAppName` / `WithHost` is unset (unless `WithDisabled` is also applied). Matches the `outputconfig.Load` YAML-path requirement so programmatic and declarative construction share identical invariants. Discriminate via `errors.Is(err, audit.ErrAppNameRequired)`.
 - `audittest.Recorder.WaitForN(tb, n, timeout)` — blocks until at least `n` events have been recorded or the timeout elapses; returns `true` on success, `false` on timeout. Use in async-mode tests (`audittest.WithAsync`) or tests whose service emits from a goroutine. Poll interval is 10 ms, matching `testify/assert.Eventually`. The fast path returns immediately when the target is already reached. Synchronous auditors (the default for `New` / `NewQuick`) do not need `WaitForN` — events are recorded before `AuditEvent` returns; prefer `Count()` / `RequireEvents` there. Closes #566.
 - `audittest.WithExcludeLabels(outputName, labels...)` — applies sensitivity-label exclusion to the test recorder, mirroring `audit.WithExcludeLabels` on a named output. Lets consumer tests assert that a compliance output does NOT receive `pii`- or `financial`-labelled fields. `outputName` MUST match the recorder's name (`"recorder"` by default, or whatever was passed to `NewNamedRecorder`) — a mismatch calls `tb.Fatalf` at construction. Multiple calls accumulate labels. Internally, `audittest.New` / `audittest.NewQuick` switch from `audit.WithOutputs(rec)` to `audit.WithNamedOutput(rec, audit.WithExcludeLabels(...))` when any `audittest.WithExcludeLabels` option is present; this is observable only when the option is used. Closes #566.
 
 > **Deviations from #566 AC (accepted):** (1) `audittest.PermissiveTaxonomy()` NOT added — `audittest.QuickTaxonomy()` already exists and fills the same role; adding a second name violates the "one obvious way" principle. (2) `WithExcludedLabels` renamed to `WithExcludeLabels` to match core `audit.WithExcludeLabels` exactly (no "d"). (3) AC named `RecordedEvents.WaitForN` (a type name from the original issue draft that was never implemented in the codebase) — the actual type is `*audittest.Recorder`, so `WaitForN` is a method on `*Recorder`. All three deviations confirmed with api-ergonomics-reviewer.
 
 ### Changed
+
+- Small API-polish bundle #593:
+  - **B-17** TLSPolicy zero-value docs & tests verified — no code change (already documented and tested at `tls_policy.go:19-39`; `TestTLSPolicy_Apply_NilReceiver_DefaultsTLS13` and `TestTLSPolicy_Apply_ZeroValue_DefaultsTLS13` already present).
+  - **B-27** Exported `MinSeverity` / `MaxSeverity` severity-range constants; updated four magic-number call sites (`filter.go`, `taxonomy.go`, `validate_taxonomy.go`). See `### Added` above.
+  - **B-29** `Auditor.Handle` godoc now documents that a disabled auditor yields a no-op `EventHandle` for any event type without taxonomy validation, matching `AuditEvent` on a disabled auditor. New `TestAuditorHandle_DisabledAuditor_ReturnsNoOpHandle` locks the contract.
+  - **B-33** `secrets/openbao.Provider.Close` and `secrets/vault.Provider.Close` godoc now explicitly claims idempotency ("repeated calls are safe, return nil, and do not panic"). Behaviour already matches; new `TestOpenbaoClose_IsIdempotent` and `TestVaultClose_IsIdempotent` lock it.
+  - **B-39** `audittest` internal helper rename: `newTestLogger` → `newTestAuditor` for symmetry with the rest of the `Logger` → `Auditor` migration (#586 et al.). Also `TestNewLogger` → `TestNew`. Unexported, no consumer impact.
+  - **B-41** `audit.New` now requires `WithAppName` and `WithHost` (unless `WithDisabled`). See `### Added` above for sentinels and `### Breaking Changes` for migration.
+  - **B-45** Option classification documented in `options.go` package comment and per-option godoc: Required options (`WithTaxonomy`, `WithFormatter`, `WithAppName`, `WithHost`, `WithTimezone`) reject nil/empty; Optional options (`WithMetrics`, `WithDiagnosticLogger`, `WithStandardFieldDefaults`) accept nil with a documented default. No runtime behaviour change — clarification of an already-mixed-but-sensible policy, following the `net/http.Client.Transport` vs `net/http.Server.Handler` pattern.
 
 - Error-prefix convention unified across every module on the Go import-path pattern (#592). A CI grep check to enforce the convention is deferred to a follow-up issue. All modules now prefix errors with their dotted module path:
   - `audit:` (core — unchanged)
@@ -41,6 +52,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Examples `02-code-generation`, `04-testing`, `06-middleware`, `13-standard-fields`, and `15-tls-policy` failed at runtime with `unknown output type "stdout"` because they declared `type: stdout` in `outputs.yaml` without blank-importing anything that registered the stdout factory (stdout auto-registration was removed in #578). The new `_ "github.com/axonops/audit/outputs"` blank import registers stdout alongside the other built-ins (#585).
 
 ### Breaking Changes
+
+- `audit.New` now rejects configurations that omit `WithAppName` or `WithHost` (#593 B-41), matching the existing `outputconfig.Load` YAML-path contract. Missing values yield `ErrAppNameRequired` / `ErrHostRequired`. Callers using `WithDisabled` remain free of the requirement. Migration:
+  ```go
+  // Before (silent empty app_name / host on programmatic path):
+  auditor, err := audit.New(
+      audit.WithTaxonomy(tax),
+      audit.WithOutputs(out),
+  )
+
+  // After (required, compiler-friendly names):
+  auditor, err := audit.New(
+      audit.WithTaxonomy(tax),
+      audit.WithAppName("my-service"),
+      audit.WithHost(os.Hostname()),  // or a deterministic ID
+      audit.WithOutputs(out),
+  )
+  ```
+  `audittest.New` / `audittest.NewQuick` gain sensible test defaults (`"audittest"` / `"localhost"`) so existing tests continue to work without changes.
 
 - `audit.Metrics.RecordEvent` now takes a typed `audit.EventStatus` instead of a raw `string` (#586). New exported type `type EventStatus string` with constants `audit.EventSuccess` (`"success"`) and `audit.EventError` (`"error"`). Prometheus / OpenTelemetry wire format is unchanged — `string(status)` is a zero-cost conversion that emits the identical label bytes that were previously hardcoded. Consumers implementing the `Metrics` interface (e.g. Prometheus adapter) must update the `RecordEvent` method signature. Test mocks migrated in lockstep: `audittest.MetricsRecorder.EventDeliveries` and `internal/testhelper.MockMetrics.GetEventCount` both now take `audit.EventStatus`. Pre-coding consult with api-ergonomics-reviewer locked the `string`-backed enum over `int`-backed for hot-path efficiency and wire-format stability. Migration:
   ```go

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -123,7 +123,7 @@ Every issue follows this sequence. Do not skip steps.
 - [x] **#590** refactor: error API polish — clone Unwrap slice, document ComputeHMAC contract, error returns from RegisterOutputFactory and NewEventKV.
 - [x] **#591** refactor: CEFFormatter ergonomics — FieldMapping opt-out path, avoid redundant severity clamp, cite maxCEFHeaderField.
 - [x] **#592** refactor: unify error wrapping conventions across modules; align self-reporting drop metrics; drop dead redactRef parameter.
-- [ ] **#593** refactor: small API polish — TLSPolicy zero-value docs, MinSeverity/MaxSeverity constants, Handle on disabled auditor, openbao Close idempotency, audittest rename, require AppName/Host, uniform nil-option handling.
+- [x] **#593** refactor: small API polish — TLSPolicy zero-value docs, MinSeverity/MaxSeverity constants, Handle on disabled auditor, openbao Close idempotency, audittest rename, require AppName/Host, uniform nil-option handling.
 - [ ] **#594** refactor: simplify 9-method Metrics interface into MetricEvent or split into lifecycle/delivery/validation interfaces.
 - [ ] **#595** refactor: Fields rejects unsupported value types; WithStandardFieldDefaults accepts any.
 - [ ] **#596** refactor: consolidate 6 optional Output interfaces into OutputCapabilities struct.

--- a/audit.go
+++ b/audit.go
@@ -133,18 +133,25 @@ type Auditor struct {
 }
 
 // New creates a new [Auditor] from the given options.
-// A taxonomy MUST be provided via [WithTaxonomy] unless [WithDisabled]
-// is applied; New returns an error if none is supplied.
+//
+// Required options (unless [WithDisabled] is applied):
+//   - [WithTaxonomy] — the event taxonomy. Missing → error.
+//   - [WithAppName]  — the application name. Missing → [ErrAppNameRequired].
+//   - [WithHost]     — the host identifier. Missing → [ErrHostRequired].
+//
+// The app_name and host requirements match the [outputconfig.Load]
+// YAML-path contract so that programmatic and declarative construction
+// produce equally complete framework fields.
 //
 // Defaults are: queue=10,000, shutdown=5s, validation=strict. Pass
 // tuning options like [WithQueueSize], [WithShutdownTimeout],
 // [WithValidationMode], or [WithOmitEmpty] to override.
 //
 // When [WithDisabled] is applied, New returns a valid no-op
-// auditor without requiring a taxonomy. All [Auditor.AuditEvent] calls
-// return nil immediately without validation or delivery. Methods
-// that require a taxonomy ([Auditor.EnableCategory], etc.) return
-// [ErrDisabled].
+// auditor without requiring a taxonomy, app name, or host. All
+// [Auditor.AuditEvent] calls return nil immediately without validation
+// or delivery. Methods that require a taxonomy
+// ([Auditor.EnableCategory], etc.) return [ErrDisabled].
 func New(opts ...Option) (*Auditor, error) {
 	a := &Auditor{}
 
@@ -171,8 +178,8 @@ func New(opts ...Option) (*Auditor, error) {
 		return a, nil
 	}
 
-	if a.taxonomy == nil {
-		return nil, fmt.Errorf("audit: taxonomy is required: use WithTaxonomy")
+	if err := checkRequiredOptions(a); err != nil {
+		return nil, err
 	}
 
 	a.applyDevTaxonomyOverrides()
@@ -202,6 +209,22 @@ func New(opts ...Option) (*Auditor, error) {
 	)
 
 	return a, nil
+}
+
+// checkRequiredOptions verifies that the non-disabled auditor has
+// every required option set. See [Option] godoc for the required /
+// optional classification (#593 B-41 / B-45).
+func checkRequiredOptions(a *Auditor) error {
+	if a.taxonomy == nil {
+		return ErrTaxonomyRequired
+	}
+	if a.appName == "" {
+		return ErrAppNameRequired
+	}
+	if a.host == "" {
+		return ErrHostRequired
+	}
+	return nil
 }
 
 // applyDevTaxonomyOverrides warns about DevTaxonomy and forces permissive
@@ -674,6 +697,12 @@ func (a *Auditor) OutputRoute(outputName string) (EventRoute, error) {
 // interface escape. Returns [ErrHandleNotFound] if the event type is
 // not registered. For event types known at compile time, prefer
 // generated typed builders from audit-gen.
+//
+// When the auditor was constructed with [WithDisabled], Handle
+// returns a no-op [EventHandle] for any event type without
+// validating the taxonomy — all subsequent Audit calls on the
+// handle are silent no-ops, matching [Auditor.AuditEvent] on a
+// disabled auditor.
 func (a *Auditor) Handle(eventType string) (*EventHandle, error) {
 	if a.disabled {
 		return &EventHandle{name: eventType, auditor: a}, nil

--- a/audit_test.go
+++ b/audit_test.go
@@ -46,6 +46,8 @@ func newTestAuditor(t *testing.T, out *testhelper.MockOutput, opts ...audit.Opti
 	t.Helper()
 	allOpts := []audit.Option{
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	}
 	allOpts = append(allOpts, opts...)
@@ -190,6 +192,8 @@ func TestLogger_Audit_ReservedStandardField_AcceptedInStrictMode(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -216,6 +220,8 @@ func TestLogger_Audit_ReservedStandardField_StillRejectsUnknown(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -238,6 +244,7 @@ func TestWithAppName_Empty_ReturnsError(t *testing.T) {
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName(""),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "app_name must not be empty")
@@ -249,6 +256,7 @@ func TestWithAppName_ExceedsMaxLength(t *testing.T) {
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName(strings.Repeat("a", 256)),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "app_name exceeds maximum length of 255 bytes")
@@ -260,6 +268,8 @@ func TestWithAppName_AtMaxLength(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithAppName(strings.Repeat("a", 255)),
 	)
@@ -272,6 +282,7 @@ func TestWithHost_Empty_ReturnsError(t *testing.T) {
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithHost(""),
+		audit.WithAppName("test-app"),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "host must not be empty")
@@ -283,6 +294,7 @@ func TestWithHost_ExceedsMaxLength(t *testing.T) {
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithHost(strings.Repeat("h", 256)),
+		audit.WithAppName("test-app"),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "host exceeds maximum length of 255 bytes")
@@ -294,6 +306,8 @@ func TestWithHost_AtMaxLength(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithHost(strings.Repeat("h", 255)),
 	)
@@ -305,6 +319,8 @@ func TestWithTimezone_Empty_ReturnsError(t *testing.T) {
 	t.Parallel()
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithTimezone(""),
 	)
 	require.Error(t, err)
@@ -316,6 +332,8 @@ func TestWithTimezone_ExceedsMaxLength(t *testing.T) {
 	// 65 bytes — one byte over the 64-byte maximum.
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithTimezone(strings.Repeat("Z", 65)),
 	)
 	require.Error(t, err)
@@ -328,6 +346,8 @@ func TestWithTimezone_AtMaxLength(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithTimezone(strings.Repeat("Z", 64)),
 	)
@@ -340,6 +360,8 @@ func TestWithStandardFieldDefaults_InvalidKey(t *testing.T) {
 	// "bogus" is not a reserved standard field and must be rejected.
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithStandardFieldDefaults(map[string]string{"bogus": "value"}),
 	)
 	require.Error(t, err)
@@ -352,6 +374,8 @@ func TestLogger_FrameworkFields_InOutput(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithAppName("testapp"),
 		audit.WithHost("testhost"),
@@ -379,6 +403,8 @@ func TestLogger_Timezone_AutoDetected(t *testing.T) {
 	// No WithTimezone — timezone should auto-detect from system.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -406,6 +432,8 @@ func TestWithStandardFieldDefaults_Applied(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
 	)
@@ -427,6 +455,8 @@ func TestWithStandardFieldDefaults_PerEventOverride(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
 	)
@@ -449,6 +479,8 @@ func TestWithStandardFieldDefaults_EmptyStringOverride(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
 	)
@@ -471,6 +503,8 @@ func TestWithStandardFieldDefaults_LastWins(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "a"}),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "b"}),
 		audit.WithValidationMode(audit.ValidationPermissive),
@@ -500,6 +534,8 @@ func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
 	)
@@ -709,6 +745,32 @@ func TestLogger_MustHandle_Panics(t *testing.T) {
 	})
 }
 
+// TestAuditorHandle_DisabledAuditor_ReturnsNoOpHandle covers #593 B-29:
+// Handle on a disabled auditor returns a no-op handle for any event
+// type without consulting the taxonomy. All Audit calls on the
+// returned handle are silent no-ops, matching AuditEvent semantics.
+func TestAuditorHandle_DisabledAuditor_ReturnsNoOpHandle(t *testing.T) {
+	t.Parallel()
+	auditor, err := audit.New(audit.WithDisabled())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auditor.Close() })
+
+	// Event type not registered in any taxonomy — still succeeds.
+	h, err := auditor.Handle("completely_unknown_event")
+	require.NoError(t, err, "Handle on disabled auditor must not fail")
+	require.NotNil(t, h)
+	assert.Equal(t, "completely_unknown_event", h.EventType())
+
+	// Audit via the handle is a silent no-op.
+	require.NoError(t, h.Audit(audit.Fields{"anything": "goes"}))
+
+	// MustHandle must also not panic on disabled auditor.
+	assert.NotPanics(t, func() {
+		h2 := auditor.MustHandle("another_unknown")
+		require.NotNil(t, h2)
+	})
+}
+
 func TestLogger_Handle_Audit(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
@@ -756,6 +818,8 @@ func TestLogger_Audit_BufferFull(t *testing.T) {
 		audit.WithQueueSize(1),
 		audit.WithShutdownTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -806,6 +870,8 @@ func TestLogger_Close_DrainsEvents(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -829,6 +895,8 @@ func TestLogger_Close_Idempotent(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -842,6 +910,8 @@ func TestLogger_Audit_AfterClose(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -866,6 +936,8 @@ func TestLogger_Close_ShutdownTimeout(t *testing.T) {
 		audit.WithQueueSize(10),
 		audit.WithShutdownTimeout(10*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -890,6 +962,8 @@ func TestLogger_Close_OutputError(t *testing.T) {
 	out := &errorOutput{name: "bad", closeErr: errors.New("close failed")}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -919,6 +993,8 @@ func TestLogger_Close_MultipleOutputErrors(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(outA, outB, outC),
 	)
 	require.NoError(t, err)
@@ -942,6 +1018,8 @@ func TestLogger_Close_AllOutputsCloseCalledOnError(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(outA, outB),
 	)
 	require.NoError(t, err)
@@ -1071,6 +1149,8 @@ func TestLogger_MultiCategory_DeliveredPerCategory(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1100,6 +1180,8 @@ func TestLogger_MultiCategory_DisableOneCategory(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1132,6 +1214,8 @@ func TestLogger_MultiCategory_DisableAllCategories(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1169,6 +1253,8 @@ func TestLogger_Uncategorised_DeliveredToUnroutedOutput(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1197,6 +1283,8 @@ func TestLogger_MultiCategory_EnableEventOverride(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1232,6 +1320,8 @@ func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})),
@@ -1264,6 +1354,8 @@ func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			ExcludeCategories: []string{"security"},
 		})),
@@ -1352,6 +1444,8 @@ func TestLogger_ConcurrentClose(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1403,6 +1497,8 @@ func TestLogger_Audit_MetricsRecordOutputError(t *testing.T) {
 	out := &errorWriteOutput{name: "bad-write"}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -1437,6 +1533,8 @@ func TestLogger_Audit_NoOutputs(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 
@@ -1457,6 +1555,8 @@ func TestNew_QueueSizeExceedsMax(t *testing.T) {
 	_, err := audit.New(
 		audit.WithQueueSize(audit.MaxQueueSize+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds maximum")
@@ -1466,6 +1566,8 @@ func TestNew_ShutdownTimeoutExceedsMax(t *testing.T) {
 	_, err := audit.New(
 		audit.WithShutdownTimeout(audit.MaxShutdownTimeout+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds maximum")
@@ -1550,6 +1652,8 @@ func TestLogger_Audit_NilFieldsNoRequiredFields(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1570,6 +1674,8 @@ func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1603,6 +1709,8 @@ func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out),
 	)
 	require.NoError(t, err)
@@ -1656,6 +1764,8 @@ func TestLogger_Handle_AuditAfterClose(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1684,6 +1794,8 @@ func TestLogger_Audit_MultipleOutputs(t *testing.T) {
 	out2 := testhelper.NewMockOutput("out2")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1, out2),
 	)
 	require.NoError(t, err)
@@ -1768,6 +1880,8 @@ func TestLogger_Close_ShutdownEventDroppedOnFullBuffer(t *testing.T) {
 		audit.WithQueueSize(1),
 		audit.WithShutdownTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1803,6 +1917,8 @@ func TestLogger_Audit_AllCategoriesEnabledByDefault(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -1850,6 +1966,8 @@ func TestAudit_UnknownFieldStrict_RecordsValidationError(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -1912,6 +2030,8 @@ func TestProcessEntry_SerializationError_RecordsMetric(t *testing.T) {
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithFormatter(badFormatter),
 		audit.WithMetrics(metrics),
@@ -1942,6 +2062,8 @@ func TestEmitShutdown_BufferFull_RecordsBufferDrop(t *testing.T) {
 		audit.WithQueueSize(1),
 		audit.WithShutdownTimeout(50*time.Millisecond),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -1973,6 +2095,8 @@ func TestAudit_NilMetrics_NoPanic(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithFormatter(badFormatter),
 		// No WithMetrics -- metrics is nil.
@@ -2031,6 +2155,8 @@ func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
@@ -2061,6 +2187,8 @@ func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
@@ -2093,6 +2221,8 @@ func TestWriteToOutput_NonDeliveryReporter_SuccessRecordsCoreMetrics(t *testing.
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -2214,6 +2344,8 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 				audit.WithOmitEmpty(),
 				audit.WithValidationMode(audit.ValidationPermissive),
 				audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+				audit.WithAppName("test-app"),
+				audit.WithHost("test-host"),
 				audit.WithOutputs(subOut),
 			)
 			require.NoError(t, err)
@@ -2259,6 +2391,8 @@ func TestWithOutputs_DuplicateDestination_ReturnsError(t *testing.T) {
 	o2 := &destKeyOutput{name: "out2", key: "/var/log/audit.log"}
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(o1, o2),
 	)
 	require.ErrorIs(t, err, audit.ErrDuplicateDestination)
@@ -2271,6 +2405,8 @@ func TestWithNamedOutput_DuplicateDestination_ReturnsError(t *testing.T) {
 	o2 := &destKeyOutput{name: "out2", key: "localhost:514"}
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(o1),
 		audit.WithNamedOutput(o2),
 	)
@@ -2285,6 +2421,8 @@ func TestWithOutputs_EmptyDestinationKey_NoCollision(t *testing.T) {
 	o2 := &destKeyOutput{name: "out2", key: ""}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(o1, o2),
 	)
 	require.NoError(t, err)
@@ -2297,6 +2435,8 @@ func TestWithOutputs_MixedTypes_NoFalsePositive(t *testing.T) {
 	o2 := testhelper.NewMockOutput("unkeyed")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(o1, o2),
 	)
 	require.NoError(t, err)
@@ -2411,6 +2551,8 @@ func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
 	out := testhelper.NewMockOutput("field-test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -2467,6 +2609,8 @@ func TestLogger_Audit_FieldCompleteness_OmittedOptionalFieldsAbsent(t *testing.T
 	auditor, err := audit.New(
 		audit.WithOmitEmpty(),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -2511,6 +2655,8 @@ func BenchmarkAudit(b *testing.B) {
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -2536,6 +2682,8 @@ func BenchmarkAuditDisabledCategory(b *testing.B) {
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -2557,6 +2705,8 @@ func BenchmarkAuditDisabledAuditor(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -2590,6 +2740,8 @@ func BenchmarkAudit_ViaHandle_vs_NewEvent(b *testing.B) {
 	out := testhelper.NewNoopOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(b, err)
@@ -2638,6 +2790,8 @@ func BenchmarkAudit_RealisticFields(b *testing.B) {
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -2670,6 +2824,8 @@ func BenchmarkAudit_Parallel(b *testing.B) {
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -2704,6 +2860,8 @@ func BenchmarkAudit_PoolAmortised(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -2744,6 +2902,8 @@ func BenchmarkAudit_FanOut_SharedFormatter(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1, out2, out3),
 	)
 	if err != nil {
@@ -2776,6 +2936,8 @@ func BenchmarkAudit_FanOut_MixedFormatters(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out1),                                    // default JSON
 		audit.WithNamedOutput(out2, audit.WithOutputFormatter(cefFmt)), // CEF
 		audit.WithNamedOutput(out3),                                    // default JSON (shared)
@@ -2810,6 +2972,8 @@ func BenchmarkAudit_FanOut_FilteredOutputs(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out1), // receives all events
 		audit.WithNamedOutput(out2, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
@@ -2849,6 +3013,8 @@ func BenchmarkAudit_FanOut_5Outputs(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(outputs...),
 	)
 	if err != nil {
@@ -2949,6 +3115,8 @@ func TestLogger_DisableEvent_UncategorisedEvent(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -2978,6 +3146,8 @@ func BenchmarkAudit_EndToEnd(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -3006,6 +3176,8 @@ func BenchmarkAudit_WithHMAC(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
 			Salt: audit.HMACSalt{
@@ -3041,6 +3213,8 @@ func BenchmarkStandardFieldDefaults_Applied(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out),
 		audit.WithStandardFieldDefaults(map[string]string{
 			"source_ip":  "10.0.0.1",
@@ -3073,6 +3247,8 @@ func BenchmarkDeliverToOutputs_WithMetadataWriter(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(mock),
 	)
 	if err != nil {
@@ -3097,6 +3273,8 @@ func BenchmarkDeliverToOutputs_MixedOutputs(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(mwOut),
 		audit.WithNamedOutput(plainOut),
 	)
@@ -3184,6 +3362,8 @@ func BenchmarkProcessEntry_AsyncOutputs(b *testing.B) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(syslogOut),
 		audit.WithSynchronousDelivery(),
@@ -3231,6 +3411,8 @@ func BenchmarkOutputClose_Drain(b *testing.B) {
 				auditor, err := audit.New(
 					audit.WithQueueSize(n+1000), // room for all events
 					audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+					audit.WithAppName("test-app"),
+					audit.WithHost("test-host"),
 					audit.WithOutputs(out),
 				)
 				if err != nil {
@@ -3255,6 +3437,8 @@ func BenchmarkFilterCheck(b *testing.B) {
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -3278,6 +3462,8 @@ func BenchmarkFilterCheck_Parallel(b *testing.B) {
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -3304,6 +3490,8 @@ func BenchmarkFilterCheck_ReadWriteContention(b *testing.B) {
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -3356,6 +3544,8 @@ func TestAuditEvent_WithNewEvent(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -3375,6 +3565,8 @@ func TestAuditEvent_UnknownEventType(t *testing.T) {
 	t.Parallel()
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	defer func() { _ = auditor.Close() }()
@@ -3388,6 +3580,8 @@ func TestAuditEvent_NilEvent(t *testing.T) {
 	t.Parallel()
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	defer func() { _ = auditor.Close() }()
@@ -3529,6 +3723,8 @@ func TestEventCategory_SingleCategory_JSON(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -3560,6 +3756,8 @@ func TestEventCategory_MultiCategory_SeparateDeliveries(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -3594,6 +3792,8 @@ func TestEventCategory_Uncategorised_NoField(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -3623,6 +3823,8 @@ func TestEventCategory_EmitFalse_NoField(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -3653,6 +3855,8 @@ func TestEventCategory_UserSupplied_Skipped(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -3724,6 +3928,8 @@ func TestHMAC_Enabled_JSON_FieldsPresent(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
 			Salt: audit.HMACSalt{
@@ -3756,6 +3962,8 @@ func TestHMAC_Disabled_NoFields(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -3781,6 +3989,8 @@ func TestHMAC_SaltVersion_InOutput(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
 			Salt: audit.HMACSalt{
@@ -3875,6 +4085,8 @@ events:
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		// "full" output: no label exclusions — gets all fields including email.
 		audit.WithNamedOutput(fullOut, audit.WithHMAC(fullHMACCfg)),
 		// "stripped" output: excludes PII — email is removed before HMAC.
@@ -3942,6 +4154,8 @@ func TestHMAC_EndToEnd_DrainLoopVerification(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(hmacOut, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
 			Salt: audit.HMACSalt{
@@ -4021,6 +4235,8 @@ events:
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		// Both outputs exclude PII. baseOut is a sanity check that
 		// stripping happened; verification uses hmacOut's own bytes.
 		audit.WithNamedOutput(hmacOut, audit.WithExcludeLabels("pii"), audit.WithHMAC(&audit.HMACConfig{
@@ -4191,6 +4407,8 @@ func TestMetadataWriter_ImplementingOutput_ReceivesMetadata(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -4218,6 +4436,8 @@ func TestMetadataWriter_NonImplementingOutput_ReceivesPlainWrite(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -4258,6 +4478,8 @@ func TestMetadataWriter_EventMetadata_FieldsCorrect(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -4310,6 +4532,8 @@ func TestMetadataWriter_MultiCategory_CategoryVaries(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -4358,6 +4582,8 @@ func TestMetadataWriter_UncategorisedEvent_EmptyCategory(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -4388,6 +4614,8 @@ func TestMetadataWriter_MetricsPreserved(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -4422,6 +4650,8 @@ func TestMetadataWriter_WriteError_RecordsMetrics(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -4456,6 +4686,8 @@ func TestMetadataWriter_DeliveryReporter_SkipsMetrics(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)
@@ -4499,6 +4731,8 @@ func TestMetadataWriter_WithHMAC_ReceivesHMACData(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
 			Salt: audit.HMACSalt{
@@ -4561,6 +4795,8 @@ events:
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		// Exclude PII — email must not appear in the data received by WriteWithMetadata.
 		audit.WithNamedOutput(out, audit.WithExcludeLabels("pii")),
 	)
@@ -4613,6 +4849,8 @@ func TestMetadataWriter_WithEventCategory_DataAndMetaConsistent(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -4656,6 +4894,8 @@ func TestMetadataWriter_MixedOutputs_IsolationOnError(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(failingMW),
 		audit.WithNamedOutput(successOut),
 	)
@@ -4691,6 +4931,8 @@ func TestMetadataWriter_CachedAssertion_Correct(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(mwOut),
 		audit.WithNamedOutput(plainOut),
 	)
@@ -4730,6 +4972,8 @@ func TestTimezoneAlwaysPopulated(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
 		audit.WithHost("test"),
@@ -4758,6 +5002,8 @@ func TestTimezoneAutoDetect(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
 		audit.WithHost("test"),
@@ -4788,6 +5034,8 @@ func TestTimezoneOverride(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithAppName("test"),
 		audit.WithHost("test"),
@@ -4851,6 +5099,8 @@ events:
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		// Excluding "pii" triggers formatWithExclusion (FormatOptions non-nil).
 		audit.WithNamedOutput(out, audit.WithOutputFormatter(&exclusionErrorFormatter{}), audit.WithExcludeLabels("pii")),
 		audit.WithMetrics(metrics),
@@ -4911,6 +5161,8 @@ func TestDrainLoop_SlowOutput_DoesNotBlockOthers(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(slow, fast),
 	)
 	require.NoError(t, err)
@@ -4935,6 +5187,8 @@ func TestDrainLoop_AllOutputsAsync_NoSequentialBlocking(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(outA, outB),
 	)
 	require.NoError(t, err)
@@ -4960,6 +5214,8 @@ func TestCoreMetrics_RecordSubmitted_CalledPerAuditEvent(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -4984,6 +5240,8 @@ func TestCoreMetrics_RecordSubmitted_CalledBeforeFiltering(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -5013,6 +5271,8 @@ func TestCoreMetrics_RecordQueueDepth_SampledEveryNEvents(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(metrics),
 	)
@@ -5064,6 +5324,8 @@ func TestAudit_NewEvent_StillDefensiveCopies(t *testing.T) {
 	out := testhelper.NewMockOutput("copy")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithSynchronousDelivery(),
 	)
@@ -5116,6 +5378,8 @@ func newFastPathBenchAuditor(tb testing.TB, opts ...audit.Option) (*audit.Audito
 	base := []audit.Option{
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	}
 	auditor, err := audit.New(append(base, opts...)...)
@@ -5236,6 +5500,8 @@ func BenchmarkAudit_FastPath_FanOut4_NoopOutputs(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1, out2, out3, out4),
 	)
 	if err != nil {
@@ -5286,6 +5552,8 @@ func BenchmarkAudit_FastPath_WithHMAC_Noop(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(hmacCfg)),
 	)
 	if err != nil {
@@ -5330,6 +5598,8 @@ func newMultiFormatterAuditor(tb testing.TB, formatters []audit.Formatter) *audi
 	opts := []audit.Option{
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	}
 	for i, f := range formatters {
 		out := testhelper.NewNoopOutput(fmt.Sprintf("noop-%d", i))
@@ -5421,6 +5691,8 @@ func BenchmarkProcessEntry_Drain(b *testing.B) {
 	out := testhelper.NewMockOutput("bench-drain")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithSynchronousDelivery(),
 	)
@@ -5453,6 +5725,8 @@ func BenchmarkAudit_Parallelism(b *testing.B) {
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithQueueSize(100_000),
 	)

--- a/audittest/audittest.go
+++ b/audittest/audittest.go
@@ -34,7 +34,7 @@ type config struct {
 
 // excludeLabelsEntry records a single [WithExcludeLabels] call so the
 // labels can be applied to the recorder via [audit.WithNamedOutput]
-// inside [newTestLogger].
+// inside [newTestAuditor].
 type excludeLabelsEntry struct {
 	outputName string
 	labels     []string
@@ -136,7 +136,7 @@ func New(tb testing.TB, taxonomyYAML []byte, opts ...Option) (*audit.Auditor, *R
 	if err != nil {
 		tb.Fatalf("audittest: parse taxonomy: %v", err)
 	}
-	return newTestLogger(tb, tax, opts...)
+	return newTestAuditor(tb, tax, opts...)
 }
 
 // NewQuick creates a test auditor with a permissive
@@ -145,7 +145,7 @@ func New(tb testing.TB, taxonomyYAML []byte, opts ...Option) (*audit.Auditor, *R
 // are available in the Recorder immediately without calling Close.
 func NewQuick(tb testing.TB, eventTypes ...string) (*audit.Auditor, *Recorder, *MetricsRecorder) {
 	tb.Helper()
-	return newTestLogger(tb, QuickTaxonomy(eventTypes...), WithValidationMode(audit.ValidationPermissive))
+	return newTestAuditor(tb, QuickTaxonomy(eventTypes...), WithValidationMode(audit.ValidationPermissive))
 }
 
 // QuickTaxonomy builds a minimal [*audit.Taxonomy] where every listed
@@ -167,7 +167,7 @@ func QuickTaxonomy(eventTypes ...string) *audit.Taxonomy {
 	}
 }
 
-func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.Auditor, *Recorder, *MetricsRecorder) {
+func newTestAuditor(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.Auditor, *Recorder, *MetricsRecorder) {
 	tb.Helper()
 
 	c := &config{}
@@ -178,9 +178,17 @@ func newTestLogger(tb testing.TB, tax *audit.Taxonomy, opts ...Option) (*audit.A
 	rec := NewRecorder()
 	met := NewMetricsRecorder()
 
+	// AppName and Host are required by audit.New (#593). For test
+	// helpers, supply sensible defaults so callers do not need to
+	// reason about them. Tests that care about specific values can
+	// override via WithOptions(audit.WithAppName("..."), ...); later
+	// options in auditOpts win because audit.New applies them in
+	// order.
 	auditOpts := []audit.Option{
 		audit.WithQueueSize(100), // small buffer — recorder has no I/O cost
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("audittest"),
+		audit.WithHost("localhost"),
 		audit.WithMetrics(met),
 	}
 

--- a/audittest/audittest_test.go
+++ b/audittest/audittest_test.go
@@ -51,7 +51,7 @@ events:
       actor_id: {required: true}
 `)
 
-func TestNewLogger(t *testing.T) {
+func TestNew(t *testing.T) {
 	t.Parallel()
 	auditor, events, metrics := audittest.New(t, testTaxonomyYAML)
 

--- a/bench_comparison_test.go
+++ b/bench_comparison_test.go
@@ -174,6 +174,8 @@ func benchAudit3FieldsSync(b *testing.B) {
 	out := testhelper.NewNoopOutput("bench-cmp")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(benchComparisonTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithSynchronousDelivery(),
 	)
@@ -258,6 +260,8 @@ func benchAudit10FieldsSync(b *testing.B) {
 	out := testhelper.NewNoopOutput("bench-cmp")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(benchComparisonTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithSynchronousDelivery(),
 	)
@@ -294,6 +298,8 @@ func benchAudit10FieldsSyncWithHMAC(b *testing.B) {
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(benchComparisonTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(hmacCfg)),
 		audit.WithSynchronousDelivery(),
 	)
@@ -325,6 +331,8 @@ func benchAudit10FieldsSyncFanOut4(b *testing.B) {
 	out4 := testhelper.NewNoopOutput("cmp-4")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(benchComparisonTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1, out2, out3, out4),
 		audit.WithSynchronousDelivery(),
 	)

--- a/config_test.go
+++ b/config_test.go
@@ -28,6 +28,8 @@ func TestNew_InvalidValidationMode(t *testing.T) {
 	_, err := audit.New(
 		audit.WithValidationMode("bogus"),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
@@ -39,6 +41,8 @@ func TestNew_QueueSizeDefault(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(0),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	require.NoError(t, auditor.Close())
@@ -48,6 +52,8 @@ func TestNew_ShutdownTimeoutDefault(t *testing.T) {
 	// ShutdownTimeout 0 should not cause an error; it defaults to 5s.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	require.NoError(t, auditor.Close())
@@ -57,6 +63,8 @@ func TestNew_CustomShutdownTimeout(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithShutdownTimeout(10*time.Second),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	require.NoError(t, auditor.Close())
@@ -67,6 +75,8 @@ func TestNew_DisabledNoOp(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -89,6 +99,8 @@ func TestNew_NegativeQueueSize_DefaultsCorrectly(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(-1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -108,6 +120,8 @@ func TestNew_NegativeShutdownTimeout_DefaultsCorrectly(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithShutdownTimeout(-1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -153,6 +153,8 @@ func TestDevTaxonomy_WarnsAtConstruction(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(audit.DevTaxonomy("ev1")),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(testhelper.NewMockOutput("test")),
 	)
 	require.NoError(t, err)
@@ -173,6 +175,8 @@ func TestFileFreePath_EndToEnd(t *testing.T) {
 	// WithValidationMode needed.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(audit.DevTaxonomy("user_create")),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/doc.go
+++ b/doc.go
@@ -65,6 +65,8 @@
 //	stdout, _ := audit.NewStdout()
 //	auditor, err := audit.New(
 //	    audit.WithTaxonomy(audit.DevTaxonomy("user_create")),
+//	    audit.WithAppName("demo"),
+//	    audit.WithHost("localhost"),
 //	    audit.WithOutputs(stdout),
 //	)
 //

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -120,6 +120,19 @@ audit: config validation failed
 | **Transient?** | No — permanent configuration error |
 | **What to do** | Check the error message for details. Common causes: `QueueSize` exceeds 1,000,000, `ShutdownTimeout` exceeds 60 seconds, `Version` is not 1. The wrapped error message tells you which field is invalid. |
 
+### `ErrTaxonomyRequired`
+
+```
+audit: taxonomy is required: use WithTaxonomy
+```
+
+| | |
+|---|---|
+| **When** | `New()` is called without [`WithTaxonomy`] (and without [`WithDisabled`]) |
+| **Meaning** | Auditor creation failed — validation and routing require a taxonomy |
+| **Transient?** | No — permanent configuration error |
+| **What to do** | Add `audit.WithTaxonomy(tax)` to the `audit.New(...)` call, or use [`WithDisabled`] for a no-op auditor. Sibling of `ErrAppNameRequired` / `ErrHostRequired`; all three mark missing required options and support `errors.Is` discrimination. |
+
 ### `ErrAppNameRequired`
 
 ```

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -120,10 +120,36 @@ audit: config validation failed
 | **Transient?** | No — permanent configuration error |
 | **What to do** | Check the error message for details. Common causes: `QueueSize` exceeds 1,000,000, `ShutdownTimeout` exceeds 60 seconds, `Version` is not 1. The wrapped error message tells you which field is invalid. |
 
+### `ErrAppNameRequired`
+
+```
+audit: app_name is required: use WithAppName
+```
+
+| | |
+|---|---|
+| **When** | `New()` is called without [`WithAppName`] (and without [`WithDisabled`]) |
+| **Meaning** | Auditor creation failed — every emitted event carries `app_name` as a framework field, and a blank value undermines attribution |
+| **Transient?** | No — permanent configuration error |
+| **What to do** | Add `audit.WithAppName("your-service-name")` to the `audit.New(...)` call. Matches the `app_name:` requirement on the [`outputconfig.Load`] YAML construction path, so the two paths share the same invariant. |
+
+### `ErrHostRequired`
+
+```
+audit: host is required: use WithHost
+```
+
+| | |
+|---|---|
+| **When** | `New()` is called without [`WithHost`] (and without [`WithDisabled`]) |
+| **Meaning** | Auditor creation failed — every emitted event carries `host` as a framework field |
+| **Transient?** | No — permanent configuration error |
+| **What to do** | Add `audit.WithHost(os.Hostname())` or `audit.WithHost("prod-host-01")` to the `audit.New(...)` call. Matches the `host:` requirement on the [`outputconfig.Load`] YAML construction path. |
+
 ### `ErrOutputConfigInvalid`
 
 ```
-audit: output config validation failed
+audit/outputconfig: output config validation failed
 ```
 
 | | |

--- a/errors.go
+++ b/errors.go
@@ -79,6 +79,27 @@ var (
 	// [Auditor.Handle] returns a valid no-op handle instead.
 	ErrDisabled = errors.New("audit: auditor is disabled")
 
+	// ErrTaxonomyRequired is returned by [New] when [WithTaxonomy] was
+	// not called (unless [WithDisabled] is applied). Sibling of
+	// [ErrAppNameRequired] / [ErrHostRequired] — all three mark missing
+	// required options and support [errors.Is] discrimination.
+	ErrTaxonomyRequired = errors.New("audit: taxonomy is required: use WithTaxonomy")
+
+	// ErrAppNameRequired is returned by [New] when [WithAppName] was
+	// not called. All auditors (except those constructed with
+	// [WithDisabled]) must set an app name for compliance — every
+	// emitted event carries app_name as a framework field, and a blank
+	// value undermines attribution. Matches the [outputconfig.Load]
+	// YAML-path requirement for symmetry across construction paths.
+	ErrAppNameRequired = errors.New("audit: app_name is required: use WithAppName")
+
+	// ErrHostRequired is returned by [New] when [WithHost] was not
+	// called. All auditors (except those constructed with [WithDisabled])
+	// must set a host identifier for compliance. Matches the
+	// [outputconfig.Load] YAML-path requirement for symmetry across
+	// construction paths.
+	ErrHostRequired = errors.New("audit: host is required: use WithHost")
+
 	// ErrTaxonomyInvalid is the sentinel error wrapped by taxonomy
 	// validation failures. Use [errors.Is] to test for it:
 	//

--- a/example_middleware_test.go
+++ b/example_middleware_test.go
@@ -38,6 +38,8 @@ func ExampleMiddleware() {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -96,6 +98,8 @@ func ExampleMiddleware_skip() {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/example_test.go
+++ b/example_test.go
@@ -40,6 +40,8 @@ func ExampleNew() {
 				"user_create": {Required: []string{"outcome", "actor_id"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(stdout),
 	)
 	if err != nil {
@@ -82,6 +84,8 @@ func ExampleAuditor_AuditEvent() {
 				"doc_create": {Required: []string{"outcome"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(stdout),
 	)
 	if err != nil {
@@ -114,6 +118,8 @@ func ExampleAuditor_MustHandle() {
 				"doc_create": {Required: []string{"outcome"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -149,6 +155,8 @@ func ExampleAuditor_EnableCategory() {
 				"doc_create": {Required: []string{"outcome"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -178,6 +186,8 @@ func ExampleAuditor_Close() {
 				"doc_create": {Required: []string{"outcome"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -215,6 +225,8 @@ func ExampleWithFormatter() {
 				"auth_failure": {Required: []string{"outcome"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithFormatter(cef),
 	)
 	if err != nil {
@@ -283,6 +295,8 @@ func ExampleAuditor_SetOutputRoute() {
 				"auth_failure": {Required: []string{"outcome"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	if err != nil {

--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -43,15 +43,20 @@ stdout, err := audit.NewStdout()
 // handle err …
 auditor, err := audit.New(
     audit.WithTaxonomy(audit.DevTaxonomy("user_create", "auth_failure")),
+    audit.WithAppName("audit-demo"),
+    audit.WithHost("localhost"),
     audit.WithOutputs(stdout),
 )
 ```
 
 `New()` takes functional options. `WithTaxonomy()` tells the auditor
-what events are valid. `WithOutputs()` tells it where to send them.
-`NewStdout()` constructs a JSON-to-stdout output — no file rotation,
-no network, no configuration. Pair it with `NewStderr()` or
-`NewWriter(w io.Writer)` when you need different destinations.
+what events are valid. `WithAppName()` and `WithHost()` populate the
+compliance framework fields stamped on every event — both are
+required (see `ErrAppNameRequired` / `ErrHostRequired`). `WithOutputs()`
+tells the auditor where to send events. `NewStdout()` constructs a
+JSON-to-stdout output — no file rotation, no network, no
+configuration. Pair it with `NewStderr()` or `NewWriter(w io.Writer)`
+when you need different destinations.
 
 In production, you'd define your taxonomy in a YAML file with required
 fields and severity levels, then use `audit-gen` to generate type-safe

--- a/examples/01-basic/main.go
+++ b/examples/01-basic/main.go
@@ -35,6 +35,8 @@ func main() {
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(audit.DevTaxonomy("user_create", "auth_failure")),
+		audit.WithAppName("audit-demo"),
+		audit.WithHost("localhost"),
 		audit.WithOutputs(stdout),
 	)
 	if err != nil {

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -33,6 +33,8 @@ func TestFanout_DeliverToAll(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1, out2, out3),
 	)
 	require.NoError(t, err)
@@ -53,6 +55,8 @@ func TestFanout_OutputFailureIsolation(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(failing, healthy),
 	)
 	require.NoError(t, err)
@@ -133,6 +137,8 @@ func TestFanout_RouteFiltering(t *testing.T) {
 			auditor, err := audit.New(
 				audit.WithValidationMode(audit.ValidationPermissive),
 				audit.WithTaxonomy(testhelper.TestTaxonomy()),
+				audit.WithAppName("test-app"),
+				audit.WithHost("test-host"),
 				audit.WithNamedOutput(out, audit.WithRoute(&tt.route)),
 			)
 			require.NoError(t, err)
@@ -152,6 +158,8 @@ func TestFanout_DuplicateOutputName_Error(t *testing.T) {
 	out2 := testhelper.NewMockOutput("same-name")
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1, out2),
 	)
 	require.Error(t, err)
@@ -163,6 +171,8 @@ func TestFanout_WithOutputs_AfterWithNamedOutput_Error(t *testing.T) {
 	out2 := testhelper.NewMockOutput("plain")
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out1, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithOutputs(out2), // should error
 	)
@@ -175,6 +185,8 @@ func TestFanout_WithNamedOutput_AfterWithOutputs_Error(t *testing.T) {
 	out2 := testhelper.NewMockOutput("named")
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1),
 		audit.WithNamedOutput(out2, audit.WithRoute(&audit.EventRoute{})), // should error
 	)
@@ -186,6 +198,8 @@ func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
 		})),
@@ -198,6 +212,8 @@ func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
 			ExcludeCategories: []string{"read"},
@@ -212,6 +228,8 @@ func TestFanout_SetOutputRoute(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
@@ -239,6 +257,8 @@ func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(outA, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithNamedOutput(outB, audit.WithRoute(&audit.EventRoute{})),
 	)
@@ -260,6 +280,8 @@ func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 func TestFanout_SetOutputRoute_UnknownOutput(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -273,6 +295,8 @@ func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
@@ -290,6 +314,8 @@ func TestFanout_ClearOutputRoute(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})),
@@ -308,6 +334,8 @@ func TestFanout_ClearOutputRoute(t *testing.T) {
 func TestFanout_ClearOutputRoute_UnknownOutput(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -322,6 +350,8 @@ func TestFanout_OutputRoute(t *testing.T) {
 	route := audit.EventRoute{IncludeCategories: []string{"security"}}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&route)),
 	)
 	require.NoError(t, err)
@@ -341,6 +371,8 @@ func TestFanout_OutputRoute(t *testing.T) {
 func TestFanout_OutputRoute_UnknownOutput(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -354,6 +386,8 @@ func TestFanout_OutputRoute_ReflectsSetAndClear(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
@@ -378,6 +412,8 @@ func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
@@ -426,6 +462,8 @@ func TestFanout_GlobalFilterTakesPrecedence(t *testing.T) {
 				"auth_failure": {Required: []string{"outcome"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
 		})),
@@ -454,6 +492,8 @@ func TestFanout_PerOutputFormatter(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(jsonOut, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithNamedOutput(cefOut, audit.WithRoute(&audit.EventRoute{}), audit.WithOutputFormatter(cefFmt)),
 	)
@@ -477,6 +517,8 @@ func TestFanout_PanicInFormatter_DrainLoopSurvives(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{}), audit.WithOutputFormatter(&panicFormatter{})),
 	)
 	require.NoError(t, err)
@@ -504,6 +546,8 @@ func TestFanout_PanicInOutputWrite_OtherOutputsStillReceive(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(panicOut, survivor),
 	)
 	require.NoError(t, err)
@@ -536,6 +580,8 @@ func TestFanout_SharedFormatter_DeliversSameBytes(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1, out2), // same default formatter
 	)
 	require.NoError(t, err)
@@ -558,6 +604,8 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithMetrics(metrics),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
@@ -579,6 +627,8 @@ func TestFanout_ExcludeEventType_EndToEnd(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
 			ExcludeEventTypes: []string{"config_get"},
 		})),
@@ -607,6 +657,8 @@ func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(goodOut, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithNamedOutput(badOut, audit.WithRoute(&audit.EventRoute{}), audit.WithOutputFormatter(&errorFormatter{})),
 	)
@@ -630,6 +682,8 @@ func TestFanout_ConcurrentEventOverrideAndAudit(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/filter.go
+++ b/filter.go
@@ -115,13 +115,15 @@ func ValidateEventRoute(route *EventRoute, taxonomy *Taxonomy) error {
 }
 
 // validateSeverityRange checks that MinSeverity and MaxSeverity are
-// within the valid CEF range 0-10 and that min does not exceed max.
+// within [MinSeverity, MaxSeverity] and that min does not exceed max.
 func validateSeverityRange(route *EventRoute) error {
-	if route.MinSeverity != nil && (*route.MinSeverity < 0 || *route.MinSeverity > 10) {
-		return fmt.Errorf("audit: EventRoute min_severity %d out of range 0-10", *route.MinSeverity)
+	if route.MinSeverity != nil && (*route.MinSeverity < MinSeverity || *route.MinSeverity > MaxSeverity) {
+		return fmt.Errorf("audit: EventRoute min_severity %d out of range %d-%d",
+			*route.MinSeverity, MinSeverity, MaxSeverity)
 	}
-	if route.MaxSeverity != nil && (*route.MaxSeverity < 0 || *route.MaxSeverity > 10) {
-		return fmt.Errorf("audit: EventRoute max_severity %d out of range 0-10", *route.MaxSeverity)
+	if route.MaxSeverity != nil && (*route.MaxSeverity < MinSeverity || *route.MaxSeverity > MaxSeverity) {
+		return fmt.Errorf("audit: EventRoute max_severity %d out of range %d-%d",
+			*route.MaxSeverity, MinSeverity, MaxSeverity)
 	}
 	if route.MinSeverity != nil && route.MaxSeverity != nil && *route.MinSeverity > *route.MaxSeverity {
 		return fmt.Errorf("audit: EventRoute min_severity %d exceeds max_severity %d",

--- a/format_test.go
+++ b/format_test.go
@@ -895,6 +895,8 @@ func TestLogger_WithFormatter_Custom(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithFormatter(custom),
 	)
@@ -922,6 +924,8 @@ func TestLogger_DefaultJSONFormatter(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -950,6 +954,8 @@ func TestLogger_CEFViaWithFormatter(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithFormatter(cef),
 	)
@@ -970,6 +976,8 @@ func TestLogger_CEFViaWithFormatter(t *testing.T) {
 func TestLogger_WithFormatter_Nil(t *testing.T) {
 	_, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithFormatter(nil),
 	)
 	require.Error(t, err)

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -393,6 +393,8 @@ func TestReservedLibraryField_RejectedAtRuntime(t *testing.T) {
 				out := testhelper.NewMockOutput("reserved-check")
 				auditor, err := audit.New(
 					audit.WithTaxonomy(tax),
+					audit.WithAppName("test-app"),
+					audit.WithHost("test-host"),
 					audit.WithValidationMode(mode),
 					audit.WithOutputs(out),
 				)
@@ -550,6 +552,8 @@ func newHMACPipelineTestAuditor(t *testing.T, name, saltVersion string, salt []b
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
 			Salt: audit.HMACSalt{
@@ -809,6 +813,8 @@ func TestVerifyHMAC_CEF_TamperingHmacVersion_Detected(t *testing.T) {
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithFormatter(cefFormatter),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
@@ -985,6 +991,8 @@ func TestVerifyHMAC_CEF_TamperingActorId_Detected(t *testing.T) {
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithFormatter(cefFormatter),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
@@ -1046,6 +1054,8 @@ func TestHMAC_CEF_OnWireBytesMatchHashedBytes(t *testing.T) {
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithFormatter(cefFormatter),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
@@ -1109,6 +1119,8 @@ func TestReservedLibraryField_RejectedEvenWhenDeclaredInTaxonomy(t *testing.T) {
 	out := testhelper.NewMockOutput("runtime-reserved")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithOutputs(out),
 	)

--- a/introspect_test.go
+++ b/introspect_test.go
@@ -29,6 +29,8 @@ func TestQueueCap_ReturnsConfiguredSize(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(500),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -40,6 +42,8 @@ func TestQueueLen_ReturnsCurrentOccupancy(t *testing.T) {
 	t.Parallel()
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -54,6 +58,8 @@ func TestOutputNames_ReturnsSortedNames(t *testing.T) {
 	outA := testhelper.NewMockOutput("alpha")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(outB, outA),
 	)
 	require.NoError(t, err)
@@ -67,6 +73,8 @@ func TestIsCategoryEnabled_ReturnsCorrectState(t *testing.T) {
 	t.Parallel()
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -82,6 +90,8 @@ func TestIsEventEnabled_ReturnsCorrectState(t *testing.T) {
 	t.Parallel()
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -95,6 +105,8 @@ func TestIntrospection_DisabledLogger_ReturnsZero(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -111,6 +123,8 @@ func TestIntrospection_SyncAuditor(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithSynchronousDelivery(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = auditor.Close() })
@@ -126,6 +140,8 @@ func TestIntrospection_ConcurrentWithAuditEvent_NoRace(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -79,6 +79,8 @@ func newMiddlewareTestAuditor(t *testing.T) (*audit.Auditor, *testhelper.MockOut
 	out := testhelper.NewMockOutput("mw-test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(middlewareTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -615,6 +617,8 @@ func BenchmarkMiddleware(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(1_000_000),
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -656,6 +660,8 @@ func BenchmarkMiddleware_Parallel(b *testing.B) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(1_000_000),
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	if err != nil {
@@ -705,6 +711,8 @@ func TestMiddleware_PoolCorrectness_ResetOnGet_ResponseWriter(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100),
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -740,6 +748,8 @@ func TestMiddleware_PoolCorrectness_TransportMetadataZeroed(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100),
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -794,6 +804,8 @@ func TestMiddleware_PoolCorrectness_HijackedRequestDoesNotLeakInnerWriter(t *tes
 	auditor, err := audit.New(
 		audit.WithQueueSize(100),
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -851,6 +863,8 @@ func TestMiddleware_PoolCorrectness_Crosstalk(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(1_000_000),
 		audit.WithTaxonomy(taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/multicat_severity_test.go
+++ b/multicat_severity_test.go
@@ -71,6 +71,8 @@ events:
 	out := testhelper.NewMockOutput("pipeline")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -131,6 +133,8 @@ events:
 	out := testhelper.NewMockOutput("consistent")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -177,6 +181,8 @@ events:
 	out := testhelper.NewMockOutput("three-cats")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -217,6 +223,8 @@ events:
 	out := testhelper.NewMockOutput("concurrent-filter")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -499,6 +507,8 @@ events:
 			out := testhelper.NewMockOutput("sev-pipeline")
 			auditor, err := audit.New(
 				audit.WithTaxonomy(tax),
+				audit.WithAppName("test-app"),
+				audit.WithHost("test-host"),
 				audit.WithOutputs(out),
 			)
 			require.NoError(t, err)
@@ -568,6 +578,8 @@ events:
 	out := testhelper.NewMockOutput("mixed-fmt")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/noop_metrics_test.go
+++ b/noop_metrics_test.go
@@ -47,6 +47,8 @@ func TestNoOpMetrics_Embedding_OverrideSingleMethod(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithMetrics(m),
 	)
@@ -81,6 +83,8 @@ func TestNoOpMetrics_WithMetrics_Accepted(t *testing.T) {
 	t.Parallel()
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithMetrics(audit.NoOpMetrics{}),
 	)
 	require.NoError(t, err)

--- a/options.go
+++ b/options.go
@@ -21,6 +21,37 @@ import (
 )
 
 // Option configures a [Auditor] during construction via [New].
+//
+// Options fall into three classes (#593 B-45):
+//
+//   - Required options — [New] returns a sentinel error if the
+//     option is absent:
+//     [WithTaxonomy] ([ErrTaxonomyRequired]),
+//     [WithAppName] ([ErrAppNameRequired]),
+//     [WithHost] ([ErrHostRequired]).
+//     These inputs have no library-supplied default.
+//
+//   - Validated-on-call options — optional to call, but reject empty
+//     arguments when called:
+//     [WithFormatter] (nil rejected; omitting yields a default
+//     [JSONFormatter]),
+//     [WithTimezone] (empty rejected; omitting emits no timezone
+//     framework field).
+//
+//   - Optional options — accept nil / unset with a documented default:
+//     [WithMetrics]         — nil or unset disables metrics collection.
+//     [WithDiagnosticLogger] — nil or unset uses [slog.Default].
+//     [WithStandardFieldDefaults] — nil or unset uses no defaults.
+//
+// Remaining options configure behaviour via value types
+// ([WithQueueSize], [WithShutdownTimeout], [WithValidationMode],
+// [WithOmitEmpty], [WithDisabled], [WithOutputs], [WithNamedOutput],
+// [WithSynchronousDelivery]) and have their own documented
+// zero-value semantics.
+//
+// The split mirrors the [net/http] convention — [http.Client.Transport]
+// is optional with [http.DefaultTransport] as the documented
+// nil-default, but the Handler on [http.Server] is required.
 type Option func(*Auditor) error
 
 // WithTaxonomy registers the event taxonomy for validation. This option
@@ -55,10 +86,11 @@ func WithTaxonomy(t *Taxonomy) Option {
 	}
 }
 
-// WithMetrics sets the metrics recorder for the auditor. If m is nil,
-// or if WithMetrics is not called, metrics are silently discarded.
-// Implementations MUST be safe for concurrent calls from the drain
-// goroutine.
+// WithMetrics sets the metrics recorder for the auditor.
+//
+// Optional. If m is nil, or if WithMetrics is not called, metrics
+// are silently discarded (no metrics collection). Implementations
+// MUST be safe for concurrent calls from the drain goroutine.
 func WithMetrics(m Metrics) Option {
 	return func(a *Auditor) error {
 		a.metrics = m
@@ -67,7 +99,11 @@ func WithMetrics(m Metrics) Option {
 }
 
 // WithAppName sets the application name emitted as a framework field
-// in every serialised event. The value must be non-empty.
+// in every serialised event.
+//
+// Required. [New] returns [ErrAppNameRequired] if WithAppName is
+// unset (unless [WithDisabled] is also applied). The value must be
+// non-empty and at most 255 bytes.
 func WithAppName(name string) Option {
 	return func(a *Auditor) error {
 		if name == "" {
@@ -82,7 +118,11 @@ func WithAppName(name string) Option {
 }
 
 // WithHost sets the hostname emitted as a framework field in every
-// serialised event. The value must be non-empty and at most 255 bytes.
+// serialised event.
+//
+// Required. [New] returns [ErrHostRequired] if WithHost is unset
+// (unless [WithDisabled] is also applied). The value must be
+// non-empty and at most 255 bytes.
 func WithHost(host string) Option {
 	return func(a *Auditor) error {
 		if host == "" {
@@ -97,8 +137,12 @@ func WithHost(host string) Option {
 }
 
 // WithTimezone sets the timezone name emitted as a framework field in
-// every serialised event. The value must be non-empty and at most 64
-// bytes. If not set, no timezone field is emitted.
+// every serialised event.
+//
+// Optional to call; if omitted, no timezone field is emitted. If
+// called, tz MUST be non-empty (the option returns an error for an
+// empty string since there is no sane default to substitute at that
+// point). At most 64 bytes.
 func WithTimezone(tz string) Option {
 	return func(a *Auditor) error {
 		if tz == "" {
@@ -128,10 +172,11 @@ func WithSynchronousDelivery() Option {
 	}
 }
 
-// WithDiagnosticLogger sets the [log/slog.Logger] used for library diagnostics
-// (lifecycle messages, buffer drops, format errors). When not set or
-// when l is nil, [slog.Default] is used. Pass
-// slog.New(slog.DiscardHandler) to silence all library output.
+// WithDiagnosticLogger sets the [log/slog.Logger] used for library
+// diagnostics (lifecycle messages, buffer drops, format errors).
+//
+// Optional. When not set or when l is nil, [slog.Default] is used.
+// Pass slog.New(slog.DiscardHandler) to silence all library output.
 func WithDiagnosticLogger(l *slog.Logger) Option {
 	return func(a *Auditor) error {
 		a.logger = l
@@ -144,6 +189,8 @@ func WithDiagnosticLogger(l *slog.Logger) Option {
 // before validation — a default satisfies required: true constraints.
 // Per-event values always override defaults (key existence check, not
 // zero value). When called multiple times, the last call wins.
+//
+// Optional. Nil or empty map means "no defaults".
 func WithStandardFieldDefaults(defaults map[string]string) Option {
 	return func(a *Auditor) error {
 		for k := range defaults {
@@ -161,10 +208,13 @@ func WithStandardFieldDefaults(defaults map[string]string) Option {
 	}
 }
 
-// WithFormatter sets the event serialisation formatter. If not
-// provided, a [JSONFormatter] with default settings is used. Use
-// this to configure a [CEFFormatter] or a custom [Formatter]
-// implementation.
+// WithFormatter sets the event serialisation formatter.
+//
+// Optional to call; if WithFormatter is not called, a [JSONFormatter]
+// with default settings is used. If WithFormatter is called, f MUST
+// be non-nil — the option returns an error for a nil formatter since
+// there is no sane default to substitute at that point. Use this to
+// configure a [CEFFormatter] or a custom [Formatter] implementation.
 func WithFormatter(f Formatter) Option {
 	return func(a *Auditor) error {
 		if f == nil {

--- a/options_test.go
+++ b/options_test.go
@@ -35,6 +35,8 @@ func TestNew_NoConfigOptions_UsesDefaults(t *testing.T) {
 	out := testhelper.NewMockOutput("defaults")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -56,7 +58,7 @@ func TestNew_NoConfigOptions_UsesDefaults(t *testing.T) {
 func TestNew_WithoutTaxonomy_ReturnsError(t *testing.T) {
 	_, err := audit.New()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "taxonomy is required")
+	assert.ErrorIs(t, err, audit.ErrTaxonomyRequired)
 }
 
 // ---------------------------------------------------------------------------
@@ -69,6 +71,8 @@ func TestNew_WithDisabled_CreatesNoOpLogger(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithDisabled(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -145,6 +149,8 @@ func TestNew_WithQueueSize_SetsCustomSize(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(50000),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	require.NoError(t, auditor.Close())
@@ -154,6 +160,8 @@ func TestNew_WithQueueSize_RejectsOverMax(t *testing.T) {
 	_, err := audit.New(
 		audit.WithQueueSize(audit.MaxQueueSize+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
@@ -169,6 +177,8 @@ func TestNew_WithShutdownTimeout_SetsCustomTimeout(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithShutdownTimeout(30*time.Second),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	require.NoError(t, auditor.Close())
@@ -178,6 +188,8 @@ func TestNew_WithShutdownTimeout_RejectsOverMax(t *testing.T) {
 	_, err := audit.New(
 		audit.WithShutdownTimeout(audit.MaxShutdownTimeout+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
@@ -194,6 +206,8 @@ func TestNew_WithValidationMode_SetsMode(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -219,6 +233,8 @@ func TestNew_WithOmitEmpty_OmitsZeroFields(t *testing.T) {
 		audit.WithOmitEmpty(),
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -295,6 +311,8 @@ func TestSuppressEventCategory_True_SuppressesCategory(t *testing.T) {
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -330,6 +348,8 @@ func TestNew_ConcurrentConstruction_NoRace(t *testing.T) {
 			tax := testhelper.ValidTaxonomy()
 			auditor, err := audit.New(
 				audit.WithTaxonomy(tax),
+				audit.WithAppName("test-app"),
+				audit.WithHost("test-host"),
 			)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -352,6 +372,8 @@ func BenchmarkNew_Construction(b *testing.B) {
 	for b.Loop() {
 		auditor, err := audit.New(
 			audit.WithTaxonomy(tax),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(out),
 		)
 		if err != nil {
@@ -359,4 +381,53 @@ func BenchmarkNew_Construction(b *testing.B) {
 		}
 		_ = auditor.Close()
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Required AppName / Host (#593 B-41)
+// ---------------------------------------------------------------------------
+
+func TestNew_MissingAppName_ReturnsErrAppNameRequired(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	_, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithHost("test-host"),
+		audit.WithOutputs(out),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrAppNameRequired)
+}
+
+func TestNew_MissingHost_ReturnsErrHostRequired(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	_, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithOutputs(out),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrHostRequired)
+}
+
+func TestNew_WithDisabled_AllowsMissingAppNameAndHost(t *testing.T) {
+	t.Parallel()
+	auditor, err := audit.New(audit.WithDisabled())
+	require.NoError(t, err, "disabled auditor must not require AppName or Host")
+	require.NotNil(t, auditor)
+	require.NoError(t, auditor.Close())
+}
+
+// ---------------------------------------------------------------------------
+// Severity constants (#593 B-27)
+// ---------------------------------------------------------------------------
+
+func TestSeverity_ExportedConstants(t *testing.T) {
+	t.Parallel()
+	// Constants exist with the documented values. Downstream code and
+	// integrations rely on these so they form part of the v1.0 API
+	// surface; regressing them requires a major-version bump.
+	assert.Equal(t, 0, audit.MinSeverity)
+	assert.Equal(t, 10, audit.MaxSeverity)
 }

--- a/processentry_zero_copy_test.go
+++ b/processentry_zero_copy_test.go
@@ -104,6 +104,8 @@ func TestProcessEntry_RetainedBytes_NoForeignImpersonation(t *testing.T) {
 	bad := newRetainingOutput("retain")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(bad),
 		audit.WithSynchronousDelivery(),
 	)
@@ -201,6 +203,8 @@ func TestProcessEntry_FanOutToMultipleOutputs_BytesIntegrity(t *testing.T) {
 	out3 := testhelper.NewMockOutput("out3")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out1, out2, out3),
 		audit.WithSynchronousDelivery(),
 	)
@@ -251,6 +255,8 @@ func TestProcessEntry_ConcurrentSubmission_NoRace(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithQueueSize(100_000),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -377,6 +383,8 @@ func TestProcessEntry_MultiCategory_BufferReuseAcrossPasses(t *testing.T) {
 	cefOut := testhelper.NewMockOutput("cef")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(jsonOut, audit.WithOutputFormatter(&audit.JSONFormatter{})),
 		audit.WithNamedOutput(cefOut, audit.WithOutputFormatter(&audit.CEFFormatter{
 			Vendor: "axonops", Product: "audit", Version: "1.0",
@@ -442,6 +450,8 @@ func TestProcessEntry_PanicMidDelivery_ReleaseStillRuns(t *testing.T) {
 	good := testhelper.NewMockOutput("good")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(bad, good),
 		audit.WithSynchronousDelivery(),
 	)
@@ -494,6 +504,8 @@ func TestProcessEntry_FormatError_CacheNilEntry_NoDoublePut(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithMetrics(metrics),
 		audit.WithNamedOutput(out1, audit.WithOutputFormatter(shared), audit.WithRoute(&audit.EventRoute{})),
 		audit.WithNamedOutput(out2, audit.WithOutputFormatter(shared), audit.WithRoute(&audit.EventRoute{})),
@@ -573,6 +585,8 @@ func TestJSONFormatter_FormatBuf_OversizeEventDropsBuffer(t *testing.T) {
 	out := testhelper.NewMockOutput("out")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 		audit.WithSynchronousDelivery(),
 	)

--- a/secrets/openbao/openbao.go
+++ b/secrets/openbao/openbao.go
@@ -370,7 +370,13 @@ func (p *Provider) fetchPath(ctx context.Context, path string) (map[string]strin
 
 // Close releases resources held by the provider and zeroes the
 // authentication token from memory (best-effort; Go GC may retain
-// copies). Close is idempotent.
+// copies).
+//
+// Close is idempotent: repeated calls are safe, return nil, and do
+// not panic. Token zeroing on an already-zero slice is a no-op, and
+// [http.Client.CloseIdleConnections] is safe to invoke multiple
+// times per the stdlib contract. Calls to [Provider.Resolve] after
+// Close will fail with a connection error.
 func (p *Provider) Close() error {
 	// Zero token from memory.
 	for i := range p.token {

--- a/secrets/openbao/openbao_test.go
+++ b/secrets/openbao/openbao_test.go
@@ -1048,3 +1048,20 @@ func TestConfig_String_TokenUnsetShowsUnsetMarker(t *testing.T) {
 	assert.Contains(t, out, "token=unset")
 	assert.NotContains(t, out, "[REDACTED]")
 }
+
+// TestOpenbaoClose_IsIdempotent covers #593 B-33: repeated Close()
+// calls are safe and return nil. Token zeroing on an already-zero
+// slice is a no-op, and http.Client.CloseIdleConnections is safe to
+// invoke multiple times per the stdlib contract.
+func TestOpenbaoClose_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	p, err := openbao.New(&openbao.Config{
+		Address: "https://bao.example.com:8200",
+		Token:   "test-token",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, p.Close(), "first Close must succeed")
+	require.NoError(t, p.Close(), "second Close must be idempotent")
+	require.NoError(t, p.Close(), "third Close must be idempotent")
+}

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -373,7 +373,13 @@ func (p *Provider) fetchPath(ctx context.Context, path string) (map[string]strin
 
 // Close releases resources held by the provider and zeroes the
 // authentication token from memory (best-effort; Go GC may retain
-// copies). Close is idempotent.
+// copies).
+//
+// Close is idempotent: repeated calls are safe, return nil, and do
+// not panic. Token zeroing on an already-zero slice is a no-op, and
+// [http.Client.CloseIdleConnections] is safe to invoke multiple
+// times per the stdlib contract. Calls to [Provider.Resolve] after
+// Close will fail with a connection error.
 func (p *Provider) Close() error {
 	for i := range p.token {
 		p.token[i] = 0

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -985,3 +985,20 @@ func TestConfig_String_TokenUnsetShowsUnsetMarker(t *testing.T) {
 	assert.Contains(t, out, "token=unset")
 	assert.NotContains(t, out, "[REDACTED]")
 }
+
+// TestVaultClose_IsIdempotent covers #593 B-33: repeated Close()
+// calls are safe and return nil. Token zeroing on an already-zero
+// slice is a no-op, and http.Client.CloseIdleConnections is safe to
+// invoke multiple times per the stdlib contract.
+func TestVaultClose_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	p, err := vault.New(&vault.Config{
+		Address: "https://vault.example.com:8200",
+		Token:   "test-token",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, p.Close(), "first Close must succeed")
+	require.NoError(t, p.Close(), "second Close must be idempotent")
+	require.NoError(t, p.Close(), "third Close must be idempotent")
+}

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -507,6 +507,8 @@ func TestFieldStripping_SingleLabel(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
@@ -555,6 +557,8 @@ func TestFieldStripping_MultiLabel_AnyOverlap(t *testing.T) {
 	// Exclude financial only — card_number is stripped.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("financial")),
 	)
 	require.NoError(t, err)
@@ -588,6 +592,8 @@ func TestFieldStripping_DifferentOutputs(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(outAll),                                   // no exclusions
 		audit.WithNamedOutput(outNoPII, audit.WithExcludeLabels("pii")), // exclude PII
 	)
@@ -627,6 +633,8 @@ func TestFieldStripping_NoExclusion_AllFields(t *testing.T) {
 	// No exclude_labels → all fields delivered.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout),
 	)
 	require.NoError(t, err)
@@ -673,6 +681,8 @@ events:
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
@@ -719,6 +729,8 @@ events:
 
 	_, err = audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.Error(t, err)
@@ -749,6 +761,8 @@ events:
 
 	_, err = audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("nonexistent")),
 	)
 	require.Error(t, err)
@@ -788,6 +802,8 @@ events:
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
@@ -828,6 +844,8 @@ func TestFormatWithExclusion_ExclusionPath(t *testing.T) {
 	// Output with exclusions — formatOpts should be pre-allocated.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
@@ -865,6 +883,8 @@ func TestFormatWithExclusion_NoExclusionNoOverhead(t *testing.T) {
 	// Output WITHOUT exclusions — formatOpts should be nil.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout),
 	)
 	require.NoError(t, err)
@@ -894,6 +914,8 @@ func TestFormatWithExclusion_MultipleOutputsDifferentExclusions(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(outAll),
 		audit.WithNamedOutput(outNoPII, audit.WithExcludeLabels("pii")),
 		audit.WithNamedOutput(outNoFinancial, audit.WithExcludeLabels("financial")),
@@ -943,6 +965,8 @@ func TestFieldStripping_Concurrent(t *testing.T) {
 	out := testhelper.NewMockOutput("concurrent")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithExcludeLabels("pii")),
 	)
 	require.NoError(t, err)
@@ -1115,6 +1139,8 @@ func BenchmarkDeliverToOutputs_MultiOutput_MixedExclusion(b *testing.B) {
 	outFiltered := testhelper.NewMockOutput("filtered")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(outAll),
 		audit.WithNamedOutput(outFiltered, audit.WithExcludeLabels("pii")),
 	)
@@ -1145,6 +1171,8 @@ func benchAuditWithExclusions(b *testing.B, taxonomyYAML string, excludeLabels [
 	out := testhelper.NewMockOutput("bench")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithExcludeLabels(excludeLabels...)),
 	)
 	if err != nil {

--- a/severity_routing_test.go
+++ b/severity_routing_test.go
@@ -369,6 +369,8 @@ func TestSetRoute_CopiesMinSeverityPointer(t *testing.T) {
 	out := testhelper.NewMockOutput("copy-min")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
@@ -401,6 +403,8 @@ func TestSetRoute_CopiesMaxSeverityPointer(t *testing.T) {
 	out := testhelper.NewMockOutput("copy-max")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
@@ -432,6 +436,8 @@ func TestGetRoute_ReturnsIndependentSeverityPointers(t *testing.T) {
 	out := testhelper.NewMockOutput("get-copy")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{MinSeverity: intPtr(4)})),
 	)
 	require.NoError(t, err)
@@ -463,6 +469,8 @@ func TestSetRoute_NilSeverityPointersPreserved(t *testing.T) {
 	out := testhelper.NewMockOutput("nil-sev")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)
@@ -679,6 +687,8 @@ func TestAudit_SeverityRouteFiltersInDrainLoop(t *testing.T) {
 	out := testhelper.NewMockOutput("sev-filter")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{MinSeverity: intPtr(7)})),
 	)
 	require.NoError(t, err)
@@ -734,6 +744,8 @@ events:
 	out := testhelper.NewMockOutput("force-enabled")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		// Output route: MinSeverity 5 — only events with severity >= 5 delivered.
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{MinSeverity: intPtr(5)})),
 	)
@@ -878,6 +890,8 @@ func TestConcurrentSetRouteWithSeverity(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{})),
 	)
 	require.NoError(t, err)

--- a/sync_delivery_test.go
+++ b/sync_delivery_test.go
@@ -30,6 +30,8 @@ func TestSyncLogger_EventAvailableImmediately(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithSynchronousDelivery(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -53,6 +55,8 @@ func TestSyncLogger_CloseIsSafe(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithSynchronousDelivery(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -70,6 +74,8 @@ func TestSyncLogger_ValidationStillRuns(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithSynchronousDelivery(),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -77,14 +77,15 @@ var syslogSeverities = [11]srslog.Priority{
 	srslog.LOG_CRIT,    // audit 10
 }
 
-// mapSeverity converts an audit event severity (0–10) to an srslog
-// priority constant using the mapping in syslogSeverities. Values
-// outside [0, 10] silently fall back to LOG_INFO (syslog severity 6).
-// The taxonomy enforces the 0–10 range at registration time, so
-// out-of-range values indicate a programming error in a custom [Output]
-// that bypasses the auditor and calls this function directly.
+// mapSeverity converts an audit event severity (in the range
+// [audit.MinSeverity, audit.MaxSeverity]) to an srslog priority
+// constant using the mapping in syslogSeverities. Values outside
+// that range silently fall back to LOG_INFO (syslog severity 6).
+// The taxonomy enforces the range at registration time, so
+// out-of-range values indicate a programming error in a custom
+// [Output] that bypasses the auditor and calls this function directly.
 func mapSeverity(auditSeverity int) srslog.Priority {
-	if auditSeverity < 0 || auditSeverity > 10 {
+	if auditSeverity < audit.MinSeverity || auditSeverity > audit.MaxSeverity {
 		return srslog.LOG_INFO
 	}
 	return syslogSeverities[auditSeverity]

--- a/taxonomy.go
+++ b/taxonomy.go
@@ -317,13 +317,25 @@ func resolveEventSeverity(def *EventDef, t *Taxonomy) int {
 	return 5
 }
 
-// clampSeverity restricts a severity value to the valid CEF range 0-10.
+// Severity bounds for event and route severity values. These follow
+// the CEF range convention (0 = least severe, 10 = most severe). Both
+// bounds are inclusive. See [EventDef.Severity], [CategoryDef.Severity],
+// and [EventRoute.MinSeverity] / [EventRoute.MaxSeverity].
+const (
+	// MinSeverity is the minimum allowed severity (inclusive).
+	MinSeverity = 0
+	// MaxSeverity is the maximum allowed severity (inclusive).
+	MaxSeverity = 10
+)
+
+// clampSeverity restricts a severity value to the valid CEF range
+// [MinSeverity, MaxSeverity].
 func clampSeverity(s int) int {
-	if s < 0 {
-		return 0
+	if s < MinSeverity {
+		return MinSeverity
 	}
-	if s > 10 {
-		return 10
+	if s > MaxSeverity {
+		return MaxSeverity
 	}
 	return s
 }

--- a/taxonomy_pointer_test.go
+++ b/taxonomy_pointer_test.go
@@ -68,6 +68,8 @@ func TestWithTaxonomy_NilPointer_ReturnsError(t *testing.T) {
 	t.Parallel()
 	_, err := audit.New(
 		audit.WithTaxonomy(nil),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
@@ -99,6 +101,8 @@ events:
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -135,6 +139,8 @@ func TestWithTaxonomy_PostConstructionMutation_DoesNotAffectAuditor(t *testing.T
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -176,6 +182,8 @@ func TestWithTaxonomy_InlineTaxonomy_TakesAddress(t *testing.T) {
 				"ev1": {Required: []string{"f1"}},
 			},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	require.NoError(t, auditor.Close())

--- a/taxonomy_test.go
+++ b/taxonomy_test.go
@@ -27,6 +27,8 @@ import (
 func TestNew_ValidTaxonomy(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, auditor)
@@ -74,6 +76,8 @@ func TestNew_TaxonomyValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := audit.New(
 				audit.WithTaxonomy(tt.taxonomy),
+				audit.WithAppName("test-app"),
+				audit.WithHost("test-host"),
 			)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
@@ -85,12 +89,14 @@ func TestNew_TaxonomyValidation(t *testing.T) {
 func TestNew_TaxonomyRequired(t *testing.T) {
 	_, err := audit.New()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "taxonomy is required")
+	assert.ErrorIs(t, err, audit.ErrTaxonomyRequired)
 }
 
 func TestNew_TaxonomyValidation_SentinelError(t *testing.T) {
 	_, err := audit.New(
 		audit.WithTaxonomy(&audit.Taxonomy{Version: 0}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, audit.ErrTaxonomyInvalid))
@@ -343,6 +349,8 @@ func TestNew_TaxonomyVersionNegative(t *testing.T) {
 			Categories: map[string]*audit.CategoryDef{"write": {Events: []string{"ev1"}}},
 			Events:     map[string]*audit.EventDef{"ev1": {Required: []string{"f1"}}},
 		}),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)

--- a/taxonomy_yaml_test.go
+++ b/taxonomy_yaml_test.go
@@ -655,6 +655,8 @@ events:
 	// should pass strict validation (no unknown fields).
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tax),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 	)
 	require.NoError(t, err)
 	defer func() { _ = auditor.Close() }()

--- a/tests/bdd/features/config_versioning.feature
+++ b/tests/bdd/features/config_versioning.feature
@@ -48,3 +48,20 @@ Feature: Auditor Configuration
       """
       audit: event "user_create" has unknown fields: [extra]
       """
+
+  # --- Required AppName / Host (#593 B-41) ---
+
+  Scenario: audit.New without WithAppName fails with ErrAppNameRequired
+    Given a standard test taxonomy
+    When I try to create an auditor without WithAppName
+    Then the auditor construction should fail with ErrAppNameRequired
+
+  Scenario: audit.New without WithHost fails with ErrHostRequired
+    Given a standard test taxonomy
+    When I try to create an auditor without WithHost
+    Then the auditor construction should fail with ErrHostRequired
+
+  Scenario: Disabled auditor bypasses AppName / Host requirement
+    Given a standard test taxonomy
+    When I try to create a disabled auditor without WithAppName or WithHost
+    Then the auditor should be created successfully

--- a/tests/bdd/features/core_audit.feature
+++ b/tests/bdd/features/core_audit.feature
@@ -77,27 +77,10 @@ Feature: Core Audit Logging
     Then the event should be delivered successfully
     And the output should contain field "pid" as a positive integer
 
-  Scenario: PID present even without app_name or host
-    Given an auditor with stdout output
-    When I audit event "user_create" with fields:
-      | field    | value   |
-      | outcome  | success |
-      | actor_id | alice   |
-    Then the event should be delivered successfully
-    And the output should contain field "pid" as a positive integer
-    And the output should not contain field "app_name"
-    And the output should not contain field "host"
-
-  Scenario: Timezone and PID auto-detected when not configured
-    Given an auditor with stdout output
-    When I audit event "user_create" with fields:
-      | field    | value   |
-      | outcome  | success |
-      | actor_id | alice   |
-    Then the event should be delivered successfully
-    And the output should not contain field "app_name"
-    And the output should not contain field "host"
-    And the output should contain field "pid" as a positive integer
+  # Scenarios that constructed auditors without app_name / host were
+  # removed in #593 B-41: audit.New now requires WithAppName and
+  # WithHost. See the "Required AppName / Host" block in
+  # config_versioning.feature for the new positive+negative coverage.
 
   Scenario: Framework fields present with OmitEmpty true
     Given framework fields app_name "myapp" host "prod-01" timezone "UTC"

--- a/tests/bdd/features/formatters.feature
+++ b/tests/bdd/features/formatters.feature
@@ -300,17 +300,12 @@ Feature: Event Formatters
     And I close the auditor
     Then the CEF line should contain "dvcpid="
 
-  Scenario: CEF app_name and host absent when not configured but timezone and pid present
-    Given an auditor with file output using CEF formatter with vendor "Test" product "Test" version "1.0"
-    When I audit event "user_create" with fields:
-      | field    | value   |
-      | outcome  | success |
-      | actor_id | alice   |
-    And I close the auditor
-    Then the CEF line should not contain "deviceProcessName="
-    And the CEF line should not contain "dvchost="
-    And the CEF line should contain "dtz="
-    And the CEF line should contain "dvcpid="
+  # Scenario "CEF app_name and host absent when not configured..." was
+  # removed in #593 B-41: audit.New now requires WithAppName and
+  # WithHost so there is no "not configured" state on the programmatic
+  # path. CEF framework-field mapping for app_name/host is covered by
+  # the "CEF maps reserved standard field to CEF key" table scenarios
+  # below.
 
   # --- CEF reserved standard field mapping (#237) ---
 

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -530,7 +530,9 @@ func assertEventMatching(tc *AuditTestContext, table *godog.Table) error {
 		return err
 	}
 	// Auto-populated fields that are allowed but not required in the table.
-	autoFields := []string{"timestamp", "severity", "event_category", "pid", "timezone"}
+	// app_name and host are required since #593 B-41 but BDD scenarios
+	// predate that contract, so they are tolerated as framework fields.
+	autoFields := []string{"timestamp", "severity", "event_category", "pid", "timezone", "app_name", "host"}
 	for _, e := range events {
 		match, mismatch := eventMatchesExactly(e, expected, autoFields)
 		if match {
@@ -598,6 +600,8 @@ func createStdoutAuditor(tc *AuditTestContext, extraOpts ...audit.Option) error 
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(stdoutOut),
 	}
 	if tc.MockMetrics != nil {

--- a/tests/bdd/steps/config_steps.go
+++ b/tests/bdd/steps/config_steps.go
@@ -60,6 +60,16 @@ func registerConfigWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 		return tryCreateAuditor(tc, audit.WithDisabled())
 	})
 
+	ctx.Step(`^I try to create an auditor without WithAppName$`, func() error {
+		return tryCreateAuditorWithoutAppNameOrHost(tc, true, false)
+	})
+	ctx.Step(`^I try to create an auditor without WithHost$`, func() error {
+		return tryCreateAuditorWithoutAppNameOrHost(tc, false, true)
+	})
+	ctx.Step(`^I try to create a disabled auditor without WithAppName or WithHost$`, func() error {
+		return tryCreateAuditorWithoutAppNameOrHost(tc, true, true, audit.WithDisabled())
+	})
+
 }
 
 func registerConfigThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
@@ -68,6 +78,12 @@ func registerConfigThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	})
 	ctx.Step(`^the auditor construction should fail wrapping "([^"]*)"$`, func(s string) error {
 		return assertConstructionSentinel(tc, s)
+	})
+	ctx.Step(`^the auditor construction should fail with ErrAppNameRequired$`, func() error {
+		return assertConstructionSentinelValue(tc, "ErrAppNameRequired", audit.ErrAppNameRequired)
+	})
+	ctx.Step(`^the auditor construction should fail with ErrHostRequired$`, func() error {
+		return assertConstructionSentinelValue(tc, "ErrHostRequired", audit.ErrHostRequired)
 	})
 	ctx.Step(`^the auditor construction should fail with an error$`, func() error {
 		return assertConstructionFailed(tc)
@@ -103,6 +119,41 @@ func registerConfigThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	})
 }
 
+// tryCreateAuditorWithoutAppNameOrHost exercises the #593 B-41 required-
+// options contract by omitting WithAppName / WithHost (as selected by
+// the flags) to trigger the sentinel error. Any extraOpts are applied
+// as-is — passing audit.WithDisabled here short-circuits validation.
+func tryCreateAuditorWithoutAppNameOrHost(tc *AuditTestContext, skipAppName, skipHost bool, extraOpts ...audit.Option) error {
+	buf := &bytes.Buffer{}
+	tc.StdoutBuf = buf
+
+	stdoutOut, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: buf})
+	if err != nil {
+		return fmt.Errorf("create stdout output: %w", err)
+	}
+
+	opts := []audit.Option{
+		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithOutputs(stdoutOut),
+	}
+	if !skipAppName {
+		opts = append(opts, audit.WithAppName("test-app"))
+	}
+	if !skipHost {
+		opts = append(opts, audit.WithHost("test-host"))
+	}
+	opts = append(opts, extraOpts...)
+
+	auditor, err := audit.New(opts...)
+	if err != nil {
+		tc.LastErr = err
+		return nil //nolint:nilerr // scenario may assert on tc.LastErr
+	}
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
+	return nil
+}
+
 // tryCreateAuditor creates an auditor with the given options and stores it
 // in the test context. If creation fails, the error is stored in tc.LastErr
 // without failing the step (the scenario may assert on the error).
@@ -117,6 +168,8 @@ func tryCreateAuditor(tc *AuditTestContext, extraOpts ...audit.Option) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(stdoutOut),
 	}
 	opts = append(opts, extraOpts...)
@@ -156,6 +209,16 @@ func assertConstructionSentinel(tc *AuditTestContext, sentinel string) error {
 		}
 	default:
 		return fmt.Errorf("unknown sentinel: %s", sentinel)
+	}
+	return nil
+}
+
+func assertConstructionSentinelValue(tc *AuditTestContext, name string, want error) error {
+	if tc.LastErr == nil {
+		return fmt.Errorf("expected %s, got nil", name)
+	}
+	if !errors.Is(tc.LastErr, want) {
+		return fmt.Errorf("expected %s, got: %w", name, tc.LastErr)
 	}
 	return nil
 }

--- a/tests/bdd/steps/event_metrics_steps.go
+++ b/tests/bdd/steps/event_metrics_steps.go
@@ -53,6 +53,8 @@ func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithNamedOutput(fileOut),
 		}
@@ -91,6 +93,8 @@ func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 	ctx.Step(`^an auditor with that file output and queue_size (\d+)$`, func(queueSize int) error {
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithQueueSize(queueSize),
 		}
 		opts = append(opts, tc.Options...)
@@ -107,6 +111,8 @@ func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 	ctx.Step(`^an auditor with that file output and pipeline metrics and queue_size (\d+)$`, func(queueSize int) error {
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithQueueSize(queueSize),
 		}
@@ -132,6 +138,8 @@ func registerEventMetricsGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(stdoutOut),
 		}
 		opts = append(opts, tc.Options...)
@@ -271,6 +279,8 @@ func registerEventMetricsThenSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 	ctx.Step(`^an auditor with those outputs and queue_size (\d+)$`, func(queueSize int) error {
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithQueueSize(queueSize),
 		}
 		opts = append(opts, tc.Options...)

--- a/tests/bdd/steps/fanout_steps.go
+++ b/tests/bdd/steps/fanout_steps.go
@@ -204,10 +204,11 @@ func createSharedFormatterAuditor(tc *AuditTestContext) error {
 	// Both outputs share the default JSON formatter (nil = auditor default).
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fA),
 		audit.WithNamedOutput(fB),
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -348,6 +349,8 @@ func tryDuplicateOutputNames(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = f1.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(f1, f1), // same output = duplicate name
 	)
 	tc.LastErr = err
@@ -372,6 +375,8 @@ func tryDuplicateFilePath(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = f2.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(f1, f2),
 	)
 	tc.LastErr = err
@@ -390,6 +395,8 @@ func tryMixedRoute(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = f.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(f, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"write"},
 			ExcludeCategories: []string{"read"},
@@ -411,6 +418,8 @@ func tryUnknownCategoryRoute(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = f.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(f, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"nonexistent"},
 		})),
@@ -455,6 +464,8 @@ func tryDuplicateSyslogAddress(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = s2.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(s1, s2),
 	)
 	tc.LastErr = err
@@ -473,6 +484,8 @@ func tryUnknownEventTypeRoute(tc *AuditTestContext) error {
 	tc.AddCleanup(func() { _ = f.Close() })
 	_, err = audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(f, audit.WithRoute(&audit.EventRoute{
 			IncludeEventTypes: []string{"nonexistent_event"},
 		})),
@@ -495,8 +508,11 @@ func assertFileContainsText(tc *AuditTestContext, name, text string) error {
 }
 
 func createFanoutAuditor(tc *AuditTestContext, useFile, useSyslog, useWebhook bool, webhookFmt audit.Formatter, batchSize *int) error {
-	var opts []audit.Option
-	opts = append(opts, audit.WithTaxonomy(tc.Taxonomy))
+	opts := []audit.Option{
+		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+	}
 
 	if useFile {
 		dir, err := tc.EnsureFileDir()
@@ -541,7 +557,6 @@ func createFanoutAuditor(tc *AuditTestContext, useFile, useSyslog, useWebhook bo
 		tc.AddCleanup(func() { _ = w.Close() })
 		opts = append(opts, audit.WithNamedOutput(w, audit.WithOutputFormatter(webhookFmt)))
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err
@@ -575,10 +590,11 @@ func createErrorOutputAuditor(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(&errorOutput{}),
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -611,10 +627,11 @@ func createPanicOutputAuditor(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(&panicOutput{}),
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -661,10 +678,11 @@ func createPanicFormatterAuditor(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut), // normal file
 		audit.WithNamedOutput(&devNullOutput{}, audit.WithOutputFormatter(&panicFormatter{})), // panicking formatter
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -697,10 +715,11 @@ func createDualFileRoutedAuditor(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(secOut, audit.WithRoute(&audit.EventRoute{IncludeCategories: []string{"security"}})),
 		audit.WithNamedOutput(writeOut, audit.WithRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -743,11 +762,12 @@ func createTripleRoutedAuditor(tc *AuditTestContext) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut), // all events
 		audit.WithNamedOutput(syslogOut, audit.WithRoute(&audit.EventRoute{IncludeCategories: []string{"security"}})), // security only
 		audit.WithNamedOutput(webhookOut, audit.WithRoute(&audit.EventRoute{IncludeCategories: []string{"write"}})),   // write only
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -782,10 +802,11 @@ func createRoutedAuditor(tc *AuditTestContext, webhookRoute *audit.EventRoute) e
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(f),
 		audit.WithNamedOutput(w, audit.WithRoute(webhookRoute)),
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err

--- a/tests/bdd/steps/file_steps.go
+++ b/tests/bdd/steps/file_steps.go
@@ -227,7 +227,11 @@ func registerFileThenValidationSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 // --- Extracted step implementations ---
 
 func createNoOutputAuditor(tc *AuditTestContext) error {
-	opts := []audit.Option{audit.WithTaxonomy(tc.Taxonomy)}
+	opts := []audit.Option{
+		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+	}
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err
@@ -530,6 +534,8 @@ func createFileAuditorImpl(tc *AuditTestContext, fileCfg file.Config, fileMetric
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(fileOut),
 	}
 	if tc.MockMetrics != nil {
@@ -537,7 +543,6 @@ func createFileAuditorImpl(tc *AuditTestContext, fileCfg file.Config, fileMetric
 	}
 	opts = append(opts, tc.Options...)
 	opts = append(opts, extraOpts...)
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		tc.LastErr = err

--- a/tests/bdd/steps/formatter_steps.go
+++ b/tests/bdd/steps/formatter_steps.go
@@ -64,6 +64,8 @@ func registerFormatterGivenJSONSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithFormatter(&audit.JSONFormatter{Timestamp: audit.TimestampUnixMillis}),
 			audit.WithOutputs(fileOut),
 		}
@@ -109,6 +111,8 @@ func registerFormatterGivenCEFSteps(ctx *godog.ScenarioContext, tc *AuditTestCon
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 		opts = append(opts, tc.Options...)
@@ -151,6 +155,8 @@ func registerFormatterGivenMultiSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(jsonOut),                                   // default JSON
 			audit.WithNamedOutput(cefOut, audit.WithOutputFormatter(cefFmt)), // CEF
 		}
@@ -192,6 +198,8 @@ func registerFormatterGivenCustomSeveritySteps(ctx *godog.ScenarioContext, tc *A
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 
@@ -229,6 +237,8 @@ func registerFormatterGivenInvalidKeySteps(ctx *godog.ScenarioContext, tc *Audit
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 
@@ -264,6 +274,8 @@ func registerFormatterGivenSeveritySteps(ctx *godog.ScenarioContext, tc *AuditTe
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 
@@ -303,6 +315,8 @@ func registerFormatterGivenExtraSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(fileOut, audit.WithOutputFormatter(cefFmt)),
 		}
 
@@ -434,7 +448,7 @@ func assertFileEventMatching(tc *AuditTestContext, table *godog.Table) error {
 	if err != nil {
 		return err
 	}
-	autoFields := []string{"timestamp", "severity", "event_category", "pid", "timezone"}
+	autoFields := []string{"timestamp", "severity", "event_category", "pid", "timezone", "app_name", "host"}
 	for _, e := range events {
 		match, mismatch := eventMatchesExactly(e, expected, autoFields)
 		if match {

--- a/tests/bdd/steps/hmac_steps.go
+++ b/tests/bdd/steps/hmac_steps.go
@@ -41,6 +41,8 @@ func registerHMACGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 			auditor, err := audit.New(
 				audit.WithTaxonomy(tc.Taxonomy),
+				audit.WithAppName("test-app"),
+				audit.WithHost("test-host"),
 				audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 					Enabled: true,
 					Salt: audit.HMACSalt{
@@ -65,6 +67,8 @@ func registerHMACWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 			_, err := audit.New(
 				audit.WithTaxonomy(tc.Taxonomy),
+				audit.WithAppName("test-app"),
+				audit.WithHost("test-host"),
 				audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 					Enabled: true,
 					Salt: audit.HMACSalt{
@@ -523,6 +527,8 @@ func createDualHMACAuditor(tc *AuditTestContext, strippedName, label, fullSalt, 
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fullOut, audit.WithHMAC(fullHMACCfg)),
 		audit.WithNamedOutput(strippedOut, audit.WithExcludeLabels(label), audit.WithHMAC(strippedHMACCfg)),
 	)

--- a/tests/bdd/steps/isolation_steps.go
+++ b/tests/bdd/steps/isolation_steps.go
@@ -67,6 +67,8 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		recOut1 = &recordingMockOutput{name: "recording-1"}
 		tc.Auditor, err = audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(stdout, recOut1),
 			audit.WithQueueSize(1000),
 		)
@@ -81,6 +83,8 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		}
 		tc.Auditor, err = audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(stdout),
 			audit.WithQueueSize(1000),
 		)
@@ -93,6 +97,8 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		var err error
 		tc.Auditor, err = audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(recOut1, recOut2),
 			audit.WithQueueSize(1000),
 		)

--- a/tests/bdd/steps/loki_fanout_steps.go
+++ b/tests/bdd/steps/loki_fanout_steps.go
@@ -246,7 +246,6 @@ func createFileAndLokiAuditor(tc *AuditTestContext, hmacCfg *audit.HMACConfig, l
 		audit.WithNamedOutput(fileOut, fileOpts...),
 		audit.WithNamedOutput(lokiOut, lokiOpts...),
 	)
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)

--- a/tests/bdd/steps/loki_hmac_steps.go
+++ b/tests/bdd/steps/loki_hmac_steps.go
@@ -279,7 +279,6 @@ func createLokiAuditorWithHMAC(tc *AuditTestContext, salt, version, hash string,
 		})))
 	}
 	opts = append(opts, audit.WithNamedOutput(out, lokiOpts...))
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)

--- a/tests/bdd/steps/loki_receiver_steps.go
+++ b/tests/bdd/steps/loki_receiver_steps.go
@@ -246,6 +246,8 @@ func registerLokiReceiverLoggerRetrySteps(ctx *godog.ScenarioContext, tc *AuditT
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(out),
 		}
 		auditor, err := audit.New(opts...)

--- a/tests/bdd/steps/metadata_writer_steps.go
+++ b/tests/bdd/steps/metadata_writer_steps.go
@@ -85,6 +85,8 @@ func registerMetadataWriterGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(mock),
 		}
 		opts = append(opts, tc.Options...)

--- a/tests/bdd/steps/metrics_steps.go
+++ b/tests/bdd/steps/metrics_steps.go
@@ -94,6 +94,8 @@ func registerMetricsGivenAdvancedSteps(ctx *godog.ScenarioContext, tc *AuditTest
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithNamedOutput(stdoutOut),
 			audit.WithNamedOutput(fileOut),
@@ -128,6 +130,8 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithOutputs(w),
 		}
@@ -152,6 +156,8 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithFormatter(&panicFormatter{}),
 			audit.WithOutputs(stdoutOut),
@@ -177,6 +183,8 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithFormatter(&errorReturningFormatter{}),
 			audit.WithOutputs(stdoutOut),
@@ -194,6 +202,8 @@ func registerMetricsGivenWebhookSteps(ctx *godog.ScenarioContext, tc *AuditTestC
 	ctx.Step(`^an auditor with error output and metrics$`, func() error {
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithNamedOutput(&errorOutput{}),
 		}
@@ -234,6 +244,8 @@ func registerMetricsGivenFilterSteps(ctx *godog.ScenarioContext, tc *AuditTestCo
 
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithMetrics(tc.MockMetrics),
 			audit.WithNamedOutput(fileOut),
 			audit.WithNamedOutput(whOut, audit.WithRoute(&audit.EventRoute{ExcludeCategories: []string{excludeCat}})),

--- a/tests/bdd/steps/multicat_steps.go
+++ b/tests/bdd/steps/multicat_steps.go
@@ -134,6 +134,8 @@ func createMultiCatAuditor(tc *AuditTestContext, route *audit.EventRoute, format
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithRoute(route), audit.WithOutputFormatter(formatter)),
 	)
 	if err != nil {

--- a/tests/bdd/steps/sensitivity_steps.go
+++ b/tests/bdd/steps/sensitivity_steps.go
@@ -72,6 +72,8 @@ func createSensitivityAuditor(tc *AuditTestContext, excludeLabels []string) erro
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels(excludeLabels...)),
 	)
 	if err != nil {

--- a/tests/bdd/steps/severity_routing_steps.go
+++ b/tests/bdd/steps/severity_routing_steps.go
@@ -131,6 +131,8 @@ func registerSeverityLoggerSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 		}
 		auditor, err := audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithNamedOutput(audit.WrapOutput(stdout, name)),
 			audit.WithSynchronousDelivery(),
 		)
@@ -159,6 +161,8 @@ func createSeverityRoutedAuditor(tc *AuditTestContext, minSev, maxSev *int, incl
 	}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithRoute(route)),
 	)
 	if err != nil {
@@ -204,6 +208,8 @@ func trySeverityLoggerCreation(tc *AuditTestContext, minSev, maxSev *int) error 
 	}
 	auditor, lErr := audit.New(
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(stdout, audit.WithRoute(route)),
 	)
 	tc.LastErr = lErr

--- a/tests/bdd/steps/shutdown_steps.go
+++ b/tests/bdd/steps/shutdown_steps.go
@@ -54,6 +54,8 @@ func registerShutdownSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 		auditor, err := audit.New(
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(blocking),
 			audit.WithShutdownTimeout(time.Duration(timeoutSecs)*time.Second),
 		)

--- a/tests/bdd/steps/syslog_severity_steps.go
+++ b/tests/bdd/steps/syslog_severity_steps.go
@@ -345,10 +345,11 @@ func createSyslogAuditorWithFormatter(tc *AuditTestContext, cfg *syslog.Config, 
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithOutputFormatter(formatter)),
 	}
 	opts = append(opts, tc.Options...)
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -373,6 +374,8 @@ func createSyslogAuditorWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt,
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithHMAC(&audit.HMACConfig{
 			Enabled: true,
 			Salt: audit.HMACSalt{
@@ -383,7 +386,6 @@ func createSyslogAuditorWithHMAC(tc *AuditTestContext, cfg *syslog.Config, salt,
 		})),
 	}
 	opts = append(opts, tc.Options...)
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -408,10 +410,11 @@ func createSyslogAuditorWithExcludeLabels(tc *AuditTestContext, cfg *syslog.Conf
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithExcludeLabels(excludeLabels...)),
 	}
 	opts = append(opts, tc.Options...)
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -451,10 +454,11 @@ func createSyslogAuditorWithRoute(tc *AuditTestContext, cfg *syslog.Config, rout
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(route)),
 	}
 	opts = append(opts, tc.Options...)
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)

--- a/tests/bdd/steps/syslog_steps.go
+++ b/tests/bdd/steps/syslog_steps.go
@@ -528,10 +528,11 @@ func createSyslogAuditor(tc *AuditTestContext, cfg *syslog.Config) error {
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	}
 	opts = append(opts, tc.Options...)
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -558,10 +559,11 @@ func createSyslogAuditorWithMetrics(tc *AuditTestContext, cfg *syslog.Config) er
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	}
 	opts = append(opts, tc.Options...)
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)

--- a/tests/bdd/steps/webhook_steps.go
+++ b/tests/bdd/steps/webhook_steps.go
@@ -313,6 +313,8 @@ func registerWebhookGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 		tc.AddCleanup(func() { _ = out.Close() })
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(out),
 		}
 		auditor, err := audit.New(opts...)
@@ -372,6 +374,8 @@ func registerWebhookGivenSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 		tc.AddCleanup(func() { _ = out.Close() })
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(out),
 		}
 		auditor, err := audit.New(opts...)
@@ -443,6 +447,8 @@ func registerWebhookGivenSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 		}
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(out),
 		}
 		auditor, err := audit.New(opts...)
@@ -478,6 +484,8 @@ func registerWebhookGivenSSRFSteps(ctx *godog.ScenarioContext, tc *AuditTestCont
 		}
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(out),
 		}
 		auditor, err := audit.New(opts...)
@@ -662,6 +670,8 @@ func registerWebhookWhenConstructionSteps(ctx *godog.ScenarioContext, tc *AuditT
 		}
 		opts := []audit.Option{
 			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
 			audit.WithOutputs(out),
 		}
 		auditor, err := audit.New(opts...)
@@ -805,9 +815,10 @@ func createWebhookAuditorWithWebhookMetrics(tc *AuditTestContext, batchSize int)
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -835,9 +846,10 @@ func createWebhookAuditorFromConfig(tc *AuditTestContext, cfg *webhook.Config) e
 
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	}
-
 	auditor, err := audit.New(opts...)
 	if err != nil {
 		return fmt.Errorf("create auditor: %w", err)
@@ -1124,6 +1136,8 @@ func createWebhookAuditorSSRF(tc *AuditTestContext, url string, allowPrivate boo
 	}
 	opts := []audit.Option{
 		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	}
 	auditor, err := audit.New(opts...)

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -179,6 +179,8 @@ func TestFanOut_AllOutputs(t *testing.T) {
 	// Create auditor with all three outputs.
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(syslogOut),
 		audit.WithNamedOutput(webhookOut),
@@ -238,6 +240,8 @@ func TestFanOut_EventRouting(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut), // all events
 		audit.WithNamedOutput(webhookOut, audit.WithRoute(&audit.EventRoute{
 			IncludeCategories: []string{"security"},
@@ -325,6 +329,8 @@ func TestFanOut_PartialFailure(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut),
 		audit.WithNamedOutput(syslogOut),
 		audit.WithNamedOutput(webhookOut),
@@ -378,6 +384,8 @@ func TestFanOut_MixedFormatters(t *testing.T) {
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut),                                       // JSON (default)
 		audit.WithNamedOutput(webhookOut, audit.WithOutputFormatter(cefFmt)), // CEF
 	)

--- a/validate_taxonomy.go
+++ b/validate_taxonomy.go
@@ -200,22 +200,25 @@ func invalidTaxonomyNameMsg(position, name string) string {
 	return ""
 }
 
-// checkSeverityRanges validates that severity values are in range 0-10.
+// checkSeverityRanges validates that severity values are in the range
+// [MinSeverity, MaxSeverity].
 func checkSeverityRanges(t Taxonomy) []string {
 	var errs []string
 	for cat, catDef := range t.Categories {
 		if catDef == nil {
 			continue // nil categories caught by checkCategoryConsistency
 		}
-		if catDef.Severity != nil && (*catDef.Severity < 0 || *catDef.Severity > 10) {
+		if catDef.Severity != nil && (*catDef.Severity < MinSeverity || *catDef.Severity > MaxSeverity) {
 			errs = append(errs, fmt.Sprintf(
-				"category %q severity %d is out of range 0-10", cat, *catDef.Severity))
+				"category %q severity %d is out of range %d-%d",
+				cat, *catDef.Severity, MinSeverity, MaxSeverity))
 		}
 	}
 	for et, def := range t.Events {
-		if def.Severity != nil && (*def.Severity < 0 || *def.Severity > 10) {
+		if def.Severity != nil && (*def.Severity < MinSeverity || *def.Severity > MaxSeverity) {
 			errs = append(errs, fmt.Sprintf(
-				"event %q severity %d is out of range 0-10", et, *def.Severity))
+				"event %q severity %d is out of range %d-%d",
+				et, *def.Severity, MinSeverity, MaxSeverity))
 		}
 	}
 	return errs

--- a/validation_error_test.go
+++ b/validation_error_test.go
@@ -34,6 +34,8 @@ func TestAuditEvent_AllValidationErrors_WrapErrValidation(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -79,6 +81,8 @@ func TestAuditEvent_UnknownEventType_WrapsErrUnknownEventType(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -98,6 +102,8 @@ func TestAuditEvent_MissingRequired_WrapsErrMissingRequiredField(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -117,6 +123,8 @@ func TestAuditEvent_UnknownFieldStrict_WrapsErrUnknownField(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -160,6 +168,8 @@ func TestValidationError_ErrorsAs(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -182,6 +192,8 @@ func TestValidationError_MessageTextUnchanged(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -207,6 +219,8 @@ func TestValidationError_ConsumerWrapping_PreservesErrorsIs(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -231,6 +245,8 @@ func TestAuditEvent_WarnMode_NoSentinelLeak(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationWarn),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -250,6 +266,8 @@ func TestAuditEvent_PermissiveMode_NoSentinelLeak(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -272,6 +290,8 @@ func TestAuditEvent_ReservedStandardField_NotErrUnknownField(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -295,6 +315,8 @@ func TestAuditEvent_EmptyEventType_WrapsErrUnknownEventType(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -318,6 +340,8 @@ func TestValidationError_Unwrap_ReturnsIndependentSlice(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1397,6 +1397,8 @@ func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithTaxonomy(testTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithNamedOutput(webhookOut, audit.WithRoute(&audit.EventRoute{})),
 		audit.WithMetrics(metrics),
 	)

--- a/with_diagnostic_logger_test.go
+++ b/with_diagnostic_logger_test.go
@@ -34,6 +34,8 @@ func TestWithDiagnosticLogger_CustomLogger_ReceivesMessages(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithDiagnosticLogger(customLogger),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -51,6 +53,8 @@ func TestWithDiagnosticLogger_NilLogger_UsesDefault(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithDiagnosticLogger(nil),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)
@@ -68,6 +72,8 @@ func TestWithDiagnosticLogger_DiscardLogger_SilencesOutput(t *testing.T) {
 	auditor, err := audit.New(
 		audit.WithDiagnosticLogger(discardLogger),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Bundled P2 API polish for v1.0 — seven findings in a single atomic commit (B-17, B-27, B-29, B-33, B-39, B-41, B-45). Pre-coding consult with api-ergonomics-reviewer locked Option A for B-41 (fail-fast with sentinels) and Option C for B-45 (mixed classification by semantic).

Closes #593.

## Findings addressed

- **B-17** TLSPolicy zero-value docs + tests already complete — verified, no code change.
- **B-27** New `audit.MinSeverity` / `audit.MaxSeverity` exported constants replace four magic-number sites.
- **B-29** `Auditor.Handle` godoc documents disabled-auditor no-op semantics; new locking test.
- **B-33** `secrets/openbao.Provider.Close` and `secrets/vault.Provider.Close` godoc claims idempotency; two new three-call tests.
- **B-39** audittest internal helper `newTestLogger` renamed to `newTestAuditor` (tail of the Logger → Auditor migration).
- **B-41** `audit.New` rejects missing `WithAppName` / `WithHost` / `WithTaxonomy` with new `ErrAppNameRequired` / `ErrHostRequired` / `ErrTaxonomyRequired` sentinels. Matches `outputconfig.Load` YAML contract. `audittest.New` seeds sensible test defaults. New BDD scenarios cover the three rejection paths plus a disabled-bypass.
- **B-45** `options.go` package doc + per-option godoc classify Required / Validated-on-call / Optional options. No runtime change.

## Breaking change

Programmatic callers of `audit.New` that omit `WithAppName` or `WithHost` now receive `ErrAppNameRequired` / `ErrHostRequired`. Migration snippet in CHANGELOG.

## Test plan

- [x] `make check` passes (lint + test + security scan across all 12 modules)
- [x] `make test-bdd` passes (core, file, syslog, webhook, loki, secrets, outputconfig)
- [x] New unit tests: `TestNew_MissingAppName_ReturnsErrAppNameRequired`, `TestNew_MissingHost_ReturnsErrHostRequired`, `TestNew_WithDisabled_AllowsMissingAppNameAndHost`, `TestSeverity_ExportedConstants`, `TestAuditorHandle_DisabledAuditor_ReturnsNoOpHandle`, `TestOpenbaoClose_IsIdempotent`, `TestVaultClose_IsIdempotent`
- [x] New BDD scenarios in `tests/bdd/features/config_versioning.feature` for B-41
- [x] `examples/01-basic` runs cleanly with the new required-options contract