### PR TITLE
test(bdd): cover WithSynchronousDelivery (#549)

### DIFF
--- a/options.go
+++ b/options.go
@@ -165,6 +165,20 @@ func WithTimezone(tz string) Option {
 // and for simple deployments (CLI tools, Lambda functions) where
 // async complexity is unwanted. [Auditor.Close] is still safe to call
 // but is not required before reading output.
+//
+// # Caller-observable contract
+//
+//   - AuditEvent returns ONLY after every output has received the
+//     event. The caller's goroutine blocks for the sum of all
+//     outputs' Write durations.
+//   - A panic inside an output's Write is RECOVERED — it is NOT
+//     propagated to the caller. The auditor logs the panic at error
+//     level, records a per-output drop metric, and continues
+//     fan-out to subsequent outputs. AuditEvent returns nil even if
+//     one or more outputs panicked.
+//   - After [Auditor.Close], AuditEvent returns [ErrClosed]
+//     synchronously without invoking any output. Close itself is
+//     idempotent: repeated calls return nil with no side effects.
 func WithSynchronousDelivery() Option {
 	return func(a *Auditor) error {
 		a.synchronous = true

--- a/tests/bdd/features/sync_delivery.feature
+++ b/tests/bdd/features/sync_delivery.feature
@@ -1,0 +1,50 @@
+@core @sync
+Feature: Synchronous Delivery
+  As a library consumer using WithSynchronousDelivery (or audittest's
+  default mode), I want AuditEvent to deliver events to every output
+  before returning so that test code can assert on outputs immediately
+  with no Close-before-assert ceremony.
+
+  Synchronous delivery is the default for the audittest helper package
+  because it eliminates timing flakiness; it is also useful for CLI
+  tools where the event count is small and async batching offers no
+  benefit.
+
+  Background:
+    Given a standard test taxonomy
+
+  Scenario: AuditEvent returns only after every output has received the event
+    Given an auditor with synchronous delivery and two recording mock outputs
+    When I audit event "user_create" with required fields
+    Then both recording outputs should have received exactly 1 events
+
+  Scenario: Synchronous delivery recovers a panicking output and returns no error
+    Given an auditor with synchronous delivery, file output, and a panicking output
+    When I audit a uniquely marked "user_create" event
+    Then the audit call should return no error
+    And the file should contain the marker
+
+  Scenario: Synchronous delivery blocks the caller for the duration of every output Write
+    Given an auditor with synchronous delivery and a slow output that blocks 50ms per write
+    When I audit event "user_create" with required fields
+    Then the audit call should return no error
+    And the audit call should have taken at least 50 milliseconds
+
+  Scenario: Synchronous Close is idempotent and AuditEvent after Close returns ErrClosed
+    Given an auditor with synchronous delivery and a recording mock output
+    When I close the auditor
+    And I close the auditor again
+    Then the second close should return no error
+    When I try to audit event "user_create" with required fields
+    Then the audit call should return an error wrapping "ErrClosed"
+    And the recording output should have received exactly 0 events
+
+  Scenario: audittest.NewQuick defaults to synchronous delivery with no Close ceremony
+    Given an audittest auditor created via NewQuick with a standard taxonomy
+    When I audit event "user_create" with required fields via the audittest auditor
+    Then the audittest recorder should contain exactly 1 "user_create" event with no Close call
+
+  Scenario: Synchronous delivery serialises concurrent AuditEvent calls without losses
+    Given an auditor with synchronous delivery and a recording mock output
+    When I audit 100 events from 10 concurrent goroutines
+    Then the recording output should have received exactly 100 events

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -143,7 +143,9 @@ func registerAuditWhenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 
 	ctx.Step(`^I audit event "([^"]*)" with required fields$`, func(eventType string) error {
 		fields := defaultRequiredFields(tc.Taxonomy, eventType)
+		start := time.Now()
 		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
+		tc.LastAuditDuration = time.Since(start)
 		return nil
 	})
 

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -37,12 +37,13 @@ import (
 // A fresh context is created for every scenario in BeforeScenario.
 type AuditTestContext struct { //nolint:govet // fieldalignment: readability preferred over packing
 	// Auditor state.
-	Auditor     *audit.Auditor
-	EventHandle *audit.EventHandle
-	LastEvent   audit.Event // captured by NewEvent / NewEventKV scenarios (#597)
-	LastErr     error
-	Taxonomy    *audit.Taxonomy
-	Options     []audit.Option
+	Auditor           *audit.Auditor
+	EventHandle       *audit.EventHandle
+	LastEvent         audit.Event // captured by NewEvent / NewEventKV scenarios (#597)
+	LastErr           error
+	LastAuditDuration time.Duration // measured by `I audit event ... with required fields` (#549 sync timing)
+	Taxonomy          *audit.Taxonomy
+	Options           []audit.Option
 
 	// Output capture.
 	StdoutBuf         *bytes.Buffer     // in-memory output for non-Docker scenarios
@@ -113,6 +114,7 @@ func (tc *AuditTestContext) Reset() {
 	tc.Auditor = nil
 	tc.EventHandle = nil
 	tc.LastErr = nil
+	tc.LastAuditDuration = 0
 	tc.Taxonomy = nil
 	tc.Options = nil
 	tc.StdoutBuf = nil
@@ -211,4 +213,5 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerContextAPISteps(ctx, tc)
 	registerSetLoggerSteps(ctx, tc)
 	registerAsyncEdgesSteps(ctx, tc)
+	registerSyncDeliverySteps(ctx, tc)
 }

--- a/tests/bdd/steps/isolation_steps.go
+++ b/tests/bdd/steps/isolation_steps.go
@@ -118,6 +118,20 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		return err //nolint:wrapcheck // BDD step
 	})
 
+	ctx.Step(`^an auditor with synchronous delivery and two recording mock outputs$`, func() error {
+		recOut1 = &recordingMockOutput{name: "recording-1"}
+		recOut2 = &recordingMockOutput{name: "recording-2"}
+		var err error
+		tc.Auditor, err = audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithOutputs(recOut1, recOut2),
+			audit.WithSynchronousDelivery(),
+		)
+		return err //nolint:wrapcheck // BDD step
+	})
+
 	ctx.Step(`^stdout should have received all (\d+) events$`, func(n int) error {
 		if stdoutBuf == nil {
 			return fmt.Errorf("no stdout buffer configured")
@@ -162,6 +176,22 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		}
 		if recOut2.eventCount() < n {
 			return fmt.Errorf("recording-2 has %d events, expected %d", recOut2.eventCount(), n)
+		}
+		return nil
+	})
+
+	// "exactly" variant rules out duplicate-fan-out regressions in
+	// addition to the dominant 0-events failure mode. Use for
+	// synchronous-delivery scenarios where the count is deterministic.
+	ctx.Step(`^both recording outputs should have received exactly (\d+) events$`, func(n int) error {
+		if recOut1 == nil || recOut2 == nil {
+			return fmt.Errorf("recording outputs not configured")
+		}
+		if got := recOut1.eventCount(); got != n {
+			return fmt.Errorf("recording-1 has %d events, expected exactly %d", got, n)
+		}
+		if got := recOut2.eventCount(); got != n {
+			return fmt.Errorf("recording-2 has %d events, expected exactly %d", got, n)
 		}
 		return nil
 	})

--- a/tests/bdd/steps/sync_delivery_steps.go
+++ b/tests/bdd/steps/sync_delivery_steps.go
@@ -1,0 +1,131 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/audittest"
+)
+
+// slowMockOutput is an audit.Output whose Write blocks for `delay`
+// then returns nil. Used to test that synchronous delivery makes the
+// caller's AuditEvent block for the duration of the slowest output's
+// Write call.
+type slowMockOutput struct {
+	delay time.Duration
+}
+
+func (s *slowMockOutput) Write(_ []byte) error {
+	time.Sleep(s.delay)
+	return nil
+}
+func (s *slowMockOutput) Close() error { return nil }
+func (s *slowMockOutput) Name() string { return "slow-output" }
+
+// registerSyncDeliverySteps registers BDD step definitions for #549
+// (synchronous-delivery feature file). The 4 step phrases below are
+// exclusive to sync_delivery.feature; sync auditor builders that
+// recur across feature files live in isolation_steps.go and
+// async_edges_steps.go.
+//
+//nolint:gocognit // BDD step registration: 4 closures inline; splitting hurts readability
+func registerSyncDeliverySteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
+	// audittest scenario state — local to sync_delivery scenarios.
+	var (
+		audittestAuditor  *audit.Auditor
+		audittestRecorder *audittest.Recorder
+	)
+
+	ctx.Step(`^an auditor with synchronous delivery and a slow output that blocks (\d+)ms per write$`, func(delayMs int) error {
+		out := &slowMockOutput{delay: time.Duration(delayMs) * time.Millisecond}
+		var err error
+		tc.Auditor, err = audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithOutputs(out),
+			audit.WithSynchronousDelivery(),
+		)
+		if err != nil {
+			return fmt.Errorf("create auditor: %w", err)
+		}
+		tc.AddCleanup(func() { _ = tc.Auditor.Close() })
+		return nil
+	})
+
+	ctx.Step(`^the audit call should have taken at least (\d+) milliseconds$`, func(minMs int) error {
+		want := time.Duration(minMs) * time.Millisecond
+		if tc.LastAuditDuration < want {
+			return fmt.Errorf("audit call took %s, expected at least %s",
+				tc.LastAuditDuration, want)
+		}
+		return nil
+	})
+
+	ctx.Step(`^an audittest auditor created via NewQuick with a standard taxonomy$`, func() error {
+		// QuickTaxonomy with a single permissive event type covers the
+		// standard "user_create" event used elsewhere in this feature.
+		// audittest.NewQuick defaults to synchronous delivery — the
+		// behaviour this scenario pins.
+		tb := &bddTB{}
+		auditor, rec, _ := audittest.NewQuick(tb, "user_create")
+		if tb.Failed() {
+			return fmt.Errorf("audittest.NewQuick failed: %s", tb.fatalMsg)
+		}
+		audittestAuditor = auditor
+		audittestRecorder = rec
+		// Cleanup: NewQuick registers tb.Cleanup; run those on scenario end.
+		tc.AddCleanup(func() { tb.runCleanups() })
+		return nil
+	})
+
+	ctx.Step(`^I audit event "([^"]*)" with required fields via the audittest auditor$`, func(eventType string) error {
+		if audittestAuditor == nil {
+			return errors.New("audittest auditor not initialised")
+		}
+		fields := audit.Fields{"outcome": "success", "actor_id": "actor-1"}
+		if err := audittestAuditor.AuditEvent(audit.NewEvent(eventType, fields)); err != nil {
+			return fmt.Errorf("audit event: %w", err)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the audittest recorder should contain exactly (\d+) "([^"]+)" event with no Close call$`, func(n int, eventType string) error {
+		if audittestRecorder == nil {
+			return errors.New("audittest recorder not initialised")
+		}
+		// CRITICAL: do NOT call Close on the audittest auditor before
+		// reading Events(). The contract under test is that
+		// synchronous delivery makes events visible to the recorder
+		// immediately after AuditEvent returns, with no Close-before-
+		// assert ceremony.
+		events := audittestRecorder.Events()
+		if len(events) != n {
+			return fmt.Errorf("audittest recorder has %d events, expected exactly %d", len(events), n)
+		}
+		for i, ev := range events {
+			if ev.EventType != eventType {
+				return fmt.Errorf("event[%d] has event_type %q, expected %q", i, ev.EventType, eventType)
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary

Closes #549 — adds 6 BDD scenarios pinning the `WithSynchronousDelivery` contract,
which had zero existing coverage despite being the default mode used by every
`audittest.New` / `NewQuick` consumer.

- Synchronicity guarantee, panic recovery, slow-output blocking, Close
  lifecycle, audittest.NewQuick default, syncMu concurrent serialisation.
- Strengthened assertions per test-analyst feedback: exact count (not
  lower-bound), event_type assertion on the audittest recorder.
- Scenario 6 (concurrent serialisation under syncMu) added at agent
  recommendation — pins a contract with zero prior BDD coverage.
- options.go WithSynchronousDelivery godoc extended with explicit
  caller-observable contract section that the BDD scenarios pin.
- LastAuditDuration timing field added to BDD context; backward-compatible
  single-line `time.Since` wrap on the existing audit step.
- Follow-up #724 covers sync+validation-error and sync+filter (test-analyst MEDIUM gaps).

## Test plan

- [x] `make test-bdd-core` — all 6 new sync scenarios green
- [x] `make check` — clean across all 15 modules (90.2% coverage)
- [x] `make lint` — zero issues
- [x] code-reviewer + test-analyst + go-quality + commit-message-reviewer all approved
- [ ] CI green