### PR TITLE
test(bdd): cover EventHandle, audittest opts, buffer_size, drain_timeout, ValidationMode warn, CEF OmitEmpty, DestinationKey, empty Name (#561)

### DIFF
--- a/audittest/missing_coverage_test.go
+++ b/audittest/missing_coverage_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audittest_test
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/audittest"
+)
+
+// Issue #561 unit tests covering audittest.WithSync, audittest.WithVerbose
+// and Recorder.RequireEvents. These supplement the BDD scenarios in
+// tests/bdd/features/missing_coverage_bundle.feature so coverage.out
+// records the symbols above 80%.
+
+const minimalTaxonomyYAML = `
+version: 1
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    fields:
+      outcome: {required: true}
+      actor_id: {required: true}
+`
+
+// TestWithSync_DefaultsToSynchronousDelivery verifies the option wires
+// audit.WithSynchronousDelivery: events appear in the recorder
+// immediately after AuditEvent returns, with no Close call.
+func TestWithSync_DefaultsToSynchronousDelivery(t *testing.T) {
+	t.Parallel()
+	auditor, rec, _ := audittest.New(t, []byte(minimalTaxonomyYAML), audittest.WithSync())
+	require.NotNil(t, auditor)
+	require.NotNil(t, rec)
+
+	err := auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "actor-1",
+	}))
+	require.NoError(t, err)
+
+	// No Close call — sync delivery makes the event visible immediately.
+	assert.Equal(t, 1, rec.Count(), "WithSync must make events visible without Close")
+	events := rec.Events()
+	require.Len(t, events, 1)
+	assert.Equal(t, "user_create", events[0].EventType)
+}
+
+// TestWithVerbose_EnablesDiagnosticLogging verifies the option wires
+// audit.WithDiagnosticLogger so lifecycle messages reach the captured
+// handler (silenced by default in test auditors).
+func TestWithVerbose_EnablesDiagnosticLogging(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	captured := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	auditor, _, _ := audittest.New(t, []byte(minimalTaxonomyYAML),
+		audittest.WithVerbose(),
+		audittest.WithAuditOption(audit.WithDiagnosticLogger(captured)),
+	)
+	require.NotNil(t, auditor)
+
+	// Trigger a lifecycle event by closing the auditor — Close emits a
+	// "shutdown started" / "shutdown complete" diagnostic log when
+	// verbose mode is enabled.
+	require.NoError(t, auditor.Close())
+
+	output := buf.String()
+	assert.Contains(t, output, "audit:",
+		"WithVerbose must produce diagnostic log output containing 'audit:' prefix")
+}
+
+// TestWithVerbose_DefaultIsNonVerbose verifies that constructing an
+// audittest auditor without WithVerbose runs cleanly. (When no
+// WithDiagnosticLogger is supplied, audittest defaults to a
+// discard-handler logger; with one, the user's handler is honoured.)
+func TestWithVerbose_DefaultIsNonVerbose(t *testing.T) {
+	t.Parallel()
+	auditor, _, _ := audittest.New(t, []byte(minimalTaxonomyYAML))
+	require.NotNil(t, auditor)
+	require.NoError(t, auditor.Close())
+}
+
+// TestRequireEvents_ExactCount returns the recorded events without
+// failing the bench when the count matches.
+func TestRequireEvents_ExactCount(t *testing.T) {
+	t.Parallel()
+	auditor, rec, _ := audittest.New(t, []byte(minimalTaxonomyYAML))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "actor-1",
+	})))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "actor-2",
+	})))
+
+	events := rec.RequireEvents(t, 2)
+	assert.Len(t, events, 2)
+	assert.Equal(t, "user_create", events[0].EventType)
+	assert.Equal(t, "user_create", events[1].EventType)
+}
+
+// TestRequireEvents_FailsBenchOnMismatch verifies RequireEvents calls
+// tb.Fatalf when the event count does not match. Uses a probe TB so
+// the failure does not propagate to this test.
+func TestRequireEvents_FailsBenchOnMismatch(t *testing.T) {
+	t.Parallel()
+	auditor, rec, _ := audittest.New(t, []byte(minimalTaxonomyYAML))
+	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "actor-1",
+	})))
+
+	probe := &probeTB{TB: t}
+	rec.RequireEvents(probe, 5)
+	assert.True(t, probe.failed, "RequireEvents must fail the bench when count mismatches")
+	assert.Contains(t, probe.fatalMsg, "5",
+		"failure message should reference the expected count")
+}
+
+// TestRequireEvents_ZeroExpectedAndZeroActual handles the n=0 boundary.
+func TestRequireEvents_ZeroExpectedAndZeroActual(t *testing.T) {
+	t.Parallel()
+	_, rec, _ := audittest.New(t, []byte(minimalTaxonomyYAML))
+	events := rec.RequireEvents(t, 0)
+	assert.Empty(t, events)
+}
+
+// probeTB is a minimal testing.TB that captures Fatalf invocations
+// without propagating them. Lets tests assert on RequireEvents'
+// failure path.
+type probeTB struct {
+	testing.TB
+	fatalMsg string
+	failed   bool
+}
+
+func (p *probeTB) Helper() {}
+func (p *probeTB) Fatalf(format string, args ...any) {
+	p.failed = true
+	p.fatalMsg = fmt.Sprintf(format, args...)
+}
+func (p *probeTB) Errorf(format string, args ...any) {
+	p.failed = true
+	p.fatalMsg = fmt.Sprintf(format, args...)
+}
+func (p *probeTB) FailNow() { p.failed = true }
+func (p *probeTB) Fail()    { p.failed = true }

--- a/event_handle_audit_event_test.go
+++ b/event_handle_audit_event_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/internal/testhelper"
+)
+
+// Issue #561 / F-21: unit tests for EventHandle.AuditEvent (event.go).
+// Pairs with the BDD scenarios in tests/bdd/features/missing_coverage_bundle.feature
+// so coverage.out shows the function above 80%.
+
+// TestEventHandle_AuditEvent_DeliversViaBoundAuditor verifies the
+// happy path: the event is delivered through the auditor that owns
+// the handle.
+func TestEventHandle_AuditEvent_DeliversViaBoundAuditor(t *testing.T) {
+	out := testhelper.NewMockOutput("test")
+	auditor := newTestAuditor(t, out, audit.WithSynchronousDelivery())
+
+	handle, err := auditor.Handle("auth_failure")
+	require.NoError(t, err)
+
+	err = handle.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "actor-1",
+	}))
+	require.NoError(t, err)
+
+	events := out.GetEvents()
+	require.Len(t, events, 1, "EventHandle.AuditEvent must deliver exactly 1 event")
+	assert.Contains(t, string(events[0]), "auth_failure")
+}
+
+// TestEventHandle_AuditEvent_AfterClose_ReturnsErrClosed verifies the
+// closed-auditor path: the handle's AuditEvent returns ErrClosed
+// without writing to the output.
+func TestEventHandle_AuditEvent_AfterClose_ReturnsErrClosed(t *testing.T) {
+	out := testhelper.NewMockOutput("test")
+	auditor, err := audit.New(
+		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithOutputs(out),
+		audit.WithSynchronousDelivery(),
+	)
+	require.NoError(t, err)
+
+	handle, err := auditor.Handle("auth_failure")
+	require.NoError(t, err)
+
+	require.NoError(t, auditor.Close())
+
+	err = handle.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "actor-1",
+	}))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, audit.ErrClosed),
+		"closed-auditor handle.AuditEvent must return ErrClosed, got: %v", err)
+	assert.Empty(t, out.GetEvents(), "no event should be delivered after Close")
+}
+
+// TestEventHandle_AuditEvent_ValidationError_Propagated verifies that
+// validation errors flow through the handle path identically to the
+// auditor path.
+func TestEventHandle_AuditEvent_ValidationError_Propagated(t *testing.T) {
+	out := testhelper.NewMockOutput("test")
+	auditor := newTestAuditor(t, out, audit.WithSynchronousDelivery())
+
+	handle, err := auditor.Handle("auth_failure")
+	require.NoError(t, err)
+
+	// Empty fields — required fields missing.
+	err = handle.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, audit.ErrValidation),
+		"missing-required validation error must wrap ErrValidation, got: %v", err)
+	assert.Empty(t, out.GetEvents(), "validation-failed event must not be delivered")
+}

--- a/options.go
+++ b/options.go
@@ -282,6 +282,9 @@ func WithOutputs(outputs ...Output) Option {
 		entries := make([]*outputEntry, len(outputs))
 		for i, o := range outputs {
 			name := o.Name()
+			if name == "" {
+				return fmt.Errorf("audit: output Name() must not return an empty string")
+			}
 			if _, dup := byName[name]; dup {
 				return fmt.Errorf("audit: duplicate output name %q", name)
 			}
@@ -390,6 +393,9 @@ func WithNamedOutput(output Output, opts ...OutputOption) Option {
 // optional route/formatter/exclude-label/HMAC configuration.
 func (a *Auditor) addNamedOutput(output Output, b *outputEntryBuilder) error {
 	name := output.Name()
+	if name == "" {
+		return fmt.Errorf("audit: output Name() must not return an empty string")
+	}
 	if a.outputsByName == nil {
 		a.outputsByName = make(map[string]*outputEntry)
 	}

--- a/output.go
+++ b/output.go
@@ -53,6 +53,11 @@ type Output interface {
 
 	// Name returns a human-readable identifier for the output,
 	// used in log messages and metrics labels.
+	//
+	// Name MUST NOT return an empty string. Empty names corrupt
+	// metrics labels, hide outputs in error messages, and break
+	// duplicate-name detection. [WithOutputs] and [WithNamedOutput]
+	// reject empty-name outputs at construction time.
 	Name() string
 }
 

--- a/tests/bdd/features/missing_coverage_bundle.feature
+++ b/tests/bdd/features/missing_coverage_bundle.feature
@@ -1,0 +1,269 @@
+@core @missing-coverage
+Feature: Missing BDD Coverage Bundle (#561)
+  Bundles BDD scenarios for documented behaviours that previously had
+  zero or insufficient BDD coverage. Each scenario block below pins
+  one of the eight master-tracker items F-21 through F-28.
+
+  Background:
+    Given a standard test taxonomy
+
+  # ---------------------------------------------------------------
+  # F-21 — EventHandle.AuditEvent (event.go:365)
+  # ---------------------------------------------------------------
+
+  Scenario: EventHandle.AuditEvent delivers an event using the handle's bound auditor
+    Given an auditor with synchronous delivery and a recording mock output
+    And I get a handle for event type "user_create"
+    When I call EventHandle.AuditEvent with a NewEvent for "user_create"
+    Then the audit call should return no error
+    And the recording output should have received exactly 1 events
+
+  Scenario: EventHandle.AuditEvent on a closed auditor returns ErrClosed
+    Given an auditor with synchronous delivery and a recording mock output
+    And I get a handle for event type "user_create"
+    When I close the auditor
+    And I call EventHandle.AuditEvent with a NewEvent for "user_create"
+    Then the audit call should return an error wrapping "ErrClosed"
+    And the recording output should have received exactly 0 events
+
+  # ---------------------------------------------------------------
+  # F-22 — audittest.WithSync, WithVerbose, RequireEvents
+  # ---------------------------------------------------------------
+
+  Scenario: audittest WithSync delivers events synchronously without WaitForN
+    Given an audittest auditor created with WithSync
+    When I audit event "user_create" with required fields via the audittest auditor
+    Then the audittest recorder should contain exactly 1 "user_create" event with no Close call
+
+  Scenario: audittest RequireEvents returns recorded events when count matches
+    Given an audittest auditor created via NewQuick with a standard taxonomy
+    When I audit event "user_create" with required fields via the audittest auditor
+    And I audit event "user_create" with required fields via the audittest auditor
+    Then RequireEvents 2 returns the recorded events
+
+  Scenario: audittest RequireEvents fails the test bench when count mismatches
+    Given an audittest auditor created via NewQuick with a standard taxonomy
+    When I audit event "user_create" with required fields via the audittest auditor
+    And I call RequireEvents with n=5 expecting failure
+    Then the audittest test bench should have been failed
+
+  Scenario: audittest WithVerbose enables diagnostic logging output
+    Given an audittest auditor created with WithVerbose and a captured logger
+    When I close the audittest auditor
+    Then the captured diagnostic log should contain "audit:" lifecycle messages
+
+  # ---------------------------------------------------------------
+  # F-23 — Webhook/Loki buffer_size YAML
+  # ---------------------------------------------------------------
+
+  Scenario: Webhook output accepts buffer_size in YAML
+    Given the following outputs YAML:
+      """
+      version: 1
+      app_name: test-app
+      host: test-host
+      outputs:
+        wh:
+          type: webhook
+          webhook:
+            url: http://example.invalid/audit
+            allow_insecure_http: true
+            buffer_size: 250
+      """
+    When I load the outputs config
+    Then the config should load successfully
+
+  Scenario: Webhook output buffer_size defaults when omitted
+    Given the following outputs YAML:
+      """
+      version: 1
+      app_name: test-app
+      host: test-host
+      outputs:
+        wh:
+          type: webhook
+          webhook:
+            url: http://example.invalid/audit
+            allow_insecure_http: true
+      """
+    When I load the outputs config
+    Then the config should load successfully
+
+  Scenario: Webhook output buffer_size exceeding maximum is rejected
+    Given the following outputs YAML:
+      """
+      version: 1
+      app_name: test-app
+      host: test-host
+      outputs:
+        wh:
+          type: webhook
+          webhook:
+            url: http://example.invalid/audit
+            allow_insecure_http: true
+            buffer_size: 2000000
+      """
+    When I load the outputs config
+    Then the config load should fail with an error containing "buffer_size"
+
+  Scenario: Loki output accepts buffer_size in YAML
+    Given the following outputs YAML:
+      """
+      version: 1
+      app_name: test-app
+      host: test-host
+      outputs:
+        lk:
+          type: loki
+          loki:
+            url: http://example.invalid/loki/api/v1/push
+            allow_insecure_http: true
+            buffer_size: 500
+      """
+    When I load the outputs config
+    Then the config should load successfully
+
+  Scenario: Loki output buffer_size defaults when omitted
+    Given the following outputs YAML:
+      """
+      version: 1
+      app_name: test-app
+      host: test-host
+      outputs:
+        lk:
+          type: loki
+          loki:
+            url: http://example.invalid/loki/api/v1/push
+            allow_insecure_http: true
+      """
+    When I load the outputs config
+    Then the config should load successfully
+
+  Scenario: Loki output buffer_size exceeding maximum is rejected
+    Given the following outputs YAML:
+      """
+      version: 1
+      app_name: test-app
+      host: test-host
+      outputs:
+        lk:
+          type: loki
+          loki:
+            url: http://example.invalid/loki/api/v1/push
+            allow_insecure_http: true
+            buffer_size: 2000000
+      """
+    When I load the outputs config
+    Then the config load should fail with an error containing "buffer_size"
+
+  # ---------------------------------------------------------------
+  # F-24 — drain_timeout deprecation error (outputconfig/auditor_config.go)
+  # ---------------------------------------------------------------
+
+  Scenario: Deprecated auditor.drain_timeout field is rejected with a rename hint
+    Given the following outputs YAML:
+      """
+      version: 1
+      app_name: test-app
+      host: test-host
+      auditor:
+        drain_timeout: 5s
+      outputs:
+        wh:
+          type: webhook
+          webhook:
+            url: http://example.invalid/audit
+            allow_insecure_http: true
+      """
+    When I load the outputs config
+    Then the config load should fail with an error containing "drain_timeout"
+    And the config load error should also contain "shutdown_timeout"
+
+  Scenario: shutdown_timeout (replacement for drain_timeout) is accepted
+    Given the following outputs YAML:
+      """
+      version: 1
+      app_name: test-app
+      host: test-host
+      auditor:
+        shutdown_timeout: 5s
+      outputs:
+        wh:
+          type: webhook
+          webhook:
+            url: http://example.invalid/audit
+            allow_insecure_http: true
+      """
+    When I load the outputs config
+    Then the config should load successfully
+
+  # ---------------------------------------------------------------
+  # F-25 — ValidationMode warn delivers (vs strict rejects)
+  # ---------------------------------------------------------------
+
+  Scenario: ValidationMode warn delivers an event with an unknown field
+    Given an auditor with synchronous delivery, a recording output, and ValidationMode warn
+    When I audit event "user_create" with required fields and an unknown field "extra_field"
+    Then the audit call should return no error
+    And the recording output should have received exactly 1 events
+
+  Scenario: ValidationMode strict rejects an event with an unknown field
+    Given an auditor with synchronous delivery, a recording output, and ValidationMode strict
+    When I try to audit event "user_create" with required fields and an unknown field "extra_field"
+    Then the audit call should return an error wrapping "ErrValidation"
+    And the recording output should have received exactly 0 events
+
+  Scenario: ValidationMode warn still rejects events missing a required field
+    Given an auditor with synchronous delivery, a recording output, and ValidationMode warn
+    When I try to audit event "user_create" with empty fields
+    Then the audit call should return an error wrapping "ErrValidation"
+    And the recording output should have received exactly 0 events
+
+  # ---------------------------------------------------------------
+  # F-26 — CEF formatter OmitEmpty (parity with JSON)
+  # ---------------------------------------------------------------
+
+  Scenario: CEF formatter with OmitEmpty true skips empty-string fields
+    Given an auditor with file output and a CEF formatter with OmitEmpty true
+    When I audit event "user_create" with an empty optional field "reason"
+    And I close the auditor
+    Then the file should not contain CEF extension key "reason"
+
+  Scenario: CEF formatter with OmitEmpty false includes empty-string fields
+    Given an auditor with file output and a CEF formatter with OmitEmpty false
+    When I audit event "user_create" with an empty optional field "reason"
+    And I close the auditor
+    Then the file should contain CEF extension key "reason"
+
+  # ---------------------------------------------------------------
+  # F-27 — DestinationKey duplicate detection (cross-type and same-type)
+  # ---------------------------------------------------------------
+
+  Scenario: Two outputs returning the same DestinationKey are rejected at construction
+    Given two outputs with destination keys "https://example.invalid/audit" and "https://example.invalid/audit"
+    When I construct an auditor with those two outputs via WithNamedOutput
+    Then the construction should fail with an error wrapping "ErrDuplicateDestination"
+
+  Scenario: Two outputs with empty DestinationKey opt out of duplicate detection
+    Given two outputs with destination keys "" and ""
+    When I construct an auditor with those two outputs via WithNamedOutput
+    Then the construction should succeed
+
+  Scenario: Two outputs with distinct DestinationKey values are accepted
+    Given two outputs with destination keys "https://a.example.invalid/audit" and "https://b.example.invalid/audit"
+    When I construct an auditor with those two outputs via WithNamedOutput
+    Then the construction should succeed
+
+  # ---------------------------------------------------------------
+  # F-28 — Output.Name() empty-string policy (rejected at construction)
+  # ---------------------------------------------------------------
+
+  Scenario: WithNamedOutput rejects an output whose Name returns the empty string
+    Given an output whose Name returns the empty string
+    When I construct an auditor with that output via WithNamedOutput
+    Then the construction should fail with a message containing "Name() must not return an empty string"
+
+  Scenario: WithOutputs rejects an output whose Name returns the empty string
+    Given an output whose Name returns the empty string
+    When I construct an auditor with that output via WithOutputs
+    Then the construction should fail with a message containing "Name() must not return an empty string"

--- a/tests/bdd/steps/audit_steps.go
+++ b/tests/bdd/steps/audit_steps.go
@@ -203,6 +203,11 @@ func registerAuditWhenBasicSteps(ctx *godog.ScenarioContext, tc *AuditTestContex
 		return nil
 	})
 
+	ctx.Step(`^I try to audit event "([^"]*)" with empty fields$`, func(eventType string) error {
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, audit.Fields{}))
+		return nil
+	})
+
 	ctx.Step(`^I get a handle for event type "([^"]*)"$`, func(eventType string) error {
 		h, err := tc.Auditor.Handle(eventType)
 		if err != nil {

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -214,4 +214,5 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerSetLoggerSteps(ctx, tc)
 	registerAsyncEdgesSteps(ctx, tc)
 	registerSyncDeliverySteps(ctx, tc)
+	registerMissingCoverageSteps(ctx, tc)
 }

--- a/tests/bdd/steps/isolation_steps.go
+++ b/tests/bdd/steps/isolation_steps.go
@@ -132,6 +132,38 @@ func registerIsolationSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) { 
 		return err //nolint:wrapcheck // BDD step
 	})
 
+	// F-25 ValidationMode warn/strict variants. Reuse recOut1 so the
+	// existing `received exactly N events` assertion step works.
+	// Sync mode has no drain goroutine, so no per-scenario Close
+	// cleanup is needed beyond the suite-wide AfterScenario hook.
+	ctx.Step(`^an auditor with synchronous delivery, a recording output, and ValidationMode warn$`, func() error {
+		recOut1 = &recordingMockOutput{name: "recording-1"}
+		var err error
+		tc.Auditor, err = audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithOutputs(recOut1),
+			audit.WithSynchronousDelivery(),
+			audit.WithValidationMode(audit.ValidationWarn),
+		)
+		return err //nolint:wrapcheck // BDD step
+	})
+
+	ctx.Step(`^an auditor with synchronous delivery, a recording output, and ValidationMode strict$`, func() error {
+		recOut1 = &recordingMockOutput{name: "recording-1"}
+		var err error
+		tc.Auditor, err = audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithOutputs(recOut1),
+			audit.WithSynchronousDelivery(),
+			audit.WithValidationMode(audit.ValidationStrict),
+		)
+		return err //nolint:wrapcheck // BDD step
+	})
+
 	ctx.Step(`^stdout should have received all (\d+) events$`, func(n int) error {
 		if stdoutBuf == nil {
 			return fmt.Errorf("no stdout buffer configured")

--- a/tests/bdd/steps/missing_coverage_steps.go
+++ b/tests/bdd/steps/missing_coverage_steps.go
@@ -1,0 +1,303 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cucumber/godog"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/file"
+)
+
+// destKeyOutput is a mock output that returns a configured destination
+// key. Used by F-27 DestinationKey duplicate-detection scenarios.
+type destKeyOutput struct {
+	name   string
+	dest   string
+	closed bool
+}
+
+func (d *destKeyOutput) Write(_ []byte) error   { return nil }
+func (d *destKeyOutput) Close() error           { d.closed = true; return nil }
+func (d *destKeyOutput) Name() string           { return d.name }
+func (d *destKeyOutput) DestinationKey() string { return d.dest }
+
+// emptyNameOutput is a mock output whose Name() returns "". Used by
+// F-28 to verify the construction-time validation rejects it.
+type emptyNameOutput struct{}
+
+func (e *emptyNameOutput) Write(_ []byte) error { return nil }
+func (e *emptyNameOutput) Close() error         { return nil }
+func (e *emptyNameOutput) Name() string         { return "" }
+
+// registerMissingCoverageSteps registers BDD step definitions for #561
+// (the bundle of previously-missing BDD coverage: F-21 EventHandle,
+// F-22 audittest options, F-23 webhook/loki buffer_size, F-24
+// drain_timeout deprecation, F-25 ValidationMode warn, F-26 CEF
+// OmitEmpty, F-27 DestinationKey, F-28 empty Name policy).
+//
+//nolint:gocognit,gocyclo,cyclop,maintidx // BDD step registration: many closures inline; splitting hurts readability
+func registerMissingCoverageSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
+	// F-27/F-28 construction state — local closure.
+	var (
+		dkOut1, dkOut2  *destKeyOutput
+		emptyOut        *emptyNameOutput
+		constructResult error
+	)
+
+	// =========================================================
+	// F-21 EventHandle.AuditEvent
+	// =========================================================
+
+	ctx.Step(`^I call EventHandle\.AuditEvent with a NewEvent for "([^"]*)"$`, func(eventType string) error {
+		if tc.EventHandle == nil {
+			return errors.New("no EventHandle — precede with 'I get a handle for event type ...'")
+		}
+		fields := defaultRequiredFields(tc.Taxonomy, eventType)
+		tc.LastErr = tc.EventHandle.AuditEvent(audit.NewEvent(eventType, fields))
+		return nil
+	})
+
+	// F-22 audittest WithSync / WithVerbose / RequireEvents step
+	// definitions live in sync_delivery_steps.go where they share the
+	// audittestAuditor / audittestRecorder closure with the other
+	// audittest scenarios.
+
+	// =========================================================
+	// F-23, F-24: extra outputconfig assertion step
+	// =========================================================
+
+	ctx.Step(`^the config load error should also contain "([^"]*)"$`, func(needle string) error {
+		if tc.LastErr == nil {
+			return errors.New("no error — load did not fail")
+		}
+		if !strings.Contains(tc.LastErr.Error(), needle) {
+			return fmt.Errorf("error %q does not also contain %q", tc.LastErr.Error(), needle)
+		}
+		return nil
+	})
+
+	// =========================================================
+	// F-25 ValidationMode warn / strict auditor builders
+	// =========================================================
+
+	// F-25 ValidationMode scenarios live in isolation_steps.go (they
+	// reuse the recOut1 closure shared with the existing
+	// `received exactly N events` assertion step).
+
+	ctx.Step(`^I try to audit event "([^"]*)" with required fields and an unknown field "([^"]*)"$`, func(eventType, extraField string) error {
+		fields := defaultRequiredFields(tc.Taxonomy, eventType)
+		fields[extraField] = "extra_value"
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
+		return nil
+	})
+
+	// =========================================================
+	// F-26 CEF formatter OmitEmpty
+	// =========================================================
+
+	ctx.Step(`^an auditor with file output and a CEF formatter with OmitEmpty (true|false)$`, func(omit string) error {
+		dir, err := tc.EnsureFileDir()
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(dir, "cef.log")
+		tc.FilePaths["default"] = path
+
+		fileOut, err := file.New(&file.Config{Path: path})
+		if err != nil {
+			return fmt.Errorf("create file: %w", err)
+		}
+		tc.AddCleanup(func() { _ = fileOut.Close() })
+
+		cefFmt := &audit.CEFFormatter{
+			Vendor:    "axonops",
+			Product:   "audit",
+			Version:   "test",
+			OmitEmpty: omit == "true",
+		}
+
+		tc.Auditor, err = audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithFormatter(cefFmt),
+			audit.WithNamedOutput(fileOut),
+			audit.WithSynchronousDelivery(),
+		)
+		if err != nil {
+			return fmt.Errorf("create auditor: %w", err)
+		}
+		tc.AddCleanup(func() { _ = tc.Auditor.Close() })
+		return nil
+	})
+
+	ctx.Step(`^I audit event "([^"]*)" with an empty optional field "([^"]*)"$`, func(eventType, fieldName string) error {
+		fields := defaultRequiredFields(tc.Taxonomy, eventType)
+		fields[fieldName] = ""
+		tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent(eventType, fields))
+		return nil
+	})
+
+	ctx.Step(`^the file should not contain CEF extension key "([^"]*)"$`, func(key string) error {
+		path := tc.FilePaths["default"]
+		data, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+		if err != nil {
+			return fmt.Errorf("read file: %w", err)
+		}
+		// CEF extension keys appear as ` <key>=` (space-prefixed).
+		needle := " " + key + "="
+		if bytes.Contains(data, []byte(needle)) {
+			return fmt.Errorf("file unexpectedly contains CEF extension key %q in %q", key, string(data))
+		}
+		return nil
+	})
+
+	ctx.Step(`^the file should contain CEF extension key "([^"]*)"$`, func(key string) error {
+		path := tc.FilePaths["default"]
+		data, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+		if err != nil {
+			return fmt.Errorf("read file: %w", err)
+		}
+		needle := " " + key + "="
+		if !bytes.Contains(data, []byte(needle)) {
+			return fmt.Errorf("file does not contain CEF extension key %q; got %q", key, string(data))
+		}
+		return nil
+	})
+
+	// =========================================================
+	// F-27 DestinationKey duplicate detection
+	// =========================================================
+
+	ctx.Step(`^two outputs with destination keys "([^"]*)" and "([^"]*)"$`, func(k1, k2 string) error {
+		dkOut1 = &destKeyOutput{name: "dk-1", dest: k1}
+		dkOut2 = &destKeyOutput{name: "dk-2", dest: k2}
+		return nil
+	})
+
+	ctx.Step(`^I construct an auditor with those two outputs via WithNamedOutput$`, func() error {
+		// Sync delivery so a successful construction doesn't leak a
+		// drain goroutine when the test discards the auditor.
+		auditor, err := audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithNamedOutput(dkOut1),
+			audit.WithNamedOutput(dkOut2),
+			audit.WithSynchronousDelivery(),
+		)
+		if auditor != nil {
+			tc.AddCleanup(func() { _ = auditor.Close() })
+		}
+		constructResult = err
+		return nil
+	})
+
+	ctx.Step(`^I construct an auditor with those two outputs via WithOutputs$`, func() error {
+		auditor, err := audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithOutputs(dkOut1, dkOut2),
+			audit.WithSynchronousDelivery(),
+		)
+		if auditor != nil {
+			tc.AddCleanup(func() { _ = auditor.Close() })
+		}
+		constructResult = err
+		return nil
+	})
+
+	ctx.Step(`^the construction should succeed$`, func() error {
+		if constructResult != nil {
+			return fmt.Errorf("expected construction to succeed, got: %w", constructResult)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the construction should fail with an error wrapping "([^"]*)"$`, func(sentinel string) error {
+		if constructResult == nil {
+			return errors.New("expected construction to fail, but it succeeded")
+		}
+		var target error
+		switch sentinel {
+		case "ErrDuplicateDestination":
+			target = audit.ErrDuplicateDestination
+		default:
+			return fmt.Errorf("unknown sentinel %q in step", sentinel)
+		}
+		if !errors.Is(constructResult, target) {
+			return fmt.Errorf("expected error wrapping %s, got: %w", sentinel, constructResult)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the construction should fail with a message containing "([^"]*)"$`, func(needle string) error {
+		if constructResult == nil {
+			return errors.New("expected construction to fail, but it succeeded")
+		}
+		if !strings.Contains(constructResult.Error(), needle) {
+			return fmt.Errorf("expected error message to contain %q, got: %w", needle, constructResult)
+		}
+		return nil
+	})
+
+	// =========================================================
+	// F-28 Output.Name() empty-string policy
+	// =========================================================
+
+	ctx.Step(`^an output whose Name returns the empty string$`, func() error {
+		emptyOut = &emptyNameOutput{}
+		return nil
+	})
+
+	ctx.Step(`^I construct an auditor with that output via WithNamedOutput$`, func() error {
+		auditor, err := audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithNamedOutput(emptyOut),
+			audit.WithSynchronousDelivery(),
+		)
+		if auditor != nil {
+			tc.AddCleanup(func() { _ = auditor.Close() })
+		}
+		constructResult = err
+		return nil
+	})
+
+	ctx.Step(`^I construct an auditor with that output via WithOutputs$`, func() error {
+		auditor, err := audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithOutputs(emptyOut),
+			audit.WithSynchronousDelivery(),
+		)
+		if auditor != nil {
+			tc.AddCleanup(func() { _ = auditor.Close() })
+		}
+		constructResult = err
+		return nil
+	})
+}

--- a/tests/bdd/steps/sync_delivery_steps.go
+++ b/tests/bdd/steps/sync_delivery_steps.go
@@ -15,8 +15,11 @@
 package steps
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
@@ -46,7 +49,7 @@ func (s *slowMockOutput) Name() string { return "slow-output" }
 // recur across feature files live in isolation_steps.go and
 // async_edges_steps.go.
 //
-//nolint:gocognit // BDD step registration: 4 closures inline; splitting hurts readability
+//nolint:gocognit,gocyclo,cyclop // BDD step registration: many closures inline; splitting hurts readability
 func registerSyncDeliverySteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	// audittest scenario state — local to sync_delivery scenarios.
 	var (
@@ -94,6 +97,94 @@ func registerSyncDeliverySteps(ctx *godog.ScenarioContext, tc *AuditTestContext)
 		audittestRecorder = rec
 		// Cleanup: NewQuick registers tb.Cleanup; run those on scenario end.
 		tc.AddCleanup(func() { tb.runCleanups() })
+		return nil
+	})
+
+	// F-22 audittest WithSync / WithVerbose / RequireEvents builders
+	// share the audittestAuditor / audittestRecorder closure with the
+	// existing scenarios in sync_delivery.feature.
+	var audittestLogBuf *bytes.Buffer
+	var audittestProbeTB *bddTB
+
+	ctx.Step(`^an audittest auditor created with WithSync$`, func() error {
+		tb := &bddTB{}
+		auditor, rec, _ := audittest.New(tb, []byte(standardTaxonomyYAML), audittest.WithSync())
+		if tb.Failed() {
+			return fmt.Errorf("audittest.New(WithSync) failed: %s", tb.fatalMsg)
+		}
+		audittestAuditor = auditor
+		audittestRecorder = rec
+		tc.AddCleanup(func() { tb.runCleanups() })
+		return nil
+	})
+
+	ctx.Step(`^an audittest auditor created with WithVerbose and a captured logger$`, func() error {
+		tb := &bddTB{}
+		audittestLogBuf = &bytes.Buffer{}
+		captured := slog.New(slog.NewTextHandler(audittestLogBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		auditor, rec, _ := audittest.New(tb, []byte(standardTaxonomyYAML),
+			audittest.WithVerbose(),
+			audittest.WithAuditOption(audit.WithDiagnosticLogger(captured)),
+		)
+		if tb.Failed() {
+			return fmt.Errorf("audittest.New(WithVerbose) failed: %s", tb.fatalMsg)
+		}
+		audittestAuditor = auditor
+		audittestRecorder = rec
+		tc.AddCleanup(func() { tb.runCleanups() })
+		return nil
+	})
+
+	ctx.Step(`^I close the audittest auditor$`, func() error {
+		if audittestAuditor == nil {
+			return errors.New("no audittest auditor")
+		}
+		_ = audittestAuditor.Close()
+		return nil
+	})
+
+	ctx.Step(`^the captured diagnostic log should contain "([^"]*)" lifecycle messages$`, func(needle string) error {
+		if audittestLogBuf == nil {
+			return errors.New("no captured log buffer — did you use 'WithVerbose and a captured logger'?")
+		}
+		if !strings.Contains(audittestLogBuf.String(), needle) {
+			return fmt.Errorf("captured log does not contain %q; got: %s", needle, audittestLogBuf.String())
+		}
+		return nil
+	})
+
+	ctx.Step(`^RequireEvents (\d+) returns the recorded events$`, func(n int) error {
+		if audittestRecorder == nil {
+			return errors.New("no audittest recorder")
+		}
+		probe := &bddTB{}
+		events := audittestRecorder.RequireEvents(probe, n)
+		if probe.Failed() {
+			return fmt.Errorf("RequireEvents(%d) unexpectedly failed: %s", n, probe.fatalMsg)
+		}
+		if len(events) != n {
+			return fmt.Errorf("RequireEvents returned %d events, expected %d", len(events), n)
+		}
+		return nil
+	})
+
+	ctx.Step(`^I call RequireEvents with n=(\d+) expecting failure$`, func(n int) error {
+		if audittestRecorder == nil {
+			return errors.New("no audittest recorder")
+		}
+		probe := &bddTB{}
+		audittestRecorder.RequireEvents(probe, n)
+		audittestProbeTB = probe
+		return nil
+	})
+
+	ctx.Step(`^the audittest test bench should have been failed$`, func() error {
+		if audittestProbeTB == nil {
+			return errors.New("no probe TB — precede with 'I call RequireEvents with n=N expecting failure'")
+		}
+		if !audittestProbeTB.Failed() {
+			return errors.New("expected audittest TB to be failed, but it was not")
+		}
 		return nil
 	})
 


### PR DESCRIPTION
## Summary

Closes #561 — bundles 24 BDD scenarios covering all 8 sub-items
F-21 through F-28 in one PR.

- **F-21 EventHandle.AuditEvent**: delivery via bound auditor; ErrClosed.
- **F-22 audittest WithSync / WithVerbose / RequireEvents**: sync default, verbose logs captured, pass+fail RequireEvents.
- **F-23 Webhook/Loki buffer_size YAML**: accepted, default, exceeding-max rejection (each output).
- **F-24 drain_timeout deprecation**: rejected with rename hint; shutdown_timeout accepted.
- **F-25 ValidationMode warn**: delivers unknown fields (no error); strict rejects; warn still rejects missing required.
- **F-26 CEF OmitEmpty**: parity with JSON — omits / includes empty extension keys.
- **F-27 DestinationKey**: duplicate rejected (ErrDuplicateDestination); empty opts out; distinct accepted.
- **F-28 Output.Name() empty-string policy**: rejected at construction by WithNamedOutput AND WithOutputs (production-code change in options.go + godoc on Output.Name()).

24 scenarios. Single PR. No follow-ups filed — every named contract delivered here.

## Test plan

- [x] make test-bdd-core (24 new + all existing core scenarios green)
- [x] make check (15 modules clean)
- [x] make lint (zero issues)
- [ ] CI green