### PR TITLE
test(bdd): cover async delivery edge cases (#564)

### DIFF
--- a/tests/bdd/features/async_buffer_shutdown.feature
+++ b/tests/bdd/features/async_buffer_shutdown.feature
@@ -41,3 +41,50 @@ Feature: Async Buffer Shutdown
     Given an auditor with a blocking output and drain timeout 1s
     When I audit event "user_create" with required fields
     Then closing the auditor should complete within 5 seconds
+
+  # #564 P0 BDD coverage for async-delivery edge cases. These scenarios
+  # pin documented contracts that were previously only covered by unit
+  # tests:
+  #
+  #   1. Synchronous AuditEvent on a closed auditor returns ErrClosed
+  #      synchronously (not after a drain wait).
+  #   2. Synchronous delivery isolates a panicking output — other
+  #      outputs still receive the event.
+  #   3. buffer_size: 0 on a per-output config silently coerces to the
+  #      per-output default capacity.
+  #   4. Delivery accounting:
+  #      submitted = delivered + filtered + dropped
+  #                + validation_errors + serialization_errors
+  #      holds under a mixed workload.
+
+  Scenario: Synchronous AuditEvent returns ErrClosed after auditor is closed
+    Given an auditor with synchronous delivery and a recording mock output
+    When I close the auditor
+    And I try to audit event "user_create" with required fields
+    Then the audit call should return an error wrapping "ErrClosed"
+    And the recording output should have received exactly 0 events
+
+  Scenario: Synchronous delivery isolates a panicking output from a healthy output
+    Given an auditor with synchronous delivery, file output, and a panicking output
+    When I audit a uniquely marked "user_create" event
+    Then the audit call should return no error
+    And the file should contain the marker
+
+  Scenario: File output with buffer_size 0 coerces to default capacity
+    Given a file output with buffer_size 0 and mock output metrics
+    Given an auditor with that file output and queue_size 1
+    When I audit event "user_create" with required fields
+    And I close the auditor
+    Then the file should contain exactly 1 event
+    And the effective output buffer capacity should be 10000
+
+  Scenario: Delivery accounting invariant holds under a mixed workload
+    Given an auditor with a recording output, pipeline metrics, and synchronous delivery
+    When I audit event "user_create" with required fields
+    And I audit event "user_create" with required fields
+    And I try to audit event "unknown_event_type" with required fields
+    And I disable category "write"
+    And I audit event "user_create" with required fields
+    And I close the auditor
+    Then RecordSubmitted should have been called 4 times
+    And the delivery accounting invariant should hold

--- a/tests/bdd/steps/async_edges_steps.go
+++ b/tests/bdd/steps/async_edges_steps.go
@@ -1,0 +1,156 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/cucumber/godog"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/file"
+)
+
+// registerAsyncEdgesSteps registers BDD step definitions for async
+// delivery edge-case scenarios (#564): sync-mode close, sync-mode
+// panic isolation, buffer_size:0 coercion, and the delivery
+// accounting invariant.
+//
+//nolint:gocognit,gocyclo,cyclop // BDD step registration: 4 closures inline; splitting hurts readability
+func registerAsyncEdgesSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
+	ctx.Step(`^an auditor with synchronous delivery, file output, and a panicking output$`, func() error {
+		dir, err := tc.EnsureFileDir()
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(dir, "audit.log")
+		tc.FilePaths["default"] = path
+
+		fileOut, err := file.New(&file.Config{Path: path})
+		if err != nil {
+			return fmt.Errorf("create file: %w", err)
+		}
+		tc.AddCleanup(func() { _ = fileOut.Close() })
+
+		opts := []audit.Option{
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithNamedOutput(fileOut),
+			audit.WithNamedOutput(&panicOutput{}),
+			audit.WithSynchronousDelivery(),
+		}
+		auditor, err := audit.New(opts...)
+		if err != nil {
+			return fmt.Errorf("create auditor: %w", err)
+		}
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
+		return nil
+	})
+
+	ctx.Step(`^the effective output buffer capacity should be (\d+)$`, func(want int) error {
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
+		}
+		if tc.OutputMetricsMock == nil {
+			return errors.New("no MockOutputMetrics configured — precede with 'a file output with buffer_size N and mock output metrics'")
+		}
+		tc.OutputMetricsMock.mu.Lock()
+		defer tc.OutputMetricsMock.mu.Unlock()
+		if len(tc.OutputMetricsMock.queueDs) == 0 {
+			return errors.New("no RecordQueueDepth call recorded; the output never observed its queue")
+		}
+		got := tc.OutputMetricsMock.queueDs[len(tc.OutputMetricsMock.queueDs)-1].Capacity
+		if got != want {
+			return fmt.Errorf("expected effective buffer capacity %d, got %d", want, got)
+		}
+		return nil
+	})
+
+	ctx.Step(`^an auditor with a recording output, pipeline metrics, and synchronous delivery$`, func() error {
+		if tc.MockMetrics == nil {
+			tc.MockMetrics = NewMockMetrics()
+		}
+
+		// Use a non-DeliveryReporter output so RecordDelivery flows
+		// through tc.MockMetrics. file/syslog/webhook/loki implement
+		// DeliveryReporter and bypass core RecordDelivery — that path
+		// has separate coverage; this scenario isolates the core
+		// metrics invariant.
+		rec := &recordingMockOutput{name: "recording"}
+
+		opts := []audit.Option{
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithMetrics(tc.MockMetrics),
+			audit.WithOutputs(rec),
+			audit.WithSynchronousDelivery(),
+		}
+		auditor, err := audit.New(opts...)
+		if err != nil {
+			return fmt.Errorf("create auditor: %w", err)
+		}
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
+		return nil
+	})
+
+	ctx.Step(`^the delivery accounting invariant should hold$`, func() error {
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
+		}
+		if tc.MockMetrics == nil {
+			return errors.New("no MockMetrics configured")
+		}
+		m := tc.MockMetrics
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		successes := 0
+		for k, v := range m.Events {
+			if strings.HasSuffix(k, ":success") {
+				successes += v
+			}
+		}
+		outputErrs := 0
+		for _, v := range m.OutputErrors {
+			outputErrs += v
+		}
+		filtered := 0
+		for _, v := range m.Filtered {
+			filtered += v
+		}
+		validation := 0
+		for _, v := range m.ValidationErrors {
+			validation += v
+		}
+		serial := 0
+		for _, v := range m.SerializationErrs {
+			serial += v
+		}
+		total := successes + outputErrs + filtered + validation + serial + m.BufferDrops
+		if total != m.Submitted {
+			return fmt.Errorf(
+				"invariant broken: submitted=%d != successes=%d + output_errors=%d + filtered=%d + validation_errors=%d + serialization_errors=%d + buffer_drops=%d (sum=%d)",
+				m.Submitted, successes, outputErrs, filtered, validation, serial, m.BufferDrops, total)
+		}
+		return nil
+	})
+}

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -210,4 +210,5 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerSanitizerSteps(ctx, tc)
 	registerContextAPISteps(ctx, tc)
 	registerSetLoggerSteps(ctx, tc)
+	registerAsyncEdgesSteps(ctx, tc)
 }

--- a/tests/bdd/steps/isolation_steps.go
+++ b/tests/bdd/steps/isolation_steps.go
@@ -75,6 +75,19 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		return err //nolint:wrapcheck // BDD step
 	})
 
+	ctx.Step(`^an auditor with synchronous delivery and a recording mock output$`, func() error {
+		recOut1 = &recordingMockOutput{name: "recording-1"}
+		var err error
+		tc.Auditor, err = audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithOutputs(recOut1),
+			audit.WithSynchronousDelivery(),
+		)
+		return err //nolint:wrapcheck // BDD step
+	})
+
 	ctx.Step(`^an auditor with stdout output only$`, func() error {
 		stdoutBuf = &bytes.Buffer{}
 		stdout, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: stdoutBuf})
@@ -122,6 +135,20 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		}
 		if recOut1.eventCount() < n {
 			return fmt.Errorf("recording output has %d events, expected %d", recOut1.eventCount(), n)
+		}
+		return nil
+	})
+
+	// "exactly" variant for scenarios where 0 events is the contract —
+	// the lower-bound `received all` step above is vacuous at n=0
+	// (count >= 0 is always true). Use this for absence assertions.
+	ctx.Step(`^the recording output should have received exactly (\d+) events$`, func(n int) error {
+		if recOut1 == nil {
+			return fmt.Errorf("no recording output configured")
+		}
+		got := recOut1.eventCount()
+		if got != n {
+			return fmt.Errorf("recording output has %d events, expected exactly %d", got, n)
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary

Closes #564 — adds 4 BDD scenarios to `async_buffer_shutdown.feature`
pinning documented contracts previously only covered by unit tests.

- Synchronous AuditEvent on closed auditor returns ErrClosed (sync path).
- Synchronous delivery isolates a panicking output — others still receive.
- File output `buffer_size: 0` coerces to the default capacity (10000).
- Delivery accounting invariant `submitted = delivered + filtered + dropped + validation_errors + serialization_errors` holds under a mixed workload.

No production-code changes. New `tests/bdd/steps/async_edges_steps.go`
holds the 4 new step definitions; one sync-mode-recording Given added
to `registerIsolationSteps`; vacuous `received all 0` lower-bound
assertion replaced with an exact-match `received exactly N` step
(test-analyst finding).

Follow-up #722 strengthens the invariant scenario to also exercise
`OutputErrors` / `SerializationErrs` / `BufferDrops` (currently 0 in
this PR's workload — math sums correctly but a mis-wiring of those
counters wouldn't be caught).

## Test plan

- [x] `make test-bdd-core` — all scenarios green
- [x] `make check` — clean across all 15 modules
- [x] `make lint` — zero issues
- [x] code-reviewer + test-analyst reviewed
- [x] commit-message-reviewer approved
- [ ] CI green