### PR TITLE
feat(secrets): add file:// and env:// secret providers (#604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `secrets/file/` and `secrets/env/` provider sub-modules (#604) — fills the G-03 BLOCKER for K8s mounted-secret and plain-env consumers (~80% of deployments). Blank-import to register: `_ "github.com/axonops/audit/secrets/file"` / `_ "github.com/axonops/audit/secrets/env"`.
+  - **`ref+file:///path/to/secret.txt`** — whole-file content as the secret value (single trailing newline trimmed).
+  - **`ref+file:///path/to/secret.json#key.subkey`** — JSON file, dotted-fragment path into nested objects, scalar string leaves only.
+  - **`ref+env://VAR_NAME`** — environment variable; POSIX `[A-Z_][A-Z0-9_]*` validation; `os.LookupEnv` distinguishes unset / empty (both are rejected).
+  - Path validation enforced: absolute paths required, `..` segments rejected, NUL byte rejected, 1 MiB file size cap. Symlinks ARE followed (Kubernetes `..data` atomic-swap pattern requires it).
+  - All errors REDACT the path / variable name — no substring of operator-controlled config appears in error messages (mirrors #486 ParseRef redaction).
+  - Stateless providers; concurrent-safe by construction (no shared state). Both pass `-race` under 50-goroutine concurrency tests.
+  - SECURITY.md updated: env vars are visible to same-UID processes via `/proc/PID/environ` (recommend file:// or vault for stronger isolation); operator is responsible for filesystem permissions on file-backed secrets.
+  - Pre-coding api-ergonomics + security consults locked: support both whole-file and JSON-fragment forms; no caching layer (re-read per Resolve); no permission-mode enforcement (K8s 0644 dominant); reuse of `secrets.ParseRef` via new scheme-aware `validatePathForScheme` helper.
+- `secrets.ParseRef` now dispatches path validation by scheme via `validatePathForScheme` (#604). The vault/openbao convention (no leading slash, mandatory `#key` fragment) remains the default; `file://` requires a leading slash and allows an optional fragment; `env://` forbids fragments. Existing vault/openbao references continue to parse with identical semantics.
 - `audit.Auditor.SetLogger(l *slog.Logger)` and `audit.Auditor.Logger() *slog.Logger` (#601) — runtime diagnostic-logger swap. Consumers that rebuild their logging stack on config change can now call `SetLogger` to replace the audit library's diagnostic logger without restarting. The new logger is propagated atomically to every output that implements `DiagnosticLoggerReceiver` (built-in: file/syslog/webhook/loki, atomic.Pointer migration from #474). Safe to call concurrently with event emission.
   - **Nil-handling**: `SetLogger(nil)` substitutes `slog.Default()` — readers never see a nil pointer. Matches the existing `WithDiagnosticLogger(nil)` and per-output `SetDiagnosticLogger(nil)` semantics.
   - **Closed/disabled auditors**: SetLogger is a no-op success — pointer is updated, no panic, no error. Matches `slog.SetDefault` precedent.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test test-all test-core test-file test-syslog test-webhook test-loki test-outputconfig test-audit-gen \
-       test-secrets test-secrets-openbao test-secrets-vault \
+       test-secrets test-secrets-env test-secrets-file test-secrets-openbao test-secrets-vault \
        test-integration test-bdd test-bdd-core test-bdd-outputconfig test-bdd-file test-bdd-syslog test-bdd-webhook test-bdd-loki test-bdd-fanout \
        test-bdd-verify \
        test-examples \
@@ -28,7 +28,7 @@
 SHELL      := bash
 .SHELLFLAGS := -e -o pipefail -c
 
-MODULES           := . file iouring syslog webhook loki outputconfig outputs cmd/audit-gen secrets secrets/openbao secrets/vault
+MODULES           := . file iouring syslog webhook loki outputconfig outputs cmd/audit-gen secrets secrets/env secrets/file secrets/openbao secrets/vault
 WORKSPACE_MODULES := $(MODULES) examples/17-capstone
 GOBIN             := $(shell go env GOPATH)/bin
 GO_TOOLCHAIN      := go1.26.2
@@ -98,7 +98,13 @@ test-secrets-openbao:
 test-secrets-vault:
 	cd secrets/vault && go test -race -v -count=1 -coverprofile=coverage.out ./...
 
-test-all: test-core test-file test-syslog test-webhook test-loki test-outputconfig test-audit-gen test-secrets test-secrets-openbao test-secrets-vault
+test-secrets-env:
+	cd secrets/env && go test -race -v -count=1 -coverprofile=coverage.out ./...
+
+test-secrets-file:
+	cd secrets/file && go test -race -v -count=1 -coverprofile=coverage.out ./...
+
+test-all: test-core test-file test-syslog test-webhook test-loki test-outputconfig test-audit-gen test-secrets test-secrets-env test-secrets-file test-secrets-openbao test-secrets-vault
 test: test-all
 
 # --- Fuzz targets (#481) ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -220,6 +220,33 @@ not expose a "scrub on free" hook. Memory dumps, core files, and
 heap profiles captured while the auditor is running will contain
 these values.
 
+### Provider threat models
+
+Each secret provider has a distinct threat model. Choose the
+provider whose model matches your deployment:
+
+- **`file://`** (Kubernetes mounted secrets, Docker secrets). The
+  path in `outputs.yaml` is the trust boundary — the library
+  follows symlinks and reads whatever is at the target. **The
+  operator is responsible for filesystem permissions on the
+  secret file**; the library does NOT enforce a permission-mode
+  check (Kubernetes mounts secrets at 0644 by default;
+  enforcement would break the dominant deployment pattern). All
+  errors redact the path; an attacker reading library logs
+  cannot infer the secret-mount layout from error messages
+  alone.
+- **`env://`** (process environment). Environment variables are
+  visible to any process running as the **same UID** via
+  `/proc/PID/environ` (Linux) or equivalent per-platform
+  mechanisms. They also appear in process listings when set via
+  the `env` command at exec time. For stronger isolation use
+  `file://` (filesystem permissions on the secret file) or
+  `vault`/`openbao` (out-of-process secret store with audit
+  log). All errors redact the variable name.
+- **`vault`** / **`openbao`**. Resolution uses TLS; bootstrap
+  token / namespace / response body are subject to the bootstrap
+  credential threat model documented above.
+
 ### Operational mitigation
 
 - Use **short-lived tokens** (TTL ≤ 1 hour where the provider

--- a/V1-RELEASE-PLAN.md
+++ b/V1-RELEASE-PLAN.md
@@ -227,7 +227,7 @@ Every issue follows this sequence. Do not skip steps.
 
 - [ ] **#602** docs: create docs/deployment.md — systemd, Kubernetes, Docker, parent-directory behaviour, capacity planning.
 - [ ] **#603** docs: create docs/v1-changes.md summarising behavioural and API changes up to v1.0.
-- [ ] **#604** feat: add file:// and env:// secret providers for K8s mounted-secret and plain-env use cases.
+- [x] **#604** feat: add file:// and env:// secret providers for K8s mounted-secret and plain-env use cases. (Two new sub-modules `secrets/file/` and `secrets/env/`; whole-file + JSON dotted-fragment for file; POSIX-validated env names; absolute paths, no `..`, no NUL, 1 MiB cap; symlinks followed for K8s `..data`; full path/name redaction in errors; stateless concurrent-safe.).
 - [ ] **#605** docs: add docs/writing-custom-secret-providers.md with complete SecretProvider example.
 - [ ] **#606** docs: add documented /healthz handler example using QueueLen/OutputNames introspection.
 - [ ] **#607** docs: complete Prometheus reference implementation in capstone and docs (tested, drop-in).

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -147,13 +147,93 @@ resolves.
 
 | Scheme | Module | Backend | KV Version |
 |--------|--------|---------|------------|
+| `file` | `github.com/axonops/audit/secrets/file` | Filesystem (K8s mounted secrets, Docker secrets) | n/a |
+| `env` | `github.com/axonops/audit/secrets/env` | Process environment variables | n/a |
 | `openbao` | `github.com/axonops/audit/secrets/openbao` | [OpenBao](https://openbao.org/) | KV v2 |
 | `vault` | `github.com/axonops/audit/secrets/vault` | [HashiCorp Vault](https://www.vaultproject.io/) | KV v2 |
 
-Both providers implement `secrets.BatchProvider`, enabling path-level
-caching (see [Caching Behaviour](#caching-behaviour)).
+The OpenBao and Vault providers implement `secrets.BatchProvider`,
+enabling path-level caching (see [Caching Behaviour](#caching-behaviour)).
+The `file` and `env` providers are intentionally simple and read on
+every Resolve — appropriate for K8s mounted secrets, where rotation
+is signalled by atomic-symlink swap and re-reading is the correct
+semantics.
+
+### When to use which
+
+- **`file://`** — Kubernetes mounted secrets at `/var/run/secrets/...`,
+  Docker secrets, host-bind-mounted credential files. The dominant
+  pattern for K8s deployments.
+- **`env://`** — Development, CI, simple deployments. Note that env
+  values are visible to any process running as the same UID via
+  `/proc/PID/environ` (Linux) or equivalent. Prefer `file://` or
+  `vault`/`openbao` for production.
+- **`vault`** / **`openbao`** — Centralised secret store with audit
+  log, dynamic secrets, fine-grained ACLs. Use when you need
+  out-of-process secret rotation or centralised access control.
 
 ## Provider Setup
+
+### File (K8s mounted secrets)
+
+```go
+import (
+	"context"
+
+	"github.com/axonops/audit/outputconfig"
+	"github.com/axonops/audit/secrets/file"
+)
+
+// ctx, yamlData, taxonomy defined by caller
+provider := file.New()
+defer provider.Close()
+
+result, err := outputconfig.Load(ctx, yamlData, taxonomy,
+	outputconfig.WithSecretProvider(provider),
+)
+```
+
+YAML usage:
+
+```yaml
+outputs:
+  - name: webhook
+    type: webhook
+    url: "https://logs.example.com/ingest"
+    bearer_token: "ref+file:///var/run/secrets/myapp/token"
+
+  # JSON file with dotted-fragment path
+  hmac:
+    secret_ref: "ref+file:///etc/secrets/audit.json#hmac.salt"
+```
+
+### Env
+
+```go
+import (
+	"context"
+
+	"github.com/axonops/audit/outputconfig"
+	"github.com/axonops/audit/secrets/env"
+)
+
+provider := env.New()
+defer provider.Close()
+
+result, err := outputconfig.Load(ctx, yamlData, taxonomy,
+	outputconfig.WithSecretProvider(provider),
+)
+```
+
+YAML usage:
+
+```yaml
+outputs:
+  - name: webhook
+    type: webhook
+    url: "ref+env://WEBHOOK_URL"
+    bearer_token: "ref+env://WEBHOOK_TOKEN"
+```
 
 ### OpenBao
 

--- a/secrets/env/doc.go
+++ b/secrets/env/doc.go
@@ -1,0 +1,50 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package env implements the env:// secret provider for the audit
+// library. Resolves secrets from process environment variables.
+//
+// # Reference syntax
+//
+//	ref+env://VAR_NAME
+//
+// The path is the variable name and MUST match the POSIX form
+// `[A-Z_][A-Z0-9_]*`. Fragments are not supported and are rejected
+// with an error.
+//
+// # When to use
+//
+// Use env:// for development, CI, and small deployments where
+// secrets are passed via the process environment. For production
+// Kubernetes deployments, prefer [github.com/axonops/audit/secrets/file]
+// reading from `/var/run/secrets/...` because env values are
+// visible to any process running as the same UID via
+// `/proc/PID/environ`.
+//
+// # Registration
+//
+// Blank-import the package to register the provider with the
+// outputconfig loader:
+//
+//	import _ "github.com/axonops/audit/secrets/env"
+//
+// # Threat model
+//
+// Environment variables are visible to any process running as the
+// same UID via `/proc/PID/environ` (Linux) or equivalent
+// per-platform mechanisms. They also appear in process listings
+// when set via the `env` command at exec time. For stronger
+// isolation use file:// (filesystem permissions on the secret file)
+// or vault/openbao (out-of-process secret store with audit log).
+package env

--- a/secrets/env/env.go
+++ b/secrets/env/env.go
@@ -1,0 +1,113 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/axonops/audit/secrets"
+)
+
+// Scheme is the URI scheme this provider handles. Use it as the
+// scheme component in `ref+env://VAR_NAME` references.
+const Scheme = "env"
+
+// Provider implements [secrets.SecretProvider] for environment-
+// variable secret references. The zero value is ready to use; the
+// provider is stateless and safe for concurrent use by multiple
+// goroutines.
+type Provider struct{}
+
+// Compile-time interface satisfaction check.
+var _ secrets.Provider = (*Provider)(nil)
+
+// New returns a new env:// secret provider. The provider is
+// stateless and accepts no configuration.
+func New() *Provider {
+	return &Provider{}
+}
+
+// Scheme returns the URI scheme this provider handles ("env").
+func (*Provider) Scheme() string { return Scheme }
+
+// Close is a no-op. The env provider holds no resources to release.
+// Idempotent; safe to call multiple times.
+func (*Provider) Close() error { return nil }
+
+// Resolve fetches the value of the environment variable named by
+// ref.Path. Returns [secrets.ErrSecretResolveFailed] when the
+// variable is unset or set to an empty string. Empty audit
+// secrets are never legitimate, so set-to-empty is treated
+// identically to unset.
+//
+// The variable name in the input ref is NOT echoed in the error
+// message — knowing which env var your config consults is itself
+// information a log scraper should not gain. Callers wanting to
+// distinguish unset / empty / invalid-name during local debugging
+// should inspect the returned error chain via [errors.Is] against
+// [secrets.ErrSecretResolveFailed] and read the diagnostic message
+// in the auditor's slog output (which is typically stderr, not
+// shipped to a log aggregator).
+func (*Provider) Resolve(_ context.Context, ref secrets.Ref) (string, error) {
+	if err := ref.Valid(); err != nil {
+		return "", fmt.Errorf("audit/secrets/env: %w", err)
+	}
+	if ref.Scheme != Scheme {
+		// Should never happen — outputconfig dispatches by scheme —
+		// but redact the scheme just in case to avoid leaking what
+		// providers a deployment uses.
+		return "", fmt.Errorf("audit/secrets/env: unexpected scheme: %w", secrets.ErrMalformedRef)
+	}
+	if ref.Key != "" {
+		// env:// has no key/fragment concept — silently dropping it
+		// would mask consumer typos that should fail loudly.
+		return "", fmt.Errorf("audit/secrets/env: fragment not supported: %w", secrets.ErrMalformedRef)
+	}
+	if !validEnvName(ref.Path) {
+		return "", fmt.Errorf("audit/secrets/env: invalid variable name (redacted): %w", secrets.ErrMalformedRef)
+	}
+	val, ok := os.LookupEnv(ref.Path)
+	if !ok {
+		return "", fmt.Errorf("audit/secrets/env: variable not set (redacted): %w", secrets.ErrSecretResolveFailed)
+	}
+	if val == "" {
+		return "", fmt.Errorf("audit/secrets/env: variable resolved to empty value (redacted): %w", secrets.ErrSecretResolveFailed)
+	}
+	return val, nil
+}
+
+// validEnvName reports whether s is a valid POSIX environment-
+// variable name: leading character `[A-Z_]`, subsequent characters
+// `[A-Z0-9_]`, non-empty. Hand-rolled linear scan — no regexp
+// import (avoids any ReDoS surface and keeps the sub-module
+// dependency footprint minimal).
+func validEnvName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case i == 0 && (r == '_' || (r >= 'A' && r <= 'Z')):
+			// valid leading character
+		case i > 0 && (r == '_' || (r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z')):
+			// valid subsequent character
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/secrets/env/env_external_test.go
+++ b/secrets/env/env_external_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit/secrets"
+	"github.com/axonops/audit/secrets/env"
+)
+
+// TestProvider_Resolve_HappyPath sets an env var and resolves it.
+func TestProvider_Resolve_HappyPath(t *testing.T) {
+	t.Setenv("AUDIT_TEST_TOKEN", "s3cret-value")
+	p := env.New()
+	got, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: env.Scheme,
+		Path:   "AUDIT_TEST_TOKEN",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "s3cret-value", got)
+}
+
+// TestProvider_Resolve_Unset returns ErrSecretResolveFailed when the
+// variable is not set.
+func TestProvider_Resolve_Unset(t *testing.T) {
+	p := env.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: env.Scheme,
+		Path:   "AUDIT_DEFINITELY_UNSET_TEST_VAR",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrSecretResolveFailed))
+}
+
+// TestProvider_Resolve_EmptyValue treats set-to-empty as unset —
+// empty audit secret is never legitimate.
+func TestProvider_Resolve_EmptyValue(t *testing.T) {
+	t.Setenv("AUDIT_TEST_EMPTY", "")
+	p := env.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: env.Scheme,
+		Path:   "AUDIT_TEST_EMPTY",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrSecretResolveFailed))
+}
+
+// TestProvider_Resolve_FragmentRejected — env:// has no key concept;
+// a non-empty fragment must be rejected.
+func TestProvider_Resolve_FragmentRejected(t *testing.T) {
+	t.Setenv("AUDIT_TEST_TOKEN", "value")
+	p := env.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: env.Scheme,
+		Path:   "AUDIT_TEST_TOKEN",
+		Key:    "subkey",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrMalformedRef))
+}
+
+// TestProvider_Resolve_InvalidName rejects names that don't match
+// POSIX `[A-Z_][A-Z0-9_]*`.
+func TestProvider_Resolve_InvalidName(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"lowercase", "lowercase"},
+		{"leading_digit", "1VAR"},
+		{"hyphen", "MY-VAR"},
+		{"dot", "MY.VAR"},
+		{"space", "MY VAR"},
+		{"unicode", "ÉCŒ"},
+	}
+	p := env.New()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := p.Resolve(context.Background(), secrets.Ref{
+				Scheme: env.Scheme,
+				Path:   tc.path,
+			})
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, secrets.ErrMalformedRef))
+		})
+	}
+}
+
+// TestProvider_Resolve_RedactsName — the variable name must NEVER
+// appear in the error message; the locked S5/Q5 contract.
+func TestProvider_Resolve_RedactsName(t *testing.T) {
+	const sentinel = "AUDIT_REDACT_SENTINEL_VAR"
+	p := env.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: env.Scheme,
+		Path:   sentinel,
+	})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), sentinel,
+		"error message MUST NOT contain the variable name (redaction contract)")
+}
+
+// TestProvider_Scheme returns "env".
+func TestProvider_Scheme(t *testing.T) {
+	t.Parallel()
+	p := env.New()
+	assert.Equal(t, "env", p.Scheme())
+	assert.Equal(t, "env", env.Scheme)
+}
+
+// TestProvider_Close is a no-op idempotent.
+func TestProvider_Close(t *testing.T) {
+	t.Parallel()
+	p := env.New()
+	require.NoError(t, p.Close())
+	require.NoError(t, p.Close())
+}
+
+// TestProvider_Concurrent — Resolve from many goroutines under
+// -race. Provider is stateless; this confirms zero-state-mutation.
+func TestProvider_Concurrent(t *testing.T) {
+	t.Setenv("AUDIT_TEST_CONCURRENT", "value")
+	p := env.New()
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			val, err := p.Resolve(context.Background(), secrets.Ref{
+				Scheme: env.Scheme,
+				Path:   "AUDIT_TEST_CONCURRENT",
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, "value", val)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestProvider_ParseRef_Integration verifies the documented URI
+// shape end-to-end via [secrets.ParseRef].
+func TestProvider_ParseRef_Integration(t *testing.T) {
+	t.Setenv("AUDIT_TEST_PARSEREF", "from-parseref")
+	ref, err := secrets.ParseRef("ref+env://AUDIT_TEST_PARSEREF")
+	require.NoError(t, err)
+	assert.Equal(t, "env", ref.Scheme)
+	assert.Equal(t, "AUDIT_TEST_PARSEREF", ref.Path)
+	assert.Empty(t, ref.Key)
+
+	p := env.New()
+	got, err := p.Resolve(context.Background(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, "from-parseref", got)
+}
+
+// TestProvider_ParseRef_RejectsFragment confirms that ParseRef
+// itself rejects env:// references with a fragment.
+func TestProvider_ParseRef_RejectsFragment(t *testing.T) {
+	t.Parallel()
+	_, err := secrets.ParseRef("ref+env://VAR#fragment")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrMalformedRef))
+}
+
+// Ensure goimports-friendly use of strings (cheap reference for
+// future maintainers who add string-manipulating tests).
+var _ = strings.HasPrefix

--- a/secrets/env/go.mod
+++ b/secrets/env/go.mod
@@ -1,0 +1,14 @@
+module github.com/axonops/audit/secrets/env
+
+go 1.26.2
+
+require (
+	github.com/axonops/audit/secrets v0.1.11
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/secrets/env/go.sum
+++ b/secrets/env/go.sum
@@ -1,0 +1,12 @@
+github.com/axonops/audit/secrets v0.1.11 h1:ilszR93wSDYRCVNK37LUJsrHUcHXyPOMjx5Lax29t9M=
+github.com/axonops/audit/secrets v0.1.11/go.mod h1:gAQX3co4e/23wOe4vkylrJ6smNicyITP+UEcx/gypak=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/secrets/file/doc.go
+++ b/secrets/file/doc.go
@@ -1,0 +1,68 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package file implements the file:// secret provider for the
+// audit library. Resolves secrets from filesystem paths — the
+// canonical pattern for Kubernetes mounted secrets at
+// `/var/run/secrets/...`.
+//
+// # Reference syntax
+//
+//	ref+file:///var/run/secrets/myapp/token       — whole file
+//	ref+file:///etc/secrets/db.json#password      — JSON, fragment
+//	ref+file:///etc/secrets/cfg.json#tls.ca       — dotted fragment
+//
+// Without a fragment, the entire file content is the secret value
+// (a single trailing newline is trimmed). With a fragment, the
+// file is parsed as JSON and the fragment is interpreted as a
+// dotted path into nested objects, returning the scalar string
+// leaf.
+//
+// # When to use
+//
+// Use file:// for Kubernetes mounted secrets, Docker secrets, and
+// any deployment that supplies secrets via the filesystem. K8s
+// atomically swaps `..data` symlinks on rotation; this provider
+// follows symlinks and re-reads on every Resolve, so consumers
+// that re-resolve (e.g. on SIGHUP) pick up rotated values.
+//
+// # Registration
+//
+// Blank-import the package to register the provider with the
+// outputconfig loader:
+//
+//	import _ "github.com/axonops/audit/secrets/file"
+//
+// # Path validation
+//
+// The path MUST be absolute, MUST NOT contain `..` segments, and
+// MUST NOT contain a NUL byte. Symlinks are followed (required for
+// the Kubernetes `..data` atomic-swap pattern).
+//
+// # File size cap
+//
+// Each Resolve reads at most 1 MiB. A file larger than the cap
+// returns [secrets.ErrSecretResolveFailed].
+//
+// # Threat model
+//
+// The path in `outputs.yaml` is the trust boundary. The provider
+// will follow symlinks and read whatever is at the target;
+// operators are responsible for ensuring filesystem permissions
+// match their threat model. The library does NOT enforce a
+// permission-mode check (K8s mounts at 0644 by default —
+// enforcement would break the dominant use case). All errors
+// redact the path; an attacker reading library logs cannot infer
+// the secret-mount layout from error messages alone.
+package file

--- a/secrets/file/file.go
+++ b/secrets/file/file.go
@@ -1,0 +1,190 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/axonops/audit/secrets"
+)
+
+// Scheme is the URI scheme this provider handles. Use it as the
+// scheme component in `ref+file:///path/to/secret` references.
+const Scheme = "file"
+
+// maxFileSize is the maximum bytes accepted from a single Resolve.
+// Mirrors the openbao provider's response cap; large enough for any
+// realistic secret (e.g. a multi-line PEM bundle ~ 20 KiB) yet small
+// enough to bound memory if a misconfigured ref points at /dev/zero
+// or a runaway log file.
+const maxFileSize = 1 << 20 // 1 MiB
+
+// Provider implements [secrets.SecretProvider] for filesystem
+// secret references. The zero value is ready to use; the provider
+// is stateless and safe for concurrent use by multiple goroutines.
+type Provider struct{}
+
+// Compile-time interface satisfaction check.
+var _ secrets.Provider = (*Provider)(nil)
+
+// Option configures a [Provider]. Reserved for future per-provider
+// settings; no options exist today.
+type Option func(*Provider)
+
+// New returns a new file:// secret provider. Accepts a variadic
+// list of [Option] for forward compatibility; no options are
+// currently defined.
+func New(opts ...Option) *Provider {
+	p := &Provider{}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Scheme returns the URI scheme this provider handles ("file").
+func (*Provider) Scheme() string { return Scheme }
+
+// Close is a no-op. The file provider holds no resources to release;
+// each Resolve call opens and closes its own file descriptor.
+// Idempotent; safe to call multiple times.
+func (*Provider) Close() error { return nil }
+
+// Resolve reads the file referenced by ref and returns its contents
+// as the secret value. The file path MUST be absolute, MUST NOT
+// contain `..` segments, and MUST NOT contain a NUL byte; symlinks
+// are followed (Kubernetes `..data` atomic-swap pattern). The file
+// MUST be at most 1 MiB ([maxFileSize]).
+//
+// If ref.Key is empty, the entire file content is returned (a
+// single trailing newline is trimmed). If ref.Key is set, the file
+// is parsed as JSON and the key is interpreted as a dotted path
+// into nested objects. Only scalar string leaves are returned;
+// numeric / boolean / object terminals return
+// [secrets.ErrSecretResolveFailed].
+//
+// The path is NEVER echoed in error messages — knowing the secret
+// path leaks deployment topology that a log scraper should not
+// gain. Use the auditor's slog diagnostic output (typically
+// stderr, not shipped to a log aggregator) for local debugging
+// and inspect the returned error chain via [errors.Is] for
+// programmatic handling.
+func (*Provider) Resolve(_ context.Context, ref secrets.Ref) (string, error) {
+	if err := ref.Valid(); err != nil {
+		return "", fmt.Errorf("audit/secrets/file: %w", err)
+	}
+	if ref.Scheme != Scheme {
+		return "", fmt.Errorf("audit/secrets/file: unexpected scheme: %w", secrets.ErrMalformedRef)
+	}
+	if err := validatePath(ref.Path); err != nil {
+		return "", fmt.Errorf("audit/secrets/file: %w", err)
+	}
+
+	content, err := readBounded(ref.Path)
+	if err != nil {
+		return "", fmt.Errorf("audit/secrets/file: %w", err)
+	}
+
+	if ref.Key == "" {
+		return strings.TrimRight(string(content), "\n"), nil
+	}
+	return extractJSONKey(content, ref.Key)
+}
+
+// validatePath enforces the security S1 contract: absolute path,
+// no `..` segments after Clean, no NUL byte. The path itself is
+// never echoed in the returned error.
+func validatePath(p string) error {
+	if !filepath.IsAbs(p) {
+		return fmt.Errorf("path must be absolute (redacted): %w", secrets.ErrMalformedRef)
+	}
+	if strings.ContainsRune(p, 0) {
+		return fmt.Errorf("path contains NUL byte (redacted): %w", secrets.ErrMalformedRef)
+	}
+	cleaned := filepath.Clean(p)
+	for _, seg := range strings.Split(cleaned, string(filepath.Separator)) {
+		if seg == ".." {
+			return fmt.Errorf("path contains parent-directory segment (redacted): %w", secrets.ErrMalformedRef)
+		}
+	}
+	return nil
+}
+
+// readBounded opens path and reads at most [maxFileSize] bytes. A
+// file that exceeds the cap returns [secrets.ErrSecretResolveFailed]
+// with no path in the message.
+func readBounded(path string) ([]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // path validated by validatePath; operator-controlled config is the trust boundary (#604 S1)
+	if err != nil {
+		// Don't echo the OS error verbatim — `os.PathError.Error()`
+		// includes the path. Wrap with a fixed message.
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("file not found (redacted): %w", secrets.ErrSecretResolveFailed)
+		}
+		return nil, fmt.Errorf("open failed (redacted): %w", secrets.ErrSecretResolveFailed)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Read up to maxFileSize+1 bytes so we can detect oversize
+	// (read exactly maxFileSize → still potentially-larger-but-
+	// truncated; read maxFileSize+1 → definitely oversize).
+	content, err := io.ReadAll(io.LimitReader(f, maxFileSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read failed (redacted): %w", secrets.ErrSecretResolveFailed)
+	}
+	if len(content) > maxFileSize {
+		return nil, fmt.Errorf("file exceeds %d bytes (redacted): %w", maxFileSize, secrets.ErrSecretResolveFailed)
+	}
+	return content, nil
+}
+
+// extractJSONKey parses content as JSON and traverses the dotted
+// path in key, returning the scalar string leaf. Anything else —
+// non-object intermediate node, missing key, non-string terminal —
+// returns [secrets.ErrSecretResolveFailed]. The key itself is not
+// echoed in errors (it is consumer-controlled config and not
+// inherently sensitive, but consistent redaction is the safer
+// default).
+func extractJSONKey(content []byte, key string) (string, error) {
+	var root any
+	if err := json.Unmarshal(content, &root); err != nil {
+		return "", fmt.Errorf("audit/secrets/file: invalid JSON (redacted): %w", secrets.ErrSecretResolveFailed)
+	}
+	cur := root
+	for _, seg := range strings.Split(key, ".") {
+		if seg == "" {
+			return "", fmt.Errorf("audit/secrets/file: empty key segment: %w", secrets.ErrMalformedRef)
+		}
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("audit/secrets/file: key path traverses non-object: %w", secrets.ErrSecretResolveFailed)
+		}
+		cur, ok = obj[seg]
+		if !ok {
+			return "", fmt.Errorf("audit/secrets/file: key not found: %w", secrets.ErrSecretResolveFailed)
+		}
+	}
+	leaf, ok := cur.(string)
+	if !ok {
+		return "", fmt.Errorf("audit/secrets/file: terminal value is not a string: %w", secrets.ErrSecretResolveFailed)
+	}
+	return leaf, nil
+}

--- a/secrets/file/file_external_test.go
+++ b/secrets/file/file_external_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit/secrets"
+	"github.com/axonops/audit/secrets/file"
+)
+
+// TestProvider_Resolve_WholeFile reads the entire file content (no
+// fragment) and trims a single trailing newline.
+func TestProvider_Resolve_WholeFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	require.NoError(t, os.WriteFile(path, []byte("s3cret-value\n"), 0o644))
+
+	p := file.New()
+	got, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   path,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "s3cret-value", got)
+}
+
+// TestProvider_Resolve_WholeFile_NoTrailingNewline confirms trim is
+// "rstrip one \n" not "all whitespace".
+func TestProvider_Resolve_WholeFile_NoTrailingNewline(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	require.NoError(t, os.WriteFile(path, []byte("s3cret"), 0o644))
+
+	p := file.New()
+	got, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   path,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "s3cret", got)
+}
+
+// TestProvider_Resolve_JSONFragment parses JSON and extracts the
+// dotted-fragment path.
+func TestProvider_Resolve_JSONFragment(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.json")
+	body := `{"db":{"password":"top-secret"},"misc":42}`
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+
+	p := file.New()
+	got, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   path,
+		Key:    "db.password",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "top-secret", got)
+}
+
+// TestProvider_Resolve_JSONFragmentNotFound returns ErrSecretResolveFailed.
+func TestProvider_Resolve_JSONFragmentNotFound(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"db":{"password":"x"}}`), 0o644))
+
+	p := file.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   path,
+		Key:    "db.missing",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrSecretResolveFailed))
+}
+
+// TestProvider_Resolve_JSONNonStringTerminal rejects numeric / object
+// terminals (only string leaves are valid secrets).
+func TestProvider_Resolve_JSONNonStringTerminal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"port":5432,"obj":{"x":1}}`), 0o644))
+
+	p := file.New()
+	for _, key := range []string{"port", "obj"} {
+		_, err := p.Resolve(context.Background(), secrets.Ref{
+			Scheme: file.Scheme,
+			Path:   path,
+			Key:    key,
+		})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, secrets.ErrSecretResolveFailed))
+	}
+}
+
+// TestProvider_Resolve_JSONInvalid rejects unparseable JSON when a
+// fragment is requested.
+func TestProvider_Resolve_JSONInvalid(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.json")
+	require.NoError(t, os.WriteFile(path, []byte("not-json"), 0o644))
+
+	p := file.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   path,
+		Key:    "any.key",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrSecretResolveFailed))
+}
+
+// TestProvider_Resolve_MissingFile reports ErrSecretResolveFailed.
+func TestProvider_Resolve_MissingFile(t *testing.T) {
+	t.Parallel()
+	p := file.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   "/nonexistent/path/abcd-1234",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrSecretResolveFailed))
+}
+
+// TestProvider_Resolve_RelativePathRejected — locked S1 contract.
+func TestProvider_Resolve_RelativePathRejected(t *testing.T) {
+	t.Parallel()
+	p := file.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   "relative/path",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrMalformedRef))
+}
+
+// TestProvider_Resolve_DotDotRejected — locked S1 contract.
+func TestProvider_Resolve_DotDotRejected(t *testing.T) {
+	t.Parallel()
+	p := file.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   "/etc/../etc/passwd",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrMalformedRef))
+}
+
+// TestProvider_Resolve_NULByteRejected — locked S1 contract; defends
+// against C-string truncation in any consumer that prints the path.
+func TestProvider_Resolve_NULByteRejected(t *testing.T) {
+	t.Parallel()
+	p := file.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   "/etc/secret\x00.txt",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrMalformedRef))
+}
+
+// TestProvider_Resolve_OversizedFile — locked S2 contract: 1 MiB cap.
+func TestProvider_Resolve_OversizedFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "huge.txt")
+	// 1 MiB + 1 byte → over the cap.
+	require.NoError(t, os.WriteFile(path, make([]byte, 1<<20+1), 0o644))
+
+	p := file.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   path,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, secrets.ErrSecretResolveFailed))
+}
+
+// TestProvider_Resolve_FollowsSymlink — the locked Q4/S4 contract.
+// K8s mounted secrets use a `..data` symlink pointing at a timestamped
+// directory; rotation atomically swaps the symlink. The provider
+// MUST follow the symlink so consumers see the current value.
+func TestProvider_Resolve_FollowsSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real-secret.txt")
+	require.NoError(t, os.WriteFile(target, []byte("via-symlink\n"), 0o644))
+	link := filepath.Join(dir, "alias.txt")
+	require.NoError(t, os.Symlink(target, link))
+
+	p := file.New()
+	got, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   link,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "via-symlink", got)
+}
+
+// TestProvider_Resolve_K8sAtomicSwap simulates the K8s
+// `..data → ..data_NEW` atomic rename pattern. After re-pointing
+// the symlink, the next Resolve sees the new content.
+func TestProvider_Resolve_K8sAtomicSwap(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	old := filepath.Join(dir, "old.txt")
+	require.NoError(t, os.WriteFile(old, []byte("v1\n"), 0o644))
+	link := filepath.Join(dir, "current")
+	require.NoError(t, os.Symlink(old, link))
+
+	p := file.New()
+	got, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   link,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "v1", got)
+
+	// Atomic-swap simulation.
+	newp := filepath.Join(dir, "new.txt")
+	require.NoError(t, os.WriteFile(newp, []byte("v2\n"), 0o644))
+	tmp := link + ".tmp"
+	require.NoError(t, os.Symlink(newp, tmp))
+	require.NoError(t, os.Rename(tmp, link))
+
+	got, err = p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   link,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "v2", got, "post-swap Resolve must see new content (no caching)")
+}
+
+// TestProvider_Resolve_PathRedaction — the path MUST NOT appear in
+// any error message (locked Extra contract).
+func TestProvider_Resolve_PathRedaction(t *testing.T) {
+	t.Parallel()
+	const sentinel = "/var/run/secrets/UNIQUE-REDACT-SENTINEL/token"
+	p := file.New()
+	_, err := p.Resolve(context.Background(), secrets.Ref{
+		Scheme: file.Scheme,
+		Path:   sentinel,
+	})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "UNIQUE-REDACT-SENTINEL",
+		"error message MUST NOT contain any path substring")
+}
+
+// TestProvider_Scheme returns "file".
+func TestProvider_Scheme(t *testing.T) {
+	t.Parallel()
+	p := file.New()
+	assert.Equal(t, "file", p.Scheme())
+	assert.Equal(t, "file", file.Scheme)
+}
+
+// TestProvider_Close is a no-op idempotent.
+func TestProvider_Close(t *testing.T) {
+	t.Parallel()
+	p := file.New()
+	require.NoError(t, p.Close())
+	require.NoError(t, p.Close())
+}
+
+// TestProvider_Concurrent — Resolve from many goroutines under
+// -race. Provider is stateless; verifies zero shared state.
+func TestProvider_Concurrent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared.txt")
+	require.NoError(t, os.WriteFile(path, []byte("shared"), 0o644))
+
+	p := file.New()
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			val, err := p.Resolve(context.Background(), secrets.Ref{
+				Scheme: file.Scheme,
+				Path:   path,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, "shared", val)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestProvider_ParseRef_Integration verifies the documented URI
+// shape end-to-end via [secrets.ParseRef].
+func TestProvider_ParseRef_Integration(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "via-parseref.txt")
+	require.NoError(t, os.WriteFile(path, []byte("ok\n"), 0o644))
+
+	ref, err := secrets.ParseRef("ref+file://" + path)
+	require.NoError(t, err)
+	assert.Equal(t, "file", ref.Scheme)
+	// ParseRef preserves the leading slash for file:// schemes.
+	assert.True(t, strings.HasPrefix(ref.Path, "/"), "file:// path must retain leading slash")
+
+	p := file.New()
+	got, err := p.Resolve(context.Background(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", got)
+}

--- a/secrets/file/go.mod
+++ b/secrets/file/go.mod
@@ -1,0 +1,14 @@
+module github.com/axonops/audit/secrets/file
+
+go 1.26.2
+
+require (
+	github.com/axonops/audit/secrets v0.1.11
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/secrets/file/go.sum
+++ b/secrets/file/go.sum
@@ -1,0 +1,12 @@
+github.com/axonops/audit/secrets v0.1.11 h1:ilszR93wSDYRCVNK37LUJsrHUcHXyPOMjx5Lax29t9M=
+github.com/axonops/audit/secrets v0.1.11/go.mod h1:gAQX3co4e/23wOe4vkylrJ6smNicyITP+UEcx/gypak=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -162,10 +162,10 @@ func (r Ref) Valid() error {
 	if r.Path == "" {
 		return fmt.Errorf("%w: empty path", ErrMalformedRef)
 	}
-	if r.Key == "" {
-		return fmt.Errorf("%w: empty key", ErrMalformedRef)
-	}
-	return validatePath(r.Path)
+	// Key requirement is scheme-dependent; delegate to the same
+	// validator [ParseRef] uses so manually-constructed refs are
+	// validated identically to parsed refs (#604).
+	return validatePathForScheme(r.Scheme, r.Path, r.Key)
 }
 
 // String returns a safe representation that redacts the secret path
@@ -241,30 +241,101 @@ func ParseRef(s string) (Ref, error) {
 	// Everything after "://"
 	pathAndKey := rest[sepIdx+len(schemeSep):]
 
-	// Find "#" fragment separator.
-	hashIdx := strings.Index(pathAndKey, "#")
-	if hashIdx < 0 {
-		return Ref{}, fmt.Errorf("%w: missing key fragment (#key)", ErrMalformedRef)
+	// Find "#" fragment separator. Whether the fragment is required
+	// is scheme-dependent — vault/openbao require #key for KV-v2 path
+	// disambiguation; file:// allows whole-file mode without a key;
+	// env:// has no key concept at all (#604).
+	var path, key string
+	if hashIdx := strings.Index(pathAndKey, "#"); hashIdx >= 0 {
+		path = pathAndKey[:hashIdx]
+		key = pathAndKey[hashIdx+1:]
+	} else {
+		path = pathAndKey
 	}
-
-	path := pathAndKey[:hashIdx]
-	key := pathAndKey[hashIdx+1:]
 
 	if path == "" {
 		return Ref{}, fmt.Errorf("%w: empty path", ErrMalformedRef)
-	}
-	if key == "" {
-		return Ref{}, fmt.Errorf("%w: empty key fragment", ErrMalformedRef)
 	}
 	if strings.Contains(key, "#") {
 		return Ref{}, fmt.Errorf("%w: key fragment must not contain \"#\"", ErrMalformedRef)
 	}
 
-	if err := validatePath(path); err != nil {
+	if err := validatePathForScheme(scheme, path, key); err != nil {
 		return Ref{}, err
 	}
 
 	return Ref{Scheme: scheme, Path: path, Key: key}, nil
+}
+
+// validatePathForScheme dispatches path-validation to scheme-
+// appropriate rules. The default rule is the vault/openbao
+// convention (no leading slash, mandatory key fragment, no `..`).
+// Filesystem-style schemes (file://) require a leading slash and
+// allow no key. Environment-variable schemes (env://) treat the
+// path as an opaque variable name and forbid keys.
+func validatePathForScheme(scheme, path, key string) error {
+	switch scheme {
+	case "file":
+		// Path is a filesystem path: must start with `/`, no
+		// percent-encoding, no control bytes, no `..` segments. Key
+		// fragment is optional (whole-file vs JSON-with-fragment).
+		if !strings.HasPrefix(path, "/") {
+			return fmt.Errorf("%w: file:// path must be absolute (start with \"/\")", ErrMalformedRef)
+		}
+		return validateFilePath(path)
+	case "env":
+		// Path is an environment-variable name: provider validates
+		// POSIX naming. ParseRef enforces only the structural rules
+		// (no key fragment; no control bytes).
+		if key != "" {
+			return fmt.Errorf("%w: env:// must not have a #fragment", ErrMalformedRef)
+		}
+		return validateEnvPath(path)
+	default:
+		// Existing vault/openbao convention: relative path, mandatory
+		// key fragment, validatePath rules.
+		if key == "" {
+			return fmt.Errorf("%w: empty key fragment", ErrMalformedRef)
+		}
+		return validatePath(path)
+	}
+}
+
+// validateFilePath enforces filesystem-path safety: no control
+// bytes (NUL et al), no `..` segments, no `%` percent-encoding.
+// Leading slash required by the caller; absolute paths are
+// expected.
+func validateFilePath(path string) error {
+	if strings.Contains(path, "%") {
+		return fmt.Errorf("%w: path must not contain percent-encoded characters", ErrMalformedRef)
+	}
+	for i := 0; i < len(path); i++ {
+		b := path[i]
+		if b < 0x20 || b == 0x7f {
+			return fmt.Errorf("%w: path contains control byte 0x%02x at offset %d",
+				ErrMalformedRef, b, i)
+		}
+	}
+	for _, seg := range strings.Split(path, "/") {
+		if seg == ".." {
+			return fmt.Errorf("%w: path contains \"..\" segment", ErrMalformedRef)
+		}
+	}
+	return nil
+}
+
+// validateEnvPath enforces structural rules on env:// paths
+// (variable names). The provider runs full POSIX validation; here
+// we only reject control bytes that the caller didn't strip.
+func validateEnvPath(path string) error {
+	for i := 0; i < len(path); i++ {
+		b := path[i]
+		if b < 0x20 || b == 0x7f || b == '/' {
+			return fmt.Errorf("%w: env path contains control byte 0x%02x at offset %d",
+				ErrMalformedRef, b, i)
+		}
+	}
+	return nil
 }
 
 // ContainsRef reports whether s contains a ref+ URI pattern anywhere

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -434,28 +434,28 @@ func TestParseRef_NeverLeaksInputInErrorMessage(t *testing.T) {
 		{"invalid_scheme_special_char", "ref+" + schemeMarker + "!://" + pathMarker + "#" + keyMarker},
 
 		// Class: missing key fragment (no "#").
-		{"missing_key_fragment", "ref+env://" + pathMarker},
+		{"missing_key_fragment", "ref+vault://" + pathMarker},
 
-		// Class: empty path ("ref+env://#key").
-		{"empty_path", "ref+env://#" + keyMarker},
+		// Class: empty path ("ref+vault://#key").
+		{"empty_path", "ref+vault://#" + keyMarker},
 
-		// Class: empty key ("ref+env://path#").
-		{"empty_key_fragment", "ref+env://" + pathMarker + "#"},
+		// Class: empty key ("ref+vault://path#").
+		{"empty_key_fragment", "ref+vault://" + pathMarker + "#"},
 
 		// Class: key contains "#".
-		{"key_contains_hash", "ref+env://" + pathMarker + "#" + keyMarker + "#extra"},
+		{"key_contains_hash", "ref+vault://" + pathMarker + "#" + keyMarker + "#extra"},
 
 		// Class: path validation — leading "/", trailing "/",
 		// percent, traversal, empty segment, dot, control byte.
-		{"path_leading_slash", "ref+env:///" + pathMarker + "#" + keyMarker},
-		{"path_trailing_slash", "ref+env://" + pathMarker + "/#" + keyMarker},
-		{"path_percent_encoded", "ref+env://" + pathMarker + "%20x#" + keyMarker},
-		{"path_traversal_dotdot", "ref+env://" + pathMarker + "/..#" + keyMarker},
-		{"path_dot_segment", "ref+env://" + pathMarker + "/.#" + keyMarker},
-		{"path_empty_segment", "ref+env://" + pathMarker + "//x#" + keyMarker},
-		{"path_control_byte_null", "ref+env://" + pathMarker + "\x00x#" + keyMarker},
-		{"path_control_byte_newline", "ref+env://" + pathMarker + "\nx#" + keyMarker},
-		{"path_control_byte_del", "ref+env://" + pathMarker + "\x7fx#" + keyMarker},
+		{"path_leading_slash", "ref+vault:///" + pathMarker + "#" + keyMarker},
+		{"path_trailing_slash", "ref+vault://" + pathMarker + "/#" + keyMarker},
+		{"path_percent_encoded", "ref+vault://" + pathMarker + "%20x#" + keyMarker},
+		{"path_traversal_dotdot", "ref+vault://" + pathMarker + "/..#" + keyMarker},
+		{"path_dot_segment", "ref+vault://" + pathMarker + "/.#" + keyMarker},
+		{"path_empty_segment", "ref+vault://" + pathMarker + "//x#" + keyMarker},
+		{"path_control_byte_null", "ref+vault://" + pathMarker + "\x00x#" + keyMarker},
+		{"path_control_byte_newline", "ref+vault://" + pathMarker + "\nx#" + keyMarker},
+		{"path_control_byte_del", "ref+vault://" + pathMarker + "\x7fx#" + keyMarker},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements #604 (G-03 BLOCKER). Adds two new stdlib-only sub-modules for the dominant deployment patterns the previous vault/openbao providers couldn't cover.

- `github.com/axonops/audit/secrets/file` — Kubernetes mounted secrets, Docker secrets
- `github.com/axonops/audit/secrets/env` — process environment variables

## Reference syntax

\`\`\`
ref+file:///path/to/secret.txt          → whole-file (single trailing newline trimmed)
ref+file:///path/to/secret.json#k.sub   → JSON, dotted-fragment path
ref+env://VAR_NAME                       → env var (POSIX-validated)
\`\`\`

## Locked design (api-ergonomics + security pre-coding consults)

- Both whole-file and JSON-fragment forms for file:// (symmetry with vault/openbao)
- env:// forbids fragments; POSIX [A-Z_][A-Z0-9_]* validation, hand-rolled (no regexp dep)
- No caching — re-read every Resolve (K8s atomic-symlink-swap requires it)
- Symlinks followed (K8s ..data atomic rotation pattern)
- Stateless providers, concurrent-safe by construction
- secrets.ParseRef gains scheme-aware path dispatch via new validatePathForScheme helper

## Security contract (enforced)

- Absolute paths only, reject .. segments, reject NUL byte
- 1 MiB file size cap (matches openbao parity; protects against /dev/zero)
- Typed JSON traversal — only scalar string leaves, no key echo on errors
- os.LookupEnv distinguishes unset vs empty (both rejected — empty secret is never legitimate)
- All errors REDACT the path / variable name (#486 ParseRef redaction contract)

## Test plan

- [x] make check passes (lint + tests + tidy + verify + security across all 13 modules)
- [x] secrets/env: 11 black-box tests pass with -race (50-goroutine concurrency stress, ParseRef integration both directions)
- [x] secrets/file: 18 tests pass with -race (whole-file, JSON fragment, oversized, symlink follow, K8s atomic-swap simulation, path redaction)
- [x] Existing secrets/secrets_test.go updated to use 'vault' as the placeholder scheme (env is now real)

Closes #604