### PR TITLE
docs: replace stale Logger references with Auditor (#529)

### DIFF
--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -179,7 +179,7 @@ outputs:
 
 > ⚠️ **No root-level `tls_policy` key.** TLS policy is configured inside each output (under `syslog:`, `webhook:`, `loki:`) and each secret provider (under `vault:`, `openbao:`). Setting `tls_policy:` at the root fails at startup with an "unknown top-level key" error. See [Per-Output TLS Policy](#-per-output-tls-policy) below.
 
-## ⚙️ Logger Configuration
+## ⚙️ Auditor Configuration
 
 The optional `auditor:` section configures the core auditor. All
 fields are optional — omitted fields use sensible defaults.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -116,7 +116,7 @@ auditor, events, metrics := audittest.New(t, taxonomyYAML)
 
 ### NewQuick — quick smoke test
 
-Creates a permissive logger — any fields accepted, no required field
+Creates a permissive auditor — any fields accepted, no required field
 enforcement:
 
 ```go

--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -28,7 +28,7 @@ how you'd use audit in a real application.
 
 | File | Purpose |
 |------|---------|
-| `main.go` | Logger setup, event emission |
+| `main.go` | Auditor setup, event emission |
 
 ## Key Concepts
 
@@ -101,7 +101,7 @@ precedes it in your code.
 > [performance guide](../../docs/performance.md) has the full
 > breakdown.
 
-### Closing the Logger
+### Closing the Auditor
 
 ```go
 defer func() { _ = auditor.Close() }()

--- a/examples/08-webhook-output/README.md
+++ b/examples/08-webhook-output/README.md
@@ -90,7 +90,7 @@ conditions is met:
 |---------|-------------|---------|--------------|
 | **Event count** | `batch_size` | 100 | 10 |
 | **Time elapsed** | `flush_interval` | 5s | 1s |
-| **Logger closed** | `auditor.Close()` | — | Triggers final flush |
+| **Auditor closed** | `auditor.Close()` | — | Triggers final flush |
 
 In this example, `auditor.Close()` triggers the flush because we emit
 only 4 events (below the batch_size threshold of 10) and close


### PR DESCRIPTION
## Summary

Closes #529. Replaces five stale "Logger" mentions left over from the #457 Logger->Auditor rename. Intentional diagnostic-logger references (\`WithDiagnosticLogger\`, \`slog.Logger\`, \`log.Logger\`) are preserved.

## Acceptance criteria

- [x] AC#1 — All three named files updated (output-configuration.md, testing.md, examples/01-basic/README.md). Plus a fourth occurrence in examples/08-webhook-output/README.md fixed in-PR.
- [x] AC#2 — \`grep -rE "Logger([^a-zA-Z]|$)" docs/ examples/*/README.md\` filtered for diagnostic-logger / log.Logger / slog.Logger / Logger-style returns no unintentional hits.
- [x] AC#3 — Tree clean; doc-only change with no rendering implications.

## Test plan

- [x] grep verification (AC#2) clean.
- [x] \`make check\` clean (full local quality gate).
- [x] commit-message-reviewer agent — pass.