### PR TITLE
docs: correct example outputs and taxonomy form (#532)

### DIFF
--- a/docs/taxonomy-validation.md
+++ b/docs/taxonomy-validation.md
@@ -100,18 +100,19 @@ events:
 
 ## 📂 Categories
 
-Categories group related events. Each category maps to either a
-simple list of event names or a struct with optional severity:
+Categories group related events. Each category supports two equivalent
+forms — both parse to the same internal representation, and mixing
+forms within a taxonomy MUST NOT change the resolved severity, the
+event-to-category mapping, or any other observable behaviour.
 
-**Simple list:**
-```yaml
-categories:
-  read:
-    - user_read
-    - config_read
-```
+### Expanded form (preferred style)
 
-**Struct with severity:**
+The expanded form is RECOMMENDED when any category in your taxonomy
+uses a default severity — keeping every category in the same shape
+makes the severity intent visible at a glance. Examples in this
+repository (root `README.md`,
+`examples/02-code-generation/taxonomy.yaml`) all use the expanded form:
+
 ```yaml
 categories:
   security:
@@ -121,8 +122,26 @@ categories:
       - auth_success
 ```
 
-Both formats can be mixed in the same taxonomy. Severity is optional
-(defaults to `5` if not set at either category or event level).
+### Compact form (shorthand)
+
+When a category does not need a default severity, the compact form is
+a flat list of event names — equivalent to the expanded form with no
+`severity` key:
+
+```yaml
+categories:
+  read:
+    - user_read
+    - config_read
+```
+
+The two forms are interchangeable. The compact form is purely a
+shorthand: `read: [user_read, config_read]` parses identically to
+`read: { events: [user_read, config_read] }` (severity defaults to
+`5` when not set at either category or event level).
+
+Both forms may be mixed within the same taxonomy, but using one form
+consistently makes the file easier to skim.
 
 An event can belong to multiple categories. Events not in any
 category are valid and always globally enabled.

--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -155,19 +155,24 @@ go run .
 ## Expected Output
 
 ```
+WARN audit: using DevTaxonomy — not suitable for production; all event types accepted without schema enforcement
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=permissive outputs=1 synchronous=false
 --- Valid event ---
 
 --- Auth failure event ---
 INFO audit: shutdown started
-{"timestamp":"...","event_type":"user_create","severity":5,"timezone":"Local","pid":...,"actor_id":"alice","outcome":"success","event_category":"dev"}
-{"timestamp":"...","event_type":"auth_failure","severity":5,"timezone":"Local","pid":...,"actor_id":"unknown","outcome":"failure","event_category":"dev"}
+{"timestamp":"...","event_type":"user_create","severity":5,"app_name":"audit-demo","host":"localhost","timezone":"Local","pid":...,"actor_id":"alice","outcome":"success","event_category":"dev"}
+{"timestamp":"...","event_type":"auth_failure","severity":5,"app_name":"audit-demo","host":"localhost","timezone":"Local","pid":...,"actor_id":"unknown","outcome":"failure","event_category":"dev"}
 INFO audit: shutdown complete duration=...
 ```
 
-The JSON events appear between the shutdown messages because
-`AuditEvent()` enqueues asynchronously and `Close()` drains the buffer
-before finishing. This is normal — `Close()` guarantees all buffered
-events are delivered before it returns.
+The first two `WARN` / `INFO` lines are emitted at construction time
+by the auditor's diagnostic logger — they confirm the dev-mode
+taxonomy and the queue / shutdown configuration. The JSON events
+appear between the shutdown messages because `AuditEvent()` enqueues
+asynchronously and `Close()` drains the buffer before finishing.
+This is normal — `Close()` guarantees all buffered events are
+delivered before it returns.
 
 ## Further Reading
 

--- a/examples/02-code-generation/README.md
+++ b/examples/02-code-generation/README.md
@@ -44,13 +44,19 @@ version: 1
 
 categories:
   write:
-    - user_create
-    - user_delete
+    severity: 3
+    events:
+      - user_create
+      - user_delete
   read:
-    - user_read
+    severity: 1
+    events:
+      - user_read
   security:
-    - auth_failure
-    - auth_success
+    severity: 8
+    events:
+      - auth_failure
+      - auth_success
 
 events:
   user_create:
@@ -79,7 +85,7 @@ comment for the generated constant.
 | `field_name: {labels: [pii]}` | Optional with sensitivity label |
 | `field_name: {required: true, labels: [pii]}` | Required with label |
 
-Sensitivity labels are covered in the [Sensitivity Labels](../12-sensitivity-labels/)
+Sensitivity labels are covered in the [Sensitivity Labels](../11-sensitivity-labels/)
 example. For now, the key point is: `required: true` means the field
 must always be present; everything else is optional.
 
@@ -170,15 +176,15 @@ setter methods:
 
 ```go
 // NewUserCreateEvent creates a EventUserCreate event with required fields.
-func NewUserCreateEvent(actorID any, outcome any) *UserCreateEvent {
+func NewUserCreateEvent(actorID string, outcome string) *UserCreateEvent {
     return &UserCreateEvent{fields: audit.Fields{
         FieldActorID: actorID,
         FieldOutcome: outcome,
     }}
 }
 
-// SetTargetID sets the FieldTargetID field.
-func (e *UserCreateEvent) SetTargetID(v any) *UserCreateEvent {
+// SetTargetID sets the reserved standard field "target_id".
+func (e *UserCreateEvent) SetTargetID(v string) *UserCreateEvent {
     e.fields[FieldTargetID] = v
     return e
 }
@@ -192,7 +198,7 @@ passing as a runtime validation error. The metadata vars reference
 the generated constants — `EventUserCreate` not `"user_create"` —
 so the entire taxonomy is type-safe. When sensitivity labels are
 defined, `FieldLabels` and `Label` constants are also generated — see
-the [Sensitivity Labels](../12-sensitivity-labels/) example.
+the [Sensitivity Labels](../11-sensitivity-labels/) example.
 
 **Code generation is optional.** The basic example used raw strings and
 it worked fine. But once you have more than a handful of event types,
@@ -210,7 +216,7 @@ Fields like `target_id`, `reason`, and `source_ip` are **reserved
 standard fields** — always available without taxonomy declaration. The
 code generator produces setter methods (`.SetTargetID()`, `.SetReason()`,
 `.SetSourceIP()`) on every builder regardless of whether those fields
-appear in the taxonomy. See [example 03](../03-standard-fields/) for the
+appear in the taxonomy. See [example 13](../13-standard-fields/) for the
 full explanation.
 
 ### Configuring Outputs in YAML
@@ -305,20 +311,23 @@ go generate .
 ## Expected Output
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1 synchronous=false
 --- Using typed event builders ---
 INFO audit: shutdown started
-{"timestamp":"...","event_type":"user_create","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"alice","outcome":"success","target_id":"user-42","event_category":"write"}
-{"timestamp":"...","event_type":"auth_failure","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"unknown","outcome":"failure","reason":"invalid credentials","source_ip":"192.168.1.100","event_category":"security"}
-{"timestamp":"...","event_type":"user_read","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"outcome":"success","actor_id":"bob","event_category":"read"}
+{"timestamp":"...","event_type":"user_create","severity":3,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"alice","outcome":"success","target_id":"user-42","event_category":"write"}
+{"timestamp":"...","event_type":"auth_failure","severity":8,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"unknown","outcome":"failure","reason":"invalid credentials","source_ip":"192.168.1.100","event_category":"security"}
+{"timestamp":"...","event_type":"user_read","severity":1,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"outcome":"success","actor_id":"bob","event_category":"read"}
 INFO audit: shutdown complete duration=...
 ```
 
 The `app_name`, `host`, and `pid` are framework fields — set once in
 `outputs.yaml` and automatically included in every event. The
 `event_category` field is automatically populated from the taxonomy's
-category definitions. The `INFO audit:` lines are lifecycle diagnostics
-on stderr — see [example 01](../01-basic/) for details.
+category definitions. Each event's `severity` reflects the per-category
+default declared in `taxonomy.yaml` (write=3, read=1, security=8) — see
+[Event Routing](../10-event-routing/) for severity-based routing. The
+`INFO audit:` lines are lifecycle diagnostics on stderr — see
+[example 01](../01-basic/) for details.
 
 ## Further Reading
 

--- a/examples/02-code-generation/audit_generated.go
+++ b/examples/02-code-generation/audit_generated.go
@@ -388,7 +388,7 @@ func (e *AuthFailureEvent) FieldInfo() AuthFailureFields {
 // Categories returns the categories this event belongs to.
 func (e *AuthFailureEvent) Categories() []audit.CategoryInfo {
 	return []audit.CategoryInfo{
-		{Name: CategorySecurity},
+		{Name: CategorySecurity, Severity: auditIntPtr(8)},
 	}
 }
 
@@ -718,7 +718,7 @@ func (e *AuthSuccessEvent) FieldInfo() AuthSuccessFields {
 // Categories returns the categories this event belongs to.
 func (e *AuthSuccessEvent) Categories() []audit.CategoryInfo {
 	return []audit.CategoryInfo{
-		{Name: CategorySecurity},
+		{Name: CategorySecurity, Severity: auditIntPtr(8)},
 	}
 }
 
@@ -1048,7 +1048,7 @@ func (e *UserCreateEvent) FieldInfo() UserCreateFields {
 // Categories returns the categories this event belongs to.
 func (e *UserCreateEvent) Categories() []audit.CategoryInfo {
 	return []audit.CategoryInfo{
-		{Name: CategoryWrite},
+		{Name: CategoryWrite, Severity: auditIntPtr(3)},
 	}
 }
 
@@ -1378,7 +1378,7 @@ func (e *UserDeleteEvent) FieldInfo() UserDeleteFields {
 // Categories returns the categories this event belongs to.
 func (e *UserDeleteEvent) Categories() []audit.CategoryInfo {
 	return []audit.CategoryInfo{
-		{Name: CategoryWrite},
+		{Name: CategoryWrite, Severity: auditIntPtr(3)},
 	}
 }
 
@@ -1713,7 +1713,7 @@ func (e *UserReadEvent) FieldInfo() UserReadFields {
 // Categories returns the categories this event belongs to.
 func (e *UserReadEvent) Categories() []audit.CategoryInfo {
 	return []audit.CategoryInfo{
-		{Name: CategoryRead},
+		{Name: CategoryRead, Severity: auditIntPtr(1)},
 	}
 }
 
@@ -1756,3 +1756,7 @@ func (e *UserReadEvent) FieldInfoMap() map[string]audit.FieldInfo {
 		FieldUserAgent:  {Name: FieldUserAgent},
 	}
 }
+
+// auditIntPtr returns a pointer to the given int. It is generator-owned
+// helper (prefixed to avoid collision with any consumer-defined intPtr).
+func auditIntPtr(n int) *int { return &n }

--- a/examples/02-code-generation/main.go
+++ b/examples/02-code-generation/main.go
@@ -24,6 +24,7 @@ package main
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"log"
 
 	"github.com/axonops/audit/outputconfig"
@@ -43,11 +44,32 @@ func main() {
 	}
 	defer func() { _ = auditor.Close() }()
 
+	fmt.Println("--- Using typed event builders ---")
+
 	// All event types, field names, and categories are generated constants.
 	// A typo like "NewUserCrateEvent" would fail at compile time.
 	if auditErr := auditor.AuditEvent(
 		NewUserCreateEvent("alice", "success").
 			SetTargetID("user-42"),
+	); auditErr != nil {
+		log.Printf("audit: %v", auditErr)
+	}
+
+	// Reserved standard fields (reason, source_ip, …) get typed
+	// setters on every generated builder.
+	if auditErr := auditor.AuditEvent(
+		NewAuthFailureEvent("unknown", "failure").
+			SetReason("invalid credentials").
+			SetSourceIP("192.168.1.100"),
+	); auditErr != nil {
+		log.Printf("audit: %v", auditErr)
+	}
+
+	// Reserved standard fields (here, actor_id) are typed even when not
+	// declared in the event's taxonomy fields.
+	if auditErr := auditor.AuditEvent(
+		NewUserReadEvent("success").
+			SetActorID("bob"),
 	); auditErr != nil {
 		log.Printf("audit: %v", auditErr)
 	}

--- a/examples/02-code-generation/taxonomy.yaml
+++ b/examples/02-code-generation/taxonomy.yaml
@@ -2,13 +2,19 @@ version: 1
 
 categories:
   write:
-    - user_create
-    - user_delete
+    severity: 3
+    events:
+      - user_create
+      - user_delete
   read:
-    - user_read
+    severity: 1
+    events:
+      - user_read
   security:
-    - auth_failure
-    - auth_success
+    severity: 8
+    events:
+      - auth_failure
+      - auth_success
 
 events:
   user_create:

--- a/examples/03-file-output/README.md
+++ b/examples/03-file-output/README.md
@@ -113,7 +113,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1 synchronous=false
 INFO audit: shutdown started
 INFO audit: shutdown complete duration=...
 --- Contents of audit.log ---

--- a/examples/05-formatters/README.md
+++ b/examples/05-formatters/README.md
@@ -120,7 +120,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=2
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=2 synchronous=false
 INFO audit: shutdown started
 INFO audit: shutdown complete duration=...
 

--- a/examples/06-middleware/README.md
+++ b/examples/06-middleware/README.md
@@ -149,7 +149,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1 synchronous=false
 GET http://127.0.0.1:.../healthz -> 200
 GET http://127.0.0.1:.../items -> 200
 POST http://127.0.0.1:.../items -> 201

--- a/examples/09-multi-output/README.md
+++ b/examples/09-multi-output/README.md
@@ -96,7 +96,7 @@ Three JSON events appear on stdout, followed by the same three events
 read back from `audit.log`:
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=2
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=2 synchronous=false
 INFO audit: shutdown started
 {"timestamp":"...","event_type":"user_create","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"alice","outcome":"success","event_category":"write"}
 {"timestamp":"...","event_type":"auth_failure","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"unknown","outcome":"failure","event_category":"security"}

--- a/examples/10-event-routing/README.md
+++ b/examples/10-event-routing/README.md
@@ -207,7 +207,7 @@ All three events appear on stdout (all events). Each file contains only
 the events matching its route:
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=4
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=4 synchronous=false
 INFO audit: shutdown started
 ... (stdout shows all three events)
 INFO audit: shutdown complete duration=...

--- a/examples/11-sensitivity-labels/README.md
+++ b/examples/11-sensitivity-labels/README.md
@@ -256,7 +256,7 @@ Three log files are created, each receiving the same events with
 different field subsets:
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=3
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=3 synchronous=false
 INFO audit: shutdown started
 INFO audit: shutdown complete duration=...
 

--- a/examples/12-hmac-integrity/README.md
+++ b/examples/12-hmac-integrity/README.md
@@ -172,7 +172,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=3
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=3 synchronous=false
 --- Security event ---
 
 --- Write event ---

--- a/examples/13-standard-fields/README.md
+++ b/examples/13-standard-fields/README.md
@@ -180,7 +180,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=1 synchronous=false
 --- Event with standard fields ---
 --- Event with default source_ip ---
 --- Event with explicit source_ip ---

--- a/examples/13-standard-fields/main.go
+++ b/examples/13-standard-fields/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Example 03: Standard Fields & Framework Configuration
+// Example 13: Standard Fields & Framework Configuration
 //
 // This example shows the 31 reserved standard audit fields that are
 // always available on every event without taxonomy declaration, and

--- a/examples/14-loki-output/main.go
+++ b/examples/14-loki-output/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Example 08: Loki Output
+// Example 14: Loki Output
 //
 // Demonstrates sending audit events to Grafana Loki with stream labels,
 // gzip compression, and multi-tenant support.

--- a/examples/16-buffering/README.md
+++ b/examples/16-buffering/README.md
@@ -134,7 +134,7 @@ go run .
 ## Expected Output
 
 ```
-INFO audit: auditor created queue_size=5 shutdown_timeout=2s validation_mode=strict outputs=2
+INFO audit: auditor created queue_size=5 shutdown_timeout=2s validation_mode=strict outputs=2 synchronous=false
 --- Level 1: Core Queue (queue_size: 5) ---
 Emitting 20 events in a tight loop...
 WARN audit: queue full, events dropped dropped=1 queue_size=5

--- a/examples/16-buffering/main.go
+++ b/examples/16-buffering/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Example 18: Buffering and Backpressure
+// Example 16: Buffering and Backpressure
 //
 // Demonstrates the two-level buffering architecture:
 //


### PR DESCRIPTION
## Summary

Closes #532. Fixes four content defects (E-17 through E-20) across example documentation and aligns all example READMEs with current runtime output.

## Changes

- **E-17** — `examples/02-code-generation/main.go` emits the three events (user_create, auth_failure, user_read) shown in the README's Expected Output.
- **E-18** — `examples/02-code-generation/taxonomy.yaml` switched to the expanded form (per-category severity), matching the root `README.md`. `docs/taxonomy-validation.md` gains named "Expanded form (preferred style)" and "Compact form (shorthand)" subsections with RFC 2119 wording on parsing equivalence.
- **E-19** — `examples/01-basic/README.md` Expected Output now includes the `WARN audit: using DevTaxonomy …` line, the `INFO audit: auditor created …` line, and the `app_name`/`host` fields, all matching actual runtime.
- **E-20** — `examples/13-standard-fields/main.go` (was Example 03), `examples/14-loki-output/main.go` (was Example 08), `examples/16-buffering/main.go` (was Example 18) — package-comment headers corrected.

Additional fixes (caught during review):
- Generated-builder snippet in example 02 README now shows typed `string` parameters instead of stale `any`.
- Broken cross-links fixed: `../12-sensitivity-labels/` → `../11-sensitivity-labels/`, `../03-standard-fields/` → `../13-standard-fields/`.
- All example READMEs that show the `INFO audit: auditor created` log line now include the `synchronous=false` token (added in #601).

## Acceptance criteria (#532)

1. Example 02 main output matches README Expected Output.
2. Example 01 expected output matches actual runtime output.
3. All `examples/*/main.go` package comments reference their correct example number.
4. README.md and example 02 use the same taxonomy YAML form.
5. `docs/taxonomy-validation.md` has a "compact form" shorthand subsection.

## Test plan

- [x] `go run .` in examples/01-basic and examples/02-code-generation matches each README's Expected Output verbatim.
- [x] `make test-examples` — all examples compile.
- [x] `make fmt-check vet` clean.
- [x] `make check` — full quality gate clean.
- [x] user-guide-reviewer agent — all five ACs verified, regenerated builder typing fixed in-PR.
- [x] docs-writer agent — RFC 2119 wording in taxonomy-validation.md tightened in-PR.
- [x] commit-message-reviewer agent — pass.