### PR TITLE
docs: add Setter Types section to code-generation reference (#530)

### DIFF
--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -148,6 +148,30 @@ err := auditor.AuditEvent(
 )
 ```
 
+### Setter Types — Typed vs `any`
+
+Every generated setter takes a typed Go parameter, never `any`. The
+type comes from one of two places:
+
+| Field origin | Setter type | Can `type:` change it? |
+|---|---|---|
+| Reserved standard field (see [Reserved Field Names](taxonomy-validation.md#-reserved-field-names) for the canonical list) | Library-authoritative Go type — `string` for most names; `int` for `source_port`, `dest_port`, `file_size`; `time.Time` for `start_time`, `end_time` | No. `type:` MUST NOT be declared on a reserved standard field; the taxonomy parser rejects any such override with an error wrapping `audit.ErrConfigInvalid`. |
+| Consumer-declared field with `type:` annotation | Annotated Go type (see [Typed Custom Fields](#typed-custom-fields)) | — the annotation *is* the source. |
+| Consumer-declared field with no `type:` annotation | `string` (default) | Yes — add `type:` to widen to `int`, `bool`, `time.Time`, etc. |
+
+The `any` parameter type does not appear in generated code: there is
+no path that produces an untyped setter. Reserved fields always use
+the library type; consumer fields default to `string` and become
+typed when annotated.
+
+Compile-time checking therefore extends to value types as well as
+field names:
+
+```go
+e.SetSourcePort(443)    // OK — SetSourcePort takes int
+e.SetSourcePort("443")  // compile error: cannot use "443" (string) as int
+```
+
 ### Typed Custom Fields
 
 Every custom (non-reserved) field in the taxonomy may carry a


### PR DESCRIPTION
## Summary

Closes #530. Adds a new "Setter Types — Typed vs \`any\`" subsection to `docs/code-generation.md` describing the typed-vs-any contract for generated setters.

## Acceptance criteria

- [x] AC#1 — `docs/code-generation.md` signatures match actual generator output (already accurate on main; verified against `examples/02-code-generation/audit_generated.go`).
- [x] AC#2 — `examples/13-standard-fields/audit_generated.go` has no \`any\` parameters for reserved standard fields (already typed on main; \`go generate\` produces no diff).
- [x] AC#3 — `docs/code-generation.md` has a "Setter Types" section explaining typed vs any (this PR).
- [x] AC#4 — \`make test-examples\` passes post-regeneration.

## What the new section covers

- Reserved standard field → library-authoritative Go type (cross-linked to the canonical reserved-field table in \`docs/taxonomy-validation.md\`).
- Consumer-declared field with \`type:\` → annotated Go type.
- Consumer-declared field without \`type:\` → defaults to \`string\`.
- The \`any\` parameter type does not appear in any generator output path.
- Inline good/bad example: \`SetSourcePort(443)\` vs \`SetSourcePort("443")\`.

## Test plan

- [x] \`make fmt-check vet\` clean.
- [x] \`make test-examples\` passes.
- [x] docs-writer agent — flagged two technical inaccuracies (latency_ms not reserved; reserved fields use \`int\` not \`int64\`) — corrected in-PR.
- [x] user-guide-reviewer agent — flagged "Override allowed?" header ambiguity, missing reserved-field reference link, and prose-only example — all corrected in-PR.
- [x] commit-message-reviewer agent — pass.