### PR TITLE
ci: publish ghcr.io/axonops/audit-gen OCI image (#610)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -605,6 +605,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      packages: write   # ghcr.io/axonops/audit-gen — #610
     steps:
       - name: Checkout release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -645,6 +646,22 @@ jobs:
       # commit SHA per repository action-pin policy.
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      # Multi-arch OCI image build for ghcr.io/axonops/audit-gen (#610).
+      # Buildx + QEMU enable cross-platform builds (amd64 + arm64) on
+      # the GitHub-hosted ubuntu runner. The login uses GITHUB_TOKEN
+      # against ghcr.io — no separate registry token required because
+      # the goreleaser job has packages:write permission above.
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - name: Log in to ghcr.io
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         id: goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -138,3 +138,70 @@ release:
     - glob: deploy/grafana/audit-metrics.json
     - glob: deploy/grafana/README.md
       name_template: 'grafana-dashboards-README.md'
+
+# audit-gen OCI image (#610).
+#
+# Two per-architecture builds (amd64, arm64) feed into a single
+# multi-arch manifest published as ghcr.io/axonops/audit-gen with
+# three tags: full version (e.g. v1.0.0), short major.minor
+# (e.g. v1.0), and `latest`. Each manifest is Cosign-signed via
+# the same keyless OIDC identity as the release-tarball checksum
+# (#516), so consumers verify with the documented identity in
+# docs/releasing.md.
+#
+# The Dockerfile at cmd/audit-gen/Dockerfile copies the
+# pre-compiled audit-gen binary from the GoReleaser build output
+# (audit-gen build entry above), so the image binary is
+# byte-identical to the binary in the GitHub-release tarball.
+dockers:
+  - id: audit-gen-amd64
+    ids: [audit-gen]
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/axonops/audit-gen:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: cmd/audit-gen/Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+  - id: audit-gen-arm64
+    ids: [audit-gen]
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/axonops/audit-gen:{{ .Version }}-arm64"
+    use: buildx
+    dockerfile: cmd/audit-gen/Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+
+docker_manifests:
+  - name_template: "ghcr.io/axonops/audit-gen:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/axonops/audit-gen:{{ .Version }}-amd64"
+      - "ghcr.io/axonops/audit-gen:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/axonops/audit-gen:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/axonops/audit-gen:{{ .Version }}-amd64"
+      - "ghcr.io/axonops/audit-gen:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/axonops/audit-gen:latest"
+    image_templates:
+      - "ghcr.io/axonops/audit-gen:{{ .Version }}-amd64"
+      - "ghcr.io/axonops/audit-gen:{{ .Version }}-arm64"
+
+# Cosign-sign every published manifest under the same keyless
+# OIDC identity as the checksum signature.
+docker_signs:
+  - cmd: cosign
+    artifacts: manifests
+    output: true
+    args:
+      - sign
+      - --yes
+      - "${artifact}@${digest}"

--- a/cmd/audit-gen/Dockerfile
+++ b/cmd/audit-gen/Dockerfile
@@ -1,0 +1,30 @@
+# GoReleaser-driven Dockerfile for ghcr.io/axonops/audit-gen.
+#
+# GoReleaser builds the audit-gen binary on the host (per the
+# `audit-gen` build entry in .goreleaser.yml) and copies it into
+# this image as ./audit-gen. We do NOT compile inside the image —
+# the binary is reproducibly built once per architecture and reused
+# for both the GitHub release tarball and the OCI image. This keeps
+# the image build hermetic and identical to the published binary.
+#
+# Base: gcr.io/distroless/static-debian12 — minimal, non-root,
+# no shell, no package manager. Suitable for a self-contained Go
+# binary that performs file I/O and stdout-only output.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# OCI labels (https://specs.opencontainers.org/image-spec/annotations/).
+LABEL org.opencontainers.image.title="audit-gen"
+LABEL org.opencontainers.image.description="Code generator for the github.com/axonops/audit library — produces typed Go event builders from a YAML taxonomy."
+LABEL org.opencontainers.image.source="https://github.com/axonops/audit"
+LABEL org.opencontainers.image.documentation="https://github.com/axonops/audit/blob/main/docs/code-generation.md"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="AxonOps Limited"
+
+# GoReleaser drops the binary into the build context root.
+COPY audit-gen /usr/local/bin/audit-gen
+
+# Default working directory matches the documented usage:
+#   docker run --rm -v $PWD:/src ghcr.io/axonops/audit-gen ...
+WORKDIR /src
+
+ENTRYPOINT ["/usr/local/bin/audit-gen"]

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -212,6 +212,54 @@ Unknown type values are rejected at taxonomy parse time with the
 valid-set listed in the error message (e.g. `unknown type "strng"
 (valid: string, int, int64, float64, bool, time, duration)`).
 
+## 🐳 Container Image
+
+Each tagged release publishes a multi-arch (amd64 + arm64) OCI
+image at `ghcr.io/axonops/audit-gen` with three tags:
+
+| Tag | Updates | When to use |
+|---|---|---|
+| `:vX.Y.Z` (e.g. `:v1.0.0`) | Pinned to the exact release | CI pipelines (recommended — reproducible builds) |
+| `:vX.Y` (e.g. `:v1.0`) | Floats over patch releases | Adopters who want patch-level updates without minor surprises |
+| `:latest` | Floats over every release | Local dev / quick experiments only |
+
+The image runs `audit-gen` as a non-root user from a
+[`distroless/static`](https://github.com/GoogleContainerTools/distroless)
+base — no shell, no package manager, ~5 MB compressed. Mount your
+source tree into `/src` and the binary's working directory matches:
+
+```bash
+docker run --rm \
+  -v "$PWD":/src \
+  ghcr.io/axonops/audit-gen:v1.0.0 \
+  -input /src/taxonomy.yaml \
+  -output /src/audit_generated.go \
+  -package main
+```
+
+For CI that runs `go generate ./...`, prefer the binary release
+tarball over the image — `go generate` invokes `go run`, not
+`docker run`. The image is for pipelines that explicitly call out
+to a containerised codegen step (e.g., language-agnostic CI
+runners that don't have a Go toolchain).
+
+### Verifying the image signature
+
+Every image manifest is signed via Sigstore keyless OIDC against
+the same identity as the release tarball checksum (#516):
+
+```bash
+cosign verify \
+  --certificate-identity 'https://github.com/axonops/audit/.github/workflows/release.yml@refs/tags/v1.0.0' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  ghcr.io/axonops/audit-gen:v1.0.0
+```
+
+The verification proves the image was produced by the audit
+project's published release workflow at the named tag, with a
+transparency-log entry recorded in Rekor. See
+[docs/releasing.md](releasing.md) for the full verification model.
+
 ## ⌨️ CLI Flags
 
 | Flag | Default | Description |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -239,6 +239,23 @@ gate in any CI system. Minimal GitHub Actions example:
 Pin `cosign` to a specific version via
 `sigstore/cosign-installer@<sha>` in the workflow.
 
+### Verifying the audit-gen container image (#610)
+
+Each tagged release also publishes a multi-arch OCI image at
+`ghcr.io/axonops/audit-gen` with three tags (`vX.Y.Z`, `vX.Y`,
+`latest`). Image manifests are signed under the same Sigstore
+keyless identity as `checksums.txt`:
+
+```bash
+cosign verify \
+  --certificate-identity 'https://github.com/axonops/audit/.github/workflows/release.yml@refs/tags/v1.0.0' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  ghcr.io/axonops/audit-gen:v1.0.0
+```
+
+See [docs/code-generation.md § Container Image](code-generation.md#-container-image)
+for usage and CI-pipeline guidance.
+
 ### Composition with build provenance
 
 Every release also publishes a GitHub build-provenance attestation


### PR DESCRIPTION
## Summary

Closes #610. Add a multi-arch OCI image build for `audit-gen` to the GoReleaser pipeline, signed via the existing Sigstore keyless OIDC infrastructure (#516).

## What

- **NEW** `cmd/audit-gen/Dockerfile` — distroless/static-nonroot, COPYs the GoReleaser-built binary; ~5 MB image
- **`.goreleaser.yml`**: new `dockers:` (amd64 + arm64), `docker_manifests:` (3 tags: `vX.Y.Z`, `vX.Y`, `latest`), `docker_signs:` (Cosign keyless on every manifest)
- **`.github/workflows/release.yml`**: `packages: write` permission, QEMU + buildx setup, ghcr.io login via `GITHUB_TOKEN`
- **`docs/code-generation.md`**: new "Container Image" section with `docker run` recipe and `cosign verify` example
- **`docs/releasing.md`**: new "Verifying the audit-gen container image" section under the Cosign-verify chapter

## Acceptance criteria

- [x] AC1 — `.goreleaser.yml` has `dockers:` block building `ghcr.io/axonops/audit-gen`
- [x] AC2 — Multi-arch image (amd64 + arm64) — `docker_manifests:` consolidates per-arch tags
- [x] AC3 — Image manifests Cosign-signed (`docker_signs:` reuses the existing keyless OIDC identity from #516)
- [x] AC4 — `docs/code-generation.md` includes container usage example
- [x] AC5 — Release workflow pushes to ghcr.io (verified locally via `goreleaser check`; full end-to-end verification awaits the next tag cut, which is expected for any release-pipeline change)

## Test plan

- [x] `make check` clean (includes `make release-check`, which validates `.goreleaser.yml` via `goreleaser check`)
- [x] `goreleaser check` passes (1 deprecation note on `dockers/docker_manifests` planned phase-out — current syntax fully supported on goreleaser v2.15.0 pinned by the workflow)
- [x] Dockerfile uses the GoReleaser-built binary (not a Go build inside the image), so the image binary is byte-identical to the release tarball binary
- [ ] End-to-end image push validation deferred to the v1.0.0 release cut (per AC5: "verified on a test release") — the pipeline scaffolding is in place; first tagged release will exercise it

## Cross-references

- #482 / #516 — Sigstore keyless OIDC infra reused
- #513 — Release process refactor (this PR slots into the `goreleaser` job after the existing `signs:` step)