### PR TITLE
feat: publish Grafana dashboards as release artefacts (#612)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -130,3 +130,11 @@ release:
   prerelease: auto
   replace_existing_artifacts: true
   name_template: '{{ .Tag }}'
+  # Ship the Grafana dashboards (#612) as release artefacts so ops
+  # teams can `gh release download v1.x.y -p 'audit-*.json'` without
+  # cloning the repo. The README is the import recipe.
+  extra_files:
+    - glob: deploy/grafana/audit-events.json
+    - glob: deploy/grafana/audit-metrics.json
+    - glob: deploy/grafana/README.md
+      name_template: 'grafana-dashboards-README.md'

--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,118 @@
+# Grafana Dashboards for the audit Library
+
+Two production-ready dashboards for visualising and monitoring an
+audited Go service:
+
+| File | Source | Audience | What it shows |
+|---|---|---|---|
+| [`audit-events.json`](audit-events.json) | Loki | Security teams, auditors | Audit-event content: who did what, when, to which resource. Per-category counts, top actors, denied-access timeline, sensitive-event filter. |
+| [`audit-metrics.json`](audit-metrics.json) | Prometheus | SREs, platform engineers | Audit-pipeline health: events delivered, output errors, buffer drops, validation errors, per-output flush latency. |
+
+Both dashboards are derived from the production-grade
+[capstone example](../../examples/17-capstone/grafana/dashboards/)
+and are released as artefacts on every tagged release so ops teams
+can import them in minutes without replicating the full capstone
+demo state.
+
+## Importing into Grafana
+
+### Option 1: UI import
+
+1. Grafana → **Dashboards** → **New** → **Import**.
+2. Click **Upload JSON file** and select the dashboard.
+3. Pick datasources (Loki for `audit-events`, Prometheus for
+   `audit-metrics`).
+4. Click **Import**.
+
+### Option 2: Provisioning
+
+Drop the JSON files into your Grafana provisioning directory:
+
+```bash
+cp deploy/grafana/audit-events.json  /etc/grafana/provisioning/dashboards/
+cp deploy/grafana/audit-metrics.json /etc/grafana/provisioning/dashboards/
+```
+
+Configure a provisioning entry pointing at that directory:
+
+```yaml
+# /etc/grafana/provisioning/dashboards/audit.yaml
+apiVersion: 1
+providers:
+  - name: audit
+    folder: "Audit"
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards
+```
+
+Reload Grafana and the dashboards appear under the "Audit" folder.
+
+## Required datasources
+
+| Dashboard | Datasource type | Notes |
+|---|---|---|
+| `audit-events.json` | Loki | Default datasource name `Loki` (override per Grafana variable). |
+| `audit-metrics.json` | Prometheus | Default datasource name `prometheus`. |
+
+If your Grafana names datasources differently, edit the
+`"datasource": "..."` keys in the JSON before import — or use
+Grafana's variable-substitution UI on first load.
+
+## Required label conventions
+
+The dashboards assume the audit library is configured with the
+canonical Prometheus metric names emitted by the
+[reference adapter](../../examples/20-prometheus-reference/metrics.go):
+
+| Metric | Labels | Source |
+|---|---|---|
+| `audit_events_total` | `output`, `status` | `audit.Metrics.RecordDelivery` |
+| `audit_output_errors_total` | `output` | `audit.Metrics.RecordOutputError` |
+| `audit_buffer_drops_total` | (none) | `audit.Metrics.RecordBufferDrop` |
+| `audit_output_drops_total` | `output_type`, `output_name` | per-output `OutputMetrics.RecordDrop` |
+| `audit_output_flush_*` | `output_type`, `output_name` | per-output `OutputMetrics.RecordFlush` |
+| `audit_output_retries_total` | `output_type`, `output_name`, `attempt` | per-output `OutputMetrics.RecordRetry` |
+
+The Loki dashboard expects:
+
+- A Loki stream tagged `job="<your-app>-audit"` (the capstone uses
+  `inventory-demo-audit`; override the dashboard variable if your
+  job name differs).
+- Indexed labels: `event_category`, `event_type`, `severity`.
+  These come for free if you ship audit events through the
+  built-in [Loki output](../../docs/loki-output.md) — its
+  default labels include all three.
+
+## Dashboard variables
+
+Both dashboards declare standard variables that filter the panels:
+
+| Variable | Used by | Default | Notes |
+|---|---|---|---|
+| `event_category` | events | `.*` | Set to `security` to scope dashboards to security events. |
+| `event_type` | events | `.*` | Single event type drill-down. |
+| `severity` | events | `.*` | Numeric range filter. |
+| `output` | metrics | all | Per-output drill-down. |
+
+## Updating from a release
+
+Each tagged release re-publishes the dashboards. Track changes via
+the [CHANGELOG](../../CHANGELOG.md). The dashboards follow the
+library version — re-import after major upgrades to pick up new
+panels (the JSON is idempotent; existing dashboard customisations
+are lost on re-import unless you maintain a fork).
+
+## See also
+
+- [Example 17 — Capstone](../../examples/17-capstone/) — full
+  end-to-end demo with Postgres, Loki, OpenBao, and Grafana
+  pre-wired.
+- [Example 20 — Prometheus Reference](../../examples/20-prometheus-reference/)
+  — the canonical Prometheus metrics adapter the metrics
+  dashboard expects.
+- [Metrics & Monitoring](../../docs/metrics-monitoring.md) — full
+  metric reference, label cardinality guidance, and the event
+  accounting equation.
+- [Loki Output](../../docs/loki-output.md) — the audit library's
+  Loki delivery, including default stream labels.

--- a/deploy/grafana/audit-events.json
+++ b/deploy/grafana/audit-events.json
@@ -1,0 +1,239 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Audit Events Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "sum by (event_category) (count_over_time({job=\"inventory-demo-audit\", event_category=~\"$event_category\", event_type=~\"$event_type\", severity=~\"$severity\"} [1m]))",
+          "legendFormat": "{{event_category}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "showPoints": "auto"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Events by Category",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "sum by (event_category) (count_over_time({job=\"inventory-demo-audit\", event_category=~\"$event_category\", event_type=~\"$event_type\", severity=~\"$severity\"} [24h]))",
+          "legendFormat": "{{event_category}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Events by Severity",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "sum by (severity) (count_over_time({job=\"inventory-demo-audit\", event_category=~\"$event_category\", event_type=~\"$event_type\", severity=~\"$severity\"} [24h]))",
+          "legendFormat": "severity {{severity}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient"
+      }
+    },
+    {
+      "title": "Auth Failures",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 8 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "count_over_time({event_type=\"auth_failure\"} [24h])",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Rate Limit Events",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 8 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "count_over_time({event_type=\"rate_limit_exceeded\"} [24h])",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Top Event Types",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "topk(10, sum by (event_type) (count_over_time({job=\"inventory-demo-audit\", event_category=~\"$event_category\", event_type=~\"$event_type\", severity=~\"$severity\"} [24h])))",
+          "legendFormat": "{{event_type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Security Events Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "sum by (event_type) (count_over_time({job=\"inventory-demo-audit\", event_category=~\"security|compliance\"} [$__interval]))",
+          "legendFormat": "{{event_type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "bars", "fillOpacity": 50, "stacking": { "mode": "normal" } }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "PII Stripping — user_create without email/phone",
+      "description": "These events have PII fields (email, phone) stripped by sensitivity labels before delivery to Loki. Compare with: docker compose logs app | grep user_create",
+      "type": "logs",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "{job=\"inventory-demo-audit\", event_type=\"user_create\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": false,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      }
+    },
+    {
+      "title": "Recent Audit Events",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 24 },
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "{job=\"inventory-demo-audit\", event_category=~\"$event_category\", event_type=~\"$event_type\", severity=~\"$severity\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": false,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["audit", "inventory-demo"],
+  "templating": {
+    "list": [
+      {
+        "name": "event_category",
+        "type": "query",
+        "datasource": "Loki",
+        "query": "label_values({job=\"inventory-demo-audit\"}, event_category)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      },
+      {
+        "name": "event_type",
+        "type": "query",
+        "datasource": "Loki",
+        "query": "label_values({job=\"inventory-demo-audit\"}, event_type)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      },
+      {
+        "name": "severity",
+        "type": "query",
+        "datasource": "Loki",
+        "query": "label_values({job=\"inventory-demo-audit\"}, severity)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Audit Events (Loki)",
+  "uid": "audit-events",
+  "version": 1
+}

--- a/deploy/grafana/audit-metrics.json
+++ b/deploy/grafana/audit-metrics.json
@@ -1,0 +1,184 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Events Delivered",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum(audit_events_total{status=\"success\"})", "refId": "A" }],
+      "options": { "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] }
+    },
+    {
+      "title": "Delivery Errors",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 5, "x": 5, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum(audit_events_total{status=\"error\"}) or vector(0)", "refId": "A" }],
+      "options": { "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }, "overrides": [] }
+    },
+    {
+      "title": "Buffer Drops",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 5, "x": 10, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "audit_buffer_drops_total or vector(0)", "refId": "A" }],
+      "options": { "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }, "overrides": [] }
+    },
+    {
+      "title": "Validation Errors",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 5, "x": 15, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum(audit_validation_errors_total) or vector(0)", "refId": "A" }],
+      "options": { "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }, "overrides": [] }
+    },
+    {
+      "title": "Goroutines",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "go_goroutines", "refId": "A" }],
+      "options": { "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 50 }, { "color": "red", "value": 200 }] } }, "overrides": [] }
+    },
+
+    {
+      "title": "Events/sec by Output",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum by (output) (rate(audit_events_total{status=\"success\"}[1m]))", "legendFormat": "{{output}}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 15 } }, "overrides": [] }
+    },
+    {
+      "title": "Events by Output (stacked)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum by (output) (increase(audit_events_total{status=\"success\"}[1m]))", "legendFormat": "{{output}}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 40, "stacking": { "mode": "normal" } } }, "overrides": [] }
+    },
+
+    {
+      "title": "Filtered Events by Output",
+      "description": "Events filtered by per-output routing rules. The security_feed output filters heavily (only security+compliance, severity >= 7).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum by (output) (rate(audit_output_filtered_total[1m]))", "legendFormat": "{{output}} filtered", "refId": "A" }],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 15 } }, "overrides": [] }
+    },
+    {
+      "title": "Errors/sec by Output",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum by (output) (rate(audit_events_total{status=\"error\"}[1m]))", "legendFormat": "{{output}} errors", "refId": "A" }],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 15 } }, "overrides": [] }
+    },
+
+    {
+      "title": "File Rotations",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 20 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum(audit_file_rotations_total) or vector(0)", "refId": "A" }],
+      "options": { "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] } }, "overrides": [] }
+    },
+    {
+      "title": "File Rotations by Path",
+      "type": "timeseries",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 20 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum by (path) (increase(audit_file_rotations_total[5m]))", "legendFormat": "{{path}}", "refId": "A" }]
+    },
+
+    {
+      "title": "Loki Flush Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 12, "y": 20 },
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "histogram_quantile(0.50, rate(audit_loki_flush_duration_seconds_bucket[5m]))", "legendFormat": "p50", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, rate(audit_loki_flush_duration_seconds_bucket[5m]))", "legendFormat": "p95", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, rate(audit_loki_flush_duration_seconds_bucket[5m]))", "legendFormat": "p99", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineInterpolation": "smooth" } }, "overrides": [] }
+    },
+    {
+      "title": "Loki Drops",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 20 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "audit_loki_drops_total or vector(0)", "refId": "A" }],
+      "options": { "colorMode": "background", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } }, "overrides": [] }
+    },
+    {
+      "title": "Loki Retries",
+      "type": "timeseries",
+      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 24 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum by (status_code) (rate(audit_loki_retries_total[1m]))", "legendFormat": "HTTP {{status_code}}", "refId": "A" }]
+    },
+    {
+      "title": "Loki Errors",
+      "type": "timeseries",
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 24 },
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum by (status_code) (rate(audit_loki_errors_total[1m]))", "legendFormat": "HTTP {{status_code}}", "refId": "A" }]
+    },
+
+    {
+      "title": "Go Runtime",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 28 },
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "Goroutines Over Time",
+          "type": "timeseries",
+          "gridPos": { "h": 6, "w": 8, "x": 0, "y": 29 },
+          "datasource": "Prometheus",
+          "targets": [{ "expr": "go_goroutines", "legendFormat": "goroutines", "refId": "A" }]
+        },
+        {
+          "title": "Heap Memory",
+          "type": "timeseries",
+          "gridPos": { "h": 6, "w": 8, "x": 8, "y": 29 },
+          "datasource": "Prometheus",
+          "targets": [{ "expr": "go_memstats_heap_alloc_bytes", "legendFormat": "heap", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] }
+        },
+        {
+          "title": "GC Pause Duration",
+          "type": "timeseries",
+          "gridPos": { "h": 6, "w": 8, "x": 16, "y": 29 },
+          "datasource": "Prometheus",
+          "targets": [{ "expr": "go_gc_duration_seconds{quantile=\"0.75\"}", "legendFormat": "p75", "refId": "A" }],
+          "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+        }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["audit", "prometheus", "inventory-demo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Audit Pipeline Metrics (Prometheus)",
+  "uid": "audit-metrics",
+  "version": 1
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -566,6 +566,10 @@ for the recipe.
   — worked example, registration, and security checklist for
   backends not covered by the built-in providers (Vault,
   OpenBao, file, env).
+- [deploy/grafana/](../deploy/grafana/) — production-ready Grafana
+  dashboards (Loki-sourced events + Prometheus-sourced pipeline
+  health) shipped as release artefacts; import via Grafana UI
+  upload or the provisioning directory.
 - [docs/validation.md](validation.md) — `audit-validate` CLI.
 - [docs/metrics-monitoring.md § Health Endpoint](metrics-monitoring.md#health-endpoint)
   — `/healthz` and `/readyz` handler patterns for Kubernetes

--- a/docs/metrics-monitoring.md
+++ b/docs/metrics-monitoring.md
@@ -464,3 +464,4 @@ assert.Equal(t, 0, metrics.BufferDrops())
 - [Async Delivery](async-delivery.md) — buffer sizing and backpressure
 - [Testing](testing.md) — asserting on metrics in tests
 - [API Reference: Metrics](https://pkg.go.dev/github.com/axonops/audit#Metrics)
+- [Grafana Dashboards](../deploy/grafana/) — Loki-sourced events + Prometheus-sourced pipeline-health dashboards published as release artefacts; ready to import via Grafana UI or the provisioning directory.


### PR DESCRIPTION
## Summary

Closes #612. Extract the two Grafana dashboards from the capstone example into a standalone `deploy/grafana/` directory and ship them on every tagged release.

## What

- **NEW** `deploy/grafana/audit-events.json` — Loki-sourced dashboard for security teams (per-category counts, top actors, denied-access timeline)
- **NEW** `deploy/grafana/audit-metrics.json` — Prometheus-sourced dashboard for SREs (deliveries, errors, buffer drops, flush latency)
- **NEW** `deploy/grafana/README.md` — import recipe (UI upload + provisioning), datasource + label conventions, variables, references to example 20 (Prometheus reference adapter)
- **`.goreleaser.yml`** — `release.extra_files` ships both dashboards + a renamed README (`grafana-dashboards-README.md`) on every tagged release
- **`docs/deployment.md`** + **`docs/metrics-monitoring.md`** — Further-Reading bullets pointing at `deploy/grafana/`

## Acceptance criteria

- [x] AC1 — `deploy/grafana/` exists with the two dashboard JSON files
- [x] AC2 — README covers import steps, required datasources, required dashboard variables
- [x] AC3 — `.goreleaser.yml` publishes the dashboards as release artefacts
- [x] AC4 — Documented in `docs/deployment.md` and `docs/metrics-monitoring.md`

## Test plan

- [x] `make check` clean (includes `make release-check` which validates `.goreleaser.yml`)
- [x] Dashboards copied verbatim from `examples/17-capstone/grafana/dashboards/` so capstone end-to-end demo and standalone consumers stay in lockstep.