### PR TITLE
refactor: validate Fields value types + typed standard defaults (#595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `audit.ReservedFieldType` typed enum + `audit.ReservedStandardFieldType(name) (ReservedFieldType, bool)` accessor (#595 B-44). Reports the declared Go value type for each of the 31 reserved standard fields. Constants: `ReservedFieldString`, `ReservedFieldInt`, `ReservedFieldInt64`, `ReservedFieldFloat64`, `ReservedFieldBool`, `ReservedFieldTime`, `ReservedFieldDuration`. Backed by a private canonical map in `std_fields.go`; `ReservedStandardFieldNames()` now derives from the same source. Consumers building taxonomy linters, IDE plugins, or pre-`audit.New` config validators have a programmatic API for type metadata.
+- `audit.ErrUnknownFieldType` sentinel error (#595 B-43). Returned by `Auditor.AuditEvent` in strict validation mode when a `Fields` value's Go type is outside the supported vocabulary (`string`, `int`/`int32`/`int64`, `float64`, `bool`, `time.Time`, `time.Duration`, `[]string`, `map[string]string`, `nil`). Discriminate via `errors.Is(err, audit.ErrUnknownFieldType)`. Always wrapped alongside `ErrValidation`. Warn and permissive modes coerce unsupported values via `fmt.Sprintf("%v", v)` instead of returning the error.
 - `audit.MinSeverity` / `audit.MaxSeverity` constants (#593 B-27) replace the magic-number `0` / `10` range checks in `filter.go:validateSeverityRange`, `taxonomy.go:clampSeverity`, and `validate_taxonomy.go:checkSeverityRanges`. Godoc on each constant documents the inclusive CEF range semantic. Consumers may use these in their own severity validation to stay aligned with the library's contract.
 - `audit.ErrTaxonomyRequired`, `audit.ErrAppNameRequired`, and `audit.ErrHostRequired` sentinel errors (#593 B-41) returned by `audit.New` when the corresponding `WithTaxonomy` / `WithAppName` / `WithHost` is unset (unless `WithDisabled` is also applied). Matches the `outputconfig.Load` YAML-path requirement so programmatic and declarative construction share identical invariants. Discriminate via `errors.Is(err, audit.ErrAppNameRequired)`.
 - `audittest.Recorder.WaitForN(tb, n, timeout)` — blocks until at least `n` events have been recorded or the timeout elapses; returns `true` on success, `false` on timeout. Use in async-mode tests (`audittest.WithAsync`) or tests whose service emits from a goroutine. Poll interval is 10 ms, matching `testify/assert.Eventually`. The fast path returns immediately when the target is already reached. Synchronous auditors (the default for `New` / `NewQuick`) do not need `WaitForN` — events are recorded before `AuditEvent` returns; prefer `Count()` / `RequireEvents` there. Closes #566.
@@ -16,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 > **Deviations from #566 AC (accepted):** (1) `audittest.PermissiveTaxonomy()` NOT added — `audittest.QuickTaxonomy()` already exists and fills the same role; adding a second name violates the "one obvious way" principle. (2) `WithExcludedLabels` renamed to `WithExcludeLabels` to match core `audit.WithExcludeLabels` exactly (no "d"). (3) AC named `RecordedEvents.WaitForN` (a type name from the original issue draft that was never implemented in the codebase) — the actual type is `*audittest.Recorder`, so `WaitForN` is a method on `*Recorder`. All three deviations confirmed with api-ergonomics-reviewer.
 
 ### Changed
+
+- `audit.Fields` value-type validation locked for v1.0 (#595 B-43). The supported vocabulary is `string`, `int`/`int32`/`int64`, `float64`, `bool`, `time.Time`, `time.Duration`, `[]string`, `map[string]string`, and `nil` — see the `Fields` godoc and `docs/taxonomy-validation.md` for the full table. Unsupported values are rejected in strict mode (with the new `ErrUnknownFieldType` sentinel above) and coerced via `fmt.Sprintf("%v", v)` in warn (with a diagnostic-logger warning) and permissive modes. Pre-coding api-ergonomics consult locked the AC list because it matches the YAML `supportedCustomFieldTypes` vocabulary already declared in `taxonomy_yaml.go:218` — runtime contract == YAML schema. `cmd/audit-gen` `standardFieldGoTypes` map extended in lockstep: `start_time` and `end_time` now generate `time.Time` setters (previously `string`), matching the `ReservedFieldTime` declaration. Generated code that uses these setters now imports `"time"` automatically.
 
 - `audit.Metrics` interface shape locked for v1.0 via [ADR 0005](docs/adr/0005-metrics-interface-shape.md) (#594). Kept the existing nine-method shape after api-ergonomics-reviewer rejected both the single-method `Record(MetricEvent)` tagged-union proposal (reintroduces untyped payload + adds a hot-path allocation) and the split `LifecycleMetrics` / `DeliveryMetrics` / `ValidationMetrics` composed-interface proposal (silent-compile footgun when consumers embed two of three no-op partial bases). Nine methods grouped by purpose matches stdlib precedent (`slog.Handler` ×4, `http.ResponseWriter` + optional extensions, `driver.Conn`/`Stmt`/`Rows` 4-6 each). Forward-compatibility policy: new metrics added in v1.x land as separate optional interfaces detected via type assertion on the `Metrics` value (same pattern as `DeliveryReporter` / `file.RotationRecorder` / `syslog.ReconnectRecorder`); consumers embedding `NoOpMetrics` automatically retain no-op implementations. Per-method Prometheus cardinality guidance added to godoc so consumers wiring label vectors see the label-space impact. Capstone Prometheus adapter rewritten using a `vec()` helper and `NoOpMetrics` embedding — the audit-side of `examples/17-capstone/metrics.go` is now 34 lines of significant code (struct + constructor + seven `Record*` methods), comfortably inside the 50-line AC target. New `TestNoOpMetrics_AllMethodsArePresent` locks the forward-compat embed pattern at test time.
 
@@ -54,6 +58,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Examples `02-code-generation`, `04-testing`, `06-middleware`, `13-standard-fields`, and `15-tls-policy` failed at runtime with `unknown output type "stdout"` because they declared `type: stdout` in `outputs.yaml` without blank-importing anything that registered the stdout factory (stdout auto-registration was removed in #578). The new `_ "github.com/axonops/audit/outputs"` blank import registers stdout alongside the other built-ins (#585).
 
 ### Breaking Changes
+
+- `audit.WithStandardFieldDefaults` signature changed from `map[string]string` to `map[string]any` (#595 B-44). Reserved fields with non-string declared types (`source_port`, `dest_port`, `file_size`: int; `start_time`, `end_time`: time.Time) now require values of the correct Go type; mismatches return an error wrapping `audit.ErrConfigInvalid` at `audit.New` time, before any event is processed. Migration:
+  ```go
+  // Before
+  audit.WithStandardFieldDefaults(map[string]string{
+      "actor_id":    "service-account",
+      "source_port": "8080", // forced string even though port is logically int
+  })
+
+  // After
+  audit.WithStandardFieldDefaults(map[string]any{
+      "actor_id":    "service-account",
+      "source_port": 8080, // typed correctly per ReservedStandardFieldType
+  })
+  ```
+  YAML `standard_fields:` consumers via `outputconfig.Load` benefit automatically — YAML decoders produce typed values (`int` for YAML integers, `string` for strings), so an existing YAML with `source_port: 8080` (no quotes) starts validating correctly without YAML changes. YAML with `source_port: "8080"` (quoted, string) now fails fast with a clear error message.
 
 - `audit.Metrics.RecordEvent` renamed to `RecordDelivery` (#594). The new name matches the method's actual role (per-output delivery outcome) and removes the semantic collision with `RecordSubmitted` in readers' heads. Migration is a one-line find-and-replace for every consumer of the interface:
   ```go

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -125,7 +125,7 @@ Every issue follows this sequence. Do not skip steps.
 - [x] **#592** refactor: unify error wrapping conventions across modules; align self-reporting drop metrics; drop dead redactRef parameter.
 - [x] **#593** refactor: small API polish — TLSPolicy zero-value docs, MinSeverity/MaxSeverity constants, Handle on disabled auditor, openbao Close idempotency, audittest rename, require AppName/Host, uniform nil-option handling.
 - [x] **#594** refactor: simplify 9-method Metrics interface into MetricEvent or split into lifecycle/delivery/validation interfaces. (ADR 0005 locks the 9-method shape; renamed `RecordEvent` → `RecordDelivery`; capstone adapter shrunk to ≤50 lines significant code.)
-- [ ] **#595** refactor: Fields rejects unsupported value types; WithStandardFieldDefaults accepts any.
+- [x] **#595** refactor: Fields rejects unsupported value types; WithStandardFieldDefaults accepts any. (Strict mode rejects with `ErrUnknownFieldType`; warn/permissive coerce; `WithStandardFieldDefaults(map[string]any)` validates per-key against the new `ReservedStandardFieldType` enum at `audit.New` time.)
 - [ ] **#596** refactor: consolidate 6 optional Output interfaces into OutputCapabilities struct.
 - [ ] **#597** refactor: enrich Event interface with Description/Categories/FieldInfo; document emission paths.
 - [ ] **#598** feat: unified Sanitizer interface — scrubs audit event fields AND re-raised middleware panic values.

--- a/audit.go
+++ b/audit.go
@@ -126,7 +126,7 @@ type Auditor struct {
 	// reserved standard fields. Set once via WithStandardFieldDefaults;
 	// read-only after construction. Applied in auditInternal before
 	// validation so that defaults satisfy required: true constraints.
-	standardFieldDefaults map[string]string
+	standardFieldDefaults map[string]any
 	logger                *slog.Logger // library diagnostics logger
 	drops                 dropLimiter  // rate-limits buffer-full warnings
 	drainCount            uint64       // events processed by drain loop; for sampling RecordQueueDepth

--- a/audit_test.go
+++ b/audit_test.go
@@ -362,7 +362,7 @@ func TestWithStandardFieldDefaults_InvalidKey(t *testing.T) {
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
-		audit.WithStandardFieldDefaults(map[string]string{"bogus": "value"}),
+		audit.WithStandardFieldDefaults(map[string]any{"bogus": "value"}),
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bogus")
@@ -435,7 +435,7 @@ func TestWithStandardFieldDefaults_Applied(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
-		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
+		audit.WithStandardFieldDefaults(map[string]any{"source_ip": "10.0.0.1"}),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -458,7 +458,7 @@ func TestWithStandardFieldDefaults_PerEventOverride(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
-		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
+		audit.WithStandardFieldDefaults(map[string]any{"source_ip": "10.0.0.1"}),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -482,7 +482,7 @@ func TestWithStandardFieldDefaults_EmptyStringOverride(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
-		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
+		audit.WithStandardFieldDefaults(map[string]any{"source_ip": "10.0.0.1"}),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -505,8 +505,8 @@ func TestWithStandardFieldDefaults_LastWins(t *testing.T) {
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
-		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "a"}),
-		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "b"}),
+		audit.WithStandardFieldDefaults(map[string]any{"source_ip": "a"}),
+		audit.WithStandardFieldDefaults(map[string]any{"source_ip": "b"}),
 		audit.WithValidationMode(audit.ValidationPermissive),
 		audit.WithOutputs(out),
 	)
@@ -537,7 +537,7 @@ func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithOutputs(out),
-		audit.WithStandardFieldDefaults(map[string]string{"source_ip": "10.0.0.1"}),
+		audit.WithStandardFieldDefaults(map[string]any{"source_ip": "10.0.0.1"}),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
@@ -1603,17 +1603,20 @@ func TestLogger_Audit_OmitEmptyZeroInt(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Serialisation failure — non-JSON-serialisable field value
+// Unsupported field value type — handled per ValidationMode (#595 B-43)
 // ---------------------------------------------------------------------------
 
-func TestLogger_Audit_SerializationFailure(t *testing.T) {
+func TestLogger_Audit_UnsupportedFieldValueType_Permissive_CoercesAndDelivers(t *testing.T) {
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationPermissive))
 
-	// A channel cannot be marshalled to JSON. The event passes validation
-	// (permissive mode) and is enqueued, but serialisation fails in the
-	// drain loop. The output should receive zero events and no panic.
+	// A channel is not in the supported Fields value vocabulary
+	// (#595 B-43). Permissive mode silently coerces via
+	// fmt.Sprintf("%v", v), so the event still delivers; the
+	// receiving system sees a stringified channel address. This is
+	// formatter-hostile output but preserves the audit-MUST-emit
+	// invariant.
 	ch := make(chan struct{})
 	err := auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
 		"outcome":  "failure",
@@ -1621,18 +1624,13 @@ func TestLogger_Audit_SerializationFailure(t *testing.T) {
 		"bad":      ch,
 	}))
 	require.NoError(t, err)
-
-	// Send a valid event as sentinel to confirm drain loop processed
-	// the bad event without crashing.
-	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
-		"outcome":  "failure",
-		"actor_id": "sentinel",
-	}))
-	require.NoError(t, err)
 	require.True(t, out.WaitForEvents(1, 2*time.Second))
+	require.Equal(t, 1, out.EventCount(), "permissive mode delivers coerced event")
 
-	// Only the valid event should have been delivered.
-	assert.Equal(t, 1, out.EventCount())
+	ev := out.GetEvent(0)
+	require.Contains(t, ev, "bad")
+	_, isString := ev["bad"].(string)
+	assert.True(t, isString, "permissive coerces unsupported types to string")
 }
 
 // ---------------------------------------------------------------------------
@@ -2242,6 +2240,36 @@ func TestWriteToOutput_NonDeliveryReporter_SuccessRecordsCoreMetrics(t *testing.
 // isZeroValue — integer and float type branches
 // ---------------------------------------------------------------------------
 
+// TestIsZeroValue_NumericTypeBranches_Direct exercises the float32,
+// uint, and uint64 branches in isZeroValue directly. They are no
+// longer reachable through AuditEvent: #595 B-43 coerces those types
+// to string in the validator before OmitEmpty consults isZeroValue.
+// The branches are kept for forward-compat (a future PR could add
+// these types to the supported vocabulary, or callers might invoke
+// the helper through a different path), and direct coverage avoids
+// dead-code drift.
+func TestIsZeroValue_NumericTypeBranches_Direct(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		v    any
+		name string
+		want bool
+	}{
+		{float32(0), "zero float32", true},
+		{float32(3.14), "non-zero float32", false},
+		{uint(0), "zero uint", true},
+		{uint(99), "non-zero uint", false},
+		{uint64(0), "zero uint64", true},
+		{uint64(1), "non-zero uint64", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, audit.IsZeroValueForTest(tc.v))
+		})
+	}
+}
+
 func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 	// Exercises the int32, float32, uint, uint64 branches in isZeroValue
 	// via the OmitEmpty path through the JSON formatter.
@@ -2266,42 +2294,12 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 			wantKey: "val",
 			wantIn:  true,
 		},
-		{
-			name:    "zero float32 omitted",
-			fields:  audit.Fields{"outcome": "ok", "actor_id": "x", "val": float32(0)},
-			wantKey: "val",
-			wantIn:  false,
-		},
-		{
-			name:    "non-zero float32 included",
-			fields:  audit.Fields{"outcome": "ok", "actor_id": "x", "val": float32(3.14)},
-			wantKey: "val",
-			wantIn:  true,
-		},
-		{
-			name:    "zero uint omitted",
-			fields:  audit.Fields{"outcome": "ok", "actor_id": "x", "val": uint(0)},
-			wantKey: "val",
-			wantIn:  false,
-		},
-		{
-			name:    "non-zero uint included",
-			fields:  audit.Fields{"outcome": "ok", "actor_id": "x", "val": uint(99)},
-			wantKey: "val",
-			wantIn:  true,
-		},
-		{
-			name:    "zero uint64 omitted",
-			fields:  audit.Fields{"outcome": "ok", "actor_id": "x", "val": uint64(0)},
-			wantKey: "val",
-			wantIn:  false,
-		},
-		{
-			name:    "non-zero uint64 included",
-			fields:  audit.Fields{"outcome": "ok", "actor_id": "x", "val": uint64(1)},
-			wantKey: "val",
-			wantIn:  true,
-		},
+		// float32, uint, uint64 are not in the #595 B-43 supported
+		// Fields value vocabulary and are coerced to string by the
+		// validator in non-strict modes — exercising them here would
+		// no longer test the OmitEmpty numeric-type branches in
+		// isZeroValue. The supported numeric types (int, int32, int64,
+		// float64) are covered above and below this comment.
 		{
 			name:    "zero int64 omitted",
 			fields:  audit.Fields{"outcome": "ok", "actor_id": "x", "val": int64(0)},
@@ -3216,7 +3214,7 @@ func BenchmarkStandardFieldDefaults_Applied(b *testing.B) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out),
-		audit.WithStandardFieldDefaults(map[string]string{
+		audit.WithStandardFieldDefaults(map[string]any{
 			"source_ip":  "10.0.0.1",
 			"actor_id":   "system",
 			"request_id": "default-req",

--- a/cmd/audit-gen/generate.go
+++ b/cmd/audit-gen/generate.go
@@ -100,12 +100,18 @@ type builderField struct {
 	Labels     []builderLabel // labels on this field
 }
 
-// standardFieldGoTypes maps reserved standard field names to their Go
-// types. Fields not in this map default to "string".
+// standardFieldGoTypes maps reserved standard field names to the
+// Go-source type the generator emits for typed setters. Mirrors the
+// runtime audit.ReservedStandardFieldType enum (see std_fields.go);
+// any addition there must land in lockstep here so the typed-builder
+// surface stays consistent with WithStandardFieldDefaults
+// validation. Fields not in this map default to "string".
 var standardFieldGoTypes = map[string]string{
 	"source_port": "int",
 	"dest_port":   "int",
 	"file_size":   "int",
+	"start_time":  "time.Time",
+	"end_time":    "time.Time",
 }
 
 func standardFieldGoType(name string) string {
@@ -147,6 +153,7 @@ type templateData struct {
 	HasBuilders           bool
 	HasSeverityInBuilders bool
 	HasMetadata           bool // true when any metadata var is emitted
+	HasTimeImport         bool // true when any builder field requires "time"
 }
 
 // generate produces Go source code from a taxonomy. The output is
@@ -239,18 +246,38 @@ func buildMetadata(data *templateData, tax audit.Taxonomy, opts generateOptions)
 	if opts.Builders {
 		data.Builders = collectBuilders(tax, opts)
 		data.HasBuilders = len(data.Builders) > 0
-		for i := range data.Builders {
-			for _, c := range data.Builders[i].Categories {
-				if c.HasSeverity {
-					data.HasSeverityInBuilders = true
-					break
-				}
+		data.HasSeverityInBuilders, data.HasTimeImport = scanBuilderFlags(data.Builders)
+	}
+}
+
+// scanBuilderFlags computes the cross-builder flags that drive
+// template branches: whether any builder has a category with a
+// declared severity (so the `Severity()` method emits) and whether
+// any builder field needs a `time.Time` typed setter (so `import
+// "time"` is added to the generated file).
+func scanBuilderFlags(builders []builderDef) (hasSeverity, hasTimeImport bool) {
+	needsTime := func(setters []builderField) bool {
+		for _, s := range setters {
+			if s.GoType == "time.Time" {
+				return true
 			}
-			if data.HasSeverityInBuilders {
+		}
+		return false
+	}
+	for i := range builders {
+		for _, c := range builders[i].Categories {
+			if c.HasSeverity {
+				hasSeverity = true
 				break
 			}
 		}
+		if needsTime(builders[i].StandardSetters) ||
+			needsTime(builders[i].Required) ||
+			needsTime(builders[i].Optional) {
+			hasTimeImport = true
+		}
 	}
+	return hasSeverity, hasTimeImport
 }
 
 // buildLabelConstants creates label constant entries from the taxonomy's

--- a/cmd/audit-gen/template.go
+++ b/cmd/audit-gen/template.go
@@ -23,7 +23,11 @@ const tmplText = `{{ .Header }}
 //nolint:all // generated code — do not lint
 package {{ .Package }}
 {{ if .HasBuilders }}
-import "github.com/axonops/audit"
+import (
+	{{ if .HasTimeImport }}"time"
+
+	{{ end }}"github.com/axonops/audit"
+)
 {{ end }}
 {{ if .HasEvents }}
 // Event type constants — use these instead of raw strings

--- a/docs/taxonomy-validation.md
+++ b/docs/taxonomy-validation.md
@@ -391,13 +391,64 @@ for practical guidance on choosing severity values.
 
 | Mode | Behaviour |
 |------|-----------|
-| `strict` (default) | Rejects events with fields not declared in the taxonomy |
-| `warn` | Accepts unknown fields but logs a warning via `log/slog` |
-| `permissive` | Accepts any fields without warning |
+| `strict` (default) | Rejects events with fields not declared in the taxonomy or with unsupported value types |
+| `warn` | Accepts unknown fields and unsupported value types; logs a warning via `log/slog` and coerces unsupported values to string |
+| `permissive` | Accepts any fields without warning; silently coerces unsupported values to string |
 
 Set via `audit.WithValidationMode(audit.ValidationWarn)` on
 `New`, the `validation_mode` key in your outputs YAML, or
 `audittest.WithValidationMode(audit.ValidationWarn)` in tests.
+
+## 🧬 Supported Field Value Types
+
+`audit.Fields` accepts `map[string]any`, but only this set of value
+types is guaranteed to render faithfully across both the JSON and
+CEF formatters:
+
+| Type | Example |
+|------|---------|
+| `string` | `"alice"` |
+| `int`, `int32`, `int64` | `8080` |
+| `float64` | `1.5` |
+| `bool` | `true` |
+| `time.Time` | `time.Now().UTC()` |
+| `time.Duration` | `5 * time.Second` |
+| `[]string` | `[]string{"admin", "auditor"}` |
+| `map[string]string` | `map[string]string{"k": "v"}` |
+| `nil` | rendered as `null` (JSON) or absent (CEF) |
+
+Behaviour for values **outside** this vocabulary depends on the
+auditor's `ValidationMode`:
+
+| Mode | Outcome |
+|------|---------|
+| `strict` | `Auditor.AuditEvent` returns `*audit.ValidationError` wrapping `audit.ErrUnknownFieldType`; the event is dropped. |
+| `warn` | The unsupported value is coerced via `fmt.Sprintf("%v", v)` and a `log/slog` warning is emitted. |
+| `permissive` | The unsupported value is coerced silently. |
+
+Coercion produces formatter-hostile output for composite types
+(struct dumps, `{}` for empty maps). Pass values from the supported
+vocabulary; the validation mode is a backstop, not a feature.
+
+### Reserved standard field types
+
+Reserved standard fields carry an additional declared Go type for
+type-aware tooling and `WithStandardFieldDefaults` validation. Query
+the type at runtime:
+
+```go
+t, ok := audit.ReservedStandardFieldType("source_port")
+// t == audit.ReservedFieldInt
+```
+
+Most reserved fields are `string`; `source_port`, `dest_port`, and
+`file_size` are `int`; `start_time` and `end_time` are `time.Time`.
+See the `ReservedFieldType` enum in the godoc for the complete list.
+
+`audit.WithStandardFieldDefaults(map[string]any{...})` rejects
+deployment-time defaults whose Go type does not match the declared
+reserved-field type. The error wraps `audit.ErrConfigInvalid` and
+surfaces at `audit.New` time, before any event is processed.
 
 ## 📦 Loading a Taxonomy
 

--- a/errors.go
+++ b/errors.go
@@ -153,6 +153,18 @@ var (
 	// [ValidationError].
 	ErrUnknownField = errors.New("audit: unknown field")
 
+	// ErrUnknownFieldType is returned by [Auditor.AuditEvent] in
+	// strict validation mode when a [Fields] entry carries a value
+	// of a type not in the supported set documented on [Fields].
+	// Always wrapped alongside [ErrValidation] via [ValidationError].
+	//
+	// In warn and permissive modes, unsupported values are coerced
+	// via fmt.Sprintf("%v", v) instead of returning this error; in
+	// warn mode a diagnostic-logger warning is emitted as well. See
+	// the Fields godoc for the full type vocabulary and behaviour
+	// matrix.
+	ErrUnknownFieldType = errors.New("audit: unsupported field value type")
+
 	// ErrHMACMalformed is returned by [VerifyHMAC] when the
 	// supplied HMAC value is structurally invalid — empty, the
 	// wrong length for the algorithm's hash size, or contains

--- a/example_test.go
+++ b/example_test.go
@@ -42,13 +42,20 @@ func ExampleNew() {
 		}),
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
+		// Synchronous delivery — single-event docs example with no
+		// async drain goroutine. Avoids a CI flake where loaded
+		// runners can starve the drain goroutine past the default 5s
+		// shutdown timeout, leaving it runnable when goleak runs.
+		audit.WithSynchronousDelivery(),
 		audit.WithOutputs(stdout),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Emit an event — it will be written to the buffer as a JSON line.
+	// Emit an event — synchronous delivery means the buffer is
+	// populated before AuditEvent returns; no Close-before-assert
+	// ceremony is needed.
 	if err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
 		"outcome":  "success",
 		"actor_id": "alice",
@@ -56,7 +63,8 @@ func ExampleNew() {
 		log.Fatal(err)
 	}
 
-	// Close drains the async buffer so all events are flushed.
+	// Close is still called for symmetry; in synchronous mode it is
+	// effectively a no-op for delivery and only closes outputs.
 	if err := auditor.Close(); err != nil {
 		log.Fatal(err)
 	}
@@ -86,6 +94,8 @@ func ExampleAuditor_AuditEvent() {
 		}),
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
+		// Synchronous delivery — see ExampleNew for rationale.
+		audit.WithSynchronousDelivery(),
 		audit.WithOutputs(stdout),
 	)
 	if err != nil {

--- a/export_test.go
+++ b/export_test.go
@@ -16,3 +16,9 @@ package audit
 
 // IsFrameworkField is exported for testing only.
 var IsFrameworkField = isFrameworkField
+
+// IsZeroValueForTest is exported for testing only. Direct coverage
+// of the float32 / uint / uint64 branches in isZeroValue, which are
+// no longer reachable through AuditEvent (#595 B-43 coerces those
+// types to string upstream of OmitEmpty in non-strict modes).
+var IsZeroValueForTest = isZeroValue

--- a/options.go
+++ b/options.go
@@ -191,15 +191,32 @@ func WithDiagnosticLogger(l *slog.Logger) Option {
 // zero value). When called multiple times, the last call wins.
 //
 // Optional. Nil or empty map means "no defaults".
-func WithStandardFieldDefaults(defaults map[string]string) Option {
+//
+// Each value's Go type MUST match the reserved field's declared type
+// reported by [ReservedStandardFieldType]. On mismatch, [New]
+// returns an error wrapping [ErrConfigInvalid] so the
+// misconfiguration surfaces at startup rather than at the first
+// AuditEvent. Numeric port fields (`source_port`, `dest_port`,
+// `file_size`) require int; timestamps (`start_time`, `end_time`)
+// require time.Time; the remaining 26 reserved fields require
+// string. Pre-#595 callers passing `map[string]string` migrate by
+// changing the literal map type; values that are already strings
+// for string-typed fields keep working unchanged.
+func WithStandardFieldDefaults(defaults map[string]any) Option {
 	return func(a *Auditor) error {
-		for k := range defaults {
-			if !IsReservedStandardField(k) {
-				return fmt.Errorf("audit: standard field default key %q is not a reserved standard field", k)
+		for k, v := range defaults {
+			t, ok := ReservedStandardFieldType(k)
+			if !ok {
+				return fmt.Errorf("%w: WithStandardFieldDefaults: %q is not a reserved standard field",
+					ErrConfigInvalid, k)
+			}
+			if !valueMatchesReservedType(v, t) {
+				return fmt.Errorf("%w: WithStandardFieldDefaults[%q]: expected %s, got %T",
+					ErrConfigInvalid, k, t, v)
 			}
 		}
 		// Copy to prevent caller mutation after construction.
-		cp := make(map[string]string, len(defaults))
+		cp := make(map[string]any, len(defaults))
 		for k, v := range defaults {
 			cp[k] = v
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -15,6 +15,8 @@
 package audit_test
 
 import (
+	"bytes"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -430,4 +432,191 @@ func TestSeverity_ExportedConstants(t *testing.T) {
 	// surface; regressing them requires a major-version bump.
 	assert.Equal(t, 0, audit.MinSeverity)
 	assert.Equal(t, 10, audit.MaxSeverity)
+}
+
+// ---------------------------------------------------------------------------
+// WithStandardFieldDefaults type validation (#595 B-44)
+// ---------------------------------------------------------------------------
+
+func TestWithStandardFieldDefaults_TypeMismatch_Error(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	_, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithStandardFieldDefaults(map[string]any{
+			"source_port": "8080", // string passed for int-typed reserved field
+		}),
+		audit.WithOutputs(out),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
+	assert.Contains(t, err.Error(), `"source_port"`)
+	assert.Contains(t, err.Error(), "expected int")
+}
+
+func TestWithStandardFieldDefaults_UnknownReservedField_Error(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	_, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithStandardFieldDefaults(map[string]any{
+			"not_a_reserved_field": "x",
+		}),
+		audit.WithOutputs(out),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
+	assert.Contains(t, err.Error(), `"not_a_reserved_field"`)
+}
+
+func TestWithStandardFieldDefaults_ValidIntDefault_Accepted(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	auditor, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithValidationMode(audit.ValidationPermissive),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithStandardFieldDefaults(map[string]any{
+			"source_port": 8080,
+		}),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
+
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	})))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	ev := out.GetEvent(0)
+	require.Contains(t, ev, "source_port")
+	// MockOutput's getter returns events through JSON marshal/unmarshal,
+	// so int values come back as float64. Compare numerically.
+	got, ok := ev["source_port"].(float64)
+	require.True(t, ok, "source_port should be a numeric type, got %T", ev["source_port"])
+	assert.Equal(t, float64(8080), got)
+}
+
+func TestWithStandardFieldDefaults_ValidTimeDefault_Accepted(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	startTime := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	auditor, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithValidationMode(audit.ValidationPermissive),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithStandardFieldDefaults(map[string]any{
+			"start_time": startTime,
+		}),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
+
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	})))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	ev := out.GetEvent(0)
+	assert.Contains(t, ev, "start_time")
+}
+
+// ---------------------------------------------------------------------------
+// Fields value-type validation (#595 B-43)
+// ---------------------------------------------------------------------------
+
+func TestAudit_UnsupportedFieldValueType_RejectedInStrictMode(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	auditor, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithValidationMode(audit.ValidationStrict),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
+
+	ch := make(chan struct{})
+	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "alice",
+		"bad":      ch,
+	}))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrUnknownFieldType)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	assert.Equal(t, 0, out.EventCount(),
+		"strict mode must drop the event before delivery")
+}
+
+func TestAudit_UnsupportedFieldValueType_WarnedAndCoercedInWarnMode(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	auditor, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithValidationMode(audit.ValidationWarn),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithDiagnosticLogger(logger),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
+
+	ch := make(chan struct{})
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "alice",
+		"bad":      ch,
+	})))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	// The unsupported value is coerced to string AND a warning is logged.
+	ev := out.GetEvent(0)
+	require.Contains(t, ev, "bad")
+	_, isString := ev["bad"].(string)
+	assert.True(t, isString, "warn mode coerces unsupported types to string")
+	assert.Contains(t, logBuf.String(), "unsupported field value types",
+		"warn mode must log a diagnostic about unsupported value types")
+}
+
+func TestAudit_UnsupportedFieldValueType_CoercedInPermissiveMode(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("test")
+	auditor, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithValidationMode(audit.ValidationPermissive),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithOutputs(out),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, auditor.Close()) })
+
+	ch := make(chan struct{})
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "failure",
+		"actor_id": "alice",
+		"bad":      ch,
+	})))
+	require.True(t, out.WaitForEvents(1, 2*time.Second))
+
+	ev := out.GetEvent(0)
+	require.Contains(t, ev, "bad")
+	_, isString := ev["bad"].(string)
+	assert.True(t, isString, "permissive mode coerces unsupported types to string")
 }

--- a/outputconfig/auditor_config.go
+++ b/outputconfig/auditor_config.go
@@ -16,6 +16,7 @@ package outputconfig
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/axonops/audit"
@@ -129,27 +130,134 @@ func defaultAuditorConfigResult() auditorConfigResult {
 	return auditorConfigResult{}
 }
 
-func parseStandardFields(raw any) (map[string]string, error) {
+func parseStandardFields(raw any) (map[string]any, error) {
 	m, ok := raw.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("%w: standard_fields must be a mapping", ErrOutputConfigInvalid)
 	}
-	result := make(map[string]string, len(m))
+	result := make(map[string]any, len(m))
 	for key, val := range m {
-		if !audit.IsReservedStandardField(key) {
+		t, isReserved := audit.ReservedStandardFieldType(key)
+		if !isReserved {
 			return nil, fmt.Errorf("%w: standard_fields: unknown field %q -- only reserved standard field names are accepted",
 				ErrOutputConfigInvalid, key)
 		}
-		s, err := toString(val)
+		// Reject empty string values regardless of reserved-field type;
+		// a deployment-time empty default is always a configuration
+		// mistake.
+		if s, isStr := val.(string); isStr && s == "" {
+			return nil, fmt.Errorf("%w: standard_fields: field %q must have a non-empty value",
+				ErrOutputConfigInvalid, key)
+		}
+		// Normalise YAML-native types to the Go types the audit
+		// package's WithStandardFieldDefaults validation expects.
+		// goccy/go-yaml decodes integers as uint64 (positive) or
+		// int64 (negative) and timestamps as string; the audit
+		// package wants int / time.Time. Reject overflows and
+		// malformed timestamps with clear errors here so the
+		// failure mode points at the YAML, not at New().
+		coerced, err := coerceStandardFieldValue(key, val, t)
 		if err != nil {
 			return nil, fmt.Errorf("%w: standard_fields: field %q: %w",
 				ErrOutputConfigInvalid, key, err)
 		}
-		if s == "" {
-			return nil, fmt.Errorf("%w: standard_fields: field %q must have a non-empty value",
-				ErrOutputConfigInvalid, key)
-		}
-		result[key] = s
+		result[key] = coerced
 	}
 	return result, nil
+}
+
+// coerceStandardFieldValue converts a YAML-decoded value to the Go
+// type declared for the reserved standard field. The conversion is
+// loss-less or a clear error: int overflow on int64→int rejects
+// rather than silently truncating; string→time.Time uses RFC3339.
+//
+// Returns the coerced value, or the original value when the YAML-
+// decoded type already matches the declared type (so the audit-
+// package validator can do the final type assertion).
+func coerceStandardFieldValue(key string, val any, t audit.ReservedFieldType) (any, error) { //nolint:gocyclo,cyclop,gocognit // flat type switch over reserved-field declared types
+	switch t {
+	case audit.ReservedFieldInt:
+		return coerceToInt(val)
+	case audit.ReservedFieldInt64:
+		return coerceToInt64(val)
+	case audit.ReservedFieldFloat64:
+		if f, ok := val.(float64); ok {
+			return f, nil
+		}
+		if i, ok := val.(uint64); ok {
+			return float64(i), nil
+		}
+		if i, ok := val.(int64); ok {
+			return float64(i), nil
+		}
+		return nil, fmt.Errorf("expected float64-compatible YAML number, got %T", val)
+	case audit.ReservedFieldBool:
+		if b, ok := val.(bool); ok {
+			return b, nil
+		}
+		return nil, fmt.Errorf("expected YAML bool, got %T", val)
+	case audit.ReservedFieldTime:
+		s, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected RFC3339 timestamp string, got %T", val)
+		}
+		ts, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid RFC3339 timestamp %q: %w", s, err)
+		}
+		return ts, nil
+	case audit.ReservedFieldDuration:
+		s, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected duration string, got %T", val)
+		}
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return d, nil
+	case audit.ReservedFieldString:
+		if _, ok := val.(string); !ok {
+			return nil, fmt.Errorf("expected string, got %T", val)
+		}
+		return val, nil
+	}
+	// Unknown ReservedFieldType (forward-compat — new enum value
+	// added without updating this switch). Pass through and let the
+	// audit-package validator report a clear error.
+	_ = key
+	return val, nil
+}
+
+func coerceToInt(val any) (int, error) {
+	switch v := val.(type) {
+	case int:
+		return v, nil
+	case uint64:
+		if v > uint64(math.MaxInt) {
+			return 0, fmt.Errorf("YAML integer %d exceeds int max %d", v, math.MaxInt)
+		}
+		return int(v), nil
+	case int64:
+		if v > int64(math.MaxInt) || v < int64(math.MinInt) {
+			return 0, fmt.Errorf("YAML integer %d out of int range [%d, %d]", v, math.MinInt, math.MaxInt)
+		}
+		return int(v), nil
+	}
+	return 0, fmt.Errorf("expected YAML integer, got %T", val)
+}
+
+func coerceToInt64(val any) (int64, error) {
+	switch v := val.(type) {
+	case int64:
+		return v, nil
+	case int:
+		return int64(v), nil
+	case uint64:
+		if v > uint64(math.MaxInt64) {
+			return 0, fmt.Errorf("YAML integer %d exceeds int64 max %d", v, int64(math.MaxInt64))
+		}
+		return int64(v), nil
+	}
+	return 0, fmt.Errorf("expected YAML integer, got %T", val)
 }

--- a/outputconfig/outputconfig.go
+++ b/outputconfig/outputconfig.go
@@ -56,7 +56,7 @@ type Loaded struct {
 	appName        string
 	host           string
 	timezone       string
-	standardFields map[string]string
+	standardFields map[string]any
 
 	// auditorCfg retains the parsed auditor: section values for
 	// package-internal introspection (e.g., black-box tests that
@@ -161,7 +161,13 @@ func (l *Loaded) Timezone() string {
 // from the top-level `standard_fields:` section, or nil when not
 // specified. The returned map is the internal one; callers MUST NOT
 // mutate it.
-func (l *Loaded) StandardFields() map[string]string {
+//
+// Values carry the YAML-decoded Go type (int for YAML integers,
+// string for YAML strings, time.Time for ISO8601 timestamps decoded
+// natively). Type mismatches against the reserved-field declared
+// type are reported by [audit.WithStandardFieldDefaults] at
+// [audit.New] time.
+func (l *Loaded) StandardFields() map[string]any {
 	if l == nil {
 		return nil
 	}
@@ -496,7 +502,7 @@ func Load(ctx context.Context, data []byte, taxonomy *audit.Taxonomy, opts ...Lo
 // topLevel holds parsed top-level YAML fields.
 type topLevel struct {
 	outputsRaw     yaml.MapSlice // preserves output declaration order
-	standardFields map[string]string
+	standardFields map[string]any
 	appName        string
 	host           string
 	timezone       string

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -1824,6 +1824,92 @@ outputs:
 	assert.Contains(t, err.Error(), "bogus_field")
 }
 
+// TestLoad_StandardFields_TypedYAMLValues verifies that YAML-native
+// integer and timestamp values for typed reserved fields are
+// coerced to the audit-package expected Go type (int and time.Time
+// respectively). Without coercion, goccy/go-yaml decodes integers
+// as uint64 and timestamps as string, which audit.WithStandardFieldDefaults
+// would reject (#595 B-44).
+func TestLoad_StandardFields_TypedYAMLValues(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+app_name: test
+host: test
+standard_fields:
+  source_port: 8080
+  file_size: 1024
+  start_time: "2026-04-24T10:00:00Z"
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	result, err := outputconfig.Load(context.Background(), data, tax)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, o := range result.OutputMetadata() {
+			_ = o.Output.Close()
+		}
+	})
+
+	sf := result.StandardFields()
+	require.NotNil(t, sf)
+
+	// YAML-native integers come through coerced to int.
+	port, ok := sf["source_port"].(int)
+	require.True(t, ok, "source_port should be coerced to int, got %T", sf["source_port"])
+	assert.Equal(t, 8080, port)
+
+	size, ok := sf["file_size"].(int)
+	require.True(t, ok, "file_size should be coerced to int, got %T", sf["file_size"])
+	assert.Equal(t, 1024, size)
+
+	// Timestamp string is parsed as time.Time.
+	start, ok := sf["start_time"].(time.Time)
+	require.True(t, ok, "start_time should be coerced to time.Time, got %T", sf["start_time"])
+	assert.Equal(t, time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC), start.UTC())
+}
+
+func TestLoad_StandardFields_TypedYAMLValues_RejectInvalidTimestamp(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+app_name: test
+host: test
+standard_fields:
+  start_time: "not-a-timestamp"
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(context.Background(), data, tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "start_time")
+	assert.Contains(t, err.Error(), "not-a-timestamp")
+}
+
+func TestLoad_StandardFields_TypedYAMLValues_RejectStringForIntField(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+version: 1
+app_name: test
+host: test
+standard_fields:
+  source_port: "8080"
+outputs:
+  console:
+    type: stdout
+`)
+	tax := testTaxonomy(t)
+	_, err := outputconfig.Load(context.Background(), data, tax)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
+	assert.Contains(t, err.Error(), "source_port")
+}
+
 func TestLoad_StandardFields_EmptyValue(t *testing.T) {
 	t.Parallel()
 	data := []byte(`

--- a/std_fields.go
+++ b/std_fields.go
@@ -1,0 +1,165 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import "time"
+
+// ReservedFieldType identifies the Go-level value type that a reserved
+// standard field accepts. Consumers use it via
+// [ReservedStandardFieldType] to validate per-field defaults and to
+// drive type-aware tooling (linters, IDE plugins, code generators).
+//
+// The library guarantees a stable enum identity for v1.x: existing
+// constants do not change value, but new types may be added. Callers
+// SHOULD include a default branch when switching on a value.
+type ReservedFieldType uint8
+
+// Defined ReservedFieldType values. Values are stable within a major
+// version. New values are added in minor releases.
+const (
+	// ReservedFieldString accepts Go string values.
+	ReservedFieldString ReservedFieldType = iota
+
+	// ReservedFieldInt accepts Go int values. Distinct from
+	// ReservedFieldInt64 because some reserved fields (port numbers)
+	// are bounded and idiomatically represented as int.
+	ReservedFieldInt
+
+	// ReservedFieldInt64 accepts Go int64 values.
+	ReservedFieldInt64
+
+	// ReservedFieldFloat64 accepts Go float64 values.
+	ReservedFieldFloat64
+
+	// ReservedFieldBool accepts Go bool values.
+	ReservedFieldBool
+
+	// ReservedFieldTime accepts Go [time.Time] values.
+	ReservedFieldTime
+
+	// ReservedFieldDuration accepts Go [time.Duration] values.
+	ReservedFieldDuration
+)
+
+// String returns the canonical string label for a ReservedFieldType.
+// The label matches the Go source-level name of the underlying type
+// (`string`, `int`, `int64`, `float64`, `bool`, `time.Time`,
+// `time.Duration`) so it is suitable for embedding in error messages
+// and YAML schemas.
+func (t ReservedFieldType) String() string {
+	switch t {
+	case ReservedFieldString:
+		return "string"
+	case ReservedFieldInt:
+		return "int"
+	case ReservedFieldInt64:
+		return "int64"
+	case ReservedFieldFloat64:
+		return "float64"
+	case ReservedFieldBool:
+		return "bool"
+	case ReservedFieldTime:
+		return "time.Time"
+	case ReservedFieldDuration:
+		return "time.Duration"
+	}
+	return "unknown"
+}
+
+// reservedStandardFieldTypes is the canonical map of reserved standard
+// field name → Go value type. The single source of truth for both
+// [ReservedStandardFieldNames] and [ReservedStandardFieldType], and
+// the basis for [WithStandardFieldDefaults] type validation.
+//
+// Adding a reserved field MUST update this map. Because
+// [ReservedStandardFieldNames] is derived from this map directly,
+// the two views are trivially consistent.
+var reservedStandardFieldTypes = map[string]ReservedFieldType{
+	"action":      ReservedFieldString,
+	"actor_id":    ReservedFieldString,
+	"actor_uid":   ReservedFieldString,
+	"dest_host":   ReservedFieldString,
+	"dest_ip":     ReservedFieldString,
+	"dest_port":   ReservedFieldInt,
+	"end_time":    ReservedFieldTime,
+	"file_hash":   ReservedFieldString,
+	"file_name":   ReservedFieldString,
+	"file_path":   ReservedFieldString,
+	"file_size":   ReservedFieldInt,
+	"message":     ReservedFieldString,
+	"method":      ReservedFieldString,
+	"outcome":     ReservedFieldString,
+	"path":        ReservedFieldString,
+	"protocol":    ReservedFieldString,
+	"reason":      ReservedFieldString,
+	"referrer":    ReservedFieldString,
+	"request_id":  ReservedFieldString,
+	"role":        ReservedFieldString,
+	"session_id":  ReservedFieldString,
+	"source_host": ReservedFieldString,
+	"source_ip":   ReservedFieldString,
+	"source_port": ReservedFieldInt,
+	"start_time":  ReservedFieldTime,
+	"target_id":   ReservedFieldString,
+	"target_role": ReservedFieldString,
+	"target_type": ReservedFieldString,
+	"target_uid":  ReservedFieldString,
+	"transport":   ReservedFieldString,
+	"user_agent":  ReservedFieldString,
+}
+
+// ReservedStandardFieldType reports the declared Go value type for a
+// reserved standard field. The second return value is false if name
+// is not a reserved standard field — see
+// [ReservedStandardFieldNames] for the canonical list.
+//
+// Consumers use this for type-aware linting, IDE assistance, or to
+// validate their own configuration before passing it to
+// [WithStandardFieldDefaults].
+func ReservedStandardFieldType(name string) (ReservedFieldType, bool) {
+	t, ok := reservedStandardFieldTypes[name]
+	return t, ok
+}
+
+// valueMatchesReservedType reports whether v's Go type matches the
+// declared ReservedFieldType. Used by [WithStandardFieldDefaults] to
+// reject deployment-time type mismatches before any event is
+// processed.
+func valueMatchesReservedType(v any, t ReservedFieldType) bool {
+	switch t {
+	case ReservedFieldString:
+		_, ok := v.(string)
+		return ok
+	case ReservedFieldInt:
+		_, ok := v.(int)
+		return ok
+	case ReservedFieldInt64:
+		_, ok := v.(int64)
+		return ok
+	case ReservedFieldFloat64:
+		_, ok := v.(float64)
+		return ok
+	case ReservedFieldBool:
+		_, ok := v.(bool)
+		return ok
+	case ReservedFieldTime:
+		_, ok := v.(time.Time)
+		return ok
+	case ReservedFieldDuration:
+		_, ok := v.(time.Duration)
+		return ok
+	}
+	return false
+}

--- a/std_fields_test.go
+++ b/std_fields_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit"
+)
+
+// TestReservedStandardFieldType_AllNamesHaveTypes asserts that every
+// name returned by [audit.ReservedStandardFieldNames] also has an
+// entry in the type map exposed via [audit.ReservedStandardFieldType].
+// The two are derived from a single private map; the test guards
+// future additions that touch one but not the other.
+func TestReservedStandardFieldType_AllNamesHaveTypes(t *testing.T) {
+	t.Parallel()
+	for _, name := range audit.ReservedStandardFieldNames() {
+		_, ok := audit.ReservedStandardFieldType(name)
+		assert.True(t, ok,
+			"reserved standard field %q has no type entry — add it to reservedStandardFieldTypes in std_fields.go",
+			name)
+	}
+}
+
+// TestReservedStandardFieldType_Unknown returns false on a
+// non-reserved name.
+func TestReservedStandardFieldType_Unknown(t *testing.T) {
+	t.Parallel()
+	_, ok := audit.ReservedStandardFieldType("definitely_not_a_reserved_field")
+	assert.False(t, ok)
+}
+
+// TestReservedFieldType_String_RoundTrip exercises every enum value
+// to ensure the canonical string label is non-empty and unique.
+func TestReservedFieldType_String_RoundTrip(t *testing.T) {
+	t.Parallel()
+	values := []audit.ReservedFieldType{
+		audit.ReservedFieldString,
+		audit.ReservedFieldInt,
+		audit.ReservedFieldInt64,
+		audit.ReservedFieldFloat64,
+		audit.ReservedFieldBool,
+		audit.ReservedFieldTime,
+		audit.ReservedFieldDuration,
+	}
+	seen := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		s := v.String()
+		require.NotEmpty(t, s, "type %d has empty String()", v)
+		assert.NotEqual(t, "unknown", s, "type %d falls through to default branch", v)
+		_, dup := seen[s]
+		assert.False(t, dup, "type label %q is shared by two values", s)
+		seen[s] = struct{}{}
+	}
+}
+
+// TestReservedStandardFieldType_KnownPortIsInt locks the contract
+// that port-typed reserved fields require int (not string) values.
+// Consumer regressions (e.g. accidentally typing a port as string)
+// would surface here first.
+func TestReservedStandardFieldType_KnownPortIsInt(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"source_port", "dest_port", "file_size"} {
+		got, ok := audit.ReservedStandardFieldType(name)
+		require.True(t, ok, "%q should be a reserved standard field", name)
+		assert.Equal(t, audit.ReservedFieldInt, got, "%q should be ReservedFieldInt", name)
+	}
+}
+
+// TestReservedStandardFieldType_KnownTimestampIsTime locks the
+// contract that timestamp reserved fields require time.Time values.
+func TestReservedStandardFieldType_KnownTimestampIsTime(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"start_time", "end_time"} {
+		got, ok := audit.ReservedStandardFieldType(name)
+		require.True(t, ok, "%q should be a reserved standard field", name)
+		assert.Equal(t, audit.ReservedFieldTime, got, "%q should be ReservedFieldTime", name)
+	}
+}

--- a/taxonomy.go
+++ b/taxonomy.go
@@ -28,6 +28,45 @@ import (
 // explicitly: audit.Fields(m).
 //
 // Comparable pattern: [net/url.Values], [net/http.Header].
+//
+// # Supported value types
+//
+// The library guarantees faithful rendering across both built-in
+// formatters (JSON and CEF) for these value types only:
+//
+//   - string
+//   - int, int32, int64
+//   - float64
+//   - bool
+//   - [time.Time]
+//   - [time.Duration]
+//   - []string
+//   - map[string]string
+//   - nil (renders as null in JSON; absent in CEF)
+//
+// Behaviour for values outside this vocabulary depends on the
+// auditor's ValidationMode (configured via [WithValidationMode]):
+//
+//   - [ValidationStrict]: [Auditor.AuditEvent] returns a
+//     [ValidationError] wrapping [ErrUnknownFieldType] and the event
+//     is dropped.
+//   - [ValidationWarn]: the unsupported value is coerced via
+//     fmt.Sprintf("%v", v) and a warning is logged through the
+//     diagnostic logger ([WithDiagnosticLogger]).
+//   - [ValidationPermissive]: the unsupported value is coerced
+//     silently.
+//
+// Coercion is functional but produces formatter-hostile output for
+// composite types (struct dumps, "{}" for empty maps). Consumers
+// should pass values in the supported vocabulary; the validation
+// mode is a backstop, not a feature.
+//
+// Reserved standard fields ([ReservedStandardFieldNames]) carry an
+// additional declared Go type (queryable via
+// [ReservedStandardFieldType]). [WithStandardFieldDefaults] enforces
+// that declared type at construction time. Per-event values supplied
+// via Fields are NOT type-checked against the reserved type — only
+// the supported-vocabulary check above runs.
 type Fields map[string]any
 
 // Has reports whether the field map contains a value for key.

--- a/tests/bdd/features/core_audit.feature
+++ b/tests/bdd/features/core_audit.feature
@@ -171,6 +171,22 @@ Feature: Core Audit Logging
     Then the event should be delivered successfully
     And the output should contain field "source_ip" with value "10.0.0.1"
 
+  # --- Fields value-type validation (#595 B-43) ---
+
+  Scenario: Unsupported Fields value type rejected in strict mode
+    Given a standard test taxonomy
+    And an auditor with stdout output and validation mode "strict"
+    When I audit event "user_create" with an unsupported channel value in field "extra"
+    Then the audit call should return an error wrapping "ErrUnknownFieldType"
+    And the audit call should return an error wrapping "ErrValidation"
+
+  Scenario: Unsupported Fields value type coerced in permissive mode
+    Given a standard test taxonomy
+    And an auditor with stdout output and validation mode "permissive"
+    When I audit event "user_create" with an unsupported channel value in field "extra"
+    Then the event should be delivered successfully
+    And the output should contain field "extra" coerced to a string
+
   # --- Error paths ---
 
   Scenario: Unknown event type returns error with exact message

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -120,7 +120,7 @@ func registerAuditGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	})
 
 	ctx.Step(`^standard field defaults:$`, func(table *godog.Table) error {
-		defaults := make(map[string]string, len(table.Rows)-1)
+		defaults := make(map[string]any, len(table.Rows)-1)
 		for _, row := range table.Rows[1:] {
 			defaults[row.Cells[0].Value] = row.Cells[1].Value
 		}
@@ -175,6 +175,17 @@ func registerAuditWhenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, nil))
 		return nil
 	})
+
+	// #595 B-43: emit an event with a value of a type outside the
+	// supported Fields vocabulary (here a chan struct{}) so the
+	// scenario can assert the validation-mode-specific behaviour.
+	ctx.Step(`^I audit event "([^"]*)" with an unsupported channel value in field "([^"]*)"$`,
+		func(eventType, fieldName string) error {
+			fields := defaultRequiredFields(tc.Taxonomy, eventType)
+			fields[fieldName] = make(chan struct{})
+			tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
+			return nil
+		})
 
 	ctx.Step(`^I close the auditor$`, func() error {
 		if tc.Auditor == nil {
@@ -428,6 +439,23 @@ func registerAuditThenOutputSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 	ctx.Step(`^the output should contain an event with event_type "([^"]*)"$`, func(et string) error { return assertEventType(tc, et) })
 	ctx.Step(`^the output should contain an event with field "([^"]*)"$`, func(f string) error { return assertFieldPresent(tc, f) })
 	ctx.Step(`^the output should contain field "([^"]*)" with value "([^"]*)"$`, func(f, v string) error { return assertFieldValue(tc, f, v) })
+	ctx.Step(`^the output should contain field "([^"]*)" coerced to a string$`, func(f string) error {
+		events, err := getStdoutEvents(tc)
+		if err != nil {
+			return err
+		}
+		for _, e := range events {
+			v, ok := e[f]
+			if !ok {
+				continue
+			}
+			if _, isStr := v.(string); isStr {
+				return nil
+			}
+			return fmt.Errorf("field %q present but not a string (got %T)", f, v)
+		}
+		return fmt.Errorf("field %q not found in %d events", f, len(events))
+	})
 	ctx.Step(`^the output should contain an event matching:$`, func(t *godog.Table) error { return assertEventMatching(tc, t) })
 	ctx.Step(`^the output should contain field "([^"]*)" as a positive integer$`, func(f string) error { return assertFieldPositiveInt(tc, f) })
 	ctx.Step(`^the output should not contain field "([^"]*)"$`, func(f string) error { return assertFieldAbsent(tc, f) })
@@ -554,6 +582,7 @@ var sentinelsByName = map[string]error{
 	"ErrUnknownEventType":     audit.ErrUnknownEventType,
 	"ErrMissingRequiredField": audit.ErrMissingRequiredField,
 	"ErrUnknownField":         audit.ErrUnknownField,
+	"ErrUnknownFieldType":     audit.ErrUnknownFieldType,
 	"ErrReservedFieldName":    audit.ErrReservedFieldName,
 	"ErrEventTooLarge":        audit.ErrEventTooLarge,
 }

--- a/validate_fields.go
+++ b/validate_fields.go
@@ -15,8 +15,10 @@
 package audit
 
 import (
+	"fmt"
 	"slices"
 	"strings"
+	"time"
 )
 
 func (a *Auditor) validateFields(eventType string, def *EventDef, fields Fields) error {
@@ -26,7 +28,88 @@ func (a *Auditor) validateFields(eventType string, def *EventDef, fields Fields)
 	if err := checkRequiredFields(eventType, def, fields); err != nil {
 		return err
 	}
+	if err := a.checkFieldValueTypes(eventType, fields); err != nil {
+		return err
+	}
 	return a.checkUnknownFields(eventType, def, fields)
+}
+
+// isSupportedFieldValue reports whether v is one of the value types
+// the audit pipeline guarantees faithful rendering for. The set is
+// the v1.0-locked vocabulary documented on [Fields]:
+//
+//   - string
+//   - int / int32 / int64
+//   - float64
+//   - bool
+//   - time.Time
+//   - time.Duration
+//   - []string
+//   - map[string]string
+//   - nil
+//
+// Other types render via fmt.Sprintf("%v", v) and may produce SIEM-
+// hostile output (e.g. struct dumps, "{}" for empty maps). The
+// validateFields path either rejects or coerces them depending on
+// the auditor's ValidationMode (#595 B-43).
+func isSupportedFieldValue(v any) bool {
+	switch v.(type) {
+	case nil,
+		string,
+		int, int32, int64,
+		float64,
+		bool,
+		time.Time, time.Duration,
+		[]string,
+		map[string]string:
+		return true
+	}
+	return false
+}
+
+// checkFieldValueTypes enforces the supported-type vocabulary for
+// Fields values per #595 B-43. Behaviour is mode-driven:
+//
+//   - Strict: returns a [ValidationError] wrapping [ErrUnknownFieldType]
+//     listing every unsupported field name.
+//   - Warn: coerces in place via fmt.Sprintf("%v", v) and emits a
+//     diagnostic-logger warning naming the affected fields.
+//   - Permissive: coerces in place silently.
+//
+// Coercion mutates the caller's Fields map (warn / permissive paths).
+// The audit pipeline already takes ownership of Fields by the time
+// validation runs (defensive copy in the slow path; FieldsDonor
+// transfer in the fast path), so no caller-visible mutation occurs.
+func (a *Auditor) checkFieldValueTypes(eventType string, fields Fields) error {
+	var unsupported []string
+	for k, v := range fields {
+		if !isSupportedFieldValue(v) {
+			unsupported = append(unsupported, k)
+		}
+	}
+	if len(unsupported) == 0 {
+		return nil
+	}
+	slices.Sort(unsupported)
+
+	switch a.cfg.ValidationMode {
+	case ValidationStrict:
+		return newValidationError(ErrUnknownFieldType,
+			"audit: event %q has unsupported field value types: [%s] — see Fields godoc for the supported vocabulary",
+			eventType, strings.Join(unsupported, ", "))
+	case ValidationWarn:
+		for _, k := range unsupported {
+			fields[k] = fmt.Sprintf("%v", fields[k])
+		}
+		a.logger.Warn("audit: event has unsupported field value types — coerced via fmt.Sprintf",
+			"event_type", eventType,
+			"unsupported_fields", unsupported)
+	case ValidationPermissive:
+		for _, k := range unsupported {
+			fields[k] = fmt.Sprintf("%v", fields[k])
+		}
+	}
+	return nil
 }
 
 // libraryReservedFields are field names the library emits on every

--- a/validate_taxonomy.go
+++ b/validate_taxonomy.go
@@ -290,41 +290,18 @@ func checkReservedFieldNames(t Taxonomy) []string {
 // that are always available on any event without explicit taxonomy
 // declaration. These fields are automatically accepted by the
 // unknown-field check and have standard CEF extension key mappings.
-// The returned slice is a fresh copy; callers may modify it safely.
+// The returned slice is a fresh copy in deterministic alphabetical
+// order; callers may modify it safely.
+//
+// The list is derived from the canonical type map in std_fields.go;
+// see [ReservedStandardFieldType] for per-field type metadata.
 func ReservedStandardFieldNames() []string {
-	return []string{
-		"action",
-		"actor_id",
-		"actor_uid",
-		"dest_host",
-		"dest_ip",
-		"dest_port",
-		"end_time",
-		"file_hash",
-		"file_name",
-		"file_path",
-		"file_size",
-		"message",
-		"method",
-		"outcome",
-		"path",
-		"protocol",
-		"reason",
-		"referrer",
-		"request_id",
-		"role",
-		"session_id",
-		"source_host",
-		"source_ip",
-		"source_port",
-		"start_time",
-		"target_id",
-		"target_role",
-		"target_type",
-		"target_uid",
-		"transport",
-		"user_agent",
+	names := make([]string, 0, len(reservedStandardFieldTypes))
+	for name := range reservedStandardFieldTypes {
+		names = append(names, name)
 	}
+	slices.Sort(names)
+	return names
 }
 
 // reservedStandardFieldMap is a precomputed set of reserved standard


### PR DESCRIPTION
## Summary

Locks the `audit.Fields` supported value vocabulary and tightens
`WithStandardFieldDefaults` to use typed values per reserved-field
declaration. Pre-coding api-ergonomics-reviewer rejected the
"accept any json.Marshaler" superset (Option B for Q1) and
"unconditional reject" (Option B for Q2), settling on:

- Vocabulary matches the YAML `supportedCustomFieldTypes` in
  `taxonomy_yaml.go:218` so YAML schema enforcement and runtime
  validation share one truth set.
- Three-mode parity (strict / warn / permissive) consistent with
  `checkUnknownFields`.
- New `ReservedFieldType` enum + `ReservedStandardFieldType(name)`
  accessor expose the canonical type map for tooling.
- `WithStandardFieldDefaults(map[string]any)` fails fast at
  `audit.New` time wrapping `ErrConfigInvalid` on type mismatch.

Closes #595.

## Breaking change

`WithStandardFieldDefaults` signature changed from `map[string]string`
to `map[string]any`. Reserved fields with typed declarations
(`source_port`/`dest_port`/`file_size` int; `start_time`/`end_time`
`time.Time`) now require values of the right Go type; mismatches
return `audit.ErrConfigInvalid` at construction. CHANGELOG includes
a before/after migration snippet.

YAML `standard_fields:` consumers via `outputconfig.Load` benefit
automatically — `parseStandardFields` coerces YAML-native types
(`uint64`/`int64` → `int` with overflow check; RFC3339 string →
`time.Time`) before the audit-package validator runs.

## Test plan

- [x] `make check` clean across all 12 modules
- [x] `make test-bdd` passes (new scenarios for strict-reject and permissive-coerce on unsupported types)
- [x] New unit tests cover: type mismatch error, unknown reserved-field error, valid int default accepted, valid time default accepted, unsupported type strict/warn/permissive paths, ReservedFieldType enum exhaustivity, YAML coercion (int/timestamp/duration)
- [x] `cmd/audit-gen` regenerates with `time.Time` setters for `start_time`/`end_time` and emits `import "time"` automatically when needed
- [x] `TestIsZeroValue_NumericTypeBranches_Direct` preserves coverage of `float32`/`uint`/`uint64` branches the validator now coerces upstream