### PR TITLE
ci: add timeout-minutes to ci-pass aggregate job (#518)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,6 +576,7 @@ jobs:
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [changes, hygiene, lint, test, integration, bdd, bdd-verify, security, security-verify, cross-build, validate-release]
     if: always()
     steps:


### PR DESCRIPTION
## Summary

Closes #518. Adds `timeout-minutes: 5` to the `ci-pass` aggregator job in `.github/workflows/ci.yml`. Every other job in this file already has a timeout; the aggregator (a sub-second bash check on `needs.*.result`) was the only one missing.

devops review PASS, commit-message-reviewer PASS.

## Test plan

- [x] devops gate (placement consistency, value sanity)
- [x] commit-message-reviewer
- [ ] CI green
- [ ] issue-closer REPORT-ONLY