### PR TITLE
test: migrate assert.Contains(err) to assert.ErrorIs (#556)

### DIFF
--- a/audit_event_context_test.go
+++ b/audit_event_context_test.go
@@ -71,6 +71,7 @@ func TestAuditEventContext_NilEvent_ReturnsError(t *testing.T) {
 	a, _ := newCtxAuditor(t)
 	err := a.AuditEventContext(context.Background(), nil)
 	require.Error(t, err)
+	// text-only: audit.go:378 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "must not be nil")
 }
 

--- a/audit_test.go
+++ b/audit_test.go
@@ -273,6 +273,8 @@ func TestLogger_Audit_ReservedStandardField_StillRejectsUnknown(t *testing.T) {
 		"foobar":    "unknown",
 	}))
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	assert.ErrorIs(t, err, audit.ErrUnknownField)
 	assert.Contains(t, err.Error(), "unknown fields")
 	assert.Contains(t, err.Error(), "foobar")
 	assert.NotContains(t, err.Error(), "source_ip")
@@ -286,6 +288,7 @@ func TestWithAppName_Empty_ReturnsError(t *testing.T) {
 		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "app_name must not be empty")
 }
 
@@ -298,6 +301,7 @@ func TestWithAppName_ExceedsMaxLength(t *testing.T) {
 		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "app_name exceeds maximum length of 255 bytes")
 }
 
@@ -324,6 +328,7 @@ func TestWithHost_Empty_ReturnsError(t *testing.T) {
 		audit.WithAppName("test-app"),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "host must not be empty")
 }
 
@@ -336,6 +341,7 @@ func TestWithHost_ExceedsMaxLength(t *testing.T) {
 		audit.WithAppName("test-app"),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "host exceeds maximum length of 255 bytes")
 }
 
@@ -363,6 +369,7 @@ func TestWithTimezone_Empty_ReturnsError(t *testing.T) {
 		audit.WithTimezone(""),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "timezone must not be empty")
 }
 
@@ -376,6 +383,7 @@ func TestWithTimezone_ExceedsMaxLength(t *testing.T) {
 		audit.WithTimezone(strings.Repeat("Z", 65)),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "timezone exceeds maximum length of 64 bytes")
 }
 
@@ -404,6 +412,7 @@ func TestWithStandardFieldDefaults_InvalidKey(t *testing.T) {
 		audit.WithStandardFieldDefaults(map[string]any{"bogus": "value"}),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "bogus")
 	assert.Contains(t, err.Error(), "not a reserved standard field")
 }
@@ -595,6 +604,8 @@ func TestLogger_Audit_NilFields(t *testing.T) {
 	// means all are missing.
 	err := auditor.AuditEvent(audit.NewEvent("schema_register", nil))
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
 	assert.Contains(t, err.Error(), "missing required fields")
 }
 
@@ -1081,6 +1092,10 @@ func TestLogger_Close_OutputError(t *testing.T) {
 
 	err = auditor.Close()
 	require.Error(t, err)
+	// text-only: the underlying error is errorOutput.closeErr (a test-
+	// injected errors.New), so there is no library sentinel to assert
+	// against here. The contract is that Close surfaces the wrapped
+	// underlying error verbatim and prefixes it with the output name.
 	assert.Contains(t, err.Error(), "close failed")
 	assert.Contains(t, err.Error(), "bad", "error should include output name")
 }
@@ -1237,6 +1252,9 @@ func TestLogger_Filter_InvalidCategory(t *testing.T) {
 
 	err := auditor.EnableCategory("nonexistent")
 	assert.Error(t, err)
+	// text-only: EnableCategory/DisableCategory return raw fmt.Errorf
+	// without a sentinel wrap (audit.go:793,809). The category-name
+	// substring is the only stable contract.
 	assert.Contains(t, err.Error(), "unknown category")
 
 	err = auditor.DisableCategory("nonexistent")
@@ -1489,6 +1507,9 @@ func TestLogger_Filter_InvalidEvent(t *testing.T) {
 
 	err := auditor.EnableEvent("nonexistent")
 	assert.Error(t, err)
+	// text-only: EnableEvent/DisableEvent return raw fmt.Errorf without
+	// a sentinel wrap (audit.go:825,842). The Auditor.AuditEvent path
+	// uses ErrUnknownEventType, but the runtime-toggle methods don't.
 	assert.Contains(t, err.Error(), "unknown event type")
 
 	err = auditor.DisableEvent("nonexistent")
@@ -1670,6 +1691,7 @@ func TestNew_QueueSizeExceedsMax(t *testing.T) {
 		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }
 
@@ -1681,6 +1703,7 @@ func TestNew_ShutdownTimeoutExceedsMax(t *testing.T) {
 		audit.WithHost("test-host"),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }
 
@@ -3682,6 +3705,8 @@ func TestAuditEvent_UnknownEventType(t *testing.T) {
 
 	err = auditor.AuditEvent(audit.NewEvent("nonexistent", audit.Fields{}))
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrValidation)
+	assert.ErrorIs(t, err, audit.ErrUnknownEventType)
 	assert.Contains(t, err.Error(), "unknown event type")
 }
 
@@ -3697,6 +3722,8 @@ func TestAuditEvent_NilEvent(t *testing.T) {
 
 	err = auditor.AuditEvent(nil)
 	require.Error(t, err)
+	// text-only: nil-event guard at audit.go:378 returns raw fmt.Errorf
+	// without a sentinel wrap. The contract is the error message.
 	assert.Contains(t, err.Error(), "event must not be nil")
 }
 
@@ -4134,6 +4161,7 @@ func TestHMAC_ReservedFieldNames(t *testing.T) {
 			}
 			err := audit.ValidateTaxonomy(*tax)
 			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrTaxonomyInvalid)
 			assert.Contains(t, err.Error(), "reserved framework field")
 		})
 	}

--- a/audittest/audittest_test.go
+++ b/audittest/audittest_test.go
@@ -92,6 +92,7 @@ func TestNew_ValidationError(t *testing.T) {
 		"outcome": "success",
 	}))
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
 	assert.Contains(t, err.Error(), "missing required")
 	require.NoError(t, auditor.Close())
 

--- a/cmd/audit-gen/generate_test.go
+++ b/cmd/audit-gen/generate_test.go
@@ -1052,6 +1052,7 @@ func TestBuildLabelConstants_NamingCollision(t *testing.T) {
 	}
 	_, err := buildLabelConstantsFromConfig(sc)
 	require.Error(t, err)
+	// text-only: generate.go:308 returns raw fmt.Errorf without an audit sentinel wrap (cmd module).
 	assert.Contains(t, err.Error(), "naming collision")
 }
 

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -115,10 +115,11 @@ audit: config validation failed
 
 | | |
 |---|---|
-| **When** | `New()` is called with an invalid `Config` struct |
+| **When** | `New()` is called with an invalid `Config` struct, an out-of-range option value, or an `EventRoute` that does not validate against the taxonomy |
 | **Meaning** | Auditor creation failed — one or more config values are out of range |
 | **Transient?** | No — permanent configuration error |
-| **What to do** | Check the error message for details. Common causes: `QueueSize` exceeds 1,000,000, `ShutdownTimeout` exceeds 60 seconds, `Version` is not 1. The wrapped error message tells you which field is invalid. |
+| **What to do** | Check the error message for details. Common causes: `QueueSize` exceeds 1,000,000, `ShutdownTimeout` exceeds 60 seconds, `Version` is not 1, an empty/over-length `WithAppName` / `WithHost` / `WithTimezone` value, an `EventRoute` that mixes include and exclude or references unknown taxonomy entries. The wrapped error message tells you which field is invalid. |
+| **Sentinel coverage** (#556) | Wrapped via `%w` by every option-validator that fails: `WithAppName` empty / over-length, `WithHost` empty / over-length, `WithTimezone` empty / over-length, `WithStandardFieldDefaults` invalid key, `EventRoute` include/exclude mix, `EventRoute` severity out-of-range, `EventRoute` references unknown taxonomy entries. Use `errors.Is(err, audit.ErrConfigInvalid)` to discriminate any of these from `ErrTaxonomyRequired` / `ErrAppNameRequired` / `ErrHostRequired` (which mark missing-option failures, distinct from invalid-value failures). |
 
 ### `ErrTaxonomyRequired`
 

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -163,6 +163,8 @@ func TestFanout_DuplicateOutputName_Error(t *testing.T) {
 		audit.WithOutputs(out1, out2),
 	)
 	require.Error(t, err)
+	// text-only: options.go:295 returns raw fmt.Errorf without a sentinel
+	// wrap. The duplicate-name guard is internal to WithOutputs.
 	assert.Contains(t, err.Error(), "duplicate output name")
 }
 
@@ -177,6 +179,8 @@ func TestFanout_WithOutputs_AfterWithNamedOutput_Error(t *testing.T) {
 		audit.WithOutputs(out2), // should error
 	)
 	require.Error(t, err)
+	// text-only: options.go:284 returns raw fmt.Errorf without a sentinel
+	// wrap (mutual-exclusion guard between WithOutputs / WithNamedOutput).
 	assert.Contains(t, err.Error(), "cannot be used with WithNamedOutput")
 }
 
@@ -191,6 +195,8 @@ func TestFanout_WithNamedOutput_AfterWithOutputs_Error(t *testing.T) {
 		audit.WithNamedOutput(out2, audit.WithRoute(&audit.EventRoute{})), // should error
 	)
 	require.Error(t, err)
+	// text-only: options.go:383 returns raw fmt.Errorf without a sentinel
+	// wrap (mutual-exclusion guard between WithOutputs / WithNamedOutput).
 	assert.Contains(t, err.Error(), "cannot be used with WithOutputs")
 }
 
@@ -205,6 +211,7 @@ func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 		})),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown taxonomy entries")
 }
 
@@ -220,6 +227,7 @@ func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 		})),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "either include or exclude")
 }
 
@@ -288,6 +296,8 @@ func TestFanout_SetOutputRoute_UnknownOutput(t *testing.T) {
 
 	err = auditor.SetOutputRoute("nonexistent", &audit.EventRoute{})
 	require.Error(t, err)
+	// text-only: audit.go:862,879,891 return raw fmt.Errorf without a
+	// sentinel wrap. The output-name substring is the contract.
 	assert.Contains(t, err.Error(), "unknown output")
 }
 
@@ -306,6 +316,7 @@ func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 		IncludeCategories: []string{"bogus"},
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown taxonomy entries")
 }
 
@@ -342,6 +353,8 @@ func TestFanout_ClearOutputRoute_UnknownOutput(t *testing.T) {
 
 	err = auditor.ClearOutputRoute("nonexistent")
 	require.Error(t, err)
+	// text-only: audit.go:862,879,891 return raw fmt.Errorf without a
+	// sentinel wrap. The output-name substring is the contract.
 	assert.Contains(t, err.Error(), "unknown output")
 }
 
@@ -379,6 +392,8 @@ func TestFanout_OutputRoute_UnknownOutput(t *testing.T) {
 
 	_, err = auditor.OutputRoute("nonexistent")
 	require.Error(t, err)
+	// text-only: audit.go:862,879,891 return raw fmt.Errorf without a
+	// sentinel wrap. The output-name substring is the contract.
 	assert.Contains(t, err.Error(), "unknown output")
 }
 

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -329,6 +329,8 @@ func TestFileOutput_InvalidConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := file.New(&tt.cfg)
 			require.Error(t, err)
+			// text-only: mixed table — empty path, parent, permissions cases use bare fmt.Errorf in file.go;
+			// only max_*/buffer_size cases wrap audit.ErrConfigInvalid (file.go:567+).
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
@@ -352,6 +354,7 @@ func TestFileOutput_Permissions0000_Rejected(t *testing.T) {
 	})
 	// "0000" is valid octal but the rotation library rejects zero mode.
 	require.Error(t, err)
+	// text-only: rotate/writer.go:411 errors.New, wrapped by file.go:292 — no audit sentinel in the chain.
 	assert.Contains(t, err.Error(), "non-zero")
 }
 
@@ -1113,6 +1116,7 @@ func TestNew_NilConfig_ReturnsError(t *testing.T) {
 	t.Parallel()
 	_, err := file.New(nil)
 	require.Error(t, err)
+	// text-only: file.go:212 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "config must not be nil")
 }
 

--- a/file/internal/rotate/compress_test.go
+++ b/file/internal/rotate/compress_test.go
@@ -187,6 +187,7 @@ func TestCompressFile_SourceMissing(t *testing.T) {
 
 	err := compressFile(src, dst, 0o600)
 	assert.Error(t, err)
+	// text-only: compress.go:50 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "compress open source")
 }
 
@@ -201,6 +202,7 @@ func TestCompressFile_DestDirMissing(t *testing.T) {
 
 	err := compressFile(src, dst, 0o600)
 	assert.Error(t, err)
+	// text-only: compress.go:58 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "create dest")
 
 	// Source should be left intact on error.
@@ -224,6 +226,7 @@ func TestCompressFile_SourceSymlink(t *testing.T) {
 
 	err := compressFile(link, dst, 0o600)
 	assert.Error(t, err)
+	// text-only: compress.go:50 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "compress open source")
 
 	// Destination should not have been created.
@@ -253,5 +256,6 @@ func TestCompressFile_RemoveSourceFails_ErrorReturned(t *testing.T) {
 
 	err := compressFile(src, dst, 0o600)
 	require.Error(t, err)
+	// text-only: compress.go:73 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "remove source")
 }

--- a/file/internal/rotate/writer_internal_test.go
+++ b/file/internal/rotate/writer_internal_test.go
@@ -111,6 +111,7 @@ func TestOldLogFiles_BadDir(t *testing.T) {
 
 	_, err := w.oldLogFiles()
 	assert.Error(t, err)
+	// text-only: mill.go:148 returns raw fmt.Errorf without an audit sentinel wrap (internal package).
 	assert.Contains(t, err.Error(), "read dir")
 }
 
@@ -339,6 +340,7 @@ func TestCloseFile_ClosedFd_ReturnsError(t *testing.T) {
 	err = w.closeFile()
 
 	require.Error(t, err)
+	// text-only: writer.go:680 returns raw fmt.Errorf without an audit sentinel wrap (internal package).
 	assert.Contains(t, err.Error(), "close file")
 	// File handle must be cleared even after Close error.
 	assert.Nil(t, w.file)
@@ -369,6 +371,7 @@ func TestRotate_CloseFileError_ReturnsError(t *testing.T) {
 
 	err = w.rotate()
 	require.Error(t, err)
+	// text-only: writer.go:680 returns raw fmt.Errorf without an audit sentinel wrap (internal package).
 	assert.Contains(t, err.Error(), "close file")
 }
 
@@ -535,6 +538,7 @@ func TestMillRunOnce_OnError_RemoveError(t *testing.T) {
 	w.millRunOnce()
 	assert.NotEmpty(t, received, "should receive remove errors")
 	for _, err := range received {
+		// text-only: mill.go:94 returns raw fmt.Errorf without an audit sentinel wrap (internal package).
 		assert.Contains(t, err.Error(), "remove")
 	}
 }

--- a/file/internal/rotate/writer_test.go
+++ b/file/internal/rotate/writer_test.go
@@ -90,6 +90,7 @@ func TestNew_Validation(t *testing.T) {
 			w, err := rotate.New(tc.filename, tc.cfg)
 			assert.Nil(t, w)
 			require.Error(t, err)
+			// text-only: rotate package errors.New returns no audit sentinel (internal package).
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
@@ -113,6 +114,7 @@ func TestNew_SymlinkPath(t *testing.T) {
 
 	_, err = w.Write([]byte("test"))
 	assert.Error(t, err)
+	// text-only: rotate package returns raw fmt.Errorf without an audit sentinel wrap (internal package).
 	assert.Contains(t, err.Error(), "symlink")
 	require.NoError(t, w.Close())
 }
@@ -819,6 +821,7 @@ func TestWriter_NoMkdirAll(t *testing.T) {
 	w, err := rotate.New(path, rotate.Config{MaxSize: 1024, Mode: 0o600})
 	assert.Nil(t, w)
 	assert.Error(t, err)
+	// text-only: writer.go:399 returns raw fmt.Errorf without an audit sentinel wrap (internal package).
 	assert.Contains(t, err.Error(), "parent directory")
 }
 

--- a/file/register_test.go
+++ b/file/register_test.go
@@ -54,6 +54,7 @@ func TestFileFactory_InvalidConfig_ReturnsError(t *testing.T) {
 
 	_, err := factory("bad_file", yaml, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err)
+	// text-only: file.go:222 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "bad_file")
 }
 
@@ -65,6 +66,7 @@ func TestFileFactory_UnknownYAMLField_Rejected(t *testing.T) {
 
 	_, err := factory("test", yaml, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err)
+	// text-only: register.go:98 wraps yaml.UnknownFieldError via WrapUnknownFieldError, not an audit sentinel.
 	assert.Contains(t, err.Error(), "unknown_field")
 }
 
@@ -74,6 +76,7 @@ func TestFileFactory_EmptyConfig_ReturnsError(t *testing.T) {
 
 	_, err := factory("empty", nil, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err)
+	// text-only: register.go:92 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "config is required")
 }
 

--- a/filter.go
+++ b/filter.go
@@ -106,7 +106,7 @@ func (r *EventRoute) isExcludeMode() bool {
 // exist in the taxonomy.
 func ValidateEventRoute(route *EventRoute, taxonomy *Taxonomy) error {
 	if route.isIncludeMode() && route.isExcludeMode() {
-		return fmt.Errorf("audit: EventRoute must use either include or exclude, not both")
+		return fmt.Errorf("%w: EventRoute must use either include or exclude, not both", ErrConfigInvalid)
 	}
 	if err := validateSeverityRange(route); err != nil {
 		return err
@@ -118,16 +118,16 @@ func ValidateEventRoute(route *EventRoute, taxonomy *Taxonomy) error {
 // within [MinSeverity, MaxSeverity] and that min does not exceed max.
 func validateSeverityRange(route *EventRoute) error {
 	if route.MinSeverity != nil && (*route.MinSeverity < MinSeverity || *route.MinSeverity > MaxSeverity) {
-		return fmt.Errorf("audit: EventRoute min_severity %d out of range %d-%d",
-			*route.MinSeverity, MinSeverity, MaxSeverity)
+		return fmt.Errorf("%w: EventRoute min_severity %d out of range %d-%d",
+			ErrConfigInvalid, *route.MinSeverity, MinSeverity, MaxSeverity)
 	}
 	if route.MaxSeverity != nil && (*route.MaxSeverity < MinSeverity || *route.MaxSeverity > MaxSeverity) {
-		return fmt.Errorf("audit: EventRoute max_severity %d out of range %d-%d",
-			*route.MaxSeverity, MinSeverity, MaxSeverity)
+		return fmt.Errorf("%w: EventRoute max_severity %d out of range %d-%d",
+			ErrConfigInvalid, *route.MaxSeverity, MinSeverity, MaxSeverity)
 	}
 	if route.MinSeverity != nil && route.MaxSeverity != nil && *route.MinSeverity > *route.MaxSeverity {
-		return fmt.Errorf("audit: EventRoute min_severity %d exceeds max_severity %d",
-			*route.MinSeverity, *route.MaxSeverity)
+		return fmt.Errorf("%w: EventRoute min_severity %d exceeds max_severity %d",
+			ErrConfigInvalid, *route.MinSeverity, *route.MaxSeverity)
 	}
 	return nil
 }
@@ -143,8 +143,8 @@ func validateRouteEntries(route *EventRoute, taxonomy *Taxonomy) error {
 
 	if len(unknown) > 0 {
 		slices.Sort(unknown)
-		return fmt.Errorf("audit: EventRoute references unknown taxonomy entries: [%s]",
-			strings.Join(unknown, ", "))
+		return fmt.Errorf("%w: EventRoute references unknown taxonomy entries: [%s]",
+			ErrConfigInvalid, strings.Join(unknown, ", "))
 	}
 	return nil
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -125,6 +125,7 @@ func TestValidateEventRoute(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
+				assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 				assert.Contains(t, err.Error(), tt.wantErr)
 			}
 		})

--- a/format_test.go
+++ b/format_test.go
@@ -742,6 +742,7 @@ func TestCEFFormatter_RejectsInvalidFieldMappingAtConstruction(t *testing.T) {
 				audit.Fields{"outcome": "ok"}, def, nil)
 			require.Error(t, err,
 				"invalid extension key %q must be rejected at construction", tc.bad)
+			// text-only: format_cef.go:463 returns raw fmt.Errorf without an audit sentinel wrap.
 			assert.Contains(t, err.Error(), "invalid extension key")
 			// A second call must return the SAME error (resolveErr is
 			// captured once, not re-computed).
@@ -981,6 +982,7 @@ func TestLogger_WithFormatter_Nil(t *testing.T) {
 		audit.WithFormatter(nil),
 	)
 	require.Error(t, err)
+	// text-only: options.go:264 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "formatter must not be nil")
 }
 
@@ -1037,6 +1039,7 @@ func TestJSONFormatter_WriteFieldError(t *testing.T) {
 		Optional: []string{"bad"},
 	}, nil)
 	require.Error(t, err)
+	// text-only: format_json.go:169 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "json format")
 }
 
@@ -2182,6 +2185,7 @@ func TestCEFFormatter_RejectsLongVendor(t *testing.T) {
 	}
 	_, err := f.Format(testTime, "ev", audit.Fields{"outcome": "ok"}, &audit.EventDef{Required: []string{"outcome"}}, nil)
 	assert.Error(t, err)
+	// text-only: format_cef.go:280 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "vendor")
 }
 
@@ -2194,6 +2198,7 @@ func TestCEFFormatter_RejectsLongProduct(t *testing.T) {
 	}
 	_, err := f.Format(testTime, "ev", audit.Fields{"outcome": "ok"}, &audit.EventDef{Required: []string{"outcome"}}, nil)
 	assert.Error(t, err)
+	// text-only: format_cef.go:283 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "product")
 }
 
@@ -2206,6 +2211,7 @@ func TestCEFFormatter_RejectsLongVersion(t *testing.T) {
 	}
 	_, err := f.Format(testTime, "ev", audit.Fields{"outcome": "ok"}, &audit.EventDef{Required: []string{"outcome"}}, nil)
 	assert.Error(t, err)
+	// text-only: format_cef.go:286 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "version")
 }
 

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -180,6 +180,7 @@ func TestComputeHMAC_EmptyPayload(t *testing.T) {
 	t.Parallel()
 	_, err := audit.ComputeHMAC(nil, []byte("salt-value-16bytes"), "HMAC-SHA-256")
 	require.Error(t, err)
+	// text-only: hmac.go:232 returns raw errors.New without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "payload")
 }
 
@@ -187,6 +188,7 @@ func TestComputeHMAC_EmptySalt(t *testing.T) {
 	t.Parallel()
 	_, err := audit.ComputeHMAC([]byte("payload"), nil, "HMAC-SHA-256")
 	require.Error(t, err)
+	// text-only: hmac.go:235 returns raw errors.New without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "salt")
 }
 
@@ -194,6 +196,7 @@ func TestComputeHMAC_UnknownAlgorithm(t *testing.T) {
 	t.Parallel()
 	_, err := audit.ComputeHMAC([]byte("payload"), []byte("salt-value-16bytes"), "MD5")
 	require.Error(t, err)
+	// text-only: hmac.go:239 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "unknown")
 }
 

--- a/loki/config_test.go
+++ b/loki/config_test.go
@@ -763,6 +763,7 @@ func TestBuildLokiTLSConfig(t *testing.T) {
 		}
 		_, _, err := loki.BuildLokiTLSConfig(cfg)
 		require.Error(t, err)
+		// text-only: config.go:549 returns raw fmt.Errorf without an audit sentinel wrap.
 		assert.Contains(t, err.Error(), "load client certificate")
 	})
 
@@ -775,6 +776,7 @@ func TestBuildLokiTLSConfig(t *testing.T) {
 		}
 		_, _, err := loki.BuildLokiTLSConfig(cfg)
 		require.Error(t, err)
+		// text-only: config.go:557 returns raw fmt.Errorf without an audit sentinel wrap.
 		assert.Contains(t, err.Error(), "read ca certificate")
 	})
 
@@ -792,6 +794,7 @@ func TestBuildLokiTLSConfig(t *testing.T) {
 		}
 		_, _, err := loki.BuildLokiTLSConfig(cfg)
 		require.Error(t, err)
+		// text-only: config.go:561 returns raw fmt.Errorf without an audit sentinel wrap.
 		assert.Contains(t, err.Error(), "no valid pem blocks")
 	})
 }

--- a/loki/loki_external_test.go
+++ b/loki/loki_external_test.go
@@ -192,5 +192,6 @@ func TestNew_NilConfig_ReturnsError(t *testing.T) {
 	t.Parallel()
 	_, err := loki.New(nil, nil)
 	require.Error(t, err)
+	// text-only: loki.go:162 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "config must not be nil")
 }

--- a/loki/push_test.go
+++ b/loki/push_test.go
@@ -577,5 +577,6 @@ func TestMaybeCompress_GzipError_ReturnsError(t *testing.T) {
 
 	_, _, err = o.MaybeCompressForTest()
 	require.Error(t, err, "maybeCompress should return error with failing writer")
+	// text-only: push.go:313 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "gzip write")
 }

--- a/loki/register_test.go
+++ b/loki/register_test.go
@@ -52,6 +52,7 @@ func TestLokiFactory_EmptyConfig(t *testing.T) {
 
 	_, err := factory("my_loki", nil, nil, nil, audit.FrameworkContext{})
 	require.Error(t, err)
+	// text-only: register.go:132 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "config is required",
 		"empty config should produce 'config is required' error, got: %q", err.Error())
 }
@@ -68,6 +69,7 @@ func TestLokiFactory_UnknownField(t *testing.T) {
 	rawYAML := []byte("url: https://loki.example.com/loki/api/v1/push\nunknown_field: oops\n")
 	_, err := factory("strict_loki", rawYAML, nil, nil, audit.FrameworkContext{})
 	require.Error(t, err)
+	// text-only: register.go:154 wraps yaml.UnknownFieldError via WrapUnknownFieldError, not an audit sentinel.
 	assert.Contains(t, err.Error(), "unknown_field",
 		"strict YAML decode should name the unexpected field, got: %q", err.Error())
 }
@@ -132,6 +134,7 @@ func TestLokiFactory_DurationParsing(t *testing.T) {
 			out, err := factory("dur_test", []byte(tt.yaml), nil, nil, audit.FrameworkContext{})
 			if tt.wantErr {
 				require.Error(t, err, "expected a parse error for YAML: %s", tt.yaml)
+				// text-only: register.go:104/108 returns raw fmt.Errorf without a sentinel wrap.
 				assert.Contains(t, err.Error(), "duration",
 					"error for invalid duration should mention 'duration', got: %q", err.Error())
 			} else {

--- a/options.go
+++ b/options.go
@@ -107,10 +107,10 @@ func WithMetrics(m Metrics) Option {
 func WithAppName(name string) Option {
 	return func(a *Auditor) error {
 		if name == "" {
-			return fmt.Errorf("audit: app_name must not be empty")
+			return fmt.Errorf("%w: app_name must not be empty", ErrConfigInvalid)
 		}
 		if len(name) > 255 {
-			return fmt.Errorf("audit: app_name exceeds maximum length of 255 bytes")
+			return fmt.Errorf("%w: app_name exceeds maximum length of 255 bytes", ErrConfigInvalid)
 		}
 		a.appName = name
 		return nil
@@ -126,10 +126,10 @@ func WithAppName(name string) Option {
 func WithHost(host string) Option {
 	return func(a *Auditor) error {
 		if host == "" {
-			return fmt.Errorf("audit: host must not be empty")
+			return fmt.Errorf("%w: host must not be empty", ErrConfigInvalid)
 		}
 		if len(host) > 255 {
-			return fmt.Errorf("audit: host exceeds maximum length of 255 bytes")
+			return fmt.Errorf("%w: host exceeds maximum length of 255 bytes", ErrConfigInvalid)
 		}
 		a.host = host
 		return nil
@@ -152,10 +152,10 @@ func WithHost(host string) Option {
 func WithTimezone(tz string) Option {
 	return func(a *Auditor) error {
 		if tz == "" {
-			return fmt.Errorf("audit: timezone must not be empty")
+			return fmt.Errorf("%w: timezone must not be empty", ErrConfigInvalid)
 		}
 		if len(tz) > 64 {
-			return fmt.Errorf("audit: timezone exceeds maximum length of 64 bytes")
+			return fmt.Errorf("%w: timezone exceeds maximum length of 64 bytes", ErrConfigInvalid)
 		}
 		a.timezone = tz
 		return nil

--- a/outputconfig/envsubst_test.go
+++ b/outputconfig/envsubst_test.go
@@ -62,6 +62,7 @@ func TestExpandEnv_UnsetNoDefault_Error(t *testing.T) {
 
 	_, err := outputconfig.ExpandEnvInValueForTest(m, "config")
 	require.Error(t, err)
+	// text-only: envsubst.go:131 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "UNSET_HOST_NO_DEFAULT")
 	assert.Contains(t, err.Error(), "not set")
 }
@@ -143,6 +144,7 @@ func TestExpandEnv_UnclosedBrace_Error(t *testing.T) {
 
 	_, err := outputconfig.ExpandEnvInValueForTest(m, "test")
 	require.Error(t, err)
+	// text-only: envsubst.go:114 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "unclosed")
 }
 

--- a/outputconfig/facade_test.go
+++ b/outputconfig/facade_test.go
@@ -104,6 +104,7 @@ func TestNew_InvalidTaxonomy(t *testing.T) {
 
 	_, err := outputconfig.New(context.Background(), []byte("not: valid: taxonomy"), path)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrInvalidInput)
 	assert.Contains(t, err.Error(), "taxonomy")
 }
 
@@ -113,6 +114,7 @@ func TestNew_InvalidOutputConfig(t *testing.T) {
 
 	_, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, path)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "load")
 }
 
@@ -122,6 +124,7 @@ func TestNew_EmptyTaxonomy(t *testing.T) {
 
 	_, err := outputconfig.New(context.Background(), nil, path)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrInvalidInput)
 	assert.Contains(t, err.Error(), "taxonomy")
 }
 
@@ -146,6 +149,7 @@ func TestNew_NotRegularFile(t *testing.T) {
 	// Directories are not regular files.
 	_, err := outputconfig.New(context.Background(), facadeTaxonomyYAML, dir)
 	require.Error(t, err)
+	// text-only: readConfigFile (facade.go:165) returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "not a regular file")
 }
 

--- a/outputconfig/formatter_test.go
+++ b/outputconfig/formatter_test.go
@@ -84,6 +84,9 @@ func TestBuildFormatter_JSON_InvalidTimestamp_Error(t *testing.T) {
 	v := parseFormatterValue(t, "type: json\ntimestamp: epoch_seconds\n")
 	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
+	// text-only: buildFormatter helpers (formatter.go:73,77,86,93,104,115)
+	// return raw fmt.Errorf without a sentinel wrap. The ErrOutputConfigInvalid
+	// wrap is added by Load() upstream (outputconfig.go).
 	assert.Contains(t, err.Error(), "unknown timestamp format")
 	assert.Contains(t, err.Error(), "epoch_seconds")
 }
@@ -140,6 +143,7 @@ func TestBuildFormatter_CEF_RejectsTimestamp(t *testing.T) {
 	v := parseFormatterValue(t, "type: cef\ntimestamp: unix_ms\nvendor: Test\n")
 	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
+	// text-only: buildFormatter helper, see TestBuildFormatter_JSON_InvalidTimestamp_Error.
 	assert.Contains(t, err.Error(), "cef does not support timestamp")
 }
 
@@ -147,6 +151,7 @@ func TestBuildFormatter_JSON_RejectsVendorProductVersion(t *testing.T) {
 	v := parseFormatterValue(t, "type: json\nvendor: AxonOps\n")
 	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
+	// text-only: buildFormatter helper, see TestBuildFormatter_JSON_InvalidTimestamp_Error.
 	assert.Contains(t, err.Error(), "json does not support vendor")
 }
 
@@ -154,6 +159,7 @@ func TestBuildFormatter_UnknownType_Error(t *testing.T) {
 	v := parseFormatterValue(t, "type: protobuf\n")
 	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
+	// text-only: buildFormatter helper, see TestBuildFormatter_JSON_InvalidTimestamp_Error.
 	assert.Contains(t, err.Error(), "unknown type")
 	assert.Contains(t, err.Error(), "protobuf")
 }
@@ -163,6 +169,7 @@ func TestBuildFormatter_InvalidStructure_Error(t *testing.T) {
 	v := []any{"item"}
 	_, err := outputconfig.BuildFormatterForTest(v)
 	require.Error(t, err)
+	// text-only: buildFormatter helper, see TestBuildFormatter_JSON_InvalidTimestamp_Error.
 	assert.Contains(t, err.Error(), "formatter")
 }
 

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -293,6 +293,7 @@ outputs:
 `)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "default_formatter has been removed")
 }
 
@@ -1013,6 +1014,7 @@ outputs:
 `)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "min_severity 11 out of range 0-10")
 }
 
@@ -1030,6 +1032,7 @@ outputs:
 `)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "max_severity -1 out of range 0-10")
 }
 
@@ -1048,6 +1051,7 @@ outputs:
 `)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "min_severity 8 exceeds max_severity 3")
 }
 
@@ -1666,6 +1670,7 @@ outputs:
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "at least")
 }
 
@@ -1688,6 +1693,7 @@ outputs:
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown")
 }
 
@@ -1707,6 +1713,7 @@ outputs:
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "salt")
 }
 
@@ -1728,6 +1735,7 @@ outputs:
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "algorithm")
 }
 
@@ -2623,12 +2631,18 @@ func TestToInt_Float64_Zero(t *testing.T) {
 func TestToInt_Float64_Fractional_ReturnsError(t *testing.T) {
 	_, err := outputconfig.ToIntForTest(float64(10.7))
 	require.Error(t, err)
+	// text-only: toInt is an internal type-coercion helper; its raw
+	// fmt.Errorf returns are wrapped at higher layers (parseAuditorConfig,
+	// parseRoute, etc.) where the parent Load test asserts ErrorIs against
+	// outputconfig.ErrOutputConfigInvalid. At this leaf level the message
+	// content is the contract.
 	assert.Contains(t, err.Error(), "fractional")
 }
 
 func TestToInt_Float64_NegativeFractional_ReturnsError(t *testing.T) {
 	_, err := outputconfig.ToIntForTest(float64(-3.5))
 	require.Error(t, err)
+	// text-only: same as TestToInt_Float64_Fractional_ReturnsError above.
 	assert.Contains(t, err.Error(), "fractional")
 }
 
@@ -2820,6 +2834,7 @@ func TestToInt_Float64Fractional(t *testing.T) {
 	t.Parallel()
 	_, err := outputconfig.ToIntForTest(42.5)
 	require.Error(t, err)
+	// text-only: toInt helper, see TestToInt_Float64_Fractional_ReturnsError.
 	assert.Contains(t, err.Error(), "fractional")
 }
 
@@ -2834,6 +2849,7 @@ func TestToInt_InvalidString(t *testing.T) {
 	t.Parallel()
 	_, err := outputconfig.ToIntForTest("not-a-number")
 	require.Error(t, err)
+	// text-only: toInt helper, see TestToInt_Float64_Fractional_ReturnsError.
 	assert.Contains(t, err.Error(), "invalid integer")
 }
 
@@ -2841,6 +2857,7 @@ func TestToInt_UnsupportedType(t *testing.T) {
 	t.Parallel()
 	_, err := outputconfig.ToIntForTest([]string{"nope"})
 	require.Error(t, err)
+	// text-only: toInt helper, see TestToInt_Float64_Fractional_ReturnsError.
 	assert.Contains(t, err.Error(), "expected integer")
 }
 
@@ -2848,6 +2865,8 @@ func TestToBool_UnsupportedType(t *testing.T) {
 	t.Parallel()
 	_, err := outputconfig.ToBoolForTest(42)
 	require.Error(t, err)
+	// text-only: toBool helper, parallels toInt — wrap chain established
+	// by parseAuditorConfig at the Load layer.
 	assert.Contains(t, err.Error(), "expected boolean")
 }
 
@@ -2855,6 +2874,7 @@ func TestToBool_InvalidString(t *testing.T) {
 	t.Parallel()
 	_, err := outputconfig.ToBoolForTest("not-bool")
 	require.Error(t, err)
+	// text-only: see TestToBool_UnsupportedType.
 	assert.Contains(t, err.Error(), "invalid boolean")
 }
 
@@ -2862,6 +2882,7 @@ func TestToStringSlice_NonStringElement(t *testing.T) {
 	t.Parallel()
 	_, err := outputconfig.ToStringSliceForTest([]any{"a", 42})
 	require.Error(t, err)
+	// text-only: toStringSlice helper, parallels toInt.
 	assert.Contains(t, err.Error(), "expected string")
 }
 
@@ -3038,6 +3059,8 @@ outputs:
 `)
 	_, err := outputconfig.Load(context.Background(), data, tax)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid,
+		"unknown-output-type error must wrap ErrOutputConfigInvalid")
 	assert.Contains(t, err.Error(), `unknown output type "not-a-real-output"`,
 		"diagnostic must name the bad type")
 	assert.Contains(t, err.Error(), "registered:",
@@ -3075,6 +3098,8 @@ outputs:
 		outputconfig.WithFactory("nil-factory", nilFactory),
 	)
 	require.Error(t, err, "Load must fail when a factory returns nil output and nil error")
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid,
+		"factory misbehaviour must surface as a config-invalid error")
 	// The exact wording is implementation detail; the diagnostic
 	// must at minimum reference the bad output and indicate the
 	// factory misbehaviour (or the symptom — nil output).

--- a/outputconfig/provider_config_test.go
+++ b/outputconfig/provider_config_test.go
@@ -418,6 +418,7 @@ outputs:
 	tax := testTaxonomy(t)
 	_, err := outputconfig.Load(context.Background(), []byte(yamlConfig), tax)
 	require.Error(t, err)
+	// text-only: envsubst.go:131 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "NONEXISTENT_BAO_ADDR")
 }
 

--- a/outputconfig/secrets_test.go
+++ b/outputconfig/secrets_test.go
@@ -293,6 +293,7 @@ func TestLoad_WithSecretProvider_DuplicateSchemeErrors(t *testing.T) {
 		outputconfig.WithSecretProvider(mock2),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "duplicate")
 }
 
@@ -849,6 +850,7 @@ func TestLoad_WithSecretProvider_NilProviderErrors(t *testing.T) {
 		outputconfig.WithSecretProvider(nil),
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "nil")
 }
 
@@ -913,6 +915,7 @@ outputs:
 	require.Error(t, err)
 	// Should get a clear error about no provider, not a toBool error
 	// leaking the ref URI.
+	// text-only: hmac.go:136 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "no provider")
 }
 
@@ -1467,6 +1470,7 @@ func TestLoad_WithSecretProvider_SameInstanceTwice_Error(t *testing.T) {
 		outputconfig.WithSecretProvider(mock), // same instance
 	)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, outputconfig.ErrOutputConfigInvalid)
 	assert.Contains(t, err.Error(), "duplicate")
 }
 
@@ -1535,5 +1539,6 @@ outputs:
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), secretPassword,
 		"resolved secret value must not leak in error message")
+	// text-only: hmac.go:163 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "not a valid boolean")
 }

--- a/secrets/openbao/openbao_test.go
+++ b/secrets/openbao/openbao_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/axonops/audit"
 	"github.com/axonops/audit/secrets"
 	"github.com/axonops/audit/secrets/openbao"
 )
@@ -113,6 +114,7 @@ func TestNew_RequiresHTTPS(t *testing.T) {
 		Token:   "token",
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "https")
 }
 
@@ -120,6 +122,7 @@ func TestNew_RequiresAddress(t *testing.T) {
 	t.Parallel()
 	_, err := openbao.New(&openbao.Config{Token: "token"})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "address")
 }
 
@@ -129,6 +132,7 @@ func TestNew_RequiresToken(t *testing.T) {
 		Address: "https://vault.example.com",
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "token")
 }
 
@@ -139,6 +143,7 @@ func TestNew_RejectsEmbeddedCredentials(t *testing.T) {
 		Token:   "token",
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "credentials")
 }
 
@@ -149,6 +154,7 @@ func TestNew_RejectsEmptyHost(t *testing.T) {
 		Token:   "token",
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "empty host")
 }
 
@@ -160,6 +166,7 @@ func TestNew_RejectsMismatchedTLSCertKey(t *testing.T) {
 		TLSCert: "/some/cert.pem",
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "both be set")
 }
 
@@ -847,6 +854,7 @@ func TestNew_CustomCA_FileNotFound(t *testing.T) {
 		TLSCA:   "/nonexistent/ca.pem",
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "ca certificate")
 }
 
@@ -862,6 +870,7 @@ func TestNew_CustomCA_InvalidPEM(t *testing.T) {
 		TLSCA:   caPath,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "parse ca")
 }
 
@@ -896,6 +905,7 @@ func TestNew_mTLS_InvalidCertPath(t *testing.T) {
 		TLSKey:  keyPath,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "client certificate")
 }
 
@@ -903,6 +913,7 @@ func TestNewWithHTTPClient_NilConfig(t *testing.T) {
 	t.Parallel()
 	_, err := openbao.NewWithHTTPClient(nil, http.DefaultClient)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "nil")
 }
 
@@ -913,6 +924,7 @@ func TestNewWithHTTPClient_NilClient(t *testing.T) {
 		Token:   "token",
 	}, nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "nil")
 }
 
@@ -923,6 +935,7 @@ func TestNewWithHTTPClient_RequiresHTTPS(t *testing.T) {
 		Token:   "token",
 	}, http.DefaultClient)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "https")
 }
 

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/axonops/audit"
 	"github.com/axonops/audit/secrets"
 	"github.com/axonops/audit/secrets/vault"
 )
@@ -83,6 +84,7 @@ func TestNew_RequiresHTTPS(t *testing.T) {
 	t.Parallel()
 	_, err := vault.New(&vault.Config{Address: "http://vault.example.com", Token: "t"})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "https")
 	assert.Contains(t, err.Error(), "AllowInsecureHTTP")
 }
@@ -116,6 +118,7 @@ func TestNew_RequiresAddress(t *testing.T) {
 	t.Parallel()
 	_, err := vault.New(&vault.Config{Token: "t"})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "address")
 }
 
@@ -123,6 +126,7 @@ func TestNew_RequiresToken(t *testing.T) {
 	t.Parallel()
 	_, err := vault.New(&vault.Config{Address: "https://vault.example.com"})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "token")
 }
 
@@ -130,6 +134,7 @@ func TestNew_RejectsEmbeddedCredentials(t *testing.T) {
 	t.Parallel()
 	_, err := vault.New(&vault.Config{Address: "https://user:pass@vault.example.com", Token: "t"})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "credentials")
 }
 
@@ -137,6 +142,7 @@ func TestNew_RejectsEmptyHost(t *testing.T) {
 	t.Parallel()
 	_, err := vault.New(&vault.Config{Address: "https://", Token: "t"})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "empty host")
 }
 
@@ -144,6 +150,7 @@ func TestNew_RejectsMismatchedTLSCertKey(t *testing.T) {
 	t.Parallel()
 	_, err := vault.New(&vault.Config{Address: "https://vault.example.com", Token: "t", TLSCert: "/some/cert.pem"})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "both be set")
 }
 
@@ -783,6 +790,7 @@ func TestNew_CustomCA_FileNotFound(t *testing.T) {
 		TLSCA:   "/nonexistent/ca.pem",
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "ca certificate")
 }
 
@@ -798,6 +806,7 @@ func TestNew_CustomCA_InvalidPEM(t *testing.T) {
 		TLSCA:   caPath,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "parse ca")
 }
 
@@ -832,6 +841,7 @@ func TestNew_mTLS_InvalidCertPath(t *testing.T) {
 		TLSKey:  keyPath,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "client certificate")
 }
 
@@ -839,6 +849,7 @@ func TestNewWithHTTPClient_NilConfig(t *testing.T) {
 	t.Parallel()
 	_, err := vault.NewWithHTTPClient(nil, http.DefaultClient)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "nil")
 }
 
@@ -849,6 +860,7 @@ func TestNewWithHTTPClient_NilClient(t *testing.T) {
 		Token:   "token",
 	}, nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "nil")
 }
 
@@ -859,6 +871,7 @@ func TestNewWithHTTPClient_RequiresHTTPS(t *testing.T) {
 		Token:   "token",
 	}, http.DefaultClient)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "https")
 	assert.Contains(t, err.Error(), "AllowInsecureHTTP")
 }

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -734,6 +734,7 @@ events:
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("pii")),
 	)
 	require.Error(t, err)
+	// text-only: audit.go:762 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "no sensitivity config")
 }
 
@@ -766,6 +767,7 @@ events:
 		audit.WithNamedOutput(stdout, audit.WithExcludeLabels("nonexistent")),
 	)
 	require.Error(t, err)
+	// text-only: audit.go:767 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "undefined sensitivity label")
 }
 

--- a/severity_routing_test.go
+++ b/severity_routing_test.go
@@ -269,6 +269,7 @@ func TestValidateEventRoute_MinSeverityOutOfRange(t *testing.T) {
 			err := audit.ValidateEventRoute(&route, tax)
 			require.Error(t, err,
 				"min_severity %d must be rejected", tt.minSev)
+			assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 			assert.Contains(t, err.Error(), tt.wantErr,
 				"error message must identify the out-of-range value")
 		})
@@ -305,6 +306,7 @@ func TestValidateEventRoute_MaxSeverityOutOfRange(t *testing.T) {
 			err := audit.ValidateEventRoute(&route, tax)
 			require.Error(t, err,
 				"max_severity %d must be rejected", tt.maxSev)
+			assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 			assert.Contains(t, err.Error(), tt.wantErr,
 				"error message must identify the out-of-range value")
 		})
@@ -324,6 +326,7 @@ func TestValidateEventRoute_MinGreaterThanMax(t *testing.T) {
 	}
 	err := audit.ValidateEventRoute(&route, tax)
 	require.Error(t, err, "min_severity 8 > max_severity 3 must be rejected")
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "min_severity 8 exceeds max_severity 3",
 		"error message must name both values")
 }
@@ -794,6 +797,7 @@ func TestValidateEventRoute_SeverityWithMixedIncludeExclude(t *testing.T) {
 	err := audit.ValidateEventRoute(&route, tax)
 	require.Error(t, err,
 		"mixed include+exclude route with valid severity must still be rejected")
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "either include or exclude, not both",
 		"error message must identify the include/exclude conflict")
 }

--- a/severity_test.go
+++ b/severity_test.go
@@ -1020,6 +1020,7 @@ events:
 `
 	_, err := audit.ParseTaxonomyYAML([]byte(yml))
 	require.Error(t, err)
+	// text-only: taxonomy_yaml.go:133 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "unknown field")
 }
 
@@ -1036,6 +1037,7 @@ events:
 `
 	_, err := audit.ParseTaxonomyYAML([]byte(yml))
 	require.Error(t, err)
+	// text-only: taxonomy_yaml.go:123 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "expected a YAML sequence")
 	assert.Contains(t, err.Error(), "or mapping")
 }

--- a/stdout_registry_test.go
+++ b/stdout_registry_test.go
@@ -67,6 +67,7 @@ func TestStdoutFactory_RejectsConfig(t *testing.T) {
 
 	_, err := factory("bad_stdout", []byte("some_option: true\n"), nil, nil, audit.FrameworkContext{})
 	require.Error(t, err)
+	// text-only: stdout.go:41 returns raw fmt.Errorf without an audit sentinel wrap.
 	assert.Contains(t, err.Error(), "does not accept configuration")
 	assert.Contains(t, err.Error(), "bad_stdout")
 }

--- a/syslog/register_test.go
+++ b/syslog/register_test.go
@@ -45,6 +45,7 @@ func TestSyslogFactory_ValidConfig(t *testing.T) {
 	if err != nil {
 		// Connection failure is expected without Docker — verify it
 		// got past YAML parsing (error should be about connection).
+		// text-only: register.go wraps the dial error from syslog.go:298 — no audit sentinel in the chain.
 		assert.Contains(t, err.Error(), "siem_syslog")
 		return
 	}
@@ -60,6 +61,7 @@ func TestSyslogFactory_InvalidConfig_EmptyAddress(t *testing.T) {
 
 	_, err := factory("bad_syslog", yaml, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "bad_syslog")
 }
 
@@ -71,6 +73,7 @@ func TestSyslogFactory_UnknownYAMLField_Rejected(t *testing.T) {
 
 	_, err := factory("test", yaml, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err)
+	// text-only: register.go:111 wraps yaml.UnknownFieldError via WrapUnknownFieldError, not an audit sentinel.
 	assert.Contains(t, err.Error(), "bogus")
 }
 
@@ -80,6 +83,7 @@ func TestSyslogFactory_EmptyConfig_ReturnsError(t *testing.T) {
 
 	_, err := factory("empty", nil, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err)
+	// text-only: register.go:105 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "config is required")
 }
 
@@ -92,6 +96,7 @@ func TestSyslogFactory_WithTLSPolicy(t *testing.T) {
 	// Will fail to connect without Docker, but should parse YAML OK.
 	_, err := factory("tls_syslog", yaml, nil, nil, audit.FrameworkContext{})
 	if err != nil {
+		// text-only: register.go wraps the dial error from syslog.go — no audit sentinel in the chain.
 		assert.Contains(t, err.Error(), "tls_syslog")
 	}
 }

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -582,6 +582,8 @@ func TestNewSyslogOutput_InvalidPEMCA(t *testing.T) {
 		FlushInterval: 5 * time.Millisecond,
 	})
 	require.Error(t, err)
+	// text-only: tls.go:49 returns raw fmt.Errorf for invalid PEM (no
+	// sentinel wrap). The "parse" substring is the contract.
 	assert.Contains(t, err.Error(), "parse")
 }
 
@@ -1039,6 +1041,7 @@ func TestParseFacility_Unknown(t *testing.T) {
 		FlushInterval: 5 * time.Millisecond,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "unknown syslog facility")
 }
 
@@ -2020,6 +2023,9 @@ func TestNewSyslogOutput_TLSConfig_InvalidCAPEM(t *testing.T) {
 		FlushInterval: 5 * time.Millisecond,
 	})
 	require.Error(t, err)
+	// text-only: tls.go:45,49 return raw fmt.Errorf for read/parse CA
+	// failures (no sentinel wrap). The "ca certificate" substring is
+	// the contract.
 	assert.Contains(t, err.Error(), "ca certificate",
 		"error should mention CA certificate when PEM parsing fails")
 }
@@ -2041,6 +2047,7 @@ func TestNewSyslogOutput_TLSCert_IsDirectory(t *testing.T) {
 		FlushInterval: 5 * time.Millisecond,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "directory",
 		"error should report that the TLS path is a directory")
 }
@@ -2083,6 +2090,8 @@ func TestNewSyslogOutput_TCP_ConnectFailure(t *testing.T) {
 		FlushInterval: 5 * time.Millisecond,
 	})
 	require.Error(t, err)
+	// text-only: syslog.go:298,500 return raw fmt.Errorf for dial
+	// failures (no sentinel wrap). The "dial" substring is the contract.
 	assert.Contains(t, err.Error(), "dial",
 		"error should describe the dial failure")
 }
@@ -2109,6 +2118,9 @@ func TestNewSyslogOutput_TLSConfig_InvalidClientCert(t *testing.T) {
 		FlushInterval: 5 * time.Millisecond,
 	})
 	require.Error(t, err)
+	// text-only: syslog.go:261 returns raw fmt.Errorf for TLS config
+	// failures (no sentinel wrap). The "tls config" substring is the
+	// contract.
 	assert.Contains(t, err.Error(), "tls config",
 		"error should indicate a TLS configuration failure")
 }
@@ -2148,6 +2160,8 @@ func TestNewSyslogOutput_TLSConfig_UnreadableCAFile(t *testing.T) {
 		FlushInterval: 5 * time.Millisecond,
 	})
 	require.Error(t, err)
+	// text-only: tls.go:45 returns raw fmt.Errorf for read CA failures
+	// (no sentinel wrap). The "ca certificate" substring is the contract.
 	assert.Contains(t, err.Error(), "ca certificate",
 		"error should mention CA certificate when ReadFile is denied")
 }

--- a/syslog/syslog_tls_handshake_timeout_test.go
+++ b/syslog/syslog_tls_handshake_timeout_test.go
@@ -168,7 +168,7 @@ func TestNew_TLSHandshakeTimeout_Validation(t *testing.T) {
 			err := syslog.ValidateConfig(cfg)
 			if tc.wantErrInvalid {
 				require.Error(t, err)
-				assert.True(t, errors.Is(err, audit.ErrConfigInvalid),
+				assert.ErrorIs(t, err, audit.ErrConfigInvalid,
 					"expected ErrConfigInvalid, got: %v", err)
 				assert.Contains(t, err.Error(), "tls_handshake_timeout",
 					"validator error must mention the YAML key (snake_case)")
@@ -277,6 +277,7 @@ func TestReconnect_TLSHandshakeTimeout_RespectedOnRetry(t *testing.T) {
 
 		require.Error(t, err, "attempt %d: stalled handshake must error", attempt)
 		assert.Nil(t, conn, "attempt %d: no connection returned on timeout", attempt)
+		// text-only: syslog.go:530 returns raw fmt.Errorf without an audit sentinel wrap.
 		assert.Contains(t, err.Error(), "tls handshake timeout",
 			"attempt %d: error must signal handshake timeout", attempt)
 		assert.Less(t, elapsed, 1*time.Second,

--- a/syslog/tests/integration/syslog_test.go
+++ b/syslog/tests/integration/syslog_test.go
@@ -206,6 +206,7 @@ func TestSyslog_InvalidCert_Rejected(t *testing.T) {
 		TLSCA:    filepath.Join(certs, "invalid.crt"),
 	})
 	assert.Error(t, err, "construction with invalid CA should fail TLS handshake")
+	// text-only: error originates from crypto/tls handshake; no audit sentinel in the chain.
 	assert.Contains(t, err.Error(), "certificate")
 }
 

--- a/taxonomy_pointer_test.go
+++ b/taxonomy_pointer_test.go
@@ -160,6 +160,7 @@ func TestWithTaxonomy_PostConstructionMutation_DoesNotAffectAuditor(t *testing.T
 		"x": "y",
 	}))
 	require.Error(t, err, "hacked_event should not be in the auditor's taxonomy")
+	assert.ErrorIs(t, err, audit.ErrUnknownEventType)
 	assert.Contains(t, err.Error(), "unknown event type")
 
 	require.NoError(t, auditor.Close())

--- a/taxonomy_yaml_test.go
+++ b/taxonomy_yaml_test.go
@@ -840,6 +840,7 @@ events:
 `, tc.reserved, tc.declared))
 			_, err := audit.ParseTaxonomyYAML(yaml)
 			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrValidation)
 			assert.Contains(t, err.Error(), tc.reserved)
 			assert.Contains(t, err.Error(), "reserved standard field cannot declare a `type:`")
 		})

--- a/validation_error_test.go
+++ b/validation_error_test.go
@@ -207,6 +207,7 @@ func TestValidationError_MessageTextUnchanged(t *testing.T) {
 	// Missing required — text starts with expected prefix.
 	err = auditor.AuditEvent(audit.NewEvent("auth_failure", audit.Fields{}))
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrMissingRequiredField)
 	assert.Contains(t, err.Error(), `audit: event "auth_failure" missing required fields:`)
 }
 

--- a/webhook/register_test.go
+++ b/webhook/register_test.go
@@ -87,6 +87,7 @@ func TestWebhookFactory_UnknownYAMLField_Rejected(t *testing.T) {
 
 	_, err := factory("test", yaml, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err)
+	// text-only: register.go:126 wraps yaml.UnknownFieldError via WrapUnknownFieldError, not an audit sentinel.
 	assert.Contains(t, err.Error(), "unknown_field")
 }
 
@@ -110,6 +111,7 @@ func TestWebhookFactory_AllowInsecureHTTP_DefaultFalse_RejectsHTTPURL(t *testing
 
 	_, err := factory("no_insecure", rawYAML, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err, "HTTP URL without allow_insecure_http should be rejected")
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "must be https")
 }
 
@@ -121,6 +123,7 @@ func TestWebhookFactory_AllowInsecureHTTP_ExplicitFalse_RejectsHTTPURL(t *testin
 
 	_, err := factory("explicit_false", rawYAML, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err, "allow_insecure_http: false should still reject HTTP URLs")
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "must be https")
 }
 
@@ -154,6 +157,7 @@ func TestWebhookFactory_EmptyConfig_ReturnsError(t *testing.T) {
 
 	_, err := factory("empty", nil, nil, nil, audit.FrameworkContext{})
 	assert.Error(t, err)
+	// text-only: register.go:120 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "config is required")
 }
 
@@ -223,6 +227,7 @@ func TestWebhookFactory_ExplicitZeroMaxRetries_Rejected(t *testing.T) {
 
 	_, err := factory("zero_retries", yaml, nil, nil, audit.FrameworkContext{})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "max_retries must be at least 1")
 }
 
@@ -234,6 +239,7 @@ func TestWebhookFactory_ExplicitZeroBatchSize_Rejected(t *testing.T) {
 
 	_, err := factory("zero_batch", yaml, nil, nil, audit.FrameworkContext{})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "batch_size must be at least 1")
 }
 

--- a/webhook/webhook_external_test.go
+++ b/webhook/webhook_external_test.go
@@ -532,6 +532,7 @@ func TestNewWebhookOutput_Valid(t *testing.T) {
 func TestNewWebhookOutput_InvalidConfig(t *testing.T) {
 	_, err := webhook.New(&webhook.Config{}, nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "must not be empty")
 }
 
@@ -1112,6 +1113,7 @@ func TestNewWebhookOutput_EmbeddedCredentials_Rejected(t *testing.T) {
 		URL: "https://user:pass@example.com/webhook",
 	}, nil)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 	assert.Contains(t, err.Error(), "must not contain credentials")
 }
 
@@ -2097,6 +2099,7 @@ func TestNew_NilConfig_ReturnsError(t *testing.T) {
 	t.Parallel()
 	_, err := webhook.New(nil, nil)
 	require.Error(t, err)
+	// text-only: webhook.go:169 returns raw fmt.Errorf without a sentinel wrap.
 	assert.Contains(t, err.Error(), "config must not be nil")
 }
 

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -243,6 +243,7 @@ func TestValidateConfig_NonexistentTLSFiles(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := webhook.New(&tt.cfg, nil)
 			require.Error(t, err)
+			assert.ErrorIs(t, err, audit.ErrConfigInvalid)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}


### PR DESCRIPTION
## Summary

Closes #556. Migrates **274 of 367** `assert.Contains(t, err.Error(), ...)` sites to add `assert.ErrorIs(t, err, ErrXxx)` as the primary sentinel-chain assertion, with `Contains` retained as a supplemental text check. Remaining **93** sites are annotated `// text-only` citing the production file:line that returns the unwrapped error.

**Conversion rate:** 82.0% of the original 334 baseline (AC threshold: 80%); 74.7% of the current 367 sites after subsequent test growth.

## Production wraps added (strictly additive)

- **`options.go`**: `WithAppName` / `WithHost` / `WithTimezone` empty + over-length validations now wrap `audit.ErrConfigInvalid`.
- **`filter.go`**: `ValidateEventRoute` include/exclude mix, severity range checks, and unknown-taxonomy-entry references now wrap `audit.ErrConfigInvalid`.

These wraps are strictly additive: existing `errors.Is` checks continue to match; new `errors.Is(err, audit.ErrConfigInvalid)` checks now also match. Pre-release v0.x — no semver concerns.

## Documentation

`docs/error-reference.md` — `ErrConfigInvalid` section extended with a "Sentinel coverage (#556)" sub-row enumerating the new wrap chains for consumer reference.

## Why text-only sites are not converted

Three categories:
1. **Internal helpers** — e.g. `outputconfig/convert.go`'s `toInt`/`toBool`/`toStringSlice` return raw `fmt.Errorf` without a sentinel; the wrap chain is established at the `Load()` upstream boundary.
2. **Third-party error stringifications** — e.g. mock errors injected by `errorOutput.closeErr` test fixtures.
3. **Production paths with bare `fmt.Errorf`** — e.g. `audit.go:378` (nil-event guard), `tls.go:45,49` (syslog TLS file errors), `audit.go:793,809,825,842` (runtime EnableX/DisableX category/event guards). Per code-reviewer's pre-coding rule, no `%s → %w` flips and no production-code modifications beyond the additive wraps above.

## Agent gates

- pre-coding: test-writer (rules confirmed), code-reviewer (warnings actioned)
- post-coding: code-reviewer (GO-WITH-CHANGES — 5 stale `// text-only` comments fixed), test-analyst (GO-WITH-CHANGES — same 5 sites; same fix applied), go-quality (GO), commit-message-reviewer (PASS)
- `make check` — exit 0
- `make lint` — 0 issues across all 14 modules
- `go test -race -count=1 ./...` — pass

## Test plan

- [x] `make check` — green
- [x] `make lint` — 0 issues
- [x] `go test -race -count=1` core, outputconfig, secrets, vault, openbao, syslog, webhook, loki, file
- [ ] CI green on push