### PR TITLE
test(bdd): tighten outputconfig success-only assertions (#551)

### DIFF
--- a/outputconfig/tests/bdd/features/output_config.feature
+++ b/outputconfig/tests/bdd/features/output_config.feature
@@ -21,6 +21,9 @@ Feature: YAML Output Configuration
       | actor_id | alice   |
     And I close the auditor
     Then the audit call should have succeeded
+    And the captured output should contain "user_create"
+    And the captured output should contain "alice"
+    And the loaded auditor metadata should have app_name "test"
 
   Scenario: Load file output with routing from YAML
     Given a test taxonomy
@@ -190,6 +193,7 @@ Feature: YAML Output Configuration
       | outcome  | success |
       | actor_id | alice   |
     Then the audit call should have succeeded
+    And the loaded auditor metadata should have timezone ""
 
   Scenario: timezone present in output config YAML
     Given a test taxonomy
@@ -209,6 +213,7 @@ Feature: YAML Output Configuration
       | outcome  | success |
       | actor_id | alice   |
     Then the audit call should have succeeded
+    And the loaded auditor metadata should have timezone "UTC"
 
   # --- standard_fields in output config (#237) ---
 
@@ -231,6 +236,8 @@ Feature: YAML Output Configuration
       | outcome  | success |
       | actor_id | alice   |
     Then the audit call should have succeeded
+    And the captured output should contain "10.0.0.1"
+    And the captured output should contain "source_ip"
 
   Scenario: standard_fields with unknown field rejected
     Given a test taxonomy
@@ -372,3 +379,5 @@ Feature: YAML Output Configuration
       | outcome  | success |
       | actor_id | alice   |
     Then the audit call should have succeeded
+    And the loaded auditor metadata should have app_name "injected-app"
+    And the captured output should contain "injected-app"

--- a/outputconfig/tests/bdd/features/secret_resolution.feature
+++ b/outputconfig/tests/bdd/features/secret_resolution.feature
@@ -34,6 +34,8 @@ Feature: Secret reference resolution in output configuration
             algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
+    And the HMAC config should have salt "my-literal-salt-32-bytes!!!!!!!"
+    And the HMAC config should have version "v1"
 
   # ---------------------------------------------------------------------------
   # Scenario 2: Environment variable HMAC values work without secret providers
@@ -56,6 +58,8 @@ Feature: Secret reference resolution in output configuration
             algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
+    And the HMAC config should have salt "literal-salt-value-32-bytes!!!!!"
+    And the HMAC config should have version "v1"
 
   # ---------------------------------------------------------------------------
   # Scenario 3: Secret reference resolved from a registered provider
@@ -80,6 +84,9 @@ Feature: Secret reference resolution in output configuration
             algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
+    And the HMAC config should have salt "resolved-salt-value-32-bytes!!!!"
+    And the HMAC config should have version "v2"
+    And the HMAC config should have algorithm "HMAC-SHA-256"
 
   # ---------------------------------------------------------------------------
   # Scenario 4: Environment variable that expands to a ref is then resolved
@@ -104,6 +111,8 @@ Feature: Secret reference resolution in output configuration
             algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
+    And the HMAC config should have salt "env-indirected-salt-32-bytes!!!!"
+    And the HMAC config should have version "v1"
 
   # ---------------------------------------------------------------------------
   # Scenario 5: Inline literal, env-var, and ref can be mixed in the same config
@@ -128,6 +137,9 @@ Feature: Secret reference resolution in output configuration
             algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
+    And the HMAC config should have salt "mixed-source-salt-32-bytes!!!!!!"
+    And the HMAC config should have version "v3"
+    And the HMAC config should have algorithm "HMAC-SHA-256"
 
   # ---------------------------------------------------------------------------
   # Scenario 6: Unresolved reference fails when no provider is registered
@@ -399,6 +411,8 @@ Feature: Secret reference resolution in output configuration
           type: stdout
       """
     Then the config load should succeed
+    And the loaded auditor metadata should have app_name "svc-from-vault"
+    And the loaded auditor metadata should have host "host-from-env"
 
   # ---------------------------------------------------------------------------
   # Scenario 17: Disabled output with unresolvable refs does not cause an error
@@ -419,6 +433,8 @@ Feature: Secret reference resolution in output configuration
             format: ref+nonexistent://path/does/not/matter#format
       """
     Then the config load should succeed
+    And the loaded outputs should number 1
+    And the loaded outputs should not include "disabled_with_refs"
 
   # ---------------------------------------------------------------------------
   # Scenario 18: HMAC enabled as literal boolean true with ref salt
@@ -443,6 +459,8 @@ Feature: Secret reference resolution in output configuration
             algorithm: HMAC-SHA-256
       """
     Then the config load should succeed
+    And the HMAC config should have salt "literal-true-resolved-salt-32bytes"
+    And the HMAC config should have version "v4"
 
   # ---------------------------------------------------------------------------
   # Scenario 19: Secret reference resolved in a non-HMAC field

--- a/outputconfig/tests/bdd/steps/real_secret_steps.go
+++ b/outputconfig/tests/bdd/steps/real_secret_steps.go
@@ -60,6 +60,16 @@ func registerRealSecretSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 		`^the HMAC config should have algorithm "([^"]*)"$`,
 		tc.stepAssertHMACAlgorithm,
 	)
+
+	ctx.Step(
+		`^the HMAC config should have version "([^"]*)"$`,
+		tc.stepAssertHMACVersion,
+	)
+
+	ctx.Step(
+		`^output "([^"]*)" HMAC should have salt "([^"]*)"$`,
+		tc.stepAssertNamedOutputHMACSalt,
+	)
 }
 
 // stepRealProvider extracts the CA cert from the container and creates
@@ -243,4 +253,44 @@ func (tc *TestContext) stepAssertHMACAlgorithm(expected string) error {
 		return fmt.Errorf("HMAC algorithm: got %q, want %q", hmac.Algorithm, expected)
 	}
 	return nil
+}
+
+// stepAssertHMACVersion checks the HMAC salt version on the first output.
+func (tc *TestContext) stepAssertHMACVersion(expected string) error {
+	if tc.LoadResult == nil {
+		return fmt.Errorf("no load result")
+	}
+	meta := tc.LoadResult.OutputMetadata()
+	if len(meta) == 0 {
+		return fmt.Errorf("no outputs")
+	}
+	hmac := meta[0].HMACConfig
+	if hmac == nil {
+		return fmt.Errorf("HMAC config is nil")
+	}
+	if hmac.Salt.Version != expected {
+		return fmt.Errorf("HMAC version: got %q, want %q", hmac.Salt.Version, expected)
+	}
+	return nil
+}
+
+// stepAssertNamedOutputHMACSalt checks the HMAC salt on the named
+// output. Used by multi-output secret-resolution scenarios.
+func (tc *TestContext) stepAssertNamedOutputHMACSalt(name, expected string) error {
+	if tc.LoadResult == nil {
+		return fmt.Errorf("no load result")
+	}
+	for _, m := range tc.LoadResult.OutputMetadata() {
+		if m.Name != name {
+			continue
+		}
+		if m.HMACConfig == nil {
+			return fmt.Errorf("output %q: HMAC config is nil", name)
+		}
+		if got := string(m.HMACConfig.Salt.Value); got != expected {
+			return fmt.Errorf("output %q HMAC salt: got %q, want %q", name, got, expected)
+		}
+		return nil
+	}
+	return fmt.Errorf("output %q not found in metadata", name)
 }

--- a/outputconfig/tests/bdd/steps/steps.go
+++ b/outputconfig/tests/bdd/steps/steps.go
@@ -16,6 +16,7 @@
 package steps
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -32,12 +33,27 @@ import (
 	"github.com/axonops/audit/outputconfig"
 )
 
+// capturedStdoutBuf collects bytes that the registered stdout factory
+// writes during the current scenario. BDD runs single-goroutine
+// (Concurrency: 1) so a package-level buffer is safe; Reset clears
+// it per scenario. Used by `the captured output should contain`.
+var capturedStdoutBuf = &bytes.Buffer{}
+
 func init() {
-	// Register stdout via the public API. The core package dropped its
-	// stdout init() in #578; blank-importing audit/outputs here would
-	// create a cross-module cycle (outputs → audit) so we register
-	// via audit.StdoutFactory() instead.
-	audit.MustRegisterOutputFactory("stdout", audit.StdoutFactory())
+	// Register a buffer-capturing stdout factory so BDD scenarios can
+	// inspect what reached the output. The original os.Stdout target
+	// from audit.StdoutFactory() is irrelevant here — tests assert on
+	// captured bytes, not console visibility.
+	audit.MustRegisterOutputFactory("stdout", func(name string, rawConfig []byte, _ audit.Metrics, _ *slog.Logger, _ audit.FrameworkContext) (audit.Output, error) {
+		if len(rawConfig) > 0 {
+			return nil, fmt.Errorf("audit: stdout output %q: stdout does not accept configuration", name)
+		}
+		out, err := audit.NewStdoutOutput(audit.StdoutConfig{Writer: capturedStdoutBuf})
+		if err != nil {
+			return nil, fmt.Errorf("create stdout: %w", err)
+		}
+		return audit.WrapOutput(out, name), nil
+	})
 	// Register a stub "loki" factory for BDD tests that validate
 	// outputconfig formatter behaviour without depending on the real
 	// Loki module. The stub ignores the raw config and returns a
@@ -116,6 +132,7 @@ func (tc *TestContext) Reset() {
 	tc.realProviderPendingSeeds = nil
 	tc.realProviderCleanup = nil
 	capturedWebhookRawConfig = nil
+	capturedStdoutBuf.Reset()
 }
 
 // InitializeScenario wires all step definitions.
@@ -267,10 +284,82 @@ func registerWhenSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 	})
 }
 
+//nolint:gocognit,gocyclo,cyclop // BDD step registration: many closures inline; splitting hurts readability
 func registerThenSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 	ctx.Step(`^the audit call should have succeeded$`, func() error {
 		if tc.LastErr != nil {
 			return fmt.Errorf("expected no error, got: %w", tc.LastErr)
+		}
+		return nil
+	})
+
+	// Strengthened-assertion steps for #551 — concrete observable
+	// effects that follow up "should succeed".
+	ctx.Step(`^the captured output should contain "([^"]*)"$`, func(needle string) error {
+		// Auditor uses sync delivery via WithSynchronousDelivery, OR
+		// async with the output's drain. To make assertions
+		// deterministic, close the auditor first (idempotent) so the
+		// drain finishes.
+		if tc.Auditor != nil {
+			_ = tc.Auditor.Close()
+			tc.Auditor = nil
+		}
+		got := capturedStdoutBuf.String()
+		if !strings.Contains(got, needle) {
+			return fmt.Errorf("captured output does not contain %q; got: %s", needle, got)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the loaded auditor metadata should have app_name "([^"]*)"$`, func(want string) error {
+		if tc.LoadResult == nil {
+			return fmt.Errorf("no load result")
+		}
+		if got := tc.LoadResult.AppName(); got != want {
+			return fmt.Errorf("app_name: got %q, want %q", got, want)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the loaded auditor metadata should have host "([^"]*)"$`, func(want string) error {
+		if tc.LoadResult == nil {
+			return fmt.Errorf("no load result")
+		}
+		if got := tc.LoadResult.Host(); got != want {
+			return fmt.Errorf("host: got %q, want %q", got, want)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the loaded auditor metadata should have timezone "([^"]*)"$`, func(want string) error {
+		if tc.LoadResult == nil {
+			return fmt.Errorf("no load result")
+		}
+		if got := tc.LoadResult.Timezone(); got != want {
+			return fmt.Errorf("timezone: got %q, want %q", got, want)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the loaded outputs should number (\d+)$`, func(n int) error {
+		if tc.LoadResult == nil {
+			return fmt.Errorf("no load result")
+		}
+		got := len(tc.LoadResult.Outputs())
+		if got != n {
+			return fmt.Errorf("outputs count: got %d, want %d", got, n)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the loaded outputs should not include "([^"]*)"$`, func(name string) error {
+		if tc.LoadResult == nil {
+			return fmt.Errorf("no load result")
+		}
+		for _, m := range tc.LoadResult.OutputMetadata() {
+			if m.Name == name {
+				return fmt.Errorf("output %q unexpectedly present in loaded metadata", name)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary

Closes #551 — 11 outputconfig BDD scenarios that previously asserted
only "config load should succeed" or "audit call should have succeeded"
now assert concrete observable effects (resolved salt/version/algorithm,
loaded metadata, captured output content, output count). Regressions
in secret resolution, env-var expansion, timezone wiring,
standard-fields injection, and YAML metadata get caught.

- 8 scenarios strengthened in secret_resolution.feature with HMAC salt/version/algorithm assertions and metadata checks.
- 5 scenarios strengthened in output_config.feature with captured-output and loaded-auditor-metadata assertions.
- New step infrastructure: `the HMAC config should have version`, `output X HMAC should have salt`, `the captured output should contain`, `the loaded auditor metadata should have app_name/host/timezone`, `the loaded outputs should number N` / `should not include X`.
- Replaced the test-time stdout factory with a buffer-capturing variant so scenarios can inspect what reached the output.
- No production-code changes.

## Test plan

- [x] make test-bdd-outputconfig — all scenarios green
- [x] make check — 15 modules clean
- [x] make lint — zero issues
- [ ] CI green