### PR TITLE
ci: include secrets/env and secrets/file in publish + CI matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,12 @@ jobs:
           - module: secrets
             target: test-secrets
             flag: secrets
+          - module: secrets/env
+            target: test-secrets-env
+            flag: secrets-env
+          - module: secrets/file
+            target: test-secrets-file
+            flag: secrets-file
           - module: secrets/openbao
             target: test-secrets-openbao
             flag: secrets-openbao
@@ -483,6 +489,8 @@ jobs:
           - cmd/audit-gen
           - cmd/audit-validate
           - secrets
+          - secrets/env
+          - secrets/file
           - secrets/openbao
           - secrets/vault
     steps:

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Save pre-update go.mod files
         run: |
-          for mod in . file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/openbao secrets/vault; do
+          for mod in . file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault; do
             cp "$mod/go.mod" "$mod/go.mod.before"
           done
 
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/openbao secrets/vault"
+          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault"
           CORE_MODULE="github.com/axonops/audit"
           FAILED=""
 
@@ -83,6 +83,8 @@ jobs:
               "$CORE_MODULE/cmd/audit-gen" \
               "$CORE_MODULE/cmd/audit-validate" \
               "$CORE_MODULE/secrets" \
+              "$CORE_MODULE/secrets/env" \
+              "$CORE_MODULE/secrets/file" \
               "$CORE_MODULE/secrets/openbao" \
               "$CORE_MODULE/secrets/vault"; do
               # `grep` returns 1 when the dep is not present in go.mod
@@ -135,7 +137,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/openbao secrets/vault"
+          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault"
           HAS_CHANGES="false"
 
           for mod in $MODULES; do
@@ -196,7 +198,7 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/openbao secrets/vault"
+          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault"
           BODY=""
 
           for mod in $MODULES; do

--- a/Makefile
+++ b/Makefile
@@ -837,6 +837,8 @@ PUBLISH_MODULES := \
   cmd/audit-gen|github.com/axonops/audit/cmd/audit-gen|cmd/audit-gen/ \
   cmd/audit-validate|github.com/axonops/audit/cmd/audit-validate|cmd/audit-validate/ \
   secrets|github.com/axonops/audit/secrets|secrets/ \
+  secrets/env|github.com/axonops/audit/secrets/env|secrets/env/ \
+  secrets/file|github.com/axonops/audit/secrets/file|secrets/file/ \
   secrets/openbao|github.com/axonops/audit/secrets/openbao|secrets/openbao/ \
   secrets/vault|github.com/axonops/audit/secrets/vault|secrets/vault/
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -60,6 +60,8 @@ removing a module:
 | `cmd/audit-gen` | `github.com/axonops/audit/cmd/audit-gen` | `cmd/audit-gen/v*` |
 | `cmd/audit-validate` | `github.com/axonops/audit/cmd/audit-validate` | `cmd/audit-validate/v*` |
 | `secrets` | `github.com/axonops/audit/secrets` | `secrets/v*` |
+| `secrets/env` | `github.com/axonops/audit/secrets/env` | `secrets/env/v*` |
+| `secrets/file` | `github.com/axonops/audit/secrets/file` | `secrets/file/v*` |
 | `secrets/openbao` | `github.com/axonops/audit/secrets/openbao` | `secrets/openbao/v*` |
 | `secrets/vault` | `github.com/axonops/audit/secrets/vault` | `secrets/vault/v*` |
 <!-- END PUBLISH_MODULES TABLE -->


### PR DESCRIPTION
## Summary

The `secrets/env` and `secrets/file` sub-modules added in #604 were never wired into the publish list, the CI matrix, or the dependency-update workflow. This PR closes those gaps so the next v0.1.x release tag will publish them, **unblocking #720**.

## What was missing

| Location | Effect of the gap |
|---|---|
| `Makefile` `PUBLISH_MODULES` | Release tag-all job skipped these modules — no `secrets/env/v0.1.x` or `secrets/file/v0.1.x` tag was ever created. Modules unreachable via `go get` at a versioned ref. |
| `ci.yml` unit-test matrix | Tests existed (`make test-secrets-env`, `make test-secrets-file`) but never ran in CI. |
| `ci.yml` security-scan matrix | `govulncheck` never ran on these modules. |
| `dependency-update.yml` | Two module lists + the inter-module pin loop both excluded env/file, so dependency updates skipped them. |

## What changes

- `Makefile`: add the two entries to `PUBLISH_MODULES`.
- `docs/releasing.md`: regenerated via `make regen-release-docs` (auto-generated table).
- `.github/workflows/ci.yml`: add the two modules to both the unit-test matrix (with their existing `make test-secrets-env` / `make test-secrets-file` targets) and the govulncheck matrix.
- `.github/workflows/dependency-update.yml`: include env/file in the module list and in the inter-module pin-restoration loop.

## Test plan

- [x] `make check` clean (full quality gate including `make regen-release-docs-check`)
- [x] `make print-publish-modules` shows the new entries

## Unblocks

After this lands and the next v0.1.x release is cut, **#720** can implement the env / file BDD scenarios because `outputconfig/go.mod` will be able to `require github.com/axonops/audit/secrets/env v0.1.x` and `go mod tidy` will succeed in CI.