### PR TITLE
ci: add OSSF Scorecard scheduled workflow (#517)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,54 @@
+name: OSSF Scorecard
+
+# Weekly OpenSSF Scorecard scan + per-merge re-scan on main.
+# Publishes results to the OpenSSF public dashboard and uploads
+# SARIF to the GitHub Security tab. The README badge links to
+# the public dashboard at securityscorecards.dev.
+#
+# See docs/releasing.md "OpenSSF Scorecard" subsection for the
+# meaning of the score and the protocol when it drops.
+
+on:
+  branch_protection_rule: {}
+  schedule:
+    - cron: '0 8 * * 1'   # Monday 08:00 UTC
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      security-events: write   # SARIF upload to Security tab
+      id-token: write          # publish_results: true (OIDC)
+      contents: read           # read repository contents
+      actions: read            # read workflow definitions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   [![CI](https://github.com/axonops/audit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/axonops/audit/actions/workflows/ci.yml)
   [![Go Reference](https://pkg.go.dev/badge/github.com/axonops/audit.svg)](https://pkg.go.dev/github.com/axonops/audit)
   [![Go Report Card](https://goreportcard.com/badge/github.com/axonops/audit)](https://goreportcard.com/report/github.com/axonops/audit)
+  [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/axonops/audit/badge)](https://securityscorecards.dev/viewer/?uri=github.com/axonops/audit)
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
   ![Status](https://img.shields.io/badge/status-pre--release-orange)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -507,6 +507,43 @@ This verifies not just the pipefail mechanism but the entire chain from test
 exit code through step status through job status through PR check status. Run
 it when modifying any test-execution step in `.github/workflows/`.
 
+### OpenSSF Scorecard
+
+The OSSF Scorecard workflow (`.github/workflows/scorecard.yml`) runs weekly on
+Monday at 08:00 UTC, on every push to `main`, and whenever a branch-protection
+rule is created or modified. It scores the repository against the OpenSSF
+supply-chain checks (Branch-Protection, Code-Review, SAST, Pinned-Dependencies,
+Token-Permissions, Vulnerabilities, etc.).
+
+Results are uploaded as SARIF to the GitHub **Security** tab and published to
+the OpenSSF public dashboard at
+<https://securityscorecards.dev/viewer/?uri=github.com/axonops/audit>. The
+README badge links to that dashboard.
+
+**If the score drops between runs:**
+
+1. Open the latest workflow run, download the `scorecard-sarif` artifact, and
+   read the per-check findings.
+2. Cross-reference with the GitHub **Security** tab — each finding includes
+   the file path and remediation guidance.
+3. File a tracking issue (labels `security`, `ci/cd`) for any regression that
+   is not a transient false positive.
+4. Common drift causes: a new workflow added without
+   `permissions: contents: read` at the top level; an action referenced by tag
+   rather than full SHA; a dependency pin bumped to a vulnerable version
+   (`govulncheck` will flag this independently in `security-scan.yml`).
+5. The **Pinned-Dependencies** check is the one most often dragged down by
+   GitHub-Actions updates that land as tag-pinned PRs from Dependabot — they
+   should be edited to a full SHA before merge, matching the convention used
+   throughout `.github/workflows/`.
+
+A score drop on **Pinned-Dependencies** or **Vulnerabilities** MUST be
+resolved before the next release — these checks measure supply-chain
+integrity and CVE exposure directly. Drops on other checks
+(Branch-Protection, Code-Review, SAST, Token-Permissions) SHOULD be
+resolved within one release cycle. File a tracking issue (labels
+`security`, `ci/cd`) for every unresolved regression before tagging.
+
 ---
 
 ## For Contributors


### PR DESCRIPTION
## Summary

Closes #517. Adds the OpenSSF Scorecard workflow to surface supply-chain hygiene to operators and consumers, plus a README badge and a maintainer-facing runbook in \`docs/releasing.md\`.

- **NEW** \`.github/workflows/scorecard.yml\` (53 lines) — weekly Monday 08:00 UTC scan + push-to-\`main\` + \`branch_protection_rule\` + \`workflow_dispatch\`. Uploads SARIF to the GitHub Security tab via \`github/codeql-action/upload-sarif\` and publishes to the OpenSSF public dashboard via \`publish_results: true\` (OIDC). All four actions pinned to full 40-char SHA per house style.
- **MODIFIED** \`README.md\` — adds the OpenSSF Scorecard badge between Go Report Card and License.
- **MODIFIED** \`docs/releasing.md\` — adds an "OpenSSF Scorecard" subsection under "For Maintainers: CI Health" describing the workflow, where results land, and a 5-step drop-handling protocol; classifies Pinned-Dependencies / Vulnerabilities drops as MUST-resolve-before-next-release and other-check drops as SHOULD-resolve-within-one-cycle.

Agent gates run: **devops** PASS (8/8 checks), **security-reviewer** PASS (0 CRITICAL/HIGH/MEDIUM, 1 LOW non-blocking), **docs-writer** found one framing issue and a recommended fix was applied verbatim, **commit-message-reviewer** PASS.

## Test plan

- [x] All 4 action pins resolved to full 40-char SHA via \`gh api\` and committed with trailing version-tag comments
- [x] devops review: pinning, permissions (\`read-all\` top-level + minimal job-level), trigger composition, timeout, dependabot interaction — PASS
- [x] security-reviewer: token permissions, OIDC publish, supply chain, SARIF leakage, trigger surface — PASS
- [x] docs-writer: badge placement, subsection structure, technical accuracy, drop-handling protocol — PASS after fix
- [ ] CI green on this PR
- [ ] Manual \`workflow_dispatch\` of \`scorecard.yml\` against this branch produces a successful run with SARIF in the Security tab
- [ ] issue-closer REPORT-ONLY confirms 4 ACs satisfied