### PR TITLE
refactor: convert white-box test packages to black-box (#555)

### DIFF
--- a/outputconfig/envsubst_test.go
+++ b/outputconfig/envsubst_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package outputconfig
+package outputconfig_test
 
 import (
 	"testing"
@@ -20,6 +20,8 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit/outputconfig"
 )
 
 func parseToMap(t *testing.T, s string) map[string]any {
@@ -33,7 +35,7 @@ func TestExpandEnv_Simple(t *testing.T) {
 	t.Setenv("TEST_HOST", "syslog.example.com")
 	m := parseToMap(t, "address: ${TEST_HOST}:514\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 	assert.Equal(t, "syslog.example.com:514", m["address"])
 }
@@ -42,7 +44,7 @@ func TestExpandEnv_WithDefault(t *testing.T) {
 	t.Setenv("TEST_PORT", "6514")
 	m := parseToMap(t, "port: ${TEST_PORT:-514}\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 	assert.Equal(t, "6514", m["port"])
 }
@@ -50,7 +52,7 @@ func TestExpandEnv_WithDefault(t *testing.T) {
 func TestExpandEnv_UnsetWithDefault_UsesDefault(t *testing.T) {
 	m := parseToMap(t, "port: ${UNSET_PORT_VAR:-514}\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 	assert.Equal(t, "514", m["port"])
 }
@@ -58,7 +60,7 @@ func TestExpandEnv_UnsetWithDefault_UsesDefault(t *testing.T) {
 func TestExpandEnv_UnsetNoDefault_Error(t *testing.T) {
 	m := parseToMap(t, "host: ${UNSET_HOST_NO_DEFAULT}\n")
 
-	_, err := expandEnvInValue(m, "config")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "config")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UNSET_HOST_NO_DEFAULT")
 	assert.Contains(t, err.Error(), "not set")
@@ -67,7 +69,7 @@ func TestExpandEnv_UnsetNoDefault_Error(t *testing.T) {
 func TestExpandEnv_EscapedDollar(t *testing.T) {
 	m := parseToMap(t, "literal: $${NOT_A_VAR}\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 	assert.Equal(t, "${NOT_A_VAR}", m["literal"])
 }
@@ -76,7 +78,7 @@ func TestExpandEnv_NoRecursive(t *testing.T) {
 	t.Setenv("TEST_INNER", "${SHOULD_NOT_EXPAND}")
 	m := parseToMap(t, "value: ${TEST_INNER}\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 	assert.Equal(t, "${SHOULD_NOT_EXPAND}", m["value"])
 }
@@ -85,7 +87,7 @@ func TestExpandEnv_OnlyStringValues_NotKeys(t *testing.T) {
 	t.Setenv("TEST_KEY_VAR", "injected")
 	m := parseToMap(t, "${TEST_KEY_VAR}: some_value\naddress: ${TEST_KEY_VAR}\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 
 	// Key remains literal (map keys are not expanded).
@@ -99,7 +101,7 @@ func TestExpandEnv_NestedYAML(t *testing.T) {
 	t.Setenv("TEST_NESTED_HOST", "deep.example.com")
 	m := parseToMap(t, "output:\n  syslog:\n    address: ${TEST_NESTED_HOST}:514\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 
 	output, ok := m["output"].(map[string]any)
@@ -112,7 +114,7 @@ func TestExpandEnv_NestedYAML(t *testing.T) {
 func TestExpandEnv_EmptyString(t *testing.T) {
 	m := parseToMap(t, "value: \"\"\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 	assert.Equal(t, "", m["value"])
 }
@@ -122,7 +124,7 @@ func TestExpandEnv_MultipleVarsInOneValue(t *testing.T) {
 	t.Setenv("TEST_ADDR", "syslog.local")
 	m := parseToMap(t, "url: ${TEST_PROTO}://${TEST_ADDR}:514\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 	assert.Equal(t, "tcp+tls://syslog.local:514", m["url"])
 }
@@ -131,7 +133,7 @@ func TestExpandEnv_EmptyDefault(t *testing.T) {
 	// ${VAR:-} with variable unset should produce empty string (not error).
 	m := parseToMap(t, "value: ${UNSET_EMPTY_DEFAULT_VAR:-}\n")
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 	assert.Equal(t, "", m["value"])
 }
@@ -139,7 +141,7 @@ func TestExpandEnv_EmptyDefault(t *testing.T) {
 func TestExpandEnv_UnclosedBrace_Error(t *testing.T) {
 	m := parseToMap(t, "bad: ${UNCLOSED\n")
 
-	_, err := expandEnvInValue(m, "test")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "test")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unclosed")
 }
@@ -152,7 +154,7 @@ func TestExpandEnv_YAMLAnchorAlias(t *testing.T) {
 	yamlDoc := "defaults: &defaults\n  host: ${TEST_ALIAS_HOST}\noutput:\n  <<: *defaults\n  port: 514\n"
 	m := parseToMap(t, yamlDoc)
 
-	_, err := expandEnvInValue(m, "")
+	_, err := outputconfig.ExpandEnvInValueForTest(m, "")
 	require.NoError(t, err)
 
 	// The anchor's value should be expanded.

--- a/outputconfig/export_test.go
+++ b/outputconfig/export_test.go
@@ -40,6 +40,20 @@ var DeepCopyValueForTest = deepCopyValue
 // while allowing the fuzz harness to run from the _test package.
 var ExpandEnvStringForTest = expandEnvString
 
+// ExpandEnvInValueForTest exposes expandEnvInValue for envsubst_test.go
+// (#555 black-box test conversion). The function recursively walks
+// a parsed YAML value and substitutes ${VAR} / ${VAR:-default}.
+var ExpandEnvInValueForTest = expandEnvInValue
+
+// BuildFormatterForTest exposes buildFormatter for formatter_test.go
+// (#555 black-box test conversion). Production callers reach the
+// same code path via outputconfig.Load.
+var BuildFormatterForTest = buildFormatter
+
+// ExtractFormatterTypeForTest exposes extractFormatterType for
+// formatter_test.go (#555 black-box test conversion).
+var ExtractFormatterTypeForTest = extractFormatterType
+
 // NewResolverForTest exposes newResolver for tests that need to drive
 // the resolver directly — used by [TestClearCaches_EmptiesBothMaps]
 // to verify clearCaches() empties both maps (#479).

--- a/outputconfig/formatter_test.go
+++ b/outputconfig/formatter_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package outputconfig
+package outputconfig_test
 
 import (
 	"testing"
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/axonops/audit"
+	"github.com/axonops/audit/outputconfig"
 )
 
 // parseFormatterValue parses a YAML string into the value type that
@@ -34,20 +35,20 @@ func parseFormatterValue(t *testing.T, yamlStr string) any {
 }
 
 func TestBuildFormatter_Nil_ReturnsNil(t *testing.T) {
-	f, err := buildFormatter(nil)
+	f, err := outputconfig.BuildFormatterForTest(nil)
 	assert.NoError(t, err)
 	assert.Nil(t, f)
 }
 
 func TestBuildFormatter_EmptyString_ReturnsNil(t *testing.T) {
-	f, err := buildFormatter("")
+	f, err := outputconfig.BuildFormatterForTest("")
 	assert.NoError(t, err)
 	assert.Nil(t, f)
 }
 
 func TestBuildFormatter_JSON_Default(t *testing.T) {
 	v := parseFormatterValue(t, "type: json\n")
-	f, err := buildFormatter(v)
+	f, err := outputconfig.BuildFormatterForTest(v)
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
@@ -59,7 +60,7 @@ func TestBuildFormatter_JSON_Default(t *testing.T) {
 
 func TestBuildFormatter_JSON_EmptyType_DefaultsToJSON(t *testing.T) {
 	v := parseFormatterValue(t, "timestamp: unix_ms\n")
-	f, err := buildFormatter(v)
+	f, err := outputconfig.BuildFormatterForTest(v)
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
@@ -70,7 +71,7 @@ func TestBuildFormatter_JSON_EmptyType_DefaultsToJSON(t *testing.T) {
 
 func TestBuildFormatter_JSON_UnixMs(t *testing.T) {
 	v := parseFormatterValue(t, "type: json\ntimestamp: unix_ms\nomit_empty: true\n")
-	f, err := buildFormatter(v)
+	f, err := outputconfig.BuildFormatterForTest(v)
 	require.NoError(t, err)
 
 	jf, ok := f.(*audit.JSONFormatter)
@@ -81,7 +82,7 @@ func TestBuildFormatter_JSON_UnixMs(t *testing.T) {
 
 func TestBuildFormatter_JSON_InvalidTimestamp_Error(t *testing.T) {
 	v := parseFormatterValue(t, "type: json\ntimestamp: epoch_seconds\n")
-	_, err := buildFormatter(v)
+	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown timestamp format")
 	assert.Contains(t, err.Error(), "epoch_seconds")
@@ -89,7 +90,7 @@ func TestBuildFormatter_JSON_InvalidTimestamp_Error(t *testing.T) {
 
 func TestBuildFormatter_CEF_WithVendorProduct(t *testing.T) {
 	v := parseFormatterValue(t, "type: cef\nvendor: AxonOps\nproduct: SchemaRegistry\nversion: \"1.0\"\n")
-	f, err := buildFormatter(v)
+	f, err := outputconfig.BuildFormatterForTest(v)
 	require.NoError(t, err)
 
 	cf, ok := f.(*audit.CEFFormatter)
@@ -101,7 +102,7 @@ func TestBuildFormatter_CEF_WithVendorProduct(t *testing.T) {
 
 func TestBuildFormatter_CEF_OmitEmpty(t *testing.T) {
 	v := parseFormatterValue(t, "type: cef\nomit_empty: true\n")
-	f, err := buildFormatter(v)
+	f, err := outputconfig.BuildFormatterForTest(v)
 	require.NoError(t, err)
 
 	cf, ok := f.(*audit.CEFFormatter)
@@ -111,7 +112,7 @@ func TestBuildFormatter_CEF_OmitEmpty(t *testing.T) {
 
 func TestBuildFormatter_CEF_NoSeverityFunc(t *testing.T) {
 	v := parseFormatterValue(t, "type: cef\nvendor: Test\n")
-	f, err := buildFormatter(v)
+	f, err := outputconfig.BuildFormatterForTest(v)
 	require.NoError(t, err)
 
 	cf, ok := f.(*audit.CEFFormatter)
@@ -121,7 +122,7 @@ func TestBuildFormatter_CEF_NoSeverityFunc(t *testing.T) {
 
 func TestBuildFormatter_CEF_Defaults(t *testing.T) {
 	v := parseFormatterValue(t, "type: cef\n")
-	f, err := buildFormatter(v)
+	f, err := outputconfig.BuildFormatterForTest(v)
 	require.NoError(t, err)
 
 	cf, ok := f.(*audit.CEFFormatter)
@@ -137,21 +138,21 @@ func TestBuildFormatter_CEF_Defaults(t *testing.T) {
 
 func TestBuildFormatter_CEF_RejectsTimestamp(t *testing.T) {
 	v := parseFormatterValue(t, "type: cef\ntimestamp: unix_ms\nvendor: Test\n")
-	_, err := buildFormatter(v)
+	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cef does not support timestamp")
 }
 
 func TestBuildFormatter_JSON_RejectsVendorProductVersion(t *testing.T) {
 	v := parseFormatterValue(t, "type: json\nvendor: AxonOps\n")
-	_, err := buildFormatter(v)
+	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "json does not support vendor")
 }
 
 func TestBuildFormatter_UnknownType_Error(t *testing.T) {
 	v := parseFormatterValue(t, "type: protobuf\n")
-	_, err := buildFormatter(v)
+	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown type")
 	assert.Contains(t, err.Error(), "protobuf")
@@ -160,7 +161,7 @@ func TestBuildFormatter_UnknownType_Error(t *testing.T) {
 func TestBuildFormatter_InvalidStructure_Error(t *testing.T) {
 	// Pass a slice where a mapping is expected.
 	v := []any{"item"}
-	_, err := buildFormatter(v)
+	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "formatter")
 }
@@ -183,11 +184,11 @@ func TestExtractFormatterType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.yaml == "" {
-				assert.Equal(t, "", extractFormatterType(nil))
+				assert.Equal(t, "", outputconfig.ExtractFormatterTypeForTest(nil))
 				return
 			}
 			v := parseFormatterValue(t, tt.yaml)
-			assert.Equal(t, tt.want, extractFormatterType(v))
+			assert.Equal(t, tt.want, outputconfig.ExtractFormatterTypeForTest(v))
 		})
 	}
 }

--- a/webhook/export_test.go
+++ b/webhook/export_test.go
@@ -1,0 +1,20 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+// ValidateConfigForTest exposes the internal config-validator to
+// black-box test packages. Production callers MUST use New, which
+// runs the same validator before constructing the output.
+var ValidateConfigForTest = validateWebhookConfig

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package webhook
+package webhook_test
 
 import (
 	"testing"
 	"time"
 
 	"github.com/axonops/audit"
+	"github.com/axonops/audit/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,43 +32,43 @@ func TestValidateConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		wantErr string
-		cfg     Config
+		cfg     webhook.Config
 	}{
 		{
 			name:    "empty URL",
-			cfg:     Config{},
+			cfg:     webhook.Config{},
 			wantErr: "must not be empty",
 		},
 		{
 			name: "HTTP without AllowInsecureHTTP",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL: "http://example.com/webhook",
 			},
 			wantErr: "must be https",
 		},
 		{
 			name: "HTTP with AllowInsecureHTTP",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:               "http://example.com/webhook",
 				AllowInsecureHTTP: true,
 			},
 		},
 		{
 			name: "HTTPS valid",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL: "https://example.com/webhook",
 			},
 		},
 		{
 			name: "invalid URL scheme",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL: "ftp://example.com/data",
 			},
 			wantErr: "scheme must be http or https",
 		},
 		{
 			name: "CRLF in header name",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:     "https://example.com/webhook",
 				Headers: map[string]string{"Bad\r\nHeader": "value"},
 			},
@@ -75,7 +76,7 @@ func TestValidateConfig(t *testing.T) {
 		},
 		{
 			name: "cert without key",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:     "https://example.com/webhook",
 				TLSCert: "/tmp/cert.pem",
 			},
@@ -83,7 +84,7 @@ func TestValidateConfig(t *testing.T) {
 		},
 		{
 			name: "key without cert",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:    "https://example.com/webhook",
 				TLSKey: "/tmp/key.pem",
 			},
@@ -91,31 +92,31 @@ func TestValidateConfig(t *testing.T) {
 		},
 		{
 			name: "batch size exceeds max",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:       "https://example.com/webhook",
-				BatchSize: MaxBatchSize + 1,
+				BatchSize: webhook.MaxBatchSize + 1,
 			},
 			wantErr: "batch_size",
 		},
 		{
 			name: "buffer size exceeds max",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:        "https://example.com/webhook",
-				BufferSize: MaxBufferSize + 1,
+				BufferSize: webhook.MaxBufferSize + 1,
 			},
 			wantErr: "buffer_size",
 		},
 		{
 			name: "max retries exceeds max",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:        "https://example.com/webhook",
-				MaxRetries: MaxMaxRetries + 1,
+				MaxRetries: webhook.MaxMaxRetries + 1,
 			},
 			wantErr: "max_retries",
 		},
 		{
 			name: "negative flush interval",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:           "https://example.com/webhook",
 				FlushInterval: -1 * time.Second,
 			},
@@ -123,7 +124,7 @@ func TestValidateConfig(t *testing.T) {
 		},
 		{
 			name: "negative timeout",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:     "https://example.com/webhook",
 				Timeout: -1 * time.Second,
 			},
@@ -133,7 +134,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateWebhookConfig(&tt.cfg)
+			err := webhook.ValidateConfigForTest(&tt.cfg)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {
@@ -147,45 +148,45 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestValidateConfig_Defaults(t *testing.T) {
-	cfg := Config{URL: "https://example.com/webhook"}
-	require.NoError(t, validateWebhookConfig(&cfg))
+	cfg := webhook.Config{URL: "https://example.com/webhook"}
+	require.NoError(t, webhook.ValidateConfigForTest(&cfg))
 
-	assert.Equal(t, DefaultBatchSize, cfg.BatchSize)
-	assert.Equal(t, DefaultFlushInterval, cfg.FlushInterval)
-	assert.Equal(t, DefaultTimeout, cfg.Timeout)
-	assert.Equal(t, DefaultMaxRetries, cfg.MaxRetries)
-	assert.Equal(t, DefaultBufferSize, cfg.BufferSize)
-	assert.Equal(t, DefaultMaxBatchBytes, cfg.MaxBatchBytes)
+	assert.Equal(t, webhook.DefaultBatchSize, cfg.BatchSize)
+	assert.Equal(t, webhook.DefaultFlushInterval, cfg.FlushInterval)
+	assert.Equal(t, webhook.DefaultTimeout, cfg.Timeout)
+	assert.Equal(t, webhook.DefaultMaxRetries, cfg.MaxRetries)
+	assert.Equal(t, webhook.DefaultBufferSize, cfg.BufferSize)
+	assert.Equal(t, webhook.DefaultMaxBatchBytes, cfg.MaxBatchBytes)
 }
 
 func TestValidateConfig_BoundaryValues(t *testing.T) {
-	cfg := Config{
+	cfg := webhook.Config{
 		URL:           "https://example.com/webhook",
-		BatchSize:     MaxBatchSize,
-		BufferSize:    MaxBufferSize,
-		MaxRetries:    MaxMaxRetries,
-		MaxBatchBytes: MaxMaxBatchBytes,
+		BatchSize:     webhook.MaxBatchSize,
+		BufferSize:    webhook.MaxBufferSize,
+		MaxRetries:    webhook.MaxMaxRetries,
+		MaxBatchBytes: webhook.MaxMaxBatchBytes,
 	}
-	require.NoError(t, validateWebhookConfig(&cfg))
+	require.NoError(t, webhook.ValidateConfigForTest(&cfg))
 }
 
 // TestValidateConfig_MaxBatchBytesDefaults verifies zero-value
 // MaxBatchBytes is normalised to DefaultMaxBatchBytes (#687 AC #1).
 func TestValidateConfig_MaxBatchBytesDefaults(t *testing.T) {
-	cfg := Config{URL: "https://example.com/webhook"}
-	require.NoError(t, validateWebhookConfig(&cfg))
-	assert.Equal(t, DefaultMaxBatchBytes, cfg.MaxBatchBytes,
+	cfg := webhook.Config{URL: "https://example.com/webhook"}
+	require.NoError(t, webhook.ValidateConfigForTest(&cfg))
+	assert.Equal(t, webhook.DefaultMaxBatchBytes, cfg.MaxBatchBytes,
 		"zero MaxBatchBytes must normalise to DefaultMaxBatchBytes")
 }
 
 // TestValidateConfig_MaxBatchBytesNegative verifies a negative
 // MaxBatchBytes value is rejected with ErrConfigInvalid (#687 AC #1).
 func TestValidateConfig_MaxBatchBytesNegative(t *testing.T) {
-	cfg := Config{
+	cfg := webhook.Config{
 		URL:           "https://example.com/webhook",
 		MaxBatchBytes: -1,
 	}
-	err := validateWebhookConfig(&cfg)
+	err := webhook.ValidateConfigForTest(&cfg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, audit.ErrConfigInvalid)
 }
@@ -193,11 +194,11 @@ func TestValidateConfig_MaxBatchBytesNegative(t *testing.T) {
 // TestValidateConfig_MaxBatchBytesBelowMin verifies a value below
 // MinMaxBatchBytes is rejected with ErrConfigInvalid.
 func TestValidateConfig_MaxBatchBytesBelowMin(t *testing.T) {
-	cfg := Config{
+	cfg := webhook.Config{
 		URL:           "https://example.com/webhook",
 		MaxBatchBytes: 512, // below 1 KiB minimum
 	}
-	err := validateWebhookConfig(&cfg)
+	err := webhook.ValidateConfigForTest(&cfg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, audit.ErrConfigInvalid)
 }
@@ -205,11 +206,11 @@ func TestValidateConfig_MaxBatchBytesBelowMin(t *testing.T) {
 // TestValidateConfig_MaxBatchBytesOverRange verifies a value above
 // MaxMaxBatchBytes is rejected with ErrConfigInvalid.
 func TestValidateConfig_MaxBatchBytesOverRange(t *testing.T) {
-	cfg := Config{
+	cfg := webhook.Config{
 		URL:           "https://example.com/webhook",
-		MaxBatchBytes: MaxMaxBatchBytes + 1,
+		MaxBatchBytes: webhook.MaxMaxBatchBytes + 1,
 	}
-	err := validateWebhookConfig(&cfg)
+	err := webhook.ValidateConfigForTest(&cfg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, audit.ErrConfigInvalid)
 }
@@ -218,11 +219,11 @@ func TestValidateConfig_NonexistentTLSFiles(t *testing.T) {
 	tests := []struct {
 		name    string
 		wantErr string
-		cfg     Config
+		cfg     webhook.Config
 	}{
 		{
 			name: "nonexistent CA",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:   "https://example.com/webhook",
 				TLSCA: "/nonexistent/ca.pem",
 			},
@@ -230,7 +231,7 @@ func TestValidateConfig_NonexistentTLSFiles(t *testing.T) {
 		},
 		{
 			name: "nonexistent cert and key",
-			cfg: Config{
+			cfg: webhook.Config{
 				URL:     "https://example.com/webhook",
 				TLSCert: "/nonexistent/cert.pem",
 				TLSKey:  "/nonexistent/key.pem",
@@ -240,7 +241,7 @@ func TestValidateConfig_NonexistentTLSFiles(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := New(&tt.cfg, nil)
+			_, err := webhook.New(&tt.cfg, nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})


### PR DESCRIPTION
## Summary

Closes #555. Convert the three remaining white-box test files to external `_test` packages per CLAUDE.md.

## Changes

- **`webhook/webhook_test.go`** — `package webhook` → `package webhook_test`
- **`outputconfig/envsubst_test.go`** — `package outputconfig` → `package outputconfig_test`
- **`outputconfig/formatter_test.go`** — `package outputconfig` → `package outputconfig_test`

## Export shims

All unexported access goes through `export_test.go` (the `_test.go` suffix scopes the symbols to test compilation only — they do not appear in the production API):

- **NEW** `webhook/export_test.go` — `ValidateConfigForTest = validateWebhookConfig`
- **`outputconfig/export_test.go`** extended with:
  - `ExpandEnvInValueForTest = expandEnvInValue`
  - `BuildFormatterForTest = buildFormatter`
  - `ExtractFormatterTypeForTest = extractFormatterType`

## Acceptance criteria

- [x] AC1 — Three files are `package <pkg>_test`
- [x] AC2 — Unexported access goes via `export_test.go` shims
- [x] AC3 — All existing tests still pass

## Test plan

- [x] `go test -count=1 ./...` passes in `webhook/` and `outputconfig/`
- [x] `make check` clean (full quality gate including lint + tidy + race)