### PR TITLE
docs: fix WithTimezone, syslog orphan, Loki labels (#527)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ is the baseline. Key points:
 
 - **External test packages** — use `package audit_test`, not `package audit`
 - **Error wrapping** — `fmt.Errorf("audit: context: %w", err)` with `%w` as the final verb
-- **Naming** — no stutter (`audit.Logger` not `audit.AuditLogger`), no `Get` prefix, acronyms in caps (`ID`, `URL`)
+- **Naming** — no stutter (`audit.Auditor` not `audit.AuditAuditor`), no `Get` prefix, acronyms in caps (`ID`, `URL`)
 - **Godoc** — all exported symbols have comments starting with the symbol name
 - **Coverage** — target 90%+; `goleak.VerifyNone(t)` on tests that start goroutines
 - **No panics** — this is a library; no `log.Fatal`, `os.Exit`, or `panic` that escapes the package boundary

--- a/loki/config.go
+++ b/loki/config.go
@@ -128,14 +128,57 @@ type LabelConfig struct {
 // DynamicLabels toggles which per-event fields become Loki stream
 // labels. All fields default to included (zero value = include).
 // Set Exclude* to true to remove a field from labels.
+//
+// Cardinality is the primary tuning concern: each unique
+// label-value combination across all included fields creates a
+// distinct Loki stream. Including high-cardinality fields (like
+// PID, which changes on every process restart) can quickly exhaust
+// Loki's per-tenant stream limits. The default-included list has
+// been chosen so that typical multi-host, multi-app deployments
+// stay within Loki's recommended ceiling of <100k active streams
+// per tenant. Tighten by excluding fields that contribute the most
+// unique values.
 type DynamicLabels struct {
-	ExcludeAppName       bool
-	ExcludeHost          bool
-	ExcludeTimezone      bool
-	ExcludePID           bool
-	ExcludeEventType     bool
+	// ExcludeAppName drops the `app_name` label. Cardinality impact:
+	// equal to the number of distinct applications writing to the
+	// same Loki tenant. Usually low (<20). Exclude only if you index
+	// by app_name through a different mechanism.
+	ExcludeAppName bool
+
+	// ExcludeHost drops the `host` label. Cardinality impact: equal
+	// to the number of distinct hosts. Significant in fleet-style
+	// deployments (hundreds to thousands of hosts) — consider
+	// excluding and storing host as a JSON field instead.
+	ExcludeHost bool
+
+	// ExcludeTimezone drops the `timezone` label. Cardinality impact:
+	// negligible (typically 1 — the deployment's timezone). Safe to
+	// keep included.
+	ExcludeTimezone bool
+
+	// ExcludePID drops the `pid` label. Cardinality impact: HIGH —
+	// every process restart creates a new label value, and labels
+	// are never garbage-collected for the active retention window.
+	// Strongly recommend excluding in production unless PID is
+	// genuinely needed for stream filtering.
+	ExcludePID bool
+
+	// ExcludeEventType drops the `event_type` label. Cardinality
+	// impact: equal to the size of the taxonomy (number of distinct
+	// event types). Usually moderate (10-200). Useful for stream
+	// filtering by event type — exclude only if your alerting paths
+	// query JSON fields instead.
+	ExcludeEventType bool
+
+	// ExcludeEventCategory drops the `event_category` label.
+	// Cardinality impact: low (typically 5-20 categories). Useful
+	// for routing by category in alerts.
 	ExcludeEventCategory bool
-	ExcludeSeverity      bool
+
+	// ExcludeSeverity drops the `severity` label. Cardinality impact:
+	// at most 11 (severity 0-10). Almost always safe to keep
+	// included; primary use is severity-based alert routing.
+	ExcludeSeverity bool
 }
 
 // Config holds configuration for the Loki [Output].

--- a/options.go
+++ b/options.go
@@ -35,8 +35,8 @@ import (
 //     arguments when called:
 //     [WithFormatter] (nil rejected; omitting yields a default
 //     [JSONFormatter]),
-//     [WithTimezone] (empty rejected; omitting emits no timezone
-//     framework field).
+//     [WithTimezone] (empty rejected; omitting defaults to the local
+//     timezone reported by [time.Now]().Location().String()).
 //
 //   - Optional options — accept nil / unset with a documented default:
 //     [WithMetrics]         — nil or unset disables metrics collection.
@@ -139,10 +139,16 @@ func WithHost(host string) Option {
 // WithTimezone sets the timezone name emitted as a framework field in
 // every serialised event.
 //
-// Optional to call; if omitted, no timezone field is emitted. If
-// called, tz MUST be non-empty (the option returns an error for an
-// empty string since there is no sane default to substitute at that
-// point). At most 64 bytes.
+// Optional to call. If omitted, the timezone defaults to the local
+// timezone as reported by [time.Now]().Location().String(); the
+// timezone field is therefore always populated on every event. To
+// suppress the timezone field entirely, supply a custom [Formatter]
+// whose [Formatter.SetFrameworkFields] discards the timezone value.
+// The built-in [JSONFormatter] and [CEFFormatter] write the timezone
+// framework field unconditionally and cannot suppress it via
+// [FormatOptions.IsExcluded]. If called, tz MUST be non-empty (the
+// option returns an error for an empty string since there is no
+// sane default to substitute at that point). At most 64 bytes.
 func WithTimezone(tz string) Option {
 	return func(a *Auditor) error {
 		if tz == "" {

--- a/syslog/config.go
+++ b/syslog/config.go
@@ -243,10 +243,6 @@ func (c Config) GoString() string { return c.String() } //nolint:gocritic // hug
 // This prevents TLS key path leakage via %+v and all other format verbs.
 func (c Config) Format(f fmt.State, _ rune) { _, _ = fmt.Fprint(f, c.String()) } //nolint:gocritic // hugeParam: value receiver required by fmt.Formatter
 
-// Output writes serialised audit events to a syslog server over
-// TCP, UDP, or TCP+TLS (including mTLS). Events are formatted as
-// RFC 5424 structured syslog messages with the pre-serialised audit
-
 // validateSyslogConfig is a top-level linear validator: each if /
 // switch maps 1-1 to a documented Config field constraint. Extracting
 // helpers per group (network, facility, retries, buffer) would hide


### PR DESCRIPTION
## Summary

Closes #527. Four focused godoc / contributor-doc corrections:

- \`WithTimezone\` godoc was factually inverted — the timezone field is always populated (defaulted to local zone) when the option is omitted, not omitted from output as the godoc claimed.
- \`syslog/config.go\` had a four-line orphaned comment fragment that landed on \`validateSyslogConfig\` — leftover from the \`Output\` type's godoc that lives in \`syslog/syslog.go\`.
- \`loki/config.go\` \`DynamicLabels\` had no per-field godoc — Loki cardinality decisions need each field's stream-impact documented inline.
- \`CONTRIBUTING.md\` stutter example referenced \`audit.Logger\` / \`audit.AuditLogger\` (renamed away in #457).

## Acceptance criteria (#527)

- [x] AC#1 — Each file:line updated per requirements.
- [x] AC#2 — Godoc renders cleanly (verified by gofmt + vet + lint).
- [x] AC#3 — \`grep -rE "audit\.Logger[^a-zA-Z]" CONTRIBUTING.md docs/\` returns no hits.

## Test plan

- [x] \`make check\` clean.
- [x] grep verification — no \`audit.Logger\` references in CONTRIBUTING.md or docs/.
- [x] docs-writer agent — flagged factually wrong escape-hatch in WithTimezone godoc (claimed \`FormatOptions.IsExcluded\` could suppress timezone — it cannot, framework fields are written before \`IsExcluded\` runs). Corrected in-PR by referencing custom \`Formatter\` + \`SetFrameworkFields\` only.
- [x] commit-message-reviewer agent — pass.