### PR TITLE
docs: fix example README cross-references and add link checker (#531)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
       - name: Check replace directives
         run: make check-replace
 
+      - name: Check example README cross-references
+        run: make check-example-links
+
       # BDD Strict-mode guard — MUST run before any test matrix so a
       # regression fails loudly and early, not buried inside a later
       # test job. There is NO circumstance under which BDD runners may

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
        lint-secrets lint-secrets-openbao lint-secrets-vault \
        vet vet-all fmt fmt-check \
        build build-all bench bench-save bench-compare bench-baseline-check coverage \
-       tidy tidy-check verify check-replace check-todos check-bdd-strict \
+       tidy tidy-check verify check-replace check-todos check-example-links check-bdd-strict \
        security release-check check clean \
        install-tools install-benchstat workspace generate-certs \
        test-infra-up test-infra-down test-infra-logs \
@@ -362,6 +362,33 @@ check-todos:
 		exit 1; \
 	fi
 
+# Reject broken numeric cross-references in example READMEs (e.g.
+# `../05-file-output/` when `examples/05-formatters/` is the actual
+# directory at index 05). Catches drift after example renumbering.
+#
+# Greps every `examples/*/README.md` for relative links of the form
+# `../NN-slug` (with or without trailing slash, with or without
+# `#anchor`) and verifies that `examples/NN-slug/` exists. Any
+# pointer to a missing directory fails the target with the offending
+# file:line and the bad target.
+check-example-links:
+	@FAILING=""; \
+	for f in examples/*/README.md; do \
+		LINKS=$$(grep -oE '\.\./[0-9][0-9]-[a-z][a-z0-9-]*' "$$f" | sort -u); \
+		for link in $$LINKS; do \
+			target=$$(echo "$$link" | sed -E 's#^\.\./##'); \
+			if [ ! -d "examples/$$target" ]; then \
+				LINENOS=$$(grep -nE "\.\./$$target([/#)]|$$)" "$$f" | cut -d: -f1 | tr '\n' ',' | sed 's/,$$//'); \
+				FAILING="$$FAILING\n  $$f:$$LINENOS -> $$link (no examples/$$target/)"; \
+			fi; \
+		done; \
+	done; \
+	if [ -n "$$FAILING" ]; then \
+		printf "ERROR: broken example README cross-references:%b\n" "$$FAILING"; \
+		exit 1; \
+	fi
+	@echo "All example README cross-references resolve."
+
 # Enforce godog runners use Strict mode so undefined steps fail the
 # suite. This is the contract established by #622 — CI must NEVER
 # silently pass a scenario whose step definition doesn't exist.
@@ -457,7 +484,7 @@ release-check:
 
 # --- Full local quality gate ---
 
-check: fmt-check vet-all lint-all test-all build-all test-examples tidy-check verify check-replace check-todos check-bdd-strict bench-baseline-check release-check security
+check: fmt-check vet-all lint-all test-all build-all test-examples tidy-check verify check-replace check-todos check-example-links check-bdd-strict bench-baseline-check release-check security
 	@echo ""
 	@echo "All checks passed."
 

--- a/examples/04-testing/README.md
+++ b/examples/04-testing/README.md
@@ -19,7 +19,7 @@ an in-memory test logger that captures events and metrics for assertion.
 ## Prerequisites
 
 - Go 1.26+
-- Completed: [Capstone](../17-capstone/)
+- Completed: [Code Generation](../02-code-generation/)
 
 ## Files
 

--- a/examples/05-formatters/README.md
+++ b/examples/05-formatters/README.md
@@ -18,7 +18,7 @@ aggregators and CEF for SIEM tools like Splunk, ArcSight, or QRadar.
 ## Prerequisites
 
 - Go 1.26+
-- Completed: [HMAC Integrity](../13-hmac-integrity/)
+- Completed: [Code Generation](../02-code-generation/)
 
 ## Files
 

--- a/examples/06-middleware/README.md
+++ b/examples/06-middleware/README.md
@@ -25,7 +25,7 @@ checks are silently skipped.
 ## Prerequisites
 
 - Go 1.26+
-- Completed: [Formatters](../14-formatters/)
+- Completed: [Formatters](../05-formatters/)
 
 ## Files
 

--- a/examples/07-syslog-output/README.md
+++ b/examples/07-syslog-output/README.md
@@ -232,7 +232,7 @@ outputs:
       version: "1.0"
 ```
 
-See [Example 14: Formatters](../14-formatters/) for JSON vs CEF
+See [Example 05: Formatters](../05-formatters/) for JSON vs CEF
 comparison.
 
 ## Blank Import Required
@@ -263,5 +263,5 @@ registers the `"syslog"` output factory.
 - [RFC 5424: The Syslog Protocol](https://datatracker.ietf.org/doc/html/rfc5424) — the standard this output implements
 - [RFC 5425: TLS Transport Mapping for Syslog](https://datatracker.ietf.org/doc/html/rfc5425) — TLS transport standard
 - [Output Types Overview](../../docs/outputs.md) — all five output types
-- [Example 14: Formatters](../14-formatters/) — JSON vs CEF side-by-side
+- [Example 05: Formatters](../05-formatters/) — JSON vs CEF side-by-side
 - [Output Configuration YAML](../../docs/output-configuration.md) — full YAML reference

--- a/examples/08-webhook-output/README.md
+++ b/examples/08-webhook-output/README.md
@@ -212,5 +212,5 @@ encounters `type: webhook` in the YAML.
 - [Webhook Output Reference](../../docs/webhook-output.md) — complete configuration, TLS, retry, SSRF, production patterns
 - [NDJSON Specification](https://github.com/ndjson/ndjson-spec) — the payload format
 - [Output Types Overview](../../docs/outputs.md) — all five output types
-- [Example 08: Loki Output](../08-loki-output/) — structured querying with stream labels
+- [Example 14: Loki Output](../14-loki-output/) — structured querying with stream labels
 - [Output Configuration YAML](../../docs/output-configuration.md) — full YAML reference

--- a/examples/09-multi-output/README.md
+++ b/examples/09-multi-output/README.md
@@ -18,7 +18,7 @@ and a log file, both defined in `outputs.yaml`.
 ## Prerequisites
 
 - Go 1.26+
-- Completed: [File Output](../05-file-output/)
+- Completed: [File Output](../03-file-output/)
 
 ## Files
 
@@ -81,7 +81,7 @@ receive the event.
 ### When to Add Routing
 
 Without routing rules, every output gets every event. The next example
-([Event Routing](../11-event-routing/)) shows how to send different event
+([Event Routing](../10-event-routing/)) shows how to send different event
 categories to different outputs.
 
 ## Run It

--- a/examples/11-sensitivity-labels/README.md
+++ b/examples/11-sensitivity-labels/README.md
@@ -20,7 +20,7 @@ and a PCI compliance log keeps PII but strips payment card data.
 ## Prerequisites
 
 - Go 1.26+
-- Completed: [Event Routing](../11-event-routing/)
+- Completed: [Event Routing](../10-event-routing/)
 
 ## Files
 

--- a/examples/12-hmac-integrity/README.md
+++ b/examples/12-hmac-integrity/README.md
@@ -21,7 +21,7 @@ patterns side by side: **selective** (only security events) and
 ## Prerequisites
 
 - Go 1.26+
-- Completed: [Sensitivity Labels](../12-sensitivity-labels/)
+- Completed: [Sensitivity Labels](../11-sensitivity-labels/)
 
 ## Files
 

--- a/examples/15-tls-policy/README.md
+++ b/examples/15-tls-policy/README.md
@@ -22,8 +22,8 @@ HTTPS) and each secret provider (vault, openbao).
 
 None — this example uses stdout output to demonstrate the TLS policy
 configuration without requiring actual TLS connections. This example is
-most useful after reading [06 — Syslog Output](../06-syslog-output/) or
-[07 — Webhook Output](../07-webhook-output/), which show the outputs
+most useful after reading [07 — Syslog Output](../07-syslog-output/) or
+[08 — Webhook Output](../08-webhook-output/), which show the outputs
 that TLS policy applies to.
 
 ## Files


### PR DESCRIPTION
## Summary

Closes #531. Repairs nine broken numeric cross-references across example READMEs (left over from #278's renumbering) and adds a Makefile + CI guard so the same drift cannot recur silently.

## Acceptance criteria (#531)

- [x] AC#1 — Every numeric cross-reference in every example README points to an existing example directory.
- [x] AC#2 — \`make check-example-links\` exists and runs clean.
- [x] AC#3 — Wired into \`make check\` and CI (Hygiene job).

## Test plan

- [x] \`make check-example-links\` passes (clean tree).
- [x] Empirically verified the check fails when a bogus \`../99-nope\` link is injected (file:line + missing target reported).
- [x] Regex tightened to also catch links without trailing slash and links with \`#anchor\` per user-guide-reviewer feedback.
- [x] \`make check\` (full quality gate) clean.
- [x] user-guide-reviewer agent — pedagogy of prereq swaps confirmed correct; flagged scratch file (deleted) and regex robustness (tightened) — both addressed in-PR.
- [x] commit-message-reviewer agent — pass (subject 67 chars).