### PR TITLE
test(bdd): add RFC 5424 parser + structural assertions (#572)

### DIFF
--- a/tests/bdd/features/syslog_output.feature
+++ b/tests/bdd/features/syslog_output.feature
@@ -51,7 +51,14 @@ Feature: Syslog Output
     When I audit a uniquely marked "user_create" event
     And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
-    And the syslog line with the marker should contain "bdd-audit"
+    # Structural assertion (#572). The audit syslog client routes
+    # Config.AppName into the RFC 5424 MSGID field per srslog's
+    # wire mapping; APP-NAME is set to the process binary path.
+    # Asserting on the parsed MSGID structurally rather than via
+    # substring matching catches framing regressions that a
+    # substring search would miss.
+    And the syslog message with the marker should have msg-id "bdd-audit"
+    And the syslog message with the marker should have well-formed RFC 5424 structure
 
   Scenario: Syslog message contains timestamp
     Given an auditor with syslog output on "tcp" to "localhost:5514"
@@ -112,7 +119,10 @@ Feature: Syslog Output
     When I audit a uniquely marked "user_create" event
     And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
-    And the syslog line with the marker should contain "bdd-custom-host"
+    # Structural assertion (#572) — pins the configured hostname
+    # to the RFC 5424 HOSTNAME field specifically, rather than a
+    # substring-anywhere search that could match a body field.
+    And the syslog message with the marker should have hostname "bdd-custom-host"
 
   Scenario: Syslog hostname defaults to os.Hostname when not configured
     Given an auditor with syslog output on "tcp" to "localhost:5514"
@@ -133,7 +143,10 @@ Feature: Syslog Output
     When I audit a uniquely marked "user_create" event
     And I close the auditor
     Then the syslog server should contain the marker within 10 seconds
-    And the syslog line with the marker should contain "audit"
+    # Structural assertion (#572). The default `Config.AppName`
+    # is the literal `audit` (syslog/config.go:29) and srslog
+    # routes it into the MSGID position on the wire.
+    And the syslog message with the marker should have msg-id "audit"
 
   Scenario Outline: Valid facility names are accepted
     Given an auditor with syslog output on "tcp" to "localhost:5514" with facility "<facility>"

--- a/tests/bdd/steps/rfc5424/parser.go
+++ b/tests/bdd/steps/rfc5424/parser.go
@@ -1,0 +1,321 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rfc5424 is a minimal RFC 5424 syslog parser used by the
+// audit BDD harness to drive structural assertions on received
+// messages (#572). It is test-only — the audit library encodes
+// via srslog and does not need an inbound parser.
+//
+// Supported subset:
+//
+//   - PRI ∈ [0, 191], VERSION must be 1.
+//   - TIMESTAMP, HOSTNAME, APP-NAME, PROCID, MSGID, STRUCTURED-DATA
+//     all parsed as space-delimited tokens (the nilvalue "-" is
+//     accepted and surfaces as the empty string in the parsed
+//     Message).
+//   - MSG is everything after the STRUCTURED-DATA token and the
+//     following space.
+//   - The optional RFC 5425 octet-count framing prefix (e.g.
+//     "135 <134>1 ...") is stripped if present.
+//
+// Out-of-scope: full STRUCTURED-DATA element parsing (we keep the
+// raw token), Unicode BOM handling in MSG, SD-PARAM escape rules.
+// If a future test needs any of these, extend deliberately —
+// silently mis-parsing is forbidden.
+package rfc5424
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Message is a parsed RFC 5424 syslog message.
+type Message struct {
+	Timestamp      string // unparsed; RFC 3339-ish, "-" surfaces as ""
+	Hostname       string
+	AppName        string
+	ProcID         string
+	MsgID          string
+	StructuredData string // raw token — "-" or [ID PARAM="VAL"]...
+	Message        string // remaining bytes after STRUCTURED-DATA + SP
+	Priority       int    // 0..191
+	Facility       int    // Priority / 8
+	Severity       int    // Priority % 8
+	Version        int    // always 1
+}
+
+// Parse parses an RFC 5424 message. The optional RFC 5425
+// octet-count prefix (e.g., "135 <134>1 ...") is stripped if
+// present. Returns (*Message, nil) on success or (nil, err) on
+// malformed input.
+//
+// On parse failure, the returned error includes the byte offset
+// of the failure point so BDD assertion diagnostics can show
+// the operator exactly where the wire format diverged from
+// expectations.
+//
+//nolint:gocognit,gocyclo,cyclop // sequential RFC 5424 grammar walk; splitting hurts readability.
+func Parse(line []byte) (*Message, error) {
+	s := line
+	off := 0
+
+	// Optional RFC 5425 octet-count framing: "<digits> ".
+	if i := indexAfterFraming(s); i > 0 {
+		s = s[i:]
+		off += i
+	}
+
+	// PRI: <digits>
+	if len(s) == 0 || s[0] != '<' {
+		return nil, fmt.Errorf("rfc5424: expected '<' at offset %d, got %q", off, peek(s, 4))
+	}
+	end, pri, err := parseAngleNumber(s[1:])
+	if err != nil {
+		return nil, fmt.Errorf("rfc5424: PRI at offset %d: %w", off, err)
+	}
+	if pri < 0 || pri > 191 {
+		return nil, fmt.Errorf("rfc5424: PRI %d out of range 0..191 at offset %d", pri, off)
+	}
+	s = s[1+end+1:] // skip '<', digits, '>'
+	off += 1 + end + 1
+
+	// VERSION: digits up to first SP.
+	verEnd := indexSP(s)
+	if verEnd <= 0 {
+		return nil, fmt.Errorf("rfc5424: missing VERSION at offset %d", off)
+	}
+	ver, err := strconv.Atoi(string(s[:verEnd]))
+	if err != nil {
+		return nil, fmt.Errorf("rfc5424: VERSION at offset %d: %w", off, err)
+	}
+	if ver != 1 {
+		return nil, fmt.Errorf("rfc5424: VERSION %d unsupported (expected 1) at offset %d", ver, off)
+	}
+	s = s[verEnd+1:] // skip digits + SP
+	off += verEnd + 1
+
+	// TIMESTAMP, HOSTNAME, APP-NAME, PROCID, MSGID — five
+	// space-delimited tokens.
+	timestamp, s, err := readToken(s, &off, "TIMESTAMP")
+	if err != nil {
+		return nil, err
+	}
+	hostname, s, err := readToken(s, &off, "HOSTNAME")
+	if err != nil {
+		return nil, err
+	}
+	appName, s, err := readToken(s, &off, "APP-NAME")
+	if err != nil {
+		return nil, err
+	}
+	procID, s, err := readToken(s, &off, "PROCID")
+	if err != nil {
+		return nil, err
+	}
+	msgID, s, err := readToken(s, &off, "MSGID")
+	if err != nil {
+		return nil, err
+	}
+
+	// STRUCTURED-DATA: either "-" or "[...]..." (one or more
+	// SD-ELEMENT). The minimal parser keeps the raw token.
+	structuredData, s, err := readStructuredData(s, &off)
+	if err != nil {
+		return nil, err
+	}
+
+	// Optional MSG: everything after the SP that follows
+	// STRUCTURED-DATA. The trailing newline (if present) is
+	// trimmed so callers that inspect the body do not see line
+	// terminators as content.
+	msg := ""
+	if len(s) > 0 {
+		if s[0] != ' ' {
+			return nil, fmt.Errorf("rfc5424: expected SP before MSG at offset %d, got %q", off, peek(s, 4))
+		}
+		msg = string(s[1:])
+		// Trim a single trailing newline.
+		if l := len(msg); l > 0 && msg[l-1] == '\n' {
+			msg = msg[:l-1]
+		}
+	}
+
+	return &Message{
+		Priority:       pri,
+		Facility:       pri / 8,
+		Severity:       pri % 8,
+		Version:        ver,
+		Timestamp:      nilvalue(timestamp),
+		Hostname:       nilvalue(hostname),
+		AppName:        nilvalue(appName),
+		ProcID:         nilvalue(procID),
+		MsgID:          nilvalue(msgID),
+		StructuredData: structuredData,
+		Message:        msg,
+	}, nil
+}
+
+// MustParse is the test-only convenience wrapper. Panics on
+// parse failure — only suitable inside a t.Helper test path
+// where the test author has already validated the wire format
+// independently.
+func MustParse(line []byte) *Message {
+	m, err := Parse(line)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// --- helpers ---
+
+//nolint:gocognit,gocyclo,cyclop // small linear scan; further splitting hurts clarity.
+func indexAfterFraming(s []byte) int {
+	// Detect a leading "<digits> " frame prefix. Distinguishes
+	// from a bare "<PRI>" (which has no preceding digits).
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '<' && i == 0 {
+			return 0 // no framing prefix
+		}
+		if c == ' ' && i > 0 {
+			// Only treat the space as a framing terminator if
+			// every preceding byte was a digit.
+			for j := 0; j < i; j++ {
+				if s[j] < '0' || s[j] > '9' {
+					return 0
+				}
+			}
+			return i + 1
+		}
+		if c < '0' || c > '9' {
+			return 0
+		}
+	}
+	return 0
+}
+
+func parseAngleNumber(s []byte) (end, val int, err error) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '>' {
+			if i == 0 {
+				return 0, 0, fmt.Errorf("empty PRI")
+			}
+			n, perr := strconv.Atoi(string(s[:i]))
+			if perr != nil {
+				return 0, 0, fmt.Errorf("PRI digit parse: %w", perr)
+			}
+			return i, n, nil
+		}
+		if s[i] < '0' || s[i] > '9' {
+			return 0, 0, fmt.Errorf("non-digit in PRI: %q", s[i])
+		}
+	}
+	return 0, 0, fmt.Errorf("missing '>' in PRI")
+}
+
+func indexSP(s []byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' {
+			return i
+		}
+	}
+	return -1
+}
+
+func readToken(s []byte, off *int, fieldName string) (token string, rest []byte, err error) {
+	end := indexSP(s)
+	if end < 0 {
+		return "", nil, fmt.Errorf("rfc5424: missing %s (no SP) at offset %d", fieldName, *off)
+	}
+	if end == 0 {
+		return "", nil, fmt.Errorf("rfc5424: empty %s at offset %d", fieldName, *off)
+	}
+	*off += end + 1
+	return string(s[:end]), s[end+1:], nil
+}
+
+//nolint:gocognit,gocyclo,cyclop // bracket-balanced scan over SD-ELEMENT(s); single linear pass.
+func readStructuredData(s []byte, off *int) (sd string, rest []byte, err error) {
+	if len(s) == 0 {
+		return "", nil, fmt.Errorf("rfc5424: missing STRUCTURED-DATA at offset %d", *off)
+	}
+	// Nilvalue.
+	if s[0] == '-' {
+		// Single '-' followed by SP or EOL.
+		if len(s) == 1 {
+			*off++
+			return "-", nil, nil
+		}
+		if s[1] != ' ' {
+			return "", nil, fmt.Errorf("rfc5424: STRUCTURED-DATA '-' must be followed by SP at offset %d", *off)
+		}
+		*off++ // consume the '-'; caller sees SP at s[1]
+		return "-", s[1:], nil
+	}
+	// SD-ELEMENT(s): one or more "[...]" — consume until SP that is
+	// outside any element. The minimal parser does not attempt to
+	// validate SD-ID or SD-PARAM; it just balances brackets.
+	if s[0] != '[' {
+		return "", nil, fmt.Errorf("rfc5424: STRUCTURED-DATA must start with '-' or '[' at offset %d, got %q", *off, peek(s, 4))
+	}
+	depth := 0
+	end := -1
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth < 0 {
+				return "", nil, fmt.Errorf("rfc5424: unbalanced ']' in STRUCTURED-DATA at offset %d", *off+i)
+			}
+			if depth == 0 {
+				// End of an SD-ELEMENT. The next char is either
+				// '[' (next element), SP (end of S-D), or EOL.
+				if i+1 == len(s) || s[i+1] == ' ' {
+					end = i + 1
+					break
+				}
+				if s[i+1] != '[' {
+					return "", nil, fmt.Errorf("rfc5424: invalid char %q after SD-ELEMENT at offset %d", s[i+1], *off+i+1)
+				}
+			}
+		}
+		if end >= 0 {
+			break
+		}
+	}
+	if end < 0 {
+		return "", nil, fmt.Errorf("rfc5424: unterminated STRUCTURED-DATA at offset %d", *off)
+	}
+	*off += end
+	return string(s[:end]), s[end:], nil
+}
+
+// nilvalue translates the RFC 5424 nilvalue marker "-" to the
+// empty string for ergonomic field access in tests.
+func nilvalue(s string) string {
+	if s == "-" {
+		return ""
+	}
+	return s
+}
+
+func peek(s []byte, n int) string {
+	if n > len(s) {
+		n = len(s)
+	}
+	return string(s[:n])
+}

--- a/tests/bdd/steps/rfc5424/parser_test.go
+++ b/tests/bdd/steps/rfc5424/parser_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rfc5424_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit/tests/bdd/steps/rfc5424"
+)
+
+func TestParse_RealSyslogNgLine(t *testing.T) {
+	t.Parallel()
+	// Real bytes from `docker exec bdd-syslog-ng-1 cat /var/log/syslog-ng/audit.log`.
+	raw := []byte(`<133>1 2026-04-27T17:29:19+02:00 linuxworkstation /tmp/go-build2861046914/b001/bdd.test 4046174 bdd-fanout - {"timestamp":"2026-04-27T17:29:19.120891563+02:00","event_type":"user_create","marker":"BDD_dac2f152beb4bfd6"}`)
+
+	m, err := rfc5424.Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, 133, m.Priority)
+	assert.Equal(t, 16, m.Facility) // 133 / 8 = 16 (local0)
+	assert.Equal(t, 5, m.Severity)  // 133 % 8 = 5 (notice)
+	assert.Equal(t, 1, m.Version)
+	assert.Equal(t, "2026-04-27T17:29:19+02:00", m.Timestamp)
+	assert.Equal(t, "linuxworkstation", m.Hostname)
+	assert.Equal(t, "/tmp/go-build2861046914/b001/bdd.test", m.AppName)
+	assert.Equal(t, "4046174", m.ProcID)
+	assert.Equal(t, "bdd-fanout", m.MsgID)
+	assert.Equal(t, "-", m.StructuredData)
+	assert.Contains(t, m.Message, "BDD_dac2f152beb4bfd6")
+}
+
+func TestParse_With5425Framing(t *testing.T) {
+	t.Parallel()
+	raw := []byte("135 <134>1 2026-04-27T17:00:00Z host app proc msgid - body")
+	m, err := rfc5424.Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, 134, m.Priority)
+	assert.Equal(t, "host", m.Hostname)
+	assert.Equal(t, "body", m.Message)
+}
+
+func TestParse_NilvalueFields(t *testing.T) {
+	t.Parallel()
+	// All optional fields set to "-" (RFC 5424 nilvalue). The
+	// parser surfaces nilvalue as the empty string for ergonomic
+	// test assertions.
+	raw := []byte("<13>1 - - - - - - body")
+	m, err := rfc5424.Parse(raw)
+	require.NoError(t, err)
+	assert.Empty(t, m.Timestamp)
+	assert.Empty(t, m.Hostname)
+	assert.Empty(t, m.AppName)
+	assert.Empty(t, m.ProcID)
+	assert.Empty(t, m.MsgID)
+	assert.Equal(t, "-", m.StructuredData) // S-D nilvalue is preserved as raw token
+	assert.Equal(t, "body", m.Message)
+}
+
+func TestParse_StructuredData(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`<13>1 - - - - - [exampleSDID@32473 iut="3" eventSource="App"] body`)
+	m, err := rfc5424.Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, `[exampleSDID@32473 iut="3" eventSource="App"]`, m.StructuredData)
+	assert.Equal(t, "body", m.Message)
+}
+
+func TestParse_StructuredData_MultipleElements(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`<13>1 - - - - - [id1 k="v"][id2 a="b"] body`)
+	m, err := rfc5424.Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, `[id1 k="v"][id2 a="b"]`, m.StructuredData)
+	assert.Equal(t, "body", m.Message)
+}
+
+func TestParse_EmptyMessage(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`<13>1 2026-04-27T00:00:00Z h a p m -`)
+	m, err := rfc5424.Parse(raw)
+	require.NoError(t, err)
+	assert.Empty(t, m.Message)
+}
+
+func TestParse_MessageWithTrailingNewline(t *testing.T) {
+	t.Parallel()
+	raw := []byte("<13>1 - - - - - - body\n")
+	m, err := rfc5424.Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, "body", m.Message,
+		"trailing newline must be trimmed for ergonomic body assertions")
+}
+
+func TestParse_PriorityBoundaries(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		raw  []byte
+		want int
+	}{
+		{[]byte("<0>1 - - - - - - x"), 0},
+		{[]byte("<7>1 - - - - - - x"), 7},
+		{[]byte("<191>1 - - - - - - x"), 191},
+	} {
+		m, err := rfc5424.Parse(tc.raw)
+		require.NoError(t, err, "boundary PRI %d must parse", tc.want)
+		assert.Equal(t, tc.want, m.Priority)
+	}
+}
+
+func TestParse_FacilitySeverity(t *testing.T) {
+	t.Parallel()
+	// <165> = facility 20 (local4) * 8 + severity 5 (notice).
+	m, err := rfc5424.Parse([]byte("<165>1 - - - - - - x"))
+	require.NoError(t, err)
+	assert.Equal(t, 20, m.Facility)
+	assert.Equal(t, 5, m.Severity)
+}
+
+func TestParse_Errors(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		wantSub string
+		raw     []byte
+	}{
+		{name: "missing-bracket", raw: []byte("13>1 - - - - - - x"), wantSub: "expected '<'"},
+		{name: "non-digit-pri", raw: []byte("<1a>1 - - - - - - x"), wantSub: "non-digit"},
+		{name: "empty-pri", raw: []byte("<>1 - - - - - - x"), wantSub: "empty PRI"},
+		{name: "unterminated-pri", raw: []byte("<13 1 - - - - - - x"), wantSub: "non-digit"},
+		{name: "pri-too-large", raw: []byte("<999>1 - - - - - - x"), wantSub: "out of range"},
+		{name: "version-not-1", raw: []byte("<13>2 - - - - - - x"), wantSub: "VERSION 2 unsupported"},
+		{name: "missing-version", raw: []byte("<13>"), wantSub: "missing VERSION"},
+		{name: "missing-hostname", raw: []byte("<13>1 ts"), wantSub: "missing"},
+		{name: "sd-bad-start", raw: []byte("<13>1 - - - - - x body"), wantSub: "must start with '-' or '['"},
+		{name: "sd-unbalanced", raw: []byte("<13>1 - - - - - [id"), wantSub: "unterminated"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := rfc5424.Parse(tc.raw)
+			require.Error(t, err)
+			assert.Truef(t, strings.Contains(err.Error(), tc.wantSub),
+				"error %q must contain %q", err, tc.wantSub)
+		})
+	}
+}
+
+func TestMustParse_PanicsOnError(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r, "MustParse must panic on bad input")
+	}()
+	rfc5424.MustParse([]byte("not valid"))
+}
+
+func TestMustParse_OK(t *testing.T) {
+	t.Parallel()
+	m := rfc5424.MustParse([]byte("<13>1 - - - - - - x"))
+	require.NotNil(t, m)
+	assert.Equal(t, 13, m.Priority)
+}

--- a/tests/bdd/steps/syslog_steps.go
+++ b/tests/bdd/steps/syslog_steps.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/axonops/audit"
 	"github.com/axonops/audit/syslog"
+	"github.com/axonops/audit/tests/bdd/steps/rfc5424"
 )
 
 // MockSyslogMetrics captures syslog reconnect events. It embeds
@@ -413,6 +414,23 @@ func registerSyslogThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 		})
 	ctx.Step(`^the syslog server should contain all (\d+) markers within (\d+) seconds$`, func(c, t int) error { return assertSyslogAllMarkers(tc, c, t) })
 	ctx.Step(`^the syslog line with the marker should contain "([^"]*)"$`, func(text string) error { return assertSyslogMarkerLineContains(tc, text) })
+	// Structural RFC 5424 assertions (#572). The substring steps
+	// above are retained for opaque-payload checks (markers, year);
+	// the structural steps below assert specific RFC 5424 fields
+	// (hostname, msg-id, app-name, facility, severity, version)
+	// via the in-tree parser at tests/bdd/steps/rfc5424.
+	ctx.Step(`^the syslog message with the marker should have well-formed RFC 5424 structure$`,
+		func() error { return assertSyslogStructureWellFormed(tc) })
+	ctx.Step(`^the syslog message with the marker should have hostname "([^"]*)"$`,
+		func(want string) error { return assertSyslogField(tc, "hostname", want) })
+	ctx.Step(`^the syslog message with the marker should have app-name "([^"]*)"$`,
+		func(want string) error { return assertSyslogField(tc, "app-name", want) })
+	ctx.Step(`^the syslog message with the marker should have msg-id "([^"]*)"$`,
+		func(want string) error { return assertSyslogField(tc, "msg-id", want) })
+	ctx.Step(`^the syslog message with the marker should have facility (\d+)$`,
+		func(want int) error { return assertSyslogIntField(tc, "facility", want) })
+	ctx.Step(`^the syslog message with the marker should have severity (\d+)$`,
+		func(want int) error { return assertSyslogIntField(tc, "severity", want) })
 	ctx.Step(`^the syslog line with the marker should contain the current year$`, func() error { return assertSyslogMarkerLineContains(tc, time.Now().Format("2006")) })
 	ctx.Step(`^the syslog line with "([^"]*)" should contain "([^"]*)"$`, assertSyslogLineContainsBoth)
 	ctx.Step(`^the syslog construction should fail with exact error:$`, func(doc *godog.DocString) error {
@@ -622,4 +640,87 @@ func assertSyslogMarkerLineContains(tc *AuditTestContext, text string) error {
 		}
 	}
 	return fmt.Errorf("no syslog line found with marker %q", m)
+}
+
+// findAndParseMarkerLine locates the syslog line in the
+// syslog-ng log that contains the default marker, then parses it
+// via the in-tree RFC 5424 parser. Used by the structural
+// assertion steps (#572).
+func findAndParseMarkerLine(tc *AuditTestContext) (*rfc5424.Message, error) {
+	m, ok := tc.Markers["default"]
+	if !ok {
+		return nil, fmt.Errorf("no default marker set")
+	}
+	log := readSyslogLogFromDocker()
+	for _, line := range strings.Split(log, "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, m) {
+			parsed, err := rfc5424.Parse([]byte(line))
+			if err != nil {
+				return nil, fmt.Errorf("rfc5424 parse failed for marker line %q: %w", line, err)
+			}
+			return parsed, nil
+		}
+	}
+	return nil, fmt.Errorf("no syslog line found with marker %q", m)
+}
+
+func assertSyslogStructureWellFormed(tc *AuditTestContext) error {
+	parsed, err := findAndParseMarkerLine(tc)
+	if err != nil {
+		return err
+	}
+	if parsed.Version != 1 {
+		return fmt.Errorf("RFC 5424 VERSION must be 1, got %d", parsed.Version)
+	}
+	if parsed.Priority < 0 || parsed.Priority > 191 {
+		return fmt.Errorf("RFC 5424 PRI must be 0..191, got %d", parsed.Priority)
+	}
+	return nil
+}
+
+func assertSyslogField(tc *AuditTestContext, fieldName, want string) error {
+	parsed, err := findAndParseMarkerLine(tc)
+	if err != nil {
+		return err
+	}
+	var got string
+	switch fieldName {
+	case "hostname":
+		got = parsed.Hostname
+	case "app-name":
+		got = parsed.AppName
+	case "msg-id":
+		got = parsed.MsgID
+	default:
+		return fmt.Errorf("unknown RFC 5424 field %q (want one of: hostname, app-name, msg-id)", fieldName)
+	}
+	if got != want {
+		return fmt.Errorf("RFC 5424 %s: got %q, want %q (parsed message: %+v)", fieldName, got, want, parsed)
+	}
+	return nil
+}
+
+func assertSyslogIntField(tc *AuditTestContext, fieldName string, want int) error {
+	parsed, err := findAndParseMarkerLine(tc)
+	if err != nil {
+		return err
+	}
+	var got int
+	switch fieldName {
+	case "facility":
+		got = parsed.Facility
+	case "severity":
+		got = parsed.Severity
+	case "priority":
+		got = parsed.Priority
+	default:
+		return fmt.Errorf("unknown RFC 5424 int field %q (want one of: facility, severity, priority)", fieldName)
+	}
+	if got != want {
+		return fmt.Errorf("RFC 5424 %s: got %d, want %d (parsed message: %+v)", fieldName, got, want, parsed)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Closes #572 — adds an in-tree RFC 5424 parser package, BDD step definitions for structural field assertions, and converts 3 substring scenarios in `syslog_output.feature` to structural form.

## What

- **NEW** `tests/bdd/steps/rfc5424/parser.go` (~250 lines, hand-rolled scanner; documented supported subset)
- **NEW** `tests/bdd/steps/rfc5424/parser_test.go` — 11 test functions covering happy path + error path
- **MODIFIED** `tests/bdd/steps/syslog_steps.go` — 6 new step definitions (well-formed structure, hostname, app-name, msg-id, facility, severity)
- **MODIFIED** `tests/bdd/features/syslog_output.feature` — 3 scenarios converted to structural assertions

No production-code changes.

## Why

Today's syslog BDD assertions are substring searches against raw lines from the syslog-ng log. Framing bugs (wrong PRI, swapped APP-NAME/MSGID, missing VERSION) slip through because substring matching ignores field boundaries. The structural parser pins each RFC 5424 field individually, catching framing regressions a substring search would miss.

## Why this location

The syslog/ submodule is a separate `go.mod`, so an internal package under `syslog/internal/rfc5424/` would not be importable from `tests/bdd/steps/`. Placing the parser under `tests/bdd/steps/rfc5424/` keeps it test-only without cross-module duplication. The G4 unit test (`TestSyslogOutput_RFC5424_HeaderParseable`, merged in #565) keeps its inline regex; cross-module duplication of the parser is not worth the maintenance cost.

## Test plan

- [x] `go test -count=1 ./tests/bdd/steps/rfc5424/...` — 11 tests pass
- [x] `make test-bdd-syslog` — converted scenarios pass; full suite green
- [x] `make lint` — clean
- [ ] CI green
- [ ] issue-closer report-only verifies the 4 ACs

## Documented divergence from issue text

The issue body suggested `syslog/internal/rfc5424/`. That location is not workable in the multi-module layout (BDD steps live in core, not syslog). The parser ships at `tests/bdd/steps/rfc5424/` instead, with rationale documented in the commit message and the package godoc.