### PR TITLE
security: enforce no InsecureSkipVerify in production code (#523)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
       - name: Check replace directives
         run: make check-replace
 
+      - name: Reject InsecureSkipVerify in production code
+        run: make check-insecure-skip-verify
+
       - name: Check example README cross-references
         run: make check-example-links
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,16 @@ Individual modules can be tested separately: `make test-core`,
 This project does not use pre-commit hooks. Run `make check` before
 committing to execute the full quality gate locally.
 
+### Security invariants enforced statically
+
+`make check` chains a set of static guards that reject
+high-impact security misuse before it can land. The most
+important is `make check-insecure-skip-verify`, which fails the
+build if any production-code `.go` file sets
+`InsecureSkipVerify: true`. CI's `Hygiene` job runs the same
+guard. See [SECURITY.md](SECURITY.md#static-analysis-guards)
+for the full list and the exemption mechanism.
+
 ### BDD Strict mode — non-negotiable
 
 Every `godog.Options{}` block in every test file MUST include

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
        lint-secrets lint-secrets-openbao lint-secrets-vault \
        vet vet-all fmt fmt-check \
        build build-all bench bench-save bench-compare bench-baseline-check coverage \
-       tidy tidy-check verify check-replace check-todos check-example-links check-bdd-strict \
+       tidy tidy-check verify check-replace check-todos check-example-links check-bdd-strict check-insecure-skip-verify \
        security release-check check clean \
        install-tools install-benchstat workspace generate-certs \
        test-infra-up test-infra-down test-infra-logs \
@@ -353,6 +353,31 @@ check-replace:
 	done
 	@echo "No replace directives found."
 
+# Reject any production-code use of InsecureSkipVerify: true.
+# The single biggest TLS footgun — must never appear outside
+# *_test.go files. To exempt a legitimate test helper, append
+# a trailing `// audit:allow-insecure-skip-verify` comment to
+# the same line as the field assignment; the rule below
+# filters those lines and the comment is grep-discoverable
+# for review.
+check-insecure-skip-verify:
+	@OFFENDERS=$$({ \
+		grep -rn -E 'InsecureSkipVerify[[:space:]]*:[[:space:]]*true' \
+			--include='*.go' \
+			--exclude='*_test.go' \
+			. 2>/dev/null || true; \
+	} | { grep -v 'audit:allow-insecure-skip-verify' || true; }); \
+	if [ -n "$$OFFENDERS" ]; then \
+		echo "ERROR: InsecureSkipVerify: true in production code:"; \
+		echo "$$OFFENDERS"; \
+		echo ""; \
+		echo "TLS verification must never be disabled in production code."; \
+		echo "If a test helper genuinely needs this, append a trailing"; \
+		echo "// audit:allow-insecure-skip-verify comment on the same line."; \
+		exit 1; \
+	fi
+	@echo "No InsecureSkipVerify: true in production code."
+
 # Enforce TODO comments must reference a GitHub issue: TODO(#NNN)
 check-todos:
 	@ORPHANED=$$({ grep -rn 'TODO' --include='*.go' || true; } | { grep -v 'TODO(#[0-9]' || true; } | { grep -v 'nolint' || true; } | { grep -v '_test.go.*TODO' || true; }); \
@@ -484,7 +509,7 @@ release-check:
 
 # --- Full local quality gate ---
 
-check: fmt-check vet-all lint-all test-all build-all test-examples tidy-check verify check-replace check-todos check-example-links check-bdd-strict bench-baseline-check release-check security
+check: fmt-check vet-all lint-all test-all build-all test-examples tidy-check verify check-replace check-insecure-skip-verify check-todos check-example-links check-bdd-strict bench-baseline-check release-check security
 	@echo ""
 	@echo "All checks passed."
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,28 @@ to report vulnerabilities. This provides a private channel for coordinated discl
 These timelines are best-effort commitments for a pre-release project
 with a small maintainer team.
 
+## Static-Analysis Guards
+
+Several security invariants are enforced by static checks, not just code
+review. The CI `Hygiene` job invokes each guard target individually;
+locally `make check` chains the same set. Contributors SHOULD run
+`make check` before pushing.
+
+| Invariant | Enforcement | Bypass mechanism |
+|---|---|---|
+| `InsecureSkipVerify: true` never appears in production code | `make check-insecure-skip-verify` (CI `Hygiene` job + local `make check`) | Append `// audit:allow-insecure-skip-verify` to the same line as the field assignment. Reserved for documented test helpers; reviewers MUST justify any exemption against the threat model. |
+| `replace` directives never appear in `go.mod` | `make check-replace` | None. |
+| `TODO` comments must reference an issue | `make check-todos` | Append `//nolint` on the same line — strongly discouraged; requires explicit reviewer justification. |
+
+The `InsecureSkipVerify` rule excludes `*_test.go` files unconditionally.
+Tests that require a self-signed CA MUST configure a custom `RootCAs`
+pool; they MUST NOT disable verification. The line-grep enforcement
+relies on `make fmt-check` running first (which it does, both as the
+first step in CI's `Hygiene` job and as the first dependency of
+`make check`): `gofmt` collapses any multi-line struct-literal back
+onto one line, so a contributor cannot evade the grep by spreading
+`InsecureSkipVerify\n: true` across lines.
+
 ## Disclosure Policy
 
 We follow coordinated disclosure with a 90-day window:

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -1613,20 +1613,6 @@ func TestBackoffDuration(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// No InsecureSkipVerify
-// ---------------------------------------------------------------------------
-
-func TestSyslogOutput_NoInsecureSkipVerify(t *testing.T) {
-	// Grep the source for InsecureSkipVerify — it must never be set to true.
-	data, err := os.ReadFile("syslog.go")
-	require.NoError(t, err)
-	assert.NotContains(t, string(data), "InsecureSkipVerify: true",
-		"InsecureSkipVerify must never be set to true")
-	assert.NotContains(t, string(data), "InsecureSkipVerify:true",
-		"InsecureSkipVerify must never be set to true")
-}
-
-// ---------------------------------------------------------------------------
 // Empty and edge-case payloads
 // ---------------------------------------------------------------------------
 

--- a/tls_policy_test.go
+++ b/tls_policy_test.go
@@ -17,10 +17,6 @@ package audit_test
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/axonops/audit"
@@ -136,35 +132,4 @@ func TestTLSPolicy_Apply_TLS13_AllowWeakCiphersNoEffect(t *testing.T) {
 	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
 	assert.Nil(t, cfg.CipherSuites)
 	assert.Empty(t, warnings, "no warning expected when AllowTLS12 is false")
-}
-
-// ---------------------------------------------------------------------------
-// Production code InsecureSkipVerify guard
-// ---------------------------------------------------------------------------
-
-func TestNoInsecureSkipVerify_InProductionCode(t *testing.T) {
-	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if path == "vendor" || path == "testdata" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		data, readErr := os.ReadFile(path)
-		require.NoError(t, readErr)
-
-		content := string(data)
-		assert.NotContains(t, content, "InsecureSkipVerify: true",
-			"%s must not set InsecureSkipVerify to true", path)
-		assert.NotContains(t, content, "InsecureSkipVerify:true",
-			"%s must not set InsecureSkipVerify to true (no space)", path)
-		return nil
-	})
-	require.NoError(t, err)
 }

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -1168,13 +1168,6 @@ func TestWebhookOutput_TLSPolicy_AllowTLS12(t *testing.T) {
 	require.NoError(t, out.Close())
 }
 
-func TestWebhookOutput_NoInsecureSkipVerify(t *testing.T) {
-	data, err := os.ReadFile("webhook.go")
-	require.NoError(t, err)
-	assert.NotContains(t, string(data), "InsecureSkipVerify: true",
-		"InsecureSkipVerify must never be set to true")
-}
-
 // ---------------------------------------------------------------------------
 // TLS tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #523. Adds a repo-wide Make target + CI step that rejects any production-code use of `tls.Config{InsecureSkipVerify: true}` across every module. Closes the gap left by three ad-hoc per-module Go tests that only scanned the core module or a single file.

- **NEW** Make target `check-insecure-skip-verify` with a `// audit:allow-insecure-skip-verify` same-line exemption comment for documented test helpers; wired into `.PHONY`, the `check:` aggregator (after `check-replace` for fail-fast), and CI's `Hygiene` job.
- **NEW** \`.github/workflows/ci.yml\` step in the `Hygiene` job: `Reject InsecureSkipVerify in production code`.
- **NEW** SECURITY.md section "Static-Analysis Guards" with table of guards and bypass mechanisms; uses RFC 2119 normative language (MUST / SHOULD / MUST NOT).
- **NEW** CONTRIBUTING.md cross-link to SECURITY.md.
- **DELETED** three redundant Go tests:
  - `TestNoInsecureSkipVerify_InProductionCode` (tls_policy_test.go) — single-module walkdir
  - `TestSyslogOutput_NoInsecureSkipVerify` (syslog/syslog_test.go) — single-file scan
  - `TestWebhookOutput_NoInsecureSkipVerify` (webhook/webhook_external_test.go) — single-file scan
  Plus unused imports.

## Manual fault-injection (AC#2 evidence)

Injecting `InsecureSkipVerify: true` into a webhook .go file produces:

\`\`\`
ERROR: InsecureSkipVerify: true in production code:
./webhook/_canary.go:3:var _ = &tls.Config{InsecureSkipVerify: true}

TLS verification must never be disabled in production code.
If a test helper genuinely needs this, append a trailing
// audit:allow-insecure-skip-verify comment on the same line.
make: *** [Makefile:363: check-insecure-skip-verify] Error 1
EXIT: 2
\`\`\`

Appending the same-line allow-comment makes the target pass with exit 0:

\`\`\`
No InsecureSkipVerify: true in production code.
\`\`\`

## Agent gates

- security-reviewer — flagged a CRITICAL CI gap (target not wired into CI's hygiene job) and 1 MEDIUM (SECURITY.md docs/reality mismatch). **Both fixed in this PR before commit** by adding the explicit CI step + correcting the docs to "CI Hygiene job + local make check".
- devops — flagged the same CI gap + chain placement. Both fixed.
- docs-writer — flagged heading capitalisation, RFC 2119 normative language, and `check-todos` bypass-cell accuracy. All fixed.
- commit-message-reviewer — PASS.

## Test plan

- [x] `make check-insecure-skip-verify` passes on clean main
- [x] `make lint` clean (12 modules)
- [x] Manual fault-injection produces exit 1 with offender printed
- [x] Same-line allow-comment exempts cleanly
- [ ] CI green on this PR (the new hygiene step is the gate)
- [ ] issue-closer REPORT-ONLY confirms 4 ACs satisfied