### PR TITLE
ci: complete docs-only CI fast-path with NOTICE exclusion (#641)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,20 @@ jobs:
           fi
 
           # Check if any non-docs files changed.
-          # ':!*.md' matches .md at all directory levels in git pathspec.
+          # Order: literal files first, then globs, then directories.
+          # ':!*.md' matches root-level .md; ':!**/*.md' matches every
+          # depth. The two together cover every .md path. Workflow
+          # files under .github/workflows/ are intentionally NOT
+          # excluded — workflow changes MUST run full CI.
           CHANGED=$(git diff --name-only "$BASE" HEAD -- \
+            ':!LICENSE' \
+            ':!NOTICE' \
             ':!*.md' \
             ':!**/*.md' \
-            ':!docs/**' \
-            ':!LICENSE' \
-            ':!.claude/**' \
             ':!**/CHANGELOG*' \
             ':!**/CONTRIBUTING*' \
+            ':!.claude/**' \
+            ':!docs/**' \
             ':!.github/ISSUE_TEMPLATE/**' \
           )
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,61 @@ in [docs/releasing.md](docs/releasing.md) under "Tag protection";
 that file is the single source of truth, regenerated from the
 canonical `PUBLISH_MODULES` list.
 
+## CI Behaviour
+
+The `CI` workflow (`.github/workflows/ci.yml`) detects whether a
+PR touches code or only documentation. The detection lives in the
+`changes` job near the top of the workflow and uses a `git diff`
+pathspec exclusion list.
+
+**Docs-only PRs skip the Go pipeline.** A PR whose diff touches
+only the following paths runs `changes` + `hygiene` +
+`validate-release` (≈2 minutes total) and skips the Go build,
+lint, test, integration, BDD, security, and cross-platform jobs:
+
+- `*.md` and `**/*.md` (every Markdown file at any depth)
+- `docs/**`
+- `LICENSE`, `NOTICE`
+- `**/CHANGELOG*`, `**/CONTRIBUTING*` (with or without `.md`)
+- `.github/ISSUE_TEMPLATE/**`
+- `.claude/**` (defensive — the directory is gitignored, but the
+  exclusion catches accidental commits)
+
+`hygiene` and `validate-release` continue to run because they catch
+real drift on docs-only PRs — for example,
+`make regen-release-docs-check` (in `hygiene`) verifies the
+auto-generated module table in `docs/releasing.md` is in sync with
+the canonical `PUBLISH_MODULES` list.
+
+**Mixed PRs run the full pipeline.** If the diff includes any
+non-docs file, every CI job runs. There is no per-job opt-out for
+mixed PRs.
+
+**Branch protection** is satisfied by a single aggregate check:
+`Test - CI Pass`. That job has `if: always()` and treats `skipped`
+results as success, so a docs-only PR satisfies the gate without
+any maintainer action.
+
+**Workflow changes always run full CI.** Files under
+`.github/workflows/**` are deliberately NOT excluded from the
+detection list — a workflow change must exercise the full pipeline
+before merging.
+
+**Forcing full CI on a docs-only change.** If a docs change needs
+the full pipeline (rare — e.g., regenerating a doc alongside an
+embedded test that depends on it), bundle the doc change with the
+code change in the same PR; mixed PRs run everything. Manually
+re-running the workflow via `Actions → CI → Run workflow` also
+forces full CI because the `workflow_dispatch` trigger sets
+`code=true` unconditionally.
+
+**Maintenance.** When adding a new docs-like path, edit the
+pathspec in `.github/workflows/ci.yml` `changes` job (single source
+of truth). When adding a new CI job, follow the maintenance note
+above the `ci-pass` job: add the job name to its `needs:` list and
+gate it on `if: needs.changes.outputs.code == 'true'` if it should
+skip on docs-only PRs.
+
 ## Dependencies
 
 Dependencies are kept minimal. The core library depends on


### PR DESCRIPTION
## Summary

Completes the docs-only CI fast-path. The `changes` job in `.github/workflows/ci.yml` already detected docs-only PRs and gated the heavy Go jobs on `needs.changes.outputs.code == 'true'`. Two acceptance criteria remained:

- `NOTICE` was missing from the pathspec exclusion list (a PR touching only `NOTICE` would have triggered the full pipeline)
- No contributor-facing documentation existed — AC 5 unmet

This PR adds `:!NOTICE`, reorders the pathspec for readability (literals → globs → directories), and adds a new "CI Behaviour" section to `CONTRIBUTING.md`. Closes #641.

Note: this PR's own diff includes `.github/workflows/ci.yml`, which is **deliberately not** in the exclusion list — workflow changes always run full CI. So this PR exercises the full pipeline (correct).

## Test plan

- [x] `make check` clean (full local quality gate)
- [x] Pre-coding devops consult; post-coding devops + docs-writer reviews
- [x] Empirically verified the new pathspec returns empty for a docs-only commit and non-empty for a code commit
- [ ] CI green on this PR
- [ ] Post-merge: open a one-line markdown-only PR and verify only `Test - Detect Changes`, `Test - Hygiene`, `Test - Validate GoReleaser Config`, and `Test - CI Pass` run; the rest skip
- [ ] Post-merge: open a mixed PR (1 .md + 1 .go file) and verify the full pipeline runs