### PR TITLE
fix(testhelper): MockOutput uses sync.Cond to eliminate signal drops (#567)

### DIFF
--- a/internal/testhelper/output.go
+++ b/internal/testhelper/output.go
@@ -63,9 +63,18 @@ func (n *NoopOutput) Writes() uint64 { return n.writes.Load() }
 
 // MockOutput is a thread-safe in-memory output that captures written
 // events for assertion.
+//
+// Synchronisation between Write and WaitForEvents uses a sync.Cond
+// keyed off mu rather than a buffered signal channel. The earlier
+// 1000-slot WriteCh design (#567) silently dropped signals once the
+// channel filled, which caused WaitForEvents to time out on
+// high-volume scenarios (10k+ events) even though every event
+// reached the output. Cond.Broadcast cannot drop signals: every
+// Write notifies every Wait, and the predicate check on EventCount
+// guarantees correctness.
 type MockOutput struct {
 	WriteErr error
-	WriteCh  chan struct{}
+	cond     *sync.Cond
 	name     string
 	events   [][]byte
 	mu       sync.Mutex
@@ -74,10 +83,9 @@ type MockOutput struct {
 
 // NewMockOutput creates a MockOutput with the given name.
 func NewMockOutput(name string) *MockOutput {
-	return &MockOutput{
-		name:    name,
-		WriteCh: make(chan struct{}, 1000),
-	}
+	m := &MockOutput{name: name}
+	m.cond = sync.NewCond(&m.mu)
+	return m
 }
 
 func (m *MockOutput) Write(data []byte) error {
@@ -89,10 +97,7 @@ func (m *MockOutput) Write(data []byte) error {
 	cp := make([]byte, len(data))
 	copy(cp, data)
 	m.events = append(m.events, cp)
-	select {
-	case m.WriteCh <- struct{}{}:
-	default:
-	}
+	m.cond.Broadcast()
 	return nil
 }
 
@@ -139,19 +144,37 @@ func (m *MockOutput) GetEvent(i int) map[string]interface{} {
 	return result
 }
 
-// WaitForEvents polls until at least n events are captured or timeout expires.
+// WaitForEvents waits until at least n events are captured or
+// timeout expires. The implementation uses sync.Cond.Wait under
+// the same mutex that protects the events slice, so the count
+// check and the wait are atomic — no signal can be dropped between
+// EventCount and the next Wait, and Write's Broadcast is observed
+// by every concurrent waiter.
+//
+// Returns true if EventCount reached n before the deadline; false
+// on timeout.
 func (m *MockOutput) WaitForEvents(n int, timeout time.Duration) bool {
-	deadline := time.After(timeout)
-	for {
-		if m.EventCount() >= n {
-			return true
-		}
-		select {
-		case <-m.WriteCh:
-		case <-deadline:
+	deadline := time.Now().Add(timeout)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Spawn a watchdog goroutine that broadcasts the cond when
+	// the deadline expires so the Wait below unblocks. Without
+	// this, sync.Cond.Wait has no built-in timeout.
+	timer := time.AfterFunc(timeout, func() {
+		m.mu.Lock()
+		m.cond.Broadcast()
+		m.mu.Unlock()
+	})
+	defer timer.Stop()
+
+	for len(m.events) < n {
+		if time.Now().After(deadline) {
 			return false
 		}
+		m.cond.Wait()
 	}
+	return true
 }
 
 // IsClosed returns whether Close has been called.

--- a/internal/testhelper/output_test.go
+++ b/internal/testhelper/output_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelper_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit/internal/testhelper"
+)
+
+// TestMockOutput_WaitForN_HighVolume drives 10000 events through
+// MockOutput from concurrent goroutines and asserts WaitForEvents
+// returns true. Pre-#567 the buffered WriteCh dropped signals at
+// 1000+ events; this test pins the post-fix sync.Cond contract
+// where every Write broadcasts and no signal is ever dropped.
+// (#567 AC#1, AC#3).
+func TestMockOutput_WaitForN_HighVolume(t *testing.T) {
+	t.Parallel()
+	const total = 10_000
+	out := testhelper.NewMockOutput("high-volume")
+
+	var wg sync.WaitGroup
+	const writers = 8
+	per := total / writers
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < per; i++ {
+				if err := out.Write([]byte(fmt.Sprintf(`{"w":%d,"i":%d}`, workerID, i))); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// All writes complete; WaitForEvents must observe them.
+	assert.True(t, out.WaitForEvents(total, 5*time.Second),
+		"WaitForEvents must return true once N events arrive — even at high volume")
+	assert.Equal(t, total, out.EventCount(),
+		"every enqueued event must be captured")
+}
+
+// TestMockOutput_WaitForEvents_ExactN proves that WaitForEvents
+// returns true exactly when EventCount reaches the requested N,
+// neither prematurely nor late. (#567 AC#2).
+func TestMockOutput_WaitForEvents_ExactN(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("exact-n")
+	const n = 5
+
+	// Spawn the waiter first; it must block until exactly N
+	// events arrive.
+	done := make(chan bool, 1)
+	go func() {
+		done <- out.WaitForEvents(n, 2*time.Second)
+	}()
+
+	// Send N-1 events; the waiter must NOT return yet.
+	for i := 0; i < n-1; i++ {
+		require.NoError(t, out.Write([]byte("e")))
+	}
+	select {
+	case <-done:
+		t.Fatalf("WaitForEvents returned before N events arrived")
+	case <-time.After(50 * time.Millisecond):
+		// expected — waiter is still blocked
+	}
+
+	// Send the Nth event; waiter must wake and return true.
+	require.NoError(t, out.Write([]byte("e")))
+	select {
+	case ok := <-done:
+		assert.True(t, ok, "WaitForEvents must return true once N events arrive")
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForEvents did not return within 2 s after Nth event arrived")
+	}
+}
+
+// TestMockOutput_WaitForEvents_TimeoutPath proves that
+// WaitForEvents returns false on timeout when fewer than N events
+// arrive. The previous channel-based implementation could deadlock
+// if the buffer was full and no further signal could arrive; the
+// sync.Cond + AfterFunc broadcast keeps the timeout path live.
+// (#567 AC#3).
+func TestMockOutput_WaitForEvents_TimeoutPath(t *testing.T) {
+	t.Parallel()
+	out := testhelper.NewMockOutput("timeout")
+	require.NoError(t, out.Write([]byte("only-one")))
+
+	start := time.Now()
+	got := out.WaitForEvents(2, 100*time.Millisecond)
+	elapsed := time.Since(start)
+	assert.False(t, got, "WaitForEvents must return false when N is not reached")
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond,
+		"WaitForEvents must wait at least the configured timeout")
+	assert.Less(t, elapsed, 1*time.Second,
+		"WaitForEvents must not wait significantly past the timeout")
+}


### PR DESCRIPTION
## Summary

Closes #567 — replaces `MockOutput.WriteCh`'s buffered signal channel with a `sync.Cond` to eliminate the silent signal-drop bug that caused `WaitForEvents` to time out on high-volume scenarios.

## Why

Pre-fix: `Write` did a non-blocking send to a 1000-slot `WriteCh`; once full, the signal was dropped. `WaitForEvents` consumed signals to wake up. With > 1000 events arriving in a burst before the waiter caught up, the late signals were dropped — so the waiter could miss the wake-up and time out, even though every event had been recorded in the events slice.

Post-fix: `Write` calls `cond.Broadcast()` under the same mutex that protects the events slice. `WaitForEvents` waits on the cond with a predicate check on `len(events)`. The timeout is honoured via a `time.AfterFunc` watchdog that broadcasts the cond on deadline. No signal can be dropped; no waiter can deadlock.

## Acceptance criteria

- [x] AC#1 — High-volume tests pass: `TestMockOutput_WaitForN_HighVolume` (10k events, 8 concurrent writers).
- [x] AC#2 — Exactly-N return: `TestMockOutput_WaitForEvents_ExactN` pins the off-by-one boundary.
- [x] AC#3 — No flakes under `-race -count=100`: stress-tested locally (`go test -race -count=100 ./internal/testhelper/...` clean).
- [x] Required test `TestMockOutput_WaitForN_HighVolume` covers 10k events.

## Test plan

- [x] `go test -race -count=100 ./internal/testhelper/...` — green
- [x] `make test` — all packages green, coverage maintained
- [x] `make lint` — clean
- [ ] CI green
- [ ] issue-closer report-only verifies all 3 ACs

## Notes

- The exported `WriteCh` field is removed since `internal/testhelper` is internal and no consumer in the repo referenced it directly (verified with `grep -rn '\.WriteCh\b'`).