### PR TITLE
refactor: rename Metrics.RecordEvent to RecordDelivery (#594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `audit.Metrics` interface shape locked for v1.0 via [ADR 0005](docs/adr/0005-metrics-interface-shape.md) (#594). Kept the existing nine-method shape after api-ergonomics-reviewer rejected both the single-method `Record(MetricEvent)` tagged-union proposal (reintroduces untyped payload + adds a hot-path allocation) and the split `LifecycleMetrics` / `DeliveryMetrics` / `ValidationMetrics` composed-interface proposal (silent-compile footgun when consumers embed two of three no-op partial bases). Nine methods grouped by purpose matches stdlib precedent (`slog.Handler` ×4, `http.ResponseWriter` + optional extensions, `driver.Conn`/`Stmt`/`Rows` 4-6 each). Forward-compatibility policy: new metrics added in v1.x land as separate optional interfaces detected via type assertion on the `Metrics` value (same pattern as `DeliveryReporter` / `file.RotationRecorder` / `syslog.ReconnectRecorder`); consumers embedding `NoOpMetrics` automatically retain no-op implementations. Per-method Prometheus cardinality guidance added to godoc so consumers wiring label vectors see the label-space impact. Capstone Prometheus adapter rewritten using a `vec()` helper and `NoOpMetrics` embedding — the audit-side of `examples/17-capstone/metrics.go` is now 34 lines of significant code (struct + constructor + seven `Record*` methods), comfortably inside the 50-line AC target. New `TestNoOpMetrics_AllMethodsArePresent` locks the forward-compat embed pattern at test time.
+
 - Small API-polish bundle #593:
   - **B-17** TLSPolicy zero-value docs & tests verified — no code change (already documented and tested at `tls_policy.go:19-39`; `TestTLSPolicy_Apply_NilReceiver_DefaultsTLS13` and `TestTLSPolicy_Apply_ZeroValue_DefaultsTLS13` already present).
   - **B-27** Exported `MinSeverity` / `MaxSeverity` severity-range constants; updated four magic-number call sites (`filter.go`, `taxonomy.go`, `validate_taxonomy.go`). See `### Added` above.
@@ -34,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   
   `outputconfig.ErrOutputConfigInvalid` now wraps `audit.ErrConfigInvalid` so `errors.Is(err, audit.ErrConfigInvalid)` matches every configuration-validation failure — a single sentinel across outputs, config, and secrets (stdlib `fs.ErrNotExist` / `os.ErrNotExist` pattern). Consumers matching errors with `strings.Contains(err.Error(), "vault:")` must migrate to `errors.Is` / `errors.As` on sentinels (already forbidden by project style).
 
-- Self-reporting output drop metrics are now consistent (#592). Webhook and Loki no longer call pipeline-level `Metrics.RecordEvent(name, audit.EventError)` on **buffer drops** (oversized event or buffer full); those drops now surface only via `OutputMetrics.RecordDrop()`, matching file + syslog. Retry-exhaustion failures in webhook/loki (where delivery WAS attempted) still call `RecordEvent(EventError)` — those are genuine delivery errors, not buffer drops. Consumers relying on `RecordEvent` as a pre-delivery drop counter should use `OutputMetrics.RecordDrop` for that counter.
+- Self-reporting output drop metrics are now consistent (#592). Webhook and Loki no longer call pipeline-level `Metrics.RecordDelivery(name, audit.EventError)` on **buffer drops** (oversized event or buffer full); those drops now surface only via `OutputMetrics.RecordDrop()`, matching file + syslog. Retry-exhaustion failures in webhook/loki (where delivery WAS attempted) still call `RecordDelivery(EventError)` — those are genuine delivery errors, not buffer drops. Consumers relying on `RecordDelivery` as a pre-delivery drop counter should use `OutputMetrics.RecordDrop` for that counter.
 
 - `secrets.redactRef` drops its unused parameter (#592 B-35). The function was already returning a constant; the `_` parameter was dead. Internal helper — no consumer impact.
 
@@ -52,6 +54,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Examples `02-code-generation`, `04-testing`, `06-middleware`, `13-standard-fields`, and `15-tls-policy` failed at runtime with `unknown output type "stdout"` because they declared `type: stdout` in `outputs.yaml` without blank-importing anything that registered the stdout factory (stdout auto-registration was removed in #578). The new `_ "github.com/axonops/audit/outputs"` blank import registers stdout alongside the other built-ins (#585).
 
 ### Breaking Changes
+
+- `audit.Metrics.RecordEvent` renamed to `RecordDelivery` (#594). The new name matches the method's actual role (per-output delivery outcome) and removes the semantic collision with `RecordSubmitted` in readers' heads. Migration is a one-line find-and-replace for every consumer of the interface:
+  ```go
+  // Before
+  func (m *myMetrics) RecordEvent(output string, status audit.EventStatus) { ... }
+  // After
+  func (m *myMetrics) RecordDelivery(output string, status audit.EventStatus) { ... }
+  ```
+  All library-internal call sites, test mocks, and the capstone example are updated in lockstep.
 
 - `audit.New` now rejects configurations that omit `WithAppName` or `WithHost` (#593 B-41), matching the existing `outputconfig.Load` YAML-path contract. Missing values yield `ErrAppNameRequired` / `ErrHostRequired`. Callers using `WithDisabled` remain free of the requirement. Migration:
   ```go
@@ -71,7 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   ```
   `audittest.New` / `audittest.NewQuick` gain sensible test defaults (`"audittest"` / `"localhost"`) so existing tests continue to work without changes.
 
-- `audit.Metrics.RecordEvent` now takes a typed `audit.EventStatus` instead of a raw `string` (#586). New exported type `type EventStatus string` with constants `audit.EventSuccess` (`"success"`) and `audit.EventError` (`"error"`). Prometheus / OpenTelemetry wire format is unchanged — `string(status)` is a zero-cost conversion that emits the identical label bytes that were previously hardcoded. Consumers implementing the `Metrics` interface (e.g. Prometheus adapter) must update the `RecordEvent` method signature. Test mocks migrated in lockstep: `audittest.MetricsRecorder.EventDeliveries` and `internal/testhelper.MockMetrics.GetEventCount` both now take `audit.EventStatus`. Pre-coding consult with api-ergonomics-reviewer locked the `string`-backed enum over `int`-backed for hot-path efficiency and wire-format stability. Migration:
+- `audit.Metrics.RecordDelivery` (renamed from `RecordEvent` by #594) now takes a typed `audit.EventStatus` instead of a raw `string` (#586). New exported type `type EventStatus string` with constants `audit.EventSuccess` (`"success"`) and `audit.EventError` (`"error"`). Prometheus / OpenTelemetry wire format is unchanged — `string(status)` is a zero-cost conversion that emits the identical label bytes that were previously hardcoded. Consumers implementing the `Metrics` interface (e.g. Prometheus adapter) must update the delivery-recording method signature. Test mocks migrated in lockstep: `audittest.MetricsRecorder.EventDeliveries` and `internal/testhelper.MockMetrics.GetEventCount` both now take `audit.EventStatus`. Pre-coding consult with api-ergonomics-reviewer locked the `string`-backed enum over `int`-backed for hot-path efficiency and wire-format stability. Migration:
   ```go
   // Before
   type myMetrics struct{ /* ... */ }
@@ -79,8 +90,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
       m.events.WithLabelValues(output, status).Inc()
   }
 
-  // After
-  func (m *myMetrics) RecordEvent(output string, status audit.EventStatus) {
+  // After (combined #586 typed status + #594 rename)
+  func (m *myMetrics) RecordDelivery(output string, status audit.EventStatus) {
       m.events.WithLabelValues(output, string(status)).Inc()
   }
   ```

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -124,7 +124,7 @@ Every issue follows this sequence. Do not skip steps.
 - [x] **#591** refactor: CEFFormatter ergonomics — FieldMapping opt-out path, avoid redundant severity clamp, cite maxCEFHeaderField.
 - [x] **#592** refactor: unify error wrapping conventions across modules; align self-reporting drop metrics; drop dead redactRef parameter.
 - [x] **#593** refactor: small API polish — TLSPolicy zero-value docs, MinSeverity/MaxSeverity constants, Handle on disabled auditor, openbao Close idempotency, audittest rename, require AppName/Host, uniform nil-option handling.
-- [ ] **#594** refactor: simplify 9-method Metrics interface into MetricEvent or split into lifecycle/delivery/validation interfaces.
+- [x] **#594** refactor: simplify 9-method Metrics interface into MetricEvent or split into lifecycle/delivery/validation interfaces. (ADR 0005 locks the 9-method shape; renamed `RecordEvent` → `RecordDelivery`; capstone adapter shrunk to ≤50 lines significant code.)
 - [ ] **#595** refactor: Fields rejects unsupported value types; WithStandardFieldDefaults accepts any.
 - [ ] **#596** refactor: consolidate 6 optional Output interfaces into OutputCapabilities struct.
 - [ ] **#597** refactor: enrich Event interface with Description/Categories/FieldInfo; document emission paths.

--- a/audit_test.go
+++ b/audit_test.go
@@ -1485,7 +1485,7 @@ func TestLogger_Audit_MetricsRecordSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
 
-	// Wait for the metric to be recorded — RecordEvent fires after
+	// Wait for the metric to be recorded — RecordDelivery fires after
 	// Write returns, so WaitForEvents alone is insufficient.
 	require.True(t, metrics.WaitForMetric("test-out:success", 1, 2*time.Second),
 		"timed out waiting for success metric")
@@ -2122,7 +2122,7 @@ func TestAudit_NilMetrics_NoPanic(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // deliveryReporterOutput is a mock output that implements DeliveryReporter.
-// It reports its own delivery, so the core auditor must NOT call RecordEvent
+// It reports its own delivery, so the core auditor must NOT call RecordDelivery
 // or RecordOutputError for it.
 type deliveryReporterOutput struct {
 	writeErrToReturn error
@@ -2149,7 +2149,7 @@ var _ audit.Output = (*deliveryReporterOutput)(nil)
 
 func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
 	// When an output satisfies DeliveryReporter and ReportsDelivery()
-	// returns true, the core auditor must NOT call RecordEvent on success.
+	// returns true, the core auditor must NOT call RecordDelivery on success.
 	metrics := testhelper.NewMockMetrics()
 	out := newDeliveryReporterOutput("self-reporting")
 
@@ -2171,16 +2171,16 @@ func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
 	// The self-reporting output received the event.
 	assert.Equal(t, 1, out.EventCount())
 
-	// The core auditor must not have called RecordEvent for this output.
+	// The core auditor must not have called RecordDelivery for this output.
 	assert.Equal(t, 0, metrics.GetEventCount("self-reporting", audit.EventSuccess),
-		"core auditor must not call RecordEvent(success) for DeliveryReporter outputs")
+		"core auditor must not call RecordDelivery(success) for DeliveryReporter outputs")
 	assert.Equal(t, 0, metrics.GetEventCount("self-reporting", audit.EventError),
-		"core auditor must not call RecordEvent(error) for DeliveryReporter outputs")
+		"core auditor must not call RecordDelivery(error) for DeliveryReporter outputs")
 }
 
 func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
 	// When a DeliveryReporter output fails on Write, the core auditor must
-	// NOT call RecordEvent or RecordOutputError — the output is responsible.
+	// NOT call RecordDelivery or RecordOutputError — the output is responsible.
 	metrics := testhelper.NewMockMetrics()
 	out := newDeliveryReporterOutput("self-reporting-fail")
 	out.writeErrToReturn = errors.New("delivery failed")
@@ -2202,9 +2202,9 @@ func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
 
 	// Core auditor must not record any metrics for the self-reporting output.
 	assert.Equal(t, 0, metrics.GetEventCount("self-reporting-fail", audit.EventSuccess),
-		"core auditor must not call RecordEvent(success) for DeliveryReporter outputs")
+		"core auditor must not call RecordDelivery(success) for DeliveryReporter outputs")
 	assert.Equal(t, 0, metrics.GetEventCount("self-reporting-fail", audit.EventError),
-		"core auditor must not call RecordEvent(error) for DeliveryReporter outputs")
+		"core auditor must not call RecordDelivery(error) for DeliveryReporter outputs")
 
 	metrics.Mu.Lock()
 	errCount := metrics.OutputErrors["self-reporting-fail"]
@@ -2214,7 +2214,7 @@ func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
 }
 
 func TestWriteToOutput_NonDeliveryReporter_SuccessRecordsCoreMetrics(t *testing.T) {
-	// A plain output (not DeliveryReporter) must have RecordEvent(success)
+	// A plain output (not DeliveryReporter) must have RecordDelivery(success)
 	// called by the core auditor on a successful write.
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("plain")
@@ -2235,7 +2235,7 @@ func TestWriteToOutput_NonDeliveryReporter_SuccessRecordsCoreMetrics(t *testing.
 	require.NoError(t, auditor.Close())
 
 	assert.Greater(t, metrics.GetEventCount("plain", audit.EventSuccess), 0,
-		"core auditor must call RecordEvent(success) for plain (non-DeliveryReporter) outputs")
+		"core auditor must call RecordDelivery(success) for plain (non-DeliveryReporter) outputs")
 }
 
 // ---------------------------------------------------------------------------
@@ -4604,7 +4604,7 @@ func TestMetadataWriter_UncategorisedEvent_EmptyCategory(t *testing.T) {
 }
 
 // TestMetadataWriter_MetricsPreserved verifies that when WriteWithMetadata
-// succeeds, the core auditor records RecordEvent(name, "success"). This mirrors
+// succeeds, the core auditor records RecordDelivery(name, "success"). This mirrors
 // the same metrics contract that Write has.
 func TestMetadataWriter_MetricsPreserved(t *testing.T) {
 	t.Parallel()
@@ -4630,17 +4630,17 @@ func TestMetadataWriter_MetricsPreserved(t *testing.T) {
 	require.NoError(t, auditor.Close())
 
 	assert.Greater(t, metrics.GetEventCount("mw-metrics", audit.EventSuccess), 0,
-		"RecordEvent(name, \"success\") must be called after a successful WriteWithMetadata")
+		"RecordDelivery(name, \"success\") must be called after a successful WriteWithMetadata")
 	assert.Equal(t, 0, metrics.GetEventCount("mw-metrics", audit.EventError),
-		"RecordEvent(name, \"error\") must not be called on success")
+		"RecordDelivery(name, \"error\") must not be called on success")
 	assert.Equal(t, 0, metrics.GetOutputErrorCount("mw-metrics"),
 		"RecordOutputError must not be called on success")
 }
 
 // TestMetadataWriter_WriteError_RecordsMetrics verifies that when
 // WriteWithMetadata returns an error, the core auditor calls both
-// RecordOutputError and RecordEvent(name, "error"), and does NOT call
-// RecordEvent(name, "success").
+// RecordOutputError and RecordDelivery(name, "error"), and does NOT call
+// RecordDelivery(name, "success").
 func TestMetadataWriter_WriteError_RecordsMetrics(t *testing.T) {
 	t.Parallel()
 
@@ -4666,16 +4666,16 @@ func TestMetadataWriter_WriteError_RecordsMetrics(t *testing.T) {
 	require.NoError(t, auditor.Close())
 
 	assert.Greater(t, metrics.GetEventCount("mw-err-out", audit.EventError), 0,
-		"RecordEvent(name, \"error\") must be called when WriteWithMetadata returns an error")
+		"RecordDelivery(name, \"error\") must be called when WriteWithMetadata returns an error")
 	assert.Greater(t, metrics.GetOutputErrorCount("mw-err-out"), 0,
 		"RecordOutputError must be called when WriteWithMetadata returns an error")
 	assert.Equal(t, 0, metrics.GetEventCount("mw-err-out", audit.EventSuccess),
-		"RecordEvent(name, \"success\") must not be called when WriteWithMetadata returns an error")
+		"RecordDelivery(name, \"success\") must not be called when WriteWithMetadata returns an error")
 }
 
 // TestMetadataWriter_DeliveryReporter_SkipsMetrics verifies that when an
 // output implements all three interfaces (Output, MetadataWriter, and
-// DeliveryReporter), the core auditor skips its own RecordEvent and
+// DeliveryReporter), the core auditor skips its own RecordDelivery and
 // RecordOutputError calls — regardless of whether WriteWithMetadata
 // succeeds or fails.
 func TestMetadataWriter_DeliveryReporter_SkipsMetrics(t *testing.T) {
@@ -4707,9 +4707,9 @@ func TestMetadataWriter_DeliveryReporter_SkipsMetrics(t *testing.T) {
 
 	// The core auditor must not have called any metrics for this output.
 	assert.Equal(t, 0, metrics.GetEventCount("mw-dr", audit.EventSuccess),
-		"core auditor must not call RecordEvent(success) for a MetadataWriter+DeliveryReporter output")
+		"core auditor must not call RecordDelivery(success) for a MetadataWriter+DeliveryReporter output")
 	assert.Equal(t, 0, metrics.GetEventCount("mw-dr", audit.EventError),
-		"core auditor must not call RecordEvent(error) for a MetadataWriter+DeliveryReporter output")
+		"core auditor must not call RecordDelivery(error) for a MetadataWriter+DeliveryReporter output")
 	assert.Equal(t, 0, metrics.GetOutputErrorCount("mw-dr"),
 		"core auditor must not call RecordOutputError for a MetadataWriter+DeliveryReporter output")
 }

--- a/audittest/metrics.go
+++ b/audittest/metrics.go
@@ -70,8 +70,8 @@ func (m *MetricsRecorder) RecordSubmitted() {
 	m.mu.Unlock()
 }
 
-// RecordEvent implements [audit.Metrics].
-func (m *MetricsRecorder) RecordEvent(output string, status audit.EventStatus) {
+// RecordDelivery implements [audit.Metrics].
+func (m *MetricsRecorder) RecordDelivery(output string, status audit.EventStatus) {
 	m.mu.Lock()
 	m.events[output+":"+string(status)]++
 	m.mu.Unlock()

--- a/audittest/metrics_test.go
+++ b/audittest/metrics_test.go
@@ -28,9 +28,9 @@ func TestMetricsRecorder_AllMethods(t *testing.T) {
 	t.Parallel()
 	m := audittest.NewMetricsRecorder()
 
-	m.RecordEvent("recorder", audit.EventSuccess)
-	m.RecordEvent("recorder", audit.EventSuccess)
-	m.RecordEvent("recorder", audit.EventError)
+	m.RecordDelivery("recorder", audit.EventSuccess)
+	m.RecordDelivery("recorder", audit.EventSuccess)
+	m.RecordDelivery("recorder", audit.EventError)
 	m.RecordOutputError("recorder")
 	m.RecordOutputFiltered("recorder")
 	m.RecordValidationError("user_create")
@@ -93,7 +93,7 @@ func TestMetricsRecorder_Reset(t *testing.T) {
 	m := audittest.NewMetricsRecorder()
 
 	// Core metrics.
-	m.RecordEvent("recorder", audit.EventSuccess)
+	m.RecordDelivery("recorder", audit.EventSuccess)
 	m.RecordBufferDrop()
 	m.RecordValidationError("test")
 
@@ -130,7 +130,7 @@ func TestMetricsRecorder_Reset_AllFields(t *testing.T) {
 
 	// Populate all 10 metric fields.
 	m.RecordSubmitted()
-	m.RecordEvent("out", audit.EventSuccess)
+	m.RecordDelivery("out", audit.EventSuccess)
 	m.RecordOutputError("out")
 	m.RecordOutputFiltered("out")
 	m.RecordValidationError("evt")
@@ -164,7 +164,7 @@ func TestMetricsRecorder_Concurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			m.RecordSubmitted()
-			m.RecordEvent("out", audit.EventSuccess)
+			m.RecordDelivery("out", audit.EventSuccess)
 			m.RecordOutputError("out")
 			m.RecordBufferDrop()
 			_ = m.SubmittedCount()

--- a/docs/adr/0005-metrics-interface-shape.md
+++ b/docs/adr/0005-metrics-interface-shape.md
@@ -1,0 +1,216 @@
+# ADR 0005: Metrics Interface Shape
+
+- **Status:** Accepted (2026-04-24)
+- **Issue:** [#594](https://github.com/axonops/audit/issues/594)
+- **Reviewers:** api-ergonomics-reviewer (APPROVED)
+- **Supersedes:** —
+
+## Context
+
+The audit pipeline exposes a pluggable instrumentation contract —
+`audit.Metrics` — so consumers can wire their preferred telemetry
+library (Prometheus, OpenTelemetry, Datadog, in-memory, etc.)
+without the core library importing any concrete metrics
+implementation. At the time of this ADR the contract has nine
+methods:
+
+```go
+type Metrics interface {
+    RecordSubmitted()
+    RecordEvent(output string, status EventStatus)
+    RecordOutputError(output string)
+    RecordOutputFiltered(output string)
+    RecordValidationError(eventType string)
+    RecordFiltered(eventType string)
+    RecordSerializationError(eventType string)
+    RecordBufferDrop()
+    RecordQueueDepth(depth, capacity int)
+}
+```
+
+The audit of issue #594 identified two specific concerns:
+
+1. **Consumer burden.** The capstone example's Prometheus adapter
+   is roughly 200 lines — every method maps to a declared
+   `*prometheus.CounterVec` or `prometheus.Gauge`, with label
+   construction, constructor registration, and per-method wiring.
+   A typical adopter wanting a Prometheus surface writes roughly
+   150 lines of boilerplate.
+2. **Method cardinality.** Nine methods is at the upper end of
+   typical Go interface design — implementers have more to
+   understand before they can get a working metrics surface.
+
+The issue proposed two candidate shapes:
+
+- **Option A** — single `Record(MetricEvent)` method where
+  `MetricEvent` is a tagged union (`Kind MetricKind` plus a
+  grab-bag of fields).
+- **Option B** — split `Metrics` into composed sub-interfaces
+  (`LifecycleMetrics`, `DeliveryMetrics`, `ValidationMetrics`) so
+  consumers implement subsets.
+
+A pre-coding consult with api-ergonomics-reviewer rejected both
+in favour of a third option: **keep the existing nine methods,
+address the real ergonomic concerns directly.**
+
+## Decision
+
+**Accept Option C — keep the nine-method `Metrics` interface.**
+Ship the following changes in the #594 PR:
+
+1. **Rename `RecordEvent(output, status)` → `RecordDelivery(output, status)`**
+   to eliminate the semantic collision with `RecordSubmitted` in
+   readers' heads. The new name matches the method's actual role
+   (per-output delivery outcome, not event ingestion). Breaking
+   pre-v1.
+2. **Expand per-method godoc with cardinality guidance** so
+   consumers choosing Prometheus label vectors see the label-
+   space impact at a glance (e.g. `RecordSubmitted` is a single
+   counter; `RecordValidationError(eventType)` is a vector keyed
+   by event type — high cardinality if events proliferate).
+3. **Document a forward-compatibility policy** in the interface
+   godoc: adding a new metric in a v1.x release is a breaking
+   interface change. The library adds new metrics via separate
+   optional interfaces detected by type assertion on the
+   `Metrics` value, mirroring the pattern already used for
+   `DeliveryReporter`, `MetadataWriter`, `file.RotationRecorder`,
+   and `syslog.ReconnectRecorder`. Consumers who embed
+   `NoOpMetrics` automatically receive no-op default
+   implementations of any new base-interface methods.
+4. **Rewrite the capstone Prometheus adapter to ≤50 lines** using
+   a table-driven registration pattern. The reduction in
+   consumer boilerplate — from ~200 to ~50 — addresses the
+   burden concern without changing the interface shape.
+5. **Update `docs/metrics-monitoring.md`** to lead with the
+   table-driven adapter pattern, include cardinality guidance
+   per method, and document the forward-compat policy.
+
+## Rationale
+
+### Why neither Option A nor Option B
+
+**Option A (tagged union)** reintroduces untyped payload
+semantics. `MetricEvent.Depth` is meaningful only when `Kind ==
+MetricQueueDepth`; `MetricEvent.Output` is meaningful only when
+`Kind` is one of the output-scoped variants. The compiler cannot
+prevent consumers from reading a meaningless field or from
+forgetting to set a meaningful one. Prometheus adapters become a
+nine-case switch on `Kind` — the same code as today with worse
+branch prediction, worse discoverability in godoc, and an
+allocation (the `MetricEvent` struct) on every invocation of
+`RecordSubmitted`, which is called every event on the hot path.
+
+**Option B (split interfaces)** introduces a silent-compile
+footgun. A consumer who embeds `NoOpLifecycleMetrics` and
+`NoOpDeliveryMetrics` but forgets `NoOpValidationMetrics`
+compiles against the composed `Metrics` interface iff their type
+happens to implement the three validation methods some other way
+— a partial-interface satisfaction via accidental method sets.
+The 9-method count is preserved; the only net change is
+additional type-system ceremony and a new class of latent bugs.
+
+### Why Option C is the right shape
+
+**Stdlib precedent favours multi-method interfaces.**
+`log/slog.Handler` has four methods. `net/http.ResponseWriter`
+has three, plus a zoo of optional extensions (`http.Flusher`,
+`http.Hijacker`, `http.Pusher`) detected by type assertion.
+`database/sql/driver.Conn`, `Stmt`, and `Rows` each have four to
+six. `prometheus.Collector` uses the "one interface per metric
+type" pattern rather than a god-method. Go's idiom is "small
+interfaces, many of them" — nine methods grouped by a clear
+semantic (pipeline-level telemetry) is not anomalous.
+
+**The actual complaint is consumer burden, not interface shape.**
+Shrinking the capstone Prometheus adapter from ~200 to ≤50 lines
+removes the ergonomic pain the issue identified, without
+requiring every existing consumer to migrate to a new shape. The
+table-driven registration pattern scales: adopters who adopt
+cardinality-sensitive labels pay for them only at the vector they
+construct. The `NoOpMetrics` embed pattern lets adopters opt into
+instrumentation a method at a time.
+
+**Forward-compat is cheaper via optional interfaces than via a
+god-method.** When we need a tenth metric in v1.x, the new
+optional interface is additive: consumers who want it implement
+it, consumers who don't keep compiling. Contrast Option A, where
+the "extension" is a new `MetricKind` constant — consumers who
+switch on `Kind` without a `default` branch silently drop the
+new metric, worse than a compile error.
+
+## Forward-compatibility policy
+
+New metrics added after v1.0 follow this pattern:
+
+```go
+// NewMetricRecorder is an optional extension interface. Consumers
+// who want the new metric implement it; consumers who don't are
+// unaffected. The library detects support via type assertion.
+type NewMetricRecorder interface {
+    RecordSomethingNew(arg Type)
+}
+
+// Inside the library:
+if r, ok := a.metrics.(audit.NewMetricRecorder); ok {
+    r.RecordSomethingNew(arg)
+}
+```
+
+The precedent is `DeliveryReporter` on the output side (`output.go`),
+and `file.RotationRecorder` / `syslog.ReconnectRecorder` on the
+`OutputMetrics` side. The same shape applies here.
+
+Methods already on `Metrics` stay on `Metrics`. We do not split
+them out after the fact — that would be a breaking change. We only
+add new methods via new optional interfaces.
+
+## Consequences
+
+### Positive
+
+- No consumer-facing interface redesign; existing `Metrics`
+  implementations continue to compile after a one-line
+  `RecordEvent` → `RecordDelivery` find-and-replace.
+- The capstone adapter's audit-side significant code is 34 lines
+  (struct + `vec` helper + `newMetrics` constructor + seven
+  `Record*` method implementations), measurably below the AC
+  target of 50. That sets a realistic lower bound on the consumer
+  burden — consumers who find the capstone "too much" can pick a
+  strict subset by leaning on the `NoOpMetrics` embed.
+- Forward-compat is explicit: extensions land as optional
+  interfaces, consumers opt in per method.
+
+### Negative / Accepted
+
+- The nine-method count is unchanged — the discomfort some
+  readers feel at the method list length is not mitigated by
+  this decision. We accept that trade-off because the
+  alternatives measurably worsen correctness (Option A) or add
+  type-system ceremony without removing methods (Option B).
+- `RecordEvent` → `RecordDelivery` is a breaking rename.
+  Migration is mechanical (single find-and-replace) and is called
+  out in the CHANGELOG `### Breaking Changes` section.
+
+### Neutral
+
+- `audit/metrics/prom` sub-module (drop-in Prometheus
+  constructor) is tempting but DEFERRED to a follow-up issue.
+  The capstone adapter already demonstrates the ≤50-line shape;
+  elevating it to a blessed sub-module is a packaging concern,
+  not an API-shape concern, and out of scope for v1.0.
+- A sentinel value (`var DiscardMetrics Metrics = noOpMetrics{}`)
+  is likewise deferred. `NoOpMetrics` stays an exported struct
+  type so the embedding pattern continues to work; a sentinel
+  style is additive and can ship later without breaking anyone.
+- Splitting `Metrics` into composed sub-interfaces is rejected
+  outright and should not be revisited without new evidence.
+
+## References
+
+- Issue #594 — bundled API-polish finding that triggered this
+  decision.
+- Issue #593 — B-45 option classification (`Metrics` is Optional
+  tier, `audit.WithMetrics(nil)` accepted).
+- `output.go` — `DeliveryReporter` precedent for optional-
+  interface extension detection.
+- api-ergonomics-reviewer consult transcript (2026-04-23).

--- a/docs/metrics-monitoring.md
+++ b/docs/metrics-monitoring.md
@@ -26,7 +26,7 @@ library never imports a concrete metrics implementation.
 ```go
 type Metrics interface {
     RecordSubmitted()                           // total events entering the pipeline
-    RecordEvent(output string, status EventStatus) // EventSuccess / EventError — see "Drop vs delivery error" below
+    RecordDelivery(output string, status EventStatus) // EventSuccess / EventError — see "Drop vs delivery error" below
     RecordOutputError(output string)
     RecordOutputFiltered(output string)
     RecordValidationError(eventType string)
@@ -47,6 +47,39 @@ auditor, err := audit.New(
 )
 ```
 
+### Interface design — nine methods, stable shape
+
+The interface has nine methods. That shape is intentional and locked
+for v1.0 by [ADR 0005](adr/0005-metrics-interface-shape.md), which
+considered and rejected two alternatives: a single-method
+`Record(MetricEvent)` tagged union, and a split into
+`LifecycleMetrics` / `DeliveryMetrics` / `ValidationMetrics` composed
+sub-interfaces.
+
+Why the nine-method shape won:
+
+- **Stdlib precedent.** `log/slog.Handler` has four methods;
+  `net/http.ResponseWriter` has three plus a zoo of optional
+  extensions detected by type assertion (`http.Flusher`,
+  `http.Hijacker`). `database/sql/driver.Conn`, `Stmt`, and `Rows`
+  each have four to six. Go culture is "small interfaces, many of
+  them" — not "one god-method that dispatches on a tag." Nine
+  methods grouped by purpose is not anomalous.
+- **Typed arguments beat tagged unions.** `RecordValidationError`
+  takes a typed `eventType string`; `RecordQueueDepth` takes typed
+  `depth, capacity int`. A single `Record(MetricEvent)` would
+  reintroduce untyped payload where `Depth` is meaningful only when
+  `Kind == MetricQueueDepth` — a `map[string]any` with extra steps.
+- **Forward-compat via optional interfaces.** New metrics added in
+  future releases land as separate optional interfaces detected via
+  type assertion (same pattern as `DeliveryReporter`,
+  `file.RotationRecorder`, `syslog.ReconnectRecorder`). Consumers
+  embedding `NoOpMetrics` retain no-op defaults for every method.
+
+The real cost — consumer boilerplate — is addressed by shipping a
+compact Prometheus adapter pattern (~35 lines of significant code;
+see the capstone example at `examples/17-capstone/metrics.go`).
+
 ## 🔍 What to Monitor
 
 ### Critical — Alert Immediately
@@ -60,7 +93,7 @@ auditor, err := audit.New(
 
 | Metric | Method | Meaning |
 |--------|--------|---------|
-| **Delivery success/error** | `RecordEvent(output, EventSuccess/EventError)` | Per-output delivery outcome. A rising error rate indicates an output is degrading. |
+| **Delivery success/error** | `RecordDelivery(output, EventSuccess/EventError)` | Per-output delivery outcome. A rising error rate indicates an output is degrading. |
 | **Serialization errors** | `RecordSerializationError(eventType)` | The formatter failed to serialize an event. This usually indicates a bug in field values (e.g., a channel or function passed as a field value). |
 
 ### Informational — Track for Visibility
@@ -73,30 +106,64 @@ auditor, err := audit.New(
 
 ## Prometheus Example
 
+A complete Prometheus adapter fits in about 35 lines of significant
+code using a small `vec()` helper and `NoOpMetrics` embedding. The
+capstone example (`examples/17-capstone/metrics.go`) ships the full
+implementation; the core shape is:
+
 ```go
 type prometheusMetrics struct {
-    events       *prometheus.CounterVec
-    bufferDrops  prometheus.Counter
-    valErrors    *prometheus.CounterVec
-    outputErrors *prometheus.CounterVec
+    audit.NoOpMetrics // forward-compat: new Metrics methods default to no-op
+
+    delivery, outputErr, outputFilt       *prometheus.CounterVec
+    valErr, filt, serErr                  *prometheus.CounterVec
+    bufferDrops                           prometheus.Counter
 }
 
-func (m *prometheusMetrics) RecordEvent(output string, status audit.EventStatus) {
-    // EventStatus is a typed string so string(status) is a zero-cost
-    // conversion — pass it straight to WithLabelValues.
-    m.events.WithLabelValues(output, string(status)).Inc()
+func vec(name, help string, labels ...string) *prometheus.CounterVec {
+    return promauto.NewCounterVec(prometheus.CounterOpts{Name: name, Help: help}, labels)
 }
 
-func (m *prometheusMetrics) RecordBufferDrop() {
-    m.bufferDrops.Inc()
+func newMetrics() *prometheusMetrics {
+    return &prometheusMetrics{
+        delivery:    vec("audit_events_total", "Audit deliveries.", "output", "status"),
+        outputErr:   vec("audit_output_errors_total", "Output write errors.", "output"),
+        outputFilt:  vec("audit_output_filtered_total", "Events filtered per output.", "output"),
+        valErr:      vec("audit_validation_errors_total", "Validation errors.", "event_type"),
+        filt:        vec("audit_filtered_total", "Globally filtered events.", "event_type"),
+        serErr:      vec("audit_serialization_errors_total", "Serialization errors.", "event_type"),
+        bufferDrops: promauto.NewCounter(prometheus.CounterOpts{
+            Name: "audit_buffer_drops_total", Help: "Events dropped due to full buffer.",
+        }),
+    }
 }
 
-func (m *prometheusMetrics) RecordValidationError(eventType string) {
-    m.valErrors.WithLabelValues(eventType).Inc()
+// EventStatus is a typed string so string(status) is a zero-cost
+// conversion — pass it straight to WithLabelValues.
+func (m *prometheusMetrics) RecordDelivery(output string, status audit.EventStatus) {
+    m.delivery.WithLabelValues(output, string(status)).Inc()
 }
-
-// ... implement remaining methods
+func (m *prometheusMetrics) RecordOutputError(output string)    { m.outputErr.WithLabelValues(output).Inc() }
+func (m *prometheusMetrics) RecordOutputFiltered(output string) { m.outputFilt.WithLabelValues(output).Inc() }
+func (m *prometheusMetrics) RecordValidationError(ev string)    { m.valErr.WithLabelValues(ev).Inc() }
+func (m *prometheusMetrics) RecordFiltered(ev string)           { m.filt.WithLabelValues(ev).Inc() }
+func (m *prometheusMetrics) RecordSerializationError(ev string) { m.serErr.WithLabelValues(ev).Inc() }
+func (m *prometheusMetrics) RecordBufferDrop()                  { m.bufferDrops.Inc() }
 ```
+
+`RecordSubmitted` and `RecordQueueDepth` are inherited no-ops from the
+embedded `audit.NoOpMetrics`; wire them yourself if you want those
+counters on your dashboard.
+
+### Cardinality guidance
+
+Each method's Prometheus label dimensionality is documented in the
+[`Metrics` interface godoc](https://pkg.go.dev/github.com/axonops/audit#Metrics).
+Pay particular attention to event-type-labelled methods
+(`RecordValidationError`, `RecordFiltered`, `RecordSerializationError`):
+if your taxonomy is large or unknown event types can leak through,
+these vectors become high-cardinality. Budget accordingly, or drop
+the `event_type` label on methods where you only need a global count.
 
 ## 📊 Event Accounting
 
@@ -123,17 +190,17 @@ Where:
 Every self-reporting output (file, syslog, webhook, loki) follows
 the same rule for drop-vs-error reporting:
 
-| Outcome | `OutputMetrics.RecordDrop()` | `Metrics.RecordEvent(_, EventError)` |
+| Outcome | `OutputMetrics.RecordDrop()` | `Metrics.RecordDelivery(_, EventError)` |
 |---|---|---|
 | Event rejected before queue (oversize, buffer full) | ✓ | ✗ |
 | Delivery attempted, all retries exhausted (webhook, loki) | ✓ | ✓ |
-| Delivery succeeded | ✗ | `RecordEvent(_, EventSuccess)` via `OutputMetrics.RecordFlush` |
+| Delivery succeeded | ✗ | `RecordDelivery(_, EventSuccess)` via `OutputMetrics.RecordFlush` |
 
 Buffer drops count only via per-output `RecordDrop` because the event
 never reached the destination — there is nothing to report as a
 delivery outcome. Retry-exhaustion failures in webhook and loki count
-via BOTH `RecordDrop` and `RecordEvent(EventError)`: `RecordDrop`
-because the event is lost, and `RecordEvent(EventError)` because the
+via BOTH `RecordDrop` and `RecordDelivery(EventError)`: `RecordDrop`
+because the event is lost, and `RecordDelivery(EventError)` because the
 output did attempt delivery and all retries failed — that is a
 genuine delivery-error signal. File and syslog do not have retries
 (they write synchronously once dequeued) so they only ever report
@@ -142,7 +209,7 @@ via `RecordDrop`.
 Consumers that want a single "events lost" counter should sum
 `RecordBufferDrop` (core queue) + per-output `RecordDrop` (this
 already includes retry-exhaustion drops for webhook/loki, so no
-double-counting with `RecordEvent(EventError)` is needed).
+double-counting with `RecordDelivery(EventError)` is needed).
 
 ## 🚨 Recommended Alerts
 
@@ -150,7 +217,7 @@ double-counting with `RecordEvent(EventError)` is needed).
 |-------|-----------|--------|
 | Audit buffer drops | `RecordBufferDrop` > 0 in 5 minutes | Increase buffer size or investigate slow outputs |
 | Output failure | `RecordOutputError` > threshold | Check output connectivity (syslog server, webhook endpoint, disk space) |
-| Delivery error rate | `RecordEvent(_, EventError)` / total > 5% | Investigate failing output |
+| Delivery error rate | `RecordDelivery(_, EventError)` / total > 5% | Investigate failing output |
 | Validation spike | `RecordValidationError` > threshold | Application bug — check recent deployments |
 
 ## 🔀 Per-Output Metrics (`OutputMetrics`)

--- a/docs/writing-custom-outputs.md
+++ b/docs/writing-custom-outputs.md
@@ -164,7 +164,7 @@ and call `OutputMetrics.RecordDrop()`. For `DeliveryReporter` outputs
 (see [Reporting Delivery Outcomes](#reporting-delivery-outcomes)),
 returning `nil` from `Write` on a drop is correct — the drop is
 accounted for by `OutputMetrics.RecordDrop()`, and the core library
-does not call `Metrics.RecordEvent` for self-reporting outputs.
+does not call `Metrics.RecordDelivery` for self-reporting outputs.
 
 There are two distinct cases for `Write`'s return value:
 
@@ -289,7 +289,7 @@ func (o *AsyncOutput) Close() error {
     return nil
 }
 
-// ReportsDelivery signals the core auditor to skip RecordEvent for
+// ReportsDelivery signals the core auditor to skip RecordDelivery for
 // this output — delivery accounting is handled by OutputMetrics in
 // writeLoop.
 func (o *AsyncOutput) ReportsDelivery() bool { return true }
@@ -355,8 +355,8 @@ type OutputMetrics interface {
 ```
 
 `RecordFlush` is the delivery-confirmed counterpart to the core
-`Metrics.RecordEvent("success")`. For `DeliveryReporter` outputs,
-the core skips `RecordEvent` entirely — `RecordFlush` is the only
+`Metrics.RecordDelivery("success")`. For `DeliveryReporter` outputs,
+the core skips `RecordDelivery` entirely — `RecordFlush` is the only
 signal that delivery succeeded.
 
 ### Storage Pattern
@@ -445,23 +445,23 @@ type DeliveryReporter interface {
 ### What It Controls
 
 When `ReportsDelivery()` returns `true`, the core auditor's post-write
-logic skips `Metrics.RecordEvent(outputName, audit.EventSuccess | audit.EventError)` and
+logic skips `Metrics.RecordDelivery(outputName, audit.EventSuccess | audit.EventError)` and
 `Metrics.RecordOutputError(outputName)` for that output. Delivery
 accounting is left entirely to the output via `OutputMetrics`:
 
-- `RecordFlush` replaces `Metrics.RecordEvent(name, audit.EventSuccess)`
-- `RecordError` replaces `Metrics.RecordEvent(name, audit.EventError)` and
+- `RecordFlush` replaces `Metrics.RecordDelivery(name, audit.EventSuccess)`
+- `RecordError` replaces `Metrics.RecordDelivery(name, audit.EventError)` and
   `Metrics.RecordOutputError(name)`
 
 **Panic exception:** if the output panics during `Write`, the core
 logger calls `Metrics.RecordOutputError` regardless of
 `ReportsDelivery()` — a panic means the output did not self-report.
-`Metrics.RecordEvent` is not called on the panic path for any output.
+`Metrics.RecordDelivery` is not called on the panic path for any output.
 
 ### Why It Exists
 
 Without `DeliveryReporter`, the core logger calls
-`RecordEvent("success")` as soon as `Write` returns. For an async
+`RecordDelivery("success")` as soon as `Write` returns. For an async
 output, `Write` returning means the event entered the buffer — not
 that it was delivered. If the output also calls
 `OutputMetrics.RecordFlush` after actual delivery, every event is
@@ -472,7 +472,7 @@ For an async output that calls `RecordFlush` after actual delivery:
 
 | | Without DeliveryReporter | With DeliveryReporter |
 |---|---|---|
-| Core calls `RecordEvent` | Yes (at enqueue) | No |
+| Core calls `RecordDelivery` | Yes (at enqueue) | No |
 | Output calls `RecordFlush` | Yes (at delivery) | Yes (at delivery) |
 | Result | Double-counted | Correct |
 

--- a/drain.go
+++ b/drain.go
@@ -534,11 +534,11 @@ func (a *Auditor) recordWrite(outputName, eventType string, selfReports bool, wr
 			"error", writeErr)
 		if a.metrics != nil && !selfReports {
 			a.metrics.RecordOutputError(outputName)
-			a.metrics.RecordEvent(outputName, EventError)
+			a.metrics.RecordDelivery(outputName, EventError)
 		}
 		return
 	}
 	if a.metrics != nil && !selfReports {
-		a.metrics.RecordEvent(outputName, EventSuccess)
+		a.metrics.RecordDelivery(outputName, EventSuccess)
 	}
 }

--- a/examples/17-capstone/metrics.go
+++ b/examples/17-capstone/metrics.go
@@ -24,185 +24,122 @@ import (
 	"github.com/axonops/audit"
 )
 
-// auditMetrics implements all three audit metrics interfaces using
-// Prometheus client_golang. A single struct satisfies everything via
-// Go's structural duck-typing:
+// auditMetrics is a Prometheus adapter for audit.Metrics.
 //
-//   - audit.Metrics (9 methods including RecordSubmitted, RecordQueueDepth)
-//   - audit.OutputMetrics (5 methods: RecordDrop, RecordFlush, RecordError, RecordRetry, RecordQueueDepth)
-//   - file.RotationRecorder  (RecordRotation)
-//   - syslog.ReconnectRecorder (RecordReconnect)
+// The struct embeds audit.NoOpMetrics so that adding a method to
+// audit.Metrics in a future library version is a no-op drop-in (ADR
+// 0005 forward-compatibility policy). Consumers override only the
+// methods they want instrumented.
+//
+// The vec() helper reduces Prometheus vector construction to a single
+// line per metric. Same struct also implements file.RotationRecorder
+// via RecordRotation.
 type auditMetrics struct {
-	events              *prometheus.CounterVec
-	outputErrors        *prometheus.CounterVec
-	validationErrors    *prometheus.CounterVec
-	filtered            *prometheus.CounterVec
-	outputFiltered      *prometheus.CounterVec
-	serializationErrors *prometheus.CounterVec
-	bufferDrops         prometheus.Counter
-	fileRotations       *prometheus.CounterVec
-	lokiDrops           prometheus.Counter
-	lokiFlushDur        prometheus.Histogram
-	lokiFlushBatch      prometheus.Histogram
-	lokiRetries         *prometheus.CounterVec
-	lokiErrors          *prometheus.CounterVec
+	audit.NoOpMetrics
+
+	delivery, outputErr, outputFilt *prometheus.CounterVec
+	valErr, filt, serErr, rot       *prometheus.CounterVec
+	bufferDrops                     prometheus.Counter
+}
+
+// Compile-time check: auditMetrics satisfies audit.Metrics. If a
+// future library version adds a method and we forget to embed the
+// refreshed NoOpMetrics, this assertion fails at build time.
+var _ audit.Metrics = (*auditMetrics)(nil)
+
+func vec(name, help string, labels ...string) *prometheus.CounterVec {
+	return promauto.NewCounterVec(prometheus.CounterOpts{Name: name, Help: help}, labels)
 }
 
 func newMetrics() *auditMetrics {
 	return &auditMetrics{
-		events: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_events_total",
-			Help: "Total audit events by output and status.",
-		}, []string{"output", "status"}),
-
-		outputErrors: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_output_errors_total",
-			Help: "Output write errors by output name.",
-		}, []string{"output"}),
-
-		validationErrors: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_validation_errors_total",
-			Help: "Validation errors by event type.",
-		}, []string{"event_type"}),
-
-		filtered: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_filtered_total",
-			Help: "Events filtered globally by event type.",
-		}, []string{"event_type"}),
-
-		outputFiltered: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_output_filtered_total",
-			Help: "Events filtered per output.",
-		}, []string{"output"}),
-
-		serializationErrors: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_serialization_errors_total",
-			Help: "Serialization errors by event type.",
-		}, []string{"event_type"}),
-
-		bufferDrops: promauto.NewCounter(prometheus.CounterOpts{
-			Name: "audit_buffer_drops_total",
-			Help: "Events dropped due to full buffer.",
-		}),
-
-		fileRotations: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_file_rotations_total",
-			Help: "File rotations by path.",
-		}, []string{"path"}),
-
-		lokiDrops: promauto.NewCounter(prometheus.CounterOpts{
-			Name: "audit_loki_drops_total",
-			Help: "Loki events dropped due to full buffer or retries exhausted.",
-		}),
-
-		lokiFlushDur: promauto.NewHistogram(prometheus.HistogramOpts{
-			Name:    "audit_loki_flush_duration_seconds",
-			Help:    "Loki batch flush duration.",
-			Buckets: prometheus.DefBuckets,
-		}),
-
-		lokiFlushBatch: promauto.NewHistogram(prometheus.HistogramOpts{
-			Name:    "audit_loki_flush_batch_size",
-			Help:    "Number of events per Loki batch flush.",
-			Buckets: []float64{1, 5, 10, 25, 50, 100, 250},
-		}),
-
-		lokiRetries: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_loki_retries_total",
-			Help: "Loki push retries by status code.",
-		}, []string{"status_code", "attempt"}),
-
-		lokiErrors: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "audit_loki_errors_total",
-			Help: "Loki non-retryable errors by status code.",
-		}, []string{"status_code"}),
+		delivery:    vec("audit_events_total", "Audit deliveries by output and status.", "output", "status"),
+		outputErr:   vec("audit_output_errors_total", "Output write errors by output name.", "output"),
+		outputFilt:  vec("audit_output_filtered_total", "Events filtered per output.", "output"),
+		valErr:      vec("audit_validation_errors_total", "Validation errors by event type.", "event_type"),
+		filt:        vec("audit_filtered_total", "Events filtered globally by event type.", "event_type"),
+		serErr:      vec("audit_serialization_errors_total", "Serialization errors by event type.", "event_type"),
+		rot:         vec("audit_file_rotations_total", "File rotations by path.", "path"),
+		bufferDrops: promauto.NewCounter(prometheus.CounterOpts{Name: "audit_buffer_drops_total", Help: "Events dropped due to full buffer."}),
 	}
 }
 
-// --- audit.Metrics ---
-
-func (m *auditMetrics) RecordSubmitted() {}
-
-func (m *auditMetrics) RecordQueueDepth(_, _ int) {}
-
-func (m *auditMetrics) RecordEvent(output string, status audit.EventStatus) {
-	m.events.WithLabelValues(output, string(status)).Inc()
+// audit.Metrics methods — the five that carry labels plus BufferDrop.
+// RecordSubmitted and RecordQueueDepth stay inherited no-ops from the
+// embedded audit.NoOpMetrics (unsampled in this capstone).
+func (m *auditMetrics) RecordDelivery(output string, status audit.EventStatus) {
+	m.delivery.WithLabelValues(output, string(status)).Inc()
 }
-
-func (m *auditMetrics) RecordOutputError(output string) {
-	m.outputErrors.WithLabelValues(output).Inc()
-}
-
-func (m *auditMetrics) RecordValidationError(eventType string) {
-	m.validationErrors.WithLabelValues(eventType).Inc()
-}
-
-func (m *auditMetrics) RecordFiltered(eventType string) {
-	m.filtered.WithLabelValues(eventType).Inc()
-}
-
+func (m *auditMetrics) RecordOutputError(output string) { m.outputErr.WithLabelValues(output).Inc() }
 func (m *auditMetrics) RecordOutputFiltered(output string) {
-	m.outputFiltered.WithLabelValues(output).Inc()
+	m.outputFilt.WithLabelValues(output).Inc()
 }
+func (m *auditMetrics) RecordValidationError(ev string)    { m.valErr.WithLabelValues(ev).Inc() }
+func (m *auditMetrics) RecordFiltered(ev string)           { m.filt.WithLabelValues(ev).Inc() }
+func (m *auditMetrics) RecordSerializationError(ev string) { m.serErr.WithLabelValues(ev).Inc() }
+func (m *auditMetrics) RecordBufferDrop()                  { m.bufferDrops.Inc() }
 
-func (m *auditMetrics) RecordSerializationError(eventType string) {
-	m.serializationErrors.WithLabelValues(eventType).Inc()
-}
-
-func (m *auditMetrics) RecordBufferDrop() {
-	m.bufferDrops.Inc()
-}
-
-// --- file.RotationRecorder ---
-
-func (m *auditMetrics) RecordRotation(path string) {
-	m.fileRotations.WithLabelValues(path).Inc()
-}
+// file.RotationRecorder — optional extension detected via type assertion.
+func (m *auditMetrics) RecordRotation(path string) { m.rot.WithLabelValues(path).Inc() }
 
 // --- audit.OutputMetrics via OutputMetricsFactory ---
 //
 // The factory creates a scoped perOutputMetrics instance for each
 // output, labelled by output type and name. This gives per-output
-// Prometheus metrics without a global shared counter.
+// Prometheus metrics without a global shared counter. Kept as a
+// separate type because OutputMetrics is a distinct contract from
+// Metrics (per-output buffer telemetry, not pipeline-wide).
 
-// perOutputMetrics implements audit.OutputMetrics with Prometheus
-// counters scoped to a specific output via WithLabelValues.
 type perOutputMetrics struct {
-	audit.NoOpOutputMetrics // forward compatibility
-	drops                   prometheus.Counter
-	flushBatch              prometheus.Observer
-	flushDur                prometheus.Observer
-	retries                 *prometheus.CounterVec
-	errors                  prometheus.Counter
+	audit.NoOpOutputMetrics
+	drops      prometheus.Counter
+	flushBatch prometheus.Observer
+	flushDur   prometheus.Observer
+	retries    *prometheus.CounterVec
+	errors     prometheus.Counter
 }
 
-func (p *perOutputMetrics) RecordDrop() {
-	p.drops.Inc()
-}
-
+func (p *perOutputMetrics) RecordDrop() { p.drops.Inc() }
 func (p *perOutputMetrics) RecordFlush(batchSize int, dur time.Duration) {
 	p.flushBatch.Observe(float64(batchSize))
 	p.flushDur.Observe(dur.Seconds())
 }
-
 func (p *perOutputMetrics) RecordRetry(attempt int) {
 	p.retries.WithLabelValues(strconv.Itoa(attempt)).Inc()
 }
+func (p *perOutputMetrics) RecordError() { p.errors.Inc() }
 
-func (p *perOutputMetrics) RecordError() {
-	p.errors.Inc()
-}
-
-// newOutputMetricsFactory returns an OutputMetricsFactory that creates
-// per-output Prometheus metrics scoped by output type and name.
+// newOutputMetricsFactory returns an OutputMetricsFactory producing
+// per-output metrics scoped by output type and name. Histograms and
+// counters are pre-registered once here; WithLabelValues lookups
+// scope them per output.
 func (m *auditMetrics) newOutputMetricsFactory() audit.OutputMetricsFactory {
+	drops := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "audit_output_drops_total", Help: "Per-output events dropped.",
+	}, []string{"output_type", "output_name"})
+	flushBatch := promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "audit_output_flush_batch_size", Help: "Events per per-output batch flush.",
+		Buckets: []float64{1, 5, 10, 25, 50, 100, 250},
+	}, []string{"output_type", "output_name"})
+	flushDur := promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "audit_output_flush_duration_seconds", Help: "Per-output batch flush duration.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"output_type", "output_name"})
+	retries := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "audit_output_retries_total", Help: "Per-output retry attempts.",
+	}, []string{"output_type", "output_name", "attempt"})
+	errs := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "audit_output_errors_by_output_total", Help: "Per-output non-retryable errors.",
+	}, []string{"output_type", "output_name"})
+
 	return func(outputType, outputName string) audit.OutputMetrics {
+		lv := []string{outputType, outputName}
 		return &perOutputMetrics{
-			drops:      m.lokiDrops,
-			flushBatch: m.lokiFlushBatch,
-			flushDur:   m.lokiFlushDur,
-			retries:    m.lokiRetries,
-			errors:     m.lokiErrors.WithLabelValues(outputType + ":" + outputName),
+			drops:      drops.WithLabelValues(lv...),
+			flushBatch: flushBatch.WithLabelValues(lv...),
+			flushDur:   flushDur.WithLabelValues(lv...),
+			retries:    retries.MustCurryWith(prometheus.Labels{"output_type": outputType, "output_name": outputName}),
+			errors:     errs.WithLabelValues(lv...),
 		}
 	}
 }

--- a/internal/testhelper/metrics.go
+++ b/internal/testhelper/metrics.go
@@ -44,7 +44,7 @@ type MockMetrics struct { //nolint:govet // fieldalignment: readability preferre
 	FileRotations       map[string]int // path -> count
 	SyslogReconnects    map[string]int // "address:success|failure" -> count
 	QueueDepths         []QueueDepthRecord
-	// EventCh is signalled (non-blocking) on every RecordEvent call.
+	// EventCh is signalled (non-blocking) on every RecordDelivery call.
 	// It is buffered to 1000 entries and is consumed internally by
 	// [MockMetrics.WaitForMetric]; consumers do not need to read it.
 	EventCh     chan struct{}
@@ -76,7 +76,7 @@ func (m *MockMetrics) RecordSubmitted() {
 	m.Submitted++
 }
 
-func (m *MockMetrics) RecordEvent(output string, status audit.EventStatus) {
+func (m *MockMetrics) RecordDelivery(output string, status audit.EventStatus) {
 	m.Mu.Lock()
 	defer m.Mu.Unlock()
 	m.Events[output+":"+string(status)]++
@@ -152,7 +152,7 @@ func (m *MockMetrics) RecordReconnect(address string, success bool) {
 
 // WaitForMetric blocks until the event metric for key reaches at least n,
 // or until timeout expires. The key format is "outputName:status" — the
-// same string [MockMetrics.RecordEvent] indexes into Events (e.g.
+// same string [MockMetrics.RecordDelivery] indexes into Events (e.g.
 // "test-out:success"). Returns true if the count reached n within the
 // deadline; returns false on timeout.
 func (m *MockMetrics) WaitForMetric(key string, n int, timeout time.Duration) bool {

--- a/loki/http.go
+++ b/loki/http.go
@@ -232,7 +232,7 @@ func (o *Output) recordSuccess(batchSize int, dur time.Duration) {
 	if o.metrics != nil {
 		name := o.Name()
 		for range batchSize {
-			o.metrics.RecordEvent(name, audit.EventSuccess)
+			o.metrics.RecordDelivery(name, audit.EventSuccess)
 		}
 	}
 }
@@ -245,7 +245,7 @@ func (o *Output) recordDrop(count int) {
 			(*omp).RecordDrop()
 		}
 		if o.metrics != nil {
-			o.metrics.RecordEvent(name, audit.EventError)
+			o.metrics.RecordDelivery(name, audit.EventError)
 		}
 	}
 }

--- a/loki/http_test.go
+++ b/loki/http_test.go
@@ -528,7 +528,7 @@ func TestHTTP_Success_RecordsCoreMetrics(t *testing.T) {
 	require.NoError(t, out.Close())
 
 	assert.Greater(t, coreMetrics.successCount(), 0,
-		"core metrics RecordEvent should be called with success")
+		"core metrics RecordDelivery should be called with success")
 }
 
 func TestHTTP_Drop_RecordsCoreMetrics(t *testing.T) {
@@ -549,7 +549,7 @@ func TestHTTP_Drop_RecordsCoreMetrics(t *testing.T) {
 	require.NoError(t, out.Close())
 
 	assert.Greater(t, coreMetrics.errorCount(), 0,
-		"core metrics RecordEvent should be called with error on drop")
+		"core metrics RecordDelivery should be called with error on drop")
 }
 
 // ---------------------------------------------------------------------------
@@ -643,7 +643,7 @@ type mockCoreMetrics struct { //nolint:govet // fieldalignment: readability pref
 	events map[string]int // status → count
 }
 
-func (m *mockCoreMetrics) RecordEvent(_ string, status audit.EventStatus) {
+func (m *mockCoreMetrics) RecordDelivery(_ string, status audit.EventStatus) {
 	m.mu.Lock()
 	if m.events == nil {
 		m.events = make(map[string]int)

--- a/loki/loki.go
+++ b/loki/loki.go
@@ -279,9 +279,9 @@ func (o *Output) WriteWithMetadata(data []byte, meta audit.EventMetadata) error 
 		})
 		// Buffer drops (event never attempted) are counted via per-
 		// output OutputMetrics.RecordDrop only — not via pipeline-
-		// level Metrics.RecordEvent. Matches file + syslog for
+		// level Metrics.RecordDelivery. Matches file + syslog for
 		// consistency across all self-reporting outputs (B-25).
-		// RecordEvent(EventError) remains for retries-exhausted
+		// RecordDelivery(EventError) remains for retries-exhausted
 		// failures in http.go where delivery WAS attempted.
 		if omp := o.outputMetrics.Load(); omp != nil {
 			(*omp).RecordDrop()

--- a/loki/loki_test.go
+++ b/loki/loki_test.go
@@ -314,8 +314,8 @@ func TestOutput_BufferFull_DropsEvent(t *testing.T) {
 
 // TestOutput_BufferFull_DoesNotRecordCoreEventError verifies the B-25
 // contract: buffer-full drops surface only via OutputMetrics.RecordDrop
-// and MUST NOT call core Metrics.RecordEvent(EventError). Delivery
-// errors (retry exhausted) still use RecordEvent(EventError) — this
+// and MUST NOT call core Metrics.RecordDelivery(EventError). Delivery
+// errors (retry exhausted) still use RecordDelivery(EventError) — this
 // test guards the buffer-drop path only.
 func TestOutput_BufferFull_DoesNotRecordCoreEventError(t *testing.T) {
 	t.Parallel()
@@ -351,7 +351,7 @@ func TestOutput_BufferFull_DoesNotRecordCoreEventError(t *testing.T) {
 	require.NoError(t, out.Close())
 
 	assert.Equal(t, 0, coreMetrics.errorCount(),
-		"buffer-full drops must not call core Metrics.RecordEvent(EventError) (B-25); use OutputMetrics.RecordDrop")
+		"buffer-full drops must not call core Metrics.RecordDelivery(EventError) (B-25); use OutputMetrics.RecordDrop")
 }
 
 // ---------------------------------------------------------------------------

--- a/metrics.go
+++ b/metrics.go
@@ -17,7 +17,7 @@ package audit
 import "time"
 
 // EventStatus is the outcome label for a delivery attempt recorded
-// via [Metrics.RecordEvent]. It is a typed string so consumers can
+// via [Metrics.RecordDelivery]. It is a typed string so consumers can
 // pass it straight to Prometheus / OpenTelemetry label vectors with
 // a zero-cost `string(status)` conversion on the hot path.
 //
@@ -48,7 +48,10 @@ const (
 // [WithMetrics]; pass nil to disable metrics collection.
 //
 // The library never imports a concrete metrics library (Prometheus,
-// OpenTelemetry, etc.). Consumers wire their own.
+// OpenTelemetry, etc.). Consumers wire their own. The
+// [examples/17-capstone] Prometheus adapter shows a complete
+// implementation in under 50 lines using a table-driven registration
+// pattern; copy it as a starting point.
 //
 // Consumers SHOULD embed [NoOpMetrics] in their implementation to
 // absorb new methods added in future versions without breaking builds.
@@ -58,7 +61,7 @@ const (
 // [Metrics] records pipeline-level counters that span the entire auditor:
 //
 //   - RecordSubmitted — total events entering the pipeline
-//   - RecordEvent — per-output delivery outcome (for non-self-reporting outputs)
+//   - RecordDelivery — per-output delivery outcome (for non-self-reporting outputs)
 //   - RecordBufferDrop — core intake queue overflow
 //   - RecordQueueDepth — core intake queue pressure gauge
 //
@@ -72,28 +75,59 @@ const (
 //   - RecordQueueDepth — per-output buffer pressure gauge
 //
 // For outputs that implement [DeliveryReporter] (webhook, loki, file,
-// syslog), the output itself calls RecordEvent after actual delivery.
-// The core auditor skips RecordEvent for these outputs to avoid
+// syslog), the output itself calls RecordDelivery after actual delivery.
+// The core auditor skips RecordDelivery for these outputs to avoid
 // phantom success counting.
+//
+// # Cardinality guidance
+//
+// Each method notes the Prometheus / OpenTelemetry label-vector
+// dimensionality implied by its arguments. "High cardinality" flags
+// methods whose label space scales with caller-supplied identifiers
+// (event types, output names) — consumers with many event types
+// should budget accordingly when wiring label vectors.
+//
+// # Forward compatibility
+//
+// Adding a method to [Metrics] in a v1.x release is a breaking
+// interface change. The library adds new metrics via separate
+// optional interfaces detected by type assertion on the passed
+// [Metrics] value, mirroring the pattern used by [DeliveryReporter]
+// on outputs and by [file.RotationRecorder] / [syslog.ReconnectRecorder]
+// on [OutputMetrics]. Consumers who embed [NoOpMetrics] retain
+// no-op implementations for every base-interface method; extensions
+// are additive. See ADR 0005 (docs/adr/0005-metrics-interface-shape.md)
+// for the full policy.
 type Metrics interface {
 	// RecordSubmitted records that an event was submitted to the
 	// pipeline via [Auditor.AuditEvent]. Called once per AuditEvent
 	// call, before any filtering or buffering. This is the "total
 	// events in" counter.
+	//
+	// Cardinality: single counter (no labels).
 	RecordSubmitted()
 
-	// RecordEvent records an event delivery attempt to the named
+	// RecordDelivery records an event delivery attempt to the named
 	// output. status is a typed enum — see [EventStatus] for the
 	// defined values.
-	RecordEvent(output string, status EventStatus)
+	//
+	// Cardinality: 2-dimensional vector (output × status).
+	// The output label set is bounded by the number of configured
+	// outputs. status has two values ([EventSuccess], [EventError]).
+	RecordDelivery(output string, status EventStatus)
 
 	// RecordOutputError records a write error on the named output.
+	//
+	// Cardinality: 1-dimensional vector (output). Bounded by the
+	// number of configured outputs.
 	RecordOutputError(output string)
 
 	// RecordOutputFiltered records that a per-output event route filter
 	// prevented an event from being delivered to the named output.
 	// This is distinct from [Metrics.RecordFiltered], which records
 	// global category/event filter drops before any output is reached.
+	//
+	// Cardinality: 1-dimensional vector (output).
 	RecordOutputFiltered(output string)
 
 	// RecordValidationError records that [Auditor.AuditEvent] rejected an
@@ -101,27 +135,44 @@ type Metrics interface {
 	// required fields, or unknown fields in strict mode. The
 	// eventType parameter is the event type string that was passed to
 	// AuditEvent.
+	//
+	// Cardinality: 1-dimensional vector (event_type). HIGH cardinality
+	// if the taxonomy grows large or if unknown event types are
+	// common. Consumers may aggregate into a single counter without
+	// the event_type label to cap the vector size.
 	RecordValidationError(eventType string)
 
 	// RecordFiltered records that an event was silently discarded by
 	// the global category/event filter. This is distinct from
 	// [Metrics.RecordOutputFiltered] which tracks per-output route
 	// filtering.
+	//
+	// Cardinality: 1-dimensional vector (event_type). HIGH cardinality
+	// — see [Metrics.RecordValidationError].
 	RecordFiltered(eventType string)
 
 	// RecordSerializationError records that the configured [Formatter]
 	// returned an error (or panicked) when serialising an event. The
 	// event is dropped when this occurs.
+	//
+	// Cardinality: 1-dimensional vector (event_type). HIGH cardinality
+	// — see [Metrics.RecordValidationError].
 	RecordSerializationError(eventType string)
 
 	// RecordBufferDrop records that an event was dropped because the
 	// main async queue was full.
+	//
+	// Cardinality: single counter (no labels).
 	RecordBufferDrop()
 
 	// RecordQueueDepth records the current depth and capacity of the
 	// core intake queue. Called from the drain loop, sampled every 64
 	// events processed. depth is len(channel), capacity is
 	// cap(channel).
+	//
+	// Cardinality: gauge (depth) and an associated gauge or constant
+	// (capacity). No per-call labels. Consumers may record the
+	// capacity once at startup and emit depth per call.
 	RecordQueueDepth(depth, capacity int)
 }
 
@@ -142,8 +193,8 @@ var _ Metrics = NoOpMetrics{}
 // RecordSubmitted is a no-op.
 func (NoOpMetrics) RecordSubmitted() {}
 
-// RecordEvent is a no-op.
-func (NoOpMetrics) RecordEvent(string, EventStatus) {}
+// RecordDelivery is a no-op.
+func (NoOpMetrics) RecordDelivery(string, EventStatus) {}
 
 // RecordOutputError is a no-op.
 func (NoOpMetrics) RecordOutputError(string) {}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -15,6 +15,7 @@
 package audit_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,7 +56,7 @@ func TestEventStatus_WireFormat_Stable(t *testing.T) {
 }
 
 // TestEventStatus_TypeCompatibility verifies that passing a
-// string literal directly to [audit.Metrics.RecordEvent] is a
+// string literal directly to [audit.Metrics.RecordDelivery] is a
 // compile error — the status parameter is typed.
 func TestEventStatus_TypeCompatibility(t *testing.T) {
 	t.Parallel()
@@ -71,13 +72,38 @@ func TestEventStatus_TypeCompatibility(t *testing.T) {
 		"typed string literal equality")
 }
 
-// TestNoOpMetrics_RecordEvent_AcceptsTypedStatus proves that
-// [audit.NoOpMetrics] compiles with the new typed signature.
-func TestNoOpMetrics_RecordEvent_AcceptsTypedStatus(t *testing.T) {
+// TestNoOpMetrics_RecordDelivery_AcceptsTypedStatus proves that
+// [audit.NoOpMetrics] compiles with the typed signature.
+func TestNoOpMetrics_RecordDelivery_AcceptsTypedStatus(t *testing.T) {
 	t.Parallel()
 
 	var m audit.Metrics = audit.NoOpMetrics{}
 	// No-op — just needs to compile and not panic.
-	m.RecordEvent("some-output", audit.EventSuccess)
-	m.RecordEvent("some-output", audit.EventError)
+	m.RecordDelivery("some-output", audit.EventSuccess)
+	m.RecordDelivery("some-output", audit.EventError)
+}
+
+// TestNoOpMetrics_AllMethodsArePresent reflects over the
+// [audit.Metrics] interface method set and asserts that
+// [audit.NoOpMetrics] has a method for every entry. The test guards
+// the forward-compatibility promise in the Metrics godoc: consumers
+// who embed [audit.NoOpMetrics] must retain a working no-op
+// implementation of every base-interface method without writing any
+// code themselves. If a future PR adds a method to [audit.Metrics]
+// without adding the matching NoOpMetrics method, this test fails.
+// See ADR 0005 (docs/adr/0005-metrics-interface-shape.md).
+func TestNoOpMetrics_AllMethodsArePresent(t *testing.T) {
+	t.Parallel()
+
+	metricsType := reflect.TypeOf((*audit.Metrics)(nil)).Elem()
+	noOpType := reflect.TypeOf(audit.NoOpMetrics{})
+
+	for i := 0; i < metricsType.NumMethod(); i++ {
+		name := metricsType.Method(i).Name
+		if _, ok := noOpType.MethodByName(name); !ok {
+			t.Errorf("NoOpMetrics is missing method %q required by audit.Metrics — "+
+				"add a no-op implementation in metrics.go to preserve the forward-"+
+				"compatibility embed pattern (ADR 0005)", name)
+		}
+	}
 }

--- a/output.go
+++ b/output.go
@@ -79,7 +79,7 @@ type DestinationKeyer interface {
 // may satisfy to indicate they handle their own delivery metrics
 // reporting. When satisfied and [DeliveryReporter.ReportsDelivery]
 // returns true, the core auditor skips its default per-event
-// [Metrics.RecordEvent] calls for that output — the output is
+// [Metrics.RecordDelivery] calls for that output — the output is
 // responsible for calling them after actual delivery.
 type DeliveryReporter interface {
 	ReportsDelivery() bool

--- a/tests/bdd/features/event_count_metrics.feature
+++ b/tests/bdd/features/event_count_metrics.feature
@@ -43,13 +43,13 @@ Feature: Event Count Metrics
     And I close the auditor
     Then RecordQueueDepth should have been called at least 1 time
 
-  Scenario: DeliveryReporter output skips core RecordEvent
+  Scenario: DeliveryReporter output skips core RecordDelivery
     Given an auditor with file output and pipeline metrics
     When I audit 5 events rapidly
     And I close the auditor
     Then the pipeline metrics should not have recorded a success event for file output
 
-  Scenario: Non-DeliveryReporter output records core RecordEvent
+  Scenario: Non-DeliveryReporter output records core RecordDelivery
     Given an auditor with stdout output and metrics
     When I audit event "user_create" with required fields
     And I close the auditor

--- a/tests/bdd/steps/helpers.go
+++ b/tests/bdd/steps/helpers.go
@@ -169,8 +169,8 @@ func NewMockMetrics() *MockMetrics {
 	}
 }
 
-// RecordEvent satisfies audit.Metrics.
-func (m *MockMetrics) RecordEvent(output string, status audit.EventStatus) {
+// RecordDelivery satisfies audit.Metrics.
+func (m *MockMetrics) RecordDelivery(output string, status audit.EventStatus) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.Events[output+":"+string(status)]++

--- a/tests/bdd/steps/metrics_steps.go
+++ b/tests/bdd/steps/metrics_steps.go
@@ -317,7 +317,7 @@ func assertMetricsEvent(tc *AuditTestContext, output, status string) error {
 	defer tc.MockMetrics.mu.Unlock()
 	key := output + ":" + status
 	if tc.MockMetrics.Events[key] == 0 {
-		return fmt.Errorf("expected RecordEvent(%q, %q), got 0 (all: %v)", output, status, tc.MockMetrics.Events)
+		return fmt.Errorf("expected RecordDelivery(%q, %q), got 0 (all: %v)", output, status, tc.MockMetrics.Events)
 	}
 	return nil
 }
@@ -403,7 +403,7 @@ func assertMetricsNoWebhookCoreSuccess(tc *AuditTestContext) error {
 	tc.MockMetrics.mu.Lock()
 	defer tc.MockMetrics.mu.Unlock()
 	// Webhook output implements DeliveryReporter, so core metrics
-	// (RecordEvent) should NOT be called for webhook outputs.
+	// (RecordDelivery) should NOT be called for webhook outputs.
 	// Check that no "webhook:*:success" key exists.
 	for k, v := range tc.MockMetrics.Events {
 		if strings.Contains(k, "webhook") && strings.HasSuffix(k, ":success") && v > 0 {

--- a/webhook/http.go
+++ b/webhook/http.go
@@ -187,7 +187,7 @@ func (w *Output) recordSuccess(batchSize int, dur time.Duration) {
 	if w.metrics != nil {
 		name := w.Name()
 		for range batchSize {
-			w.metrics.RecordEvent(name, audit.EventSuccess)
+			w.metrics.RecordDelivery(name, audit.EventSuccess)
 		}
 	}
 }
@@ -195,7 +195,7 @@ func (w *Output) recordSuccess(batchSize int, dur time.Duration) {
 // recordDrop records dropped events in metrics. Called when retries
 // are exhausted or a non-retryable error occurs.
 // RecordDrop is called per dropped event on OutputMetrics.
-// RecordEvent(name, audit.EventError) is called per dropped event on core Metrics.
+// RecordDelivery(name, audit.EventError) is called per dropped event on core Metrics.
 func (w *Output) recordDrop(count int) {
 	name := w.Name()
 	for range count {
@@ -203,7 +203,7 @@ func (w *Output) recordDrop(count int) {
 			(*omp).RecordDrop()
 		}
 		if w.metrics != nil {
-			w.metrics.RecordEvent(name, audit.EventError)
+			w.metrics.RecordDelivery(name, audit.EventError)
 		}
 	}
 }

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -254,7 +254,7 @@ func (w *Output) Write(data []byte) error {
 				"dropped", dropped)
 		})
 		// Drops are counted once via per-output OutputMetrics.RecordDrop
-		// only — not via pipeline-level Metrics.RecordEvent. This
+		// only — not via pipeline-level Metrics.RecordDelivery. This
 		// matches file + syslog behaviour for consistency across all
 		// self-reporting outputs (B-25).
 		if omp := w.outputMetrics.Load(); omp != nil {

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -202,7 +202,7 @@ func newMockMetrics() *mockMetrics {
 
 // --- audit.Metrics methods ---
 
-func (m *mockMetrics) RecordEvent(output string, status audit.EventStatus) {
+func (m *mockMetrics) RecordDelivery(output string, status audit.EventStatus) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.events[output+":"+string(status)]++
@@ -1304,12 +1304,12 @@ func TestWebhookOutput_DeliveryMetrics_SuccessOnHTTP200(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return metrics.getEventCount(name, audit.EventSuccess) == 3
 	}, 5*time.Second, 10*time.Millisecond,
-		"RecordEvent(success) should be called once per delivered event")
+		"RecordDelivery(success) should be called once per delivered event")
 
 	require.NoError(t, out.Close())
 
 	assert.Equal(t, 0, metrics.getEventCount(name, audit.EventError),
-		"RecordEvent(error) should not be called on success")
+		"RecordDelivery(error) should not be called on success")
 }
 
 func TestWebhookOutput_DeliveryMetrics_ErrorOnRetryExhausted(t *testing.T) {
@@ -1336,9 +1336,9 @@ func TestWebhookOutput_DeliveryMetrics_ErrorOnRetryExhausted(t *testing.T) {
 
 	name := out.Name()
 	assert.Equal(t, 2, metrics.getEventCount(name, audit.EventError),
-		"RecordEvent(error) should be called once per dropped event")
+		"RecordDelivery(error) should be called once per dropped event")
 	assert.Equal(t, 0, metrics.getEventCount(name, audit.EventSuccess),
-		"RecordEvent(success) should not be called when retries exhausted")
+		"RecordDelivery(success) should not be called when retries exhausted")
 }
 
 func TestWebhookOutput_DeliveryMetrics_ErrorOnBufferOverflow(t *testing.T) {
@@ -1361,7 +1361,7 @@ func TestWebhookOutput_DeliveryMetrics_ErrorOnBufferOverflow(t *testing.T) {
 	require.NoError(t, err)
 
 	// Fill buffer — overflow events are no longer recorded via
-	// core Metrics.RecordEvent (B-25 consistency with file + syslog).
+	// core Metrics.RecordDelivery (B-25 consistency with file + syslog).
 	// They surface only via OutputMetrics.RecordDrop — asserted in
 	// the separate per-output metrics test suite.
 	for range 15 {
@@ -1371,11 +1371,11 @@ func TestWebhookOutput_DeliveryMetrics_ErrorOnBufferOverflow(t *testing.T) {
 
 	name := out.Name()
 	assert.Equal(t, 0, metrics.getEventCount(name, audit.EventError),
-		"buffer overflow drops must not be recorded via core Metrics.RecordEvent (B-25); use OutputMetrics.RecordDrop")
+		"buffer overflow drops must not be recorded via core Metrics.RecordDelivery (B-25); use OutputMetrics.RecordDrop")
 }
 
 func TestWebhookOutput_CoreMetrics_SkippedForDeliveryReporter(t *testing.T) {
-	// Verify that the core recordWrite does NOT call RecordEvent
+	// Verify that the core recordWrite does NOT call RecordDelivery
 	// for webhook outputs (they report their own delivery).
 	srv := newWebhookTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(200)
@@ -1429,7 +1429,7 @@ type coreOnlyMetrics struct {
 	mu     sync.Mutex
 }
 
-func (m *coreOnlyMetrics) RecordEvent(output string, status audit.EventStatus) {
+func (m *coreOnlyMetrics) RecordDelivery(output string, status audit.EventStatus) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.events[output+":"+string(status)]++
@@ -1467,7 +1467,7 @@ func TestWebhookOutput_NilWebhookMetrics(t *testing.T) {
 
 	// Overflow the buffer — should not panic despite missing
 	// OutputMetrics. Buffer-overflow drops are no longer recorded via
-	// core Metrics.RecordEvent (B-25); the per-output RecordDrop path
+	// core Metrics.RecordDelivery (B-25); the per-output RecordDrop path
 	// is exercised in the OutputMetrics-specific tests. Here we only
 	// assert that the code does not panic.
 	for range 15 {
@@ -1476,11 +1476,11 @@ func TestWebhookOutput_NilWebhookMetrics(t *testing.T) {
 	require.NoError(t, out.Close())
 
 	// Core Metrics should NOT have recorded the overflow drops as
-	// RecordEvent(EventError) — B-25 alignment with file + syslog.
+	// RecordDelivery(EventError) — B-25 alignment with file + syslog.
 	m.mu.Lock()
 	errorCount := m.events[out.Name()+":error"]
 	m.mu.Unlock()
-	assert.Equal(t, 0, errorCount, "buffer overflow drops must not be recorded via Metrics.RecordEvent (B-25)")
+	assert.Equal(t, 0, errorCount, "buffer overflow drops must not be recorded via Metrics.RecordDelivery (B-25)")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Locks the `audit.Metrics` interface shape for v1.0 via [ADR 0005](docs/adr/0005-metrics-interface-shape.md). Keeps the nine-method interface after api-ergonomics-reviewer rejected both options listed in the issue AC:

- **Option A** (single `Record(MetricEvent)` tagged union) — rejected because it reintroduces untyped payload (`Depth` meaningful only for `MetricQueueDepth`), allocates on every hot-path `RecordSubmitted` call, and makes Prometheus adapters a 9-case switch.
- **Option B** (split `LifecycleMetrics` / `DeliveryMetrics` / `ValidationMetrics` composed sub-interfaces) — rejected because it preserves the method count, adds type-system ceremony, and introduces a silent-compile footgun when consumers embed two of three no-op partial bases.

The actual ergonomic complaint — consumer burden (~200 lines of Prometheus wiring in the capstone) — is addressed directly: capstone Prometheus adapter rewritten using a `vec()` helper + `NoOpMetrics` embed, now **34 lines of audit-side significant code** (down from ~80), well inside the 50-line AC target.

Closes #594.

## Breaking change

`Metrics.RecordEvent(output, status)` → `Metrics.RecordDelivery(output, status)`. Migration is a one-line find-and-replace.

## Forward compatibility

New metrics in v1.x land as separate optional interfaces detected via type assertion (same pattern as `DeliveryReporter` / `file.RotationRecorder` / `syslog.ReconnectRecorder`). Consumers embedding `NoOpMetrics` retain no-op defaults for every base-interface method; extensions are additive. New `TestNoOpMetrics_AllMethodsArePresent` locks this at test time via reflection.

## Test plan

- [x] `make check` passes (lint + test + security scan across all 12 modules)
- [x] `make test-bdd` passes (updated `event_count_metrics.feature` scenario titles)
- [x] `TestNoOpMetrics_AllMethodsArePresent` passes
- [x] Capstone example builds and the compile-time `var _ audit.Metrics = (*auditMetrics)(nil)` assertion holds
- [x] ADR 0005 follows the 0001/0002-style metadata header format