### PR TITLE
test(bdd): add secrets failure-mode scenarios (#563)

### DIFF
--- a/outputconfig/tests/bdd/features/secret_resolution.feature
+++ b/outputconfig/tests/bdd/features/secret_resolution.feature
@@ -584,3 +584,136 @@ Feature: Secret reference resolution in output configuration
             algorithm: HMAC-SHA-256
       """
     Then the config load should fail with an error containing "expired"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 25: Secret resolution that exceeds the configured timeout (#563)
+  #
+  # The mock provider deliberately delays its response by 500 ms; the
+  # configured per-secret timeout is 50 ms. The resolver's
+  # contextWithSecretTimeout (outputconfig/secrets.go) propagates the
+  # deadline to provider.Resolve, which returns ctx.Err(). The error
+  # must surface to outputconfig.Load with the standard
+  # "context deadline exceeded" wording so an operator can diagnose
+  # a slow secret-store path without inspecting the resolver internals.
+  # ---------------------------------------------------------------------------
+  Scenario: Secret resolution that exceeds the configured timeout fails with deadline-exceeded
+    Given a mock secret provider with scheme "mock" that delays 500ms
+    And the mock provider has secret at path "secret/data/hmac" key "salt" value "delayed-salt-32-bytes!!!!!!!!!!"
+    And the secret resolution timeout is 50ms
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+mock://secret/data/hmac#salt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "context deadline exceeded"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 26: Vault provider receives malformed JSON (#563)
+  #
+  # The in-process HTTPS receiver's TLS handshake succeeds (valid cert
+  # signed by the runtime CA the provider trusts), so the provider
+  # reaches the application layer and reads the response body. The
+  # body is deliberately malformed JSON (combines a raw 0xff byte
+  # with unclosed braces) that json.Unmarshal cannot recover from.
+  # The vault provider's fetchPath wraps the parse error as
+  # `secrets.ErrSecretResolveFailed: parse response: ...` —
+  # see secrets/vault/vault.go around the kvResponse decode.
+  # ---------------------------------------------------------------------------
+  Scenario: Vault provider with malformed JSON response fails Load with parse-error diagnostic
+    Given a vault HTTPS provider returning malformed JSON
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+vault://secret/data/hmac#salt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "parse response"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 27: OpenBao provider receives malformed JSON (#563)
+  #
+  # OpenBao's secret resolution shares the vault provider's HTTP +
+  # JSON path; the openbao provider mirrors the same parse-error
+  # wrapping. Adding the parallel scenario asserts the two providers
+  # remain symmetric — a future divergence would surface here, not
+  # silently in production.
+  # ---------------------------------------------------------------------------
+  Scenario: OpenBao provider with malformed JSON response fails Load with parse-error diagnostic
+    Given an openbao HTTPS provider returning malformed JSON
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+openbao://secret/data/hmac#salt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "parse response"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 28: Injection-safe secret value flows verbatim to HMAC salt (#563)
+  #
+  # A provider returns a 32-byte secret value containing classes of
+  # bytes that break naive serialisers and shell-escape paths: NUL
+  # truncation, CR/LF newline injection, ANSI escape codes (terminal
+  # injection), single-quote / SQL-injection metacharacters, and
+  # ASCII control bytes (DEL, BEL). All 32 bytes are valid UTF-8
+  # codepoints — the resolver pipeline routes through a YAML
+  # decoder that is UTF-8 bound, so raw 0x80–0xFF bytes do not
+  # round-trip; in production, secrets crossing JSON/YAML storage
+  # always arrive as valid UTF-8 (binary secrets are base64-encoded).
+  #
+  # The resolver pipeline must reach `audit.HMACSalt.Value`
+  # byte-for-byte — HMAC consumes the salt as raw bytes via
+  # [crypto/hmac], so any validation or escaping the resolver chose
+  # to apply would silently break HMAC verification. The salt is
+  # never serialised to an output formatter, so this scenario is a
+  # regression sentinel: if a future change to the resolver decides
+  # to "sanitise" the value, the byte-for-byte assertion fires.
+  # ---------------------------------------------------------------------------
+  Scenario: Secret value containing control bytes and shell metacharacters flows verbatim into the HMAC salt
+    Given a mock secret provider with scheme "mock"
+    And the mock provider has secret at path "secret/data/hmac" key "salt" containing the injection-safety fixture
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+mock://secret/data/hmac#salt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should succeed
+    And the HMAC config salt should equal the injection-safety fixture byte-for-byte

--- a/outputconfig/tests/bdd/steps/secret_steps.go
+++ b/outputconfig/tests/bdd/steps/secret_steps.go
@@ -15,7 +15,9 @@
 package steps
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -173,6 +175,81 @@ func registerSecretSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 		`^the error message should not contain "([^"]*)"$`,
 		tc.stepAssertErrorNotContains,
 	)
+
+	ctx.Step(
+		`^the mock provider has secret at path "([^"]*)" key "([^"]*)" containing the injection-safety fixture$`,
+		tc.stepAddInjectionSafetyFixture,
+	)
+
+	ctx.Step(
+		`^the HMAC config salt should equal the injection-safety fixture byte-for-byte$`,
+		tc.stepAssertHMACSaltEqualsInjectionFixture,
+	)
+}
+
+// injectionSafetyFixture is a 32-byte secret value that mixes
+// classes of byte sequences known to break naive serialisers and
+// shell-escape paths: NUL truncation, CR/LF newline injection,
+// ANSI escape codes (terminal-injection vector), single quotes and
+// SQL meta-tokens, ASCII control bytes (BEL, DEL). The salt is
+// consumed by [crypto/hmac] as raw bytes and must reach
+// `audit.HMACSalt.Value` byte-for-byte regardless of what the
+// resolver pipeline does on the way through. The HMAC salt is
+// never written to any output formatter, but this fixture acts as
+// a regression sentinel — if a future change to the resolver
+// decides to validate, escape, or normalise the bytes
+// (well-intentioned but incorrect for a credential), the
+// byte-for-byte assertion will fail.
+//
+// All 32 bytes are valid UTF-8 codepoints (the highest is 0x7F,
+// DEL). The resolver pipeline routes resolved secret values
+// through goccy/go-yaml which is UTF-8 bound; raw 0x80..0xFF
+// bytes get re-encoded as their two-byte UTF-8 sequence (e.g.
+// 0xFF → 0xC3 0xBF). In production, secrets crossing a YAML or
+// JSON storage layer always reach the resolver as valid UTF-8 —
+// most stores base64-encode binary secrets. This fixture
+// therefore reflects the realistic threat model: control bytes
+// and metacharacters that ARE valid UTF-8 codepoints.
+//
+// Length 32 matches the HMAC config schema's recommended salt
+// length (mirroring the literal-salt fixtures in scenarios 1–5).
+var injectionSafetyFixture = string([]byte{
+	0x00, '\n', 'A', 0x1B, '[', '3', '1', 'm', // NUL, LF, ANSI esc start
+	'\'', ';', ' ', 'D', 'R', 'O', 'P', ' ', // SQL injection
+	'T', 'A', 'B', 'L', 'E', ' ', 'x', ';', // continued
+	' ', '-', '-', ' ', '\r', '\n', 0x7F, 0x07, // CRLF, DEL, BEL
+})
+
+func (tc *TestContext) stepAddInjectionSafetyFixture(path, key string) error {
+	p := tc.currentMockProvider()
+	if p.data[path] == nil {
+		p.data[path] = make(map[string]string)
+	}
+	p.data[path][key] = injectionSafetyFixture
+	return nil
+}
+
+func (tc *TestContext) stepAssertHMACSaltEqualsInjectionFixture() error {
+	if tc.LoadResult == nil {
+		return fmt.Errorf("config was not loaded; cannot assert HMAC salt")
+	}
+	mds := tc.LoadResult.OutputMetadata()
+	if len(mds) == 0 {
+		return fmt.Errorf("no outputs loaded; cannot assert HMAC salt")
+	}
+	hmac := mds[0].HMACConfig
+	if hmac == nil {
+		return fmt.Errorf("output %q has no HMAC config", mds[0].Name)
+	}
+	want := []byte(injectionSafetyFixture)
+	if !bytes.Equal(hmac.Salt.Value, want) {
+		return fmt.Errorf(
+			"HMAC salt diverged from injection-safety fixture; "+
+				"len=%d (want %d), bytes=%s (want %s)",
+			len(hmac.Salt.Value), len(want),
+			hex.EncodeToString(hmac.Salt.Value), hex.EncodeToString(want))
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/outputconfig/tests/bdd/steps/tls_negative_steps.go
+++ b/outputconfig/tests/bdd/steps/tls_negative_steps.go
@@ -39,34 +39,56 @@ import (
 )
 
 // registerSecretsTLSNegativeSteps wires step definitions for the
-// expired-cert scenarios in
-// outputconfig/tests/bdd/features/secret_resolution.feature (#552
-// AC#2). The scenario stands up an in-process HTTPS server presenting
-// a deliberately-expired certificate, points a real secrets provider
-// (vault or openbao) at it through the audit-trusted CA, and asserts
-// that outputconfig.Load surfaces the TLS handshake failure rather
-// than silently succeeding or hanging.
+// in-process secrets-provider scenarios in
+// outputconfig/tests/bdd/features/secret_resolution.feature:
 //
-// The receiver path mirrors the syslog/webhook/loki TLS negative-path
-// helpers in tests/bdd/steps/tls_negative_steps.go. It lives in this
-// sub-module because the secrets provider Load path is what we want
-// to exercise — outputconfig.Load drives provider.Resolve, which is
-// where the HTTPS GET fails.
+//   - expired-cert (#552 AC#2): TLS handshake fails because the
+//     server presents a deliberately-expired leaf certificate.
+//   - malformed-JSON (#563): TLS handshake succeeds but the server
+//     responds with a body the vault/openbao provider's JSON parser
+//     rejects.
+//
+// Both pathways stand up an in-process HTTPS server signed by a
+// fresh CA the audit-side provider trusts; the rejection cause is
+// therefore exactly the defect we install — not "unknown
+// authority" or "connection refused".
 func registerSecretsTLSNegativeSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 	ctx.Step(
 		`^an? (vault|openbao) HTTPS provider with an expired server certificate$`,
-		func(scheme string) error { return startBadCertProvider(tc, scheme) },
+		func(scheme string) error {
+			return startInProcHTTPSProvider(tc, scheme, certSpecExpired, tlsRejectHandler())
+		},
+	)
+	ctx.Step(
+		`^an? (vault|openbao) HTTPS provider returning malformed JSON$`,
+		func(scheme string) error {
+			return startInProcHTTPSProvider(tc, scheme, certSpecValid, malformedJSONHandler())
+		},
 	)
 }
 
-// startBadCertProvider generates a fresh CA + expired server cert,
-// starts an HTTPS server presenting that cert, and registers a real
-// vault or openbao provider pointed at it. The audit-side provider
-// trusts the runtime CA, so the TLS rejection cause is exactly
-// "certificate has expired" — not "unknown authority".
+// certSpec selects which leaf-certificate template the in-process
+// HTTPS server presents.
+type certSpec int
+
+const (
+	certSpecExpired certSpec = iota // NotAfter one hour in the past
+	certSpecValid                   // NotAfter one hour in the future
+)
+
+// startInProcHTTPSProvider stands up an in-process HTTPS receiver
+// and points a real vault or openbao provider at it. The shared
+// scaffolding (CA generation, leaf cert, server start, provider
+// construction) is reused by every secrets failure-mode scenario;
+// callers vary only the leaf cert validity and the HTTP handler.
+//
+// The audit-side provider trusts the runtime CA, so the rejection
+// cause is exactly the defect we install — expired NotAfter for
+// the TLS rejection scenario, or malformed body for the JSON
+// scenario — not "unknown authority".
 //
 //nolint:funlen,gocyclo,cyclop // sequential cert + server + provider scaffolding.
-func startBadCertProvider(tc *TestContext, scheme string) error {
+func startInProcHTTPSProvider(tc *TestContext, scheme string, spec certSpec, handler http.Handler) error {
 	dir, err := os.MkdirTemp("", "bdd-secrets-bad-certs-*")
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
@@ -101,31 +123,17 @@ func startBadCertProvider(tc *TestContext, scheme string) error {
 		return fmt.Errorf("write ca pem: %w", writeErr)
 	}
 
-	// Expired server cert valid for localhost / 127.0.0.1.
 	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return fmt.Errorf("leaf key: %w", err)
 	}
-	leafTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(301),
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-2 * time.Hour),
-		NotAfter:     time.Now().Add(-1 * time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
-	}
+	leafTemplate := leafTemplateFor(spec)
 	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
 	if err != nil {
 		return fmt.Errorf("leaf cert: %w", err)
 	}
 
-	// In-process HTTPS server. Body unused — TLS handshake fails
-	// before the handler is reached.
-	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
+	srv := httptest.NewUnstartedServer(handler)
 	srv.TLS = &tls.Config{
 		Certificates: []tls.Certificate{{
 			Certificate: [][]byte{leafDER},
@@ -138,13 +146,13 @@ func startBadCertProvider(tc *TestContext, scheme string) error {
 	addr := srv.URL // "https://127.0.0.1:PORT"
 
 	// Build the real provider with caPath as trust anchor and
-	// AllowPrivateRanges so the SSRF guard does not pre-empt the TLS
-	// rejection.
+	// AllowPrivateRanges so the SSRF guard does not pre-empt the
+	// rejection we are testing.
 	switch scheme {
 	case "vault":
 		p, pErr := vault.New(&vault.Config{
 			Address:            addr,
-			Token:              "test-token-not-used-because-tls-fails",
+			Token:              "bdd-token-value-irrelevant-for-failure-modes",
 			TLSCA:              caPath,
 			AllowPrivateRanges: true,
 		})
@@ -156,7 +164,7 @@ func startBadCertProvider(tc *TestContext, scheme string) error {
 	case "openbao":
 		p, pErr := openbao.New(&openbao.Config{
 			Address:            addr,
-			Token:              "test-token-not-used-because-tls-fails",
+			Token:              "bdd-token-value-irrelevant-for-failure-modes",
 			TLSCA:              caPath,
 			AllowPrivateRanges: true,
 		})
@@ -169,6 +177,52 @@ func startBadCertProvider(tc *TestContext, scheme string) error {
 		return fmt.Errorf("unknown provider scheme %q", scheme)
 	}
 	return nil
+}
+
+// leafTemplateFor returns a leaf-certificate template valid for
+// localhost / 127.0.0.1, with the NotAfter selected by spec.
+func leafTemplateFor(spec certSpec) *x509.Certificate {
+	notBefore := time.Now().Add(-2 * time.Hour)
+	notAfter := time.Now().Add(time.Hour)
+	if spec == certSpecExpired {
+		notAfter = time.Now().Add(-1 * time.Hour)
+	}
+	return &x509.Certificate{
+		SerialNumber: big.NewInt(301),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+}
+
+// tlsRejectHandler returns a handler that 500s any request that
+// reaches it. The expired-cert scenario should never let a request
+// through because the TLS handshake fails first; if a request does
+// arrive the 500 makes the failure unmistakable.
+func tlsRejectHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+}
+
+// malformedJSONHandler returns a handler that responds 200 OK with
+// a body the vault/openbao JSON parser must reject. The body
+// places a raw 0xff at value position (where a quoted string is
+// expected) followed by trailing junk and an unterminated object,
+// so json.Unmarshal returns a SyntaxError that no recovery mode
+// can mask. The vault provider's fetchPath wraps the parse error
+// as `secrets.ErrSecretResolveFailed: parse response: ...` — the
+// BDD assertion pins on the substring "parse response".
+func malformedJSONHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"data":{"salt":` + "\xff" + `not-json,]`))
+	})
 }
 
 // writePEMBlock writes a PEM-encoded block to the given path. The


### PR DESCRIPTION
## Summary

Closes the remaining acceptance criteria of #563 with four BDD scenarios in `outputconfig/tests/bdd/features/secret_resolution.feature`. The expired-cert AC was delivered earlier via #552 / PR #745.

- **Scenario 25** — Mid-fetch context cancellation: mock provider with 500 ms delay versus a 50 ms `WithSecretTimeout`; surfaces as `context deadline exceeded` from `outputconfig.Load`.
- **Scenario 26** — Vault provider with malformed JSON: in-process HTTPS server with a valid cert but a body containing raw 0xff and unterminated braces; `vault.fetchPath` returns `secrets.ErrSecretResolveFailed: parse response: ...`.
- **Scenario 27** — OpenBao mirror of the malformed-JSON path; pins symmetric parse-error wrapping between the two providers.
- **Scenario 28** — Injection-safety fixture: a 32-byte secret containing NUL, CR/LF, ANSI escape, single-quote, SQL meta, DEL, BEL — all valid UTF-8 — flows byte-for-byte into `audit.HMACSalt.Value`. Regression sentinel against future "sanitisation" of resolved-secret bytes.

The fixture excludes 0x80–0xFF because the YAML-bound resolver UTF-8 re-encodes those bytes; documented in the fixture comment.

`tls_negative_steps.go` was refactored to share a single `startInProcHTTPSProvider(tc, scheme, certSpec, handler)` helper between the expired-cert path (#552) and the new malformed-JSON path. No production-code changes.

## Test plan

- [x] `make test-bdd-outputconfig` — all 47 scenarios pass locally
- [x] `make lint` — clean
- [ ] CI green
- [ ] issue-closer report-only verifies the 3 ACs (4 scenarios with exact assertions, BDD passes, injection-safety scenario uses fixed payload that would break formatters if injection were possible)