### PR TITLE
docs: lock down version:1 schema versioning model (#544)

### DIFF
--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -170,7 +170,7 @@ outputs:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `version` | Yes | Must be `1`. Schema version for future migration. |
+| `version` | Yes | Must be `1`. Schema version for future migration. See [Config Schema Versioning](#-config-schema-versioning) below. |
 | `app_name` | Yes | Application name. Emitted as a framework field in every event. Max 255 bytes. |
 | `host` | Yes | Hostname/environment. Emitted as a framework field. Max 255 bytes. Env vars supported. |
 | `timezone` | No | Timezone name (e.g. `UTC`, `America/New_York`). Max 64 bytes. Auto-detected from system when absent. |
@@ -180,6 +180,110 @@ outputs:
 | `outputs` | Yes | Map of named outputs. At least one must be defined. Maximum: 100. |
 
 > ⚠️ **No root-level `tls_policy` key.** TLS policy is configured inside each output (under `syslog:`, `webhook:`, `loki:`) and each secret provider (under `vault:`, `openbao:`). Setting `tls_policy:` at the root fails at startup with an "unknown top-level key" error. See [Per-Output TLS Policy](#-per-output-tls-policy) below.
+
+## 🔄 Config Schema Versioning
+
+The outputs YAML carries a top-level `version:` field so the
+library can recognise the shape of the document and apply
+migrations when a future schema change lands.
+
+### What `version: 1` means today
+
+`version: 1` is the only currently-defined schema version. Every
+outputs config MUST set `version: 1` explicitly:
+
+```yaml
+version: 1
+app_name: my-service
+host: my-host
+outputs:
+  ...
+```
+
+A missing or wrong `version:` value is rejected at load time
+with:
+
+```
+audit/outputconfig: output config validation failed: audit: config invalid: unsupported version 0 (expected 1)
+audit/outputconfig: output config validation failed: audit: config invalid: unsupported version 2 (expected 1)
+```
+
+These errors wrap both
+[`outputconfig.ErrOutputConfigInvalid`](https://pkg.go.dev/github.com/axonops/audit/outputconfig#pkg-variables)
+and the parent
+[`audit.ErrConfigInvalid`](https://pkg.go.dev/github.com/axonops/audit#pkg-variables);
+consumers can match either via `errors.Is` without coupling to
+the message text.
+
+### Schema version is independent of library release version
+
+The schema version (`version: 1` in YAML) is **not** the library
+release version (e.g., v1.0.0, v1.5.0, v2.0.0). They evolve
+independently:
+
+- A v1.5 library MAY still use schema `version: 1` — operators
+  upgrading the library do NOT need to touch their YAML.
+- The schema version bumps only when the YAML shape itself
+  changes in a way that older libraries cannot interpret (new
+  required field, removed field, or restructured nesting). This
+  is a maintainer-side decision; consumers do not need to touch
+  the version field on routine library upgrades.
+- A library release version bumps for any release reason — bug
+  fix, new feature, performance improvement — even when the
+  schema is unchanged.
+
+For the lifetime of v1.x of the library, `version: 1` will remain
+accepted. Schema-breaking changes are themselves library-major
+events: a `version: 2` schema would land in v2.x of the library
+(or earlier, with `version: 1` still accepted alongside it).
+
+### Future migration contract
+
+When `version: 2` is introduced, the library will:
+
+1. Accept both `version: 1` and `version: 2` configs side-by-side
+   for at least one tagged library release; the deprecation
+   timeline for `version: 1` will be announced via the
+   `CHANGELOG.md` `### Deprecated` section.
+2. Silently upgrade `version: 1` configs to the new internal
+   shape — operators do not need to rewrite their YAML.
+3. Reject `version: N+1` from a library that only knows up to
+   `N`, with a clear "upgrade the library" error.
+4. Reject `version: K-M` once support for `K-M` is dropped, with
+   a clear "no longer supported" error that names the lowest
+   still-accepted version.
+
+The current code path in `outputconfig.Load` performs a single
+hardcoded equality check against `1`. When the second schema
+version arrives, that check will be replaced with a migration
+mechanism analogous to the taxonomy's
+[`MigrateTaxonomy`](https://pkg.go.dev/github.com/axonops/audit#MigrateTaxonomy)
+— inline version handling rather than a public `RegisterMigration`
+API. This keeps migrations as library-implementation detail
+rather than a consumer extension point.
+
+The taxonomy schema versioning model is documented in parallel at
+[`docs/taxonomy-validation.md` "Taxonomy Schema Versioning"](taxonomy-validation.md#-taxonomy-schema-versioning).
+The two schemas (taxonomy + outputs) version independently — a
+taxonomy bump does not require an outputs config bump and vice
+versa.
+
+### When the maintainer adds `version: 2`
+
+The schema-bump workflow for the outputs config is:
+
+1. Replace the hardcoded equality check in `outputconfig.Load`
+   with a migration switch (`switch version { case 1: ...; case
+   2: ...; default: reject }`).
+2. Update the YAML examples under `outputconfig/testdata/` and
+   `examples/*/outputs.yaml` to use the new version where
+   appropriate (keeping at least one `version: 1` example to
+   lock the migration path).
+3. Add a regression BDD scenario that loads a `version: 1`
+   outputs config and asserts the in-memory `Loaded` shape
+   matches a hand-written `version: 2` equivalent.
+4. Update this section with the new version literal and the
+   shape change.
 
 ## ⚙️ Auditor Configuration
 

--- a/docs/taxonomy-validation.md
+++ b/docs/taxonomy-validation.md
@@ -93,10 +93,113 @@ events:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `version` | Yes | Must be `1`. Schema version for future migration. |
+| `version` | Yes | Must be `1`. Schema version for future migration. See [Taxonomy Schema Versioning](#-taxonomy-schema-versioning) below. |
 | `categories` | Yes | Map of category name to event list or struct. |
 | `events` | Yes | Map of event type name to event definition. |
 | `sensitivity` | No | Sensitivity label configuration for field classification. |
+
+## 🔄 Taxonomy Schema Versioning
+
+The taxonomy YAML carries a top-level `version:` field so the
+library can recognise the shape of the document and apply
+migrations when a future schema change lands.
+
+### What `version: 1` means today
+
+`version: 1` is the only currently-defined schema version. Every
+taxonomy MUST set `version: 1` explicitly:
+
+```yaml
+version: 1
+categories:
+  ...
+events:
+  ...
+```
+
+A missing or zero `version:` is rejected at parse time with:
+
+```
+audit: taxonomy validation failed: taxonomy version is required: set version to 1
+```
+
+A `version:` value the library does not recognise is rejected
+with one of the two messages below, depending on whether the
+value is from the future or from a no-longer-supported past:
+
+```
+audit: taxonomy validation failed: taxonomy version 2 is not supported by this library version (max: 1), upgrade the library
+audit: taxonomy validation failed: taxonomy version 0 is no longer supported, minimum supported is 1
+```
+
+All three errors wrap the [`audit.ErrTaxonomyInvalid`](https://pkg.go.dev/github.com/axonops/audit#ErrTaxonomyInvalid)
+sentinel; consumers can match with `errors.Is(err, audit.ErrTaxonomyInvalid)`
+without coupling to the message text.
+
+The parse path lives in [`audit.MigrateTaxonomy`](https://pkg.go.dev/github.com/axonops/audit#MigrateTaxonomy),
+auto-invoked by [`audit.ParseTaxonomyYAML`](https://pkg.go.dev/github.com/axonops/audit#ParseTaxonomyYAML).
+
+### Schema version is independent of library release version
+
+The schema version (`version: 1` in YAML) is **not** the library
+release version (e.g., v1.0.0, v1.5.0, v2.0.0). They evolve
+independently:
+
+- A v1.5 library MAY still use schema `version: 1` — operators
+  upgrading the library do NOT need to touch their YAML.
+- The schema version bumps only when the YAML shape itself
+  changes in a way that older libraries cannot interpret (new
+  required field, removed field, or restructured nesting). This
+  is a maintainer-side decision; consumers do not need to touch
+  the version field on routine library upgrades.
+- A library release version bumps for any release reason — bug
+  fix, new feature, performance improvement — even when the
+  schema is unchanged.
+
+For the lifetime of v1.x of the library, `version: 1` will remain
+accepted. Schema-breaking changes are themselves library-major
+events: a `version: 2` schema would land in v2.x of the library
+(or earlier, with `version: 1` still accepted alongside it).
+
+### Future migration contract
+
+When `version: 2` is introduced, the library will:
+
+1. Accept both `version: 1` and `version: 2` configs side-by-side
+   for at least one tagged library release; the deprecation
+   timeline for `version: 1` will be announced via the
+   `CHANGELOG.md` `### Deprecated` section.
+2. Silently upgrade `version: 1` configs to the new internal
+   shape — operators do not need to rewrite their YAML.
+3. Reject `version: N+1` from a library that only knows up to
+   `N`, with a clear "upgrade the library" error (the message
+   above).
+4. Reject `version: K-M` once support for `K-M` is dropped, with
+   a clear "no longer supported, minimum supported is N" error
+   that names the lowest still-accepted version.
+
+Migrations land inline inside `MigrateTaxonomy` — the function
+already has the structure (version check, future migration
+hook). There is no public `RegisterMigration` API today, by
+design: migrations are library-implementation detail, not a
+consumer extension point.
+
+### When the maintainer adds `version: 2`
+
+The schema-bump workflow is:
+
+1. Bump `currentTaxonomyVersion` in `migrate.go` and add a
+   migration step (`if t.Version == 1 { ... }`) that
+   transforms the old shape into the new one.
+2. Update the YAML examples under `examples/`,
+   `tests/bdd/features/`, and `outputconfig/testdata/` to use the
+   new version where appropriate (keeping at least one
+   `version: 1` example to lock the migration path).
+3. Add a regression BDD scenario that loads a `version: 1`
+   document, runs migration, and asserts the in-memory shape
+   matches a hand-written `version: 2` equivalent.
+4. Update this section with the new version literal and the
+   shape change.
 
 ## 📂 Categories
 


### PR DESCRIPTION
## Summary

Closes #544 / Walkthrough decision #24.

Adds a "Schema Versioning" section to both `docs/output-configuration.md` ("Config Schema Versioning") and `docs/taxonomy-validation.md` ("Taxonomy Schema Versioning"). Locks down the meaning of `version: 1`, the schema-version-vs-library-release-version independence, the future migration contract, and the maintainer workflow when `version: 2` lands.

## ACs

- [x] Both docs have the new section with parallel structure.
- [x] "Schema-version vs library-version" independence paragraph in both, with the v1.5-library-accepting-version-1 concrete example.
- [x] `migrate.go` godoc verified accurate per the documented model — no edit needed.

## Agent gates addressed

**docs-writer pre-commit** — 2 BLOCKERS + 2 IMPORTANT — all addressed before push:

- BLOCKER: Taxonomy doc had wrong error prefix (`audit: taxonomy invalid:` vs actual `audit: taxonomy validation failed:`). Verified against `errors.go:107`.
- BLOCKER: outputconfig doc was missing the full nested wrap (`audit/outputconfig: ... : audit: config invalid: ...`).
- IMPORTANT: `SHOULD bump` implied a consumer obligation — reworded to declarative + explicit maintainer-side note.
- IMPORTANT: `at least one minor version` was undefined in v0.x — replaced with "at least one tagged release" + pointer at CHANGELOG Deprecated section.

## Test plan
- [x] `make check` clean
- [ ] CI green