### PR TITLE
ci: add mutation-test workflow + PR-scope + release gate (#524)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,37 +41,58 @@ jobs:
     timeout-minutes: 2
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      mutation-targets: ${{ steps.mutation.outputs.targets }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - name: Check for code changes
-        id: filter
+      # Resolve the diff base shared by both filter steps below.
+      # Sets BASE in $GITHUB_ENV plus a sentinel BASE_RESOLVED that
+      # downstream steps check before running their own diff.
+      #   BASE_RESOLVED=skip       — workflow_dispatch / workflow_call
+      #                              (each consumer decides what skip
+      #                              means: full-CI for `filter`, empty
+      #                              targets for `mutation`).
+      #   BASE_RESOLVED=force-full — base unreachable / first push;
+      #                              run everything.
+      #   BASE_RESOLVED=ok         — BASE is set to a usable commit SHA.
+      - name: Resolve diff base
+        id: base
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "BASE_RESOLVED=skip" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          # For PRs, diff against the base branch. For pushes, diff against parent.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
           else
             BASE="${{ github.event.before }}"
           fi
 
-          # If BASE is empty or all zeros (new branch), run everything.
           if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "BASE_RESOLVED=force-full" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          # Verify base commit is reachable (handles force-pushes).
           if ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "BASE_RESOLVED=force-full" >> "$GITHUB_ENV"
+            echo "Base commit $BASE not reachable — downstream steps will run full CI"
+            exit 0
+          fi
+
+          echo "BASE=$BASE" >> "$GITHUB_ENV"
+          echo "BASE_RESOLVED=ok" >> "$GITHUB_ENV"
+
+      - name: Check for code changes
+        id: filter
+        run: |
+          # filter treats both `skip` (manual trigger) and `force-full`
+          # (unreachable base) as "run full CI" — historical behaviour.
+          if [ "$BASE_RESOLVED" != "ok" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
-            echo "Base commit $BASE not reachable — running full CI"
             exit 0
           fi
 
@@ -100,6 +121,57 @@ jobs:
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "Code changes detected:"
             echo "$CHANGED" | head -20
+          fi
+
+      # Detect which mutation-test targets need to run for this PR.
+      # Output is a JSON array consumed by the `mutation-test` job's
+      # matrix strategy. Empty array → matrix expands to zero jobs and
+      # the gate trivially passes (no surviving-mutant risk introduced).
+      #
+      # A target runs when EITHER its source file OR its test file
+      # changes — a test refactor that drops an `errors.Is` check is
+      # exactly the regression mutation testing is designed to catch.
+      # `.gremlins.yaml` changing forces all 6 targets to run since
+      # config affects every per-file invocation. (#524)
+      - name: Detect mutation-test targets
+        id: mutation
+        run: |
+          # mutation treats `skip` and `force-full` as "no targets" —
+          # the standalone mutation-test workflow handles full-suite
+          # runs explicitly, and a first push without a reachable base
+          # is covered by the next weekly scheduled run.
+          if [ "$BASE_RESOLVED" != "ok" ]; then
+            echo 'targets=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          DIFF=$(git diff --name-only "$BASE" HEAD)
+
+          # If .gremlins.yaml changed, every target must re-run because
+          # operator/threshold config affects every file equally.
+          if echo "$DIFF" | grep -q '^\.gremlins\.yaml$'; then
+            echo 'targets=["validate_fields","validate_taxonomy","hmac","filter","format_cef","sensitivity"]' >> "$GITHUB_OUTPUT"
+            echo ".gremlins.yaml changed — running all 6 mutation targets"
+            exit 0
+          fi
+
+          # Otherwise, run a target if its source OR test file changed.
+          # Test-file suffixes covered: _test, _boundary_test,
+          # _property_test, _internal_test.
+          declare -a TARGETS=()
+          for t in validate_fields validate_taxonomy hmac filter format_cef sensitivity; do
+            if echo "$DIFF" | grep -qE "^${t}(_(boundary|property|internal))?(_test)?\.go$"; then
+              TARGETS+=("\"${t}\"")
+            fi
+          done
+
+          if [ "${#TARGETS[@]}" -eq 0 ]; then
+            echo 'targets=[]' >> "$GITHUB_OUTPUT"
+            echo "No mutation-test targets affected by this PR"
+          else
+            JSON="[$(IFS=,; echo "${TARGETS[*]}")]"
+            echo "targets=${JSON}" >> "$GITHUB_OUTPUT"
+            echo "Mutation-test targets: ${JSON}"
           fi
 
   # Requires Dependency Graph enabled in repo settings:
@@ -563,6 +635,59 @@ jobs:
       - name: Build all examples
         run: make test-examples
 
+  # PR-scope mutation testing (#524). Matrix-fan-out across the six
+  # mutation targets, but ONLY for the targets actually affected by
+  # this PR (per `changes.outputs.mutation-targets` — see the change
+  # detection job above). The matrix expands to zero jobs when no
+  # target source/test file changed; the job result is then "skipped",
+  # which the ci-pass aggregate treats as success.
+  #
+  # Full-suite mutation testing runs weekly via `mutation-test.yml`
+  # and on every release tag via `release.yml`; this PR-scope job
+  # gates the common case (regression in one file's tests) cheaply.
+  mutation-test:
+    name: Test - Mutation (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # 60 min budget per target — local wall time is ~10 min per file
+    # on Ryzen 9 32-thread; ubuntu-latest 4-core runners are 2-3x
+    # slower (~20-30 min), with headroom for the gather-coverage
+    # warm-up and tool install.
+    timeout-minutes: 60
+    needs: [hygiene, changes]
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.mutation-targets != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.changes.outputs.mutation-targets) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up audit workspace
+        uses: ./.github/actions/setup-audit
+        with:
+          install-tools: 'true'
+
+      - name: Run mutation-test for ${{ matrix.target }}
+        run: |
+          set -o pipefail
+          # Recipe naming: target stems map 1:1 to make targets — e.g.
+          # `format_cef` -> `mutation-test-format-cef`. Hyphenate the
+          # underscore tail per CLI naming convention applied in the
+          # Makefile (`mutation-test-format-cef`).
+          NAME=$(echo '${{ matrix.target }}' | tr '_' '-')
+          make "mutation-test-${NAME}" 2>&1 | tee mutation-test-report-${{ matrix.target }}.txt
+
+      - name: Upload mutation-test report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-test-report-${{ matrix.target }}-${{ github.sha }}
+          path: mutation-test-report-${{ matrix.target }}.txt
+          retention-days: 7
+
   # Benchmarks removed from CI — GitHub Actions runners have inconsistent
   # performance, making results unreliable for comparison. Run benchmarks
   # locally on consistent hardware: make bench && make bench-compare
@@ -590,7 +715,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 5
-    needs: [changes, hygiene, lint, test, test-cross-platform, integration, bdd, bdd-verify, security, security-verify, cross-build, examples-build, validate-release]
+    needs: [changes, hygiene, lint, test, test-cross-platform, integration, bdd, bdd-verify, security, security-verify, cross-build, examples-build, validate-release, mutation-test]
     if: always()
     steps:
       - name: Check all jobs passed

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -1,0 +1,92 @@
+name: Mutation Test
+
+# Standalone full-suite mutation testing for the six security-critical
+# files in the root audit package: validate_fields.go, validate_taxonomy.go,
+# hmac.go, filter.go, format_cef.go, sensitivity.go.
+#
+# Triggers:
+#   - workflow_dispatch  — ad-hoc, optionally scoped to a single target
+#   - schedule (weekly)  — Sunday 04:00 UTC; report lands before
+#                          Monday morning EU workday review.
+#
+# PR-scope mutation testing (per-file targets matching files changed
+# in the PR) is wired into ci.yml; this workflow runs the FULL suite
+# and uploads the report as a 90-day artefact so quarterly trend
+# comparison is possible. Release-tag mutation testing runs from
+# release.yml and attaches the report to the GitHub Release.
+#
+# If wall-time exceeds budget on ubuntu-latest runners, switch
+# `runs-on:` to a self-hosted runner per #524 AC#3.
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: |
+          Mutation target to run. `all` runs the full suite (~90-150 min
+          on ubuntu-latest). Single-target shortcuts cut wall time to
+          ~20-30 min for ad-hoc verification.
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - 'all'
+          - 'validate_fields'
+          - 'validate_taxonomy'
+          - 'hmac'
+          - 'filter'
+          - 'format_cef'
+          - 'sensitivity'
+
+permissions:
+  contents: read
+
+# Scheduled and dispatched runs are allowed to queue — never cancel
+# in-flight mutation work since the per-mutant test invocations are
+# expensive to redo. A maintainer's manual dispatch during a Sunday
+# scheduled run will queue behind it (~3 hour worst case).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation-test:
+    name: Mutation test (${{ inputs.target || 'all' }})
+    runs-on: ubuntu-latest
+    # 4-hour budget covers the full suite (60 min local, 90-150 min on
+    # 4-core ubuntu-latest) with headroom for cold caches and tool install.
+    timeout-minutes: 240
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up audit workspace
+        uses: ./.github/actions/setup-audit
+        with:
+          install-tools: 'true'
+
+      - name: Run mutation test
+        env:
+          TARGET: ${{ inputs.target || 'all' }}
+        run: |
+          set -o pipefail
+          if [ "$TARGET" = "all" ]; then
+            make mutation-test 2>&1 | tee mutation-test-report.txt
+          else
+            # Underscore -> hyphen in target stem to match Makefile
+            # target names (mutation-test-format-cef, etc.).
+            NAME=$(echo "$TARGET" | tr '_' '-')
+            make "mutation-test-${NAME}" 2>&1 | tee mutation-test-report.txt
+          fi
+
+      - name: Upload mutation-test report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-test-report-${{ inputs.target || 'all' }}-${{ github.sha }}
+          path: mutation-test-report.txt
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,59 @@ jobs:
           if-no-files-found: ignore
 
   # =====================================================================
+  # Job: mutation-test-release (#524)
+  # =====================================================================
+  # Full mutation-test suite as a release gate. Runs after preflight
+  # alongside the other workflow_dispatch-only gates (ci, fuzz-long,
+  # bench-advisory, api-check) and gates `update-deps-pr` (the release
+  # PR cannot land if mutation-test efficacy is below threshold).
+  #
+  # workflow_dispatch ONLY: the push-tag recovery path skips this job
+  # under the assumption that the gates already passed on the original
+  # workflow_dispatch run that aborted before tag publication. Adding
+  # this 4-hour gate to the recovery path would block legitimate
+  # tag-republish operations behind a re-run of work that already
+  # passed — unacceptable for incident-recovery flows.
+  #
+  # The report artefact is also re-attached to the published GitHub
+  # Release by the `mutation-test-attach` job after goreleaser
+  # succeeds (per #524 AC#3).
+  # =====================================================================
+  mutation-test-release:
+    name: Mutation Test (release gate)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # 4-hour budget — full suite is 60 min on local Ryzen 9, expected
+    # 90-150 min on 4-core ubuntu-latest with headroom for cold caches.
+    timeout-minutes: 240
+    needs: [preflight]
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up audit workspace
+        uses: ./.github/actions/setup-audit
+        with:
+          install-tools: 'true'
+
+      - name: Run full mutation-test suite
+        run: |
+          set -o pipefail
+          make mutation-test 2>&1 | tee mutation-test-report.txt
+
+      - name: Upload mutation-test report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-test-report-release-${{ needs.preflight.outputs.version }}
+          path: mutation-test-report.txt
+          retention-days: 90
+
+  # =====================================================================
   # Job: api-check (workflow_dispatch only)
   # =====================================================================
   # Runs `make api-check` — gorelease per published module against
@@ -331,7 +384,7 @@ jobs:
     name: Open release PR
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [preflight, ci, fuzz-long, api-check]
+    needs: [preflight, ci, fuzz-long, api-check, mutation-test-release]
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: read  # job-level — App token grants the writes
@@ -688,6 +741,41 @@ jobs:
   # Triggers proxy.golang.org indexing and runs a smoke test
   # (go get + compile + install) against the freshly tagged versions.
   # =====================================================================
+  # =====================================================================
+  # Job: mutation-test-attach (#524)
+  # =====================================================================
+  # Downloads the mutation-test report artefact uploaded by the
+  # mutation-test-release gate job and attaches it to the published
+  # GitHub Release. The release was already gated on a passing
+  # mutation-test run; this step makes the report permanently
+  # discoverable from the release page.
+  # =====================================================================
+  mutation-test-attach:
+    name: Attach Mutation Report to Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [preflight, goreleaser, mutation-test-release]
+    permissions:
+      contents: write
+    # workflow_dispatch ONLY: matches mutation-test-release gating —
+    # the push-tag recovery path does not produce a mutation-test
+    # artefact to attach.
+    if: github.event_name == 'workflow_dispatch'
+    env:
+      PUBLISH_VERSION: ${{ needs.preflight.outputs.version }}
+    steps:
+      - name: Download mutation-test report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mutation-test-report-release-${{ needs.preflight.outputs.version }}
+
+      - name: Attach report to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "$PUBLISH_VERSION" mutation-test-report.txt --clobber --repo "$GITHUB_REPOSITORY"
+
   verify:
     name: Verify Release
     runs-on: ubuntu-latest
@@ -803,10 +891,12 @@ jobs:
       - fuzz-long
       - bench-advisory
       - api-check
+      - mutation-test-release
       - update-deps-pr
       - wait-for-pr-merge
       - tag-all
       - goreleaser
+      - mutation-test-attach
       - verify
       - invariants
     if: always()
@@ -831,10 +921,12 @@ jobs:
             echo "| Long Fuzz | ${{ needs.fuzz-long.result }} |"
             echo "| Bench (advisory) | ${{ needs.bench-advisory.result }} |"
             echo "| API Check | ${{ needs.api-check.result }} |"
+            echo "| Mutation Test (gate) | ${{ needs.mutation-test-release.result }} |"
             echo "| Open release PR | ${{ needs.update-deps-pr.result }} |"
             echo "| Wait for merge | ${{ needs.wait-for-pr-merge.result }} |"
             echo "| Tag all modules | ${{ needs.tag-all.result }} |"
             echo "| GoReleaser | ${{ needs.goreleaser.result }} |"
+            echo "| Mutation Report Attached | ${{ needs.mutation-test-attach.result }} |"
             echo "| Verify | ${{ needs.verify.result }} |"
             echo "| Invariants | ${{ needs.invariants.result }} |"
             echo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,6 +275,62 @@ order of preference:
 (`scripts/tool-versions.txt`). For a local-only install, run
 `make install-gremlins`.
 
+#### Reading the CI workflow report (#524)
+
+Mutation testing runs in CI in three modes (workflow files at
+`.github/workflows/`):
+
+- **Per PR** (`ci.yml`) — only the targets whose source or test file
+  changed in the PR (or all six if `.gremlins.yaml` changed). Each
+  matrix shard uploads an artefact named
+  `mutation-test-report-<target>-<sha>` where `<target>` matches the
+  make-target stem with underscores (e.g.
+  `mutation-test-report-validate_fields-abc1234`); 7-day retention.
+- **Weekly** (`mutation-test.yml`, Sundays 04:00 UTC) — full suite,
+  uploads `mutation-test-report-all-<sha>`; 90-day retention. Also
+  triggerable manually via `workflow_dispatch` with optional
+  per-target scope (single-target dispatches upload
+  `mutation-test-report-<target>-<sha>` instead).
+- **On release tag** (`release.yml`, workflow_dispatch path only) —
+  full suite as a release gate. The Actions artefact name is
+  `mutation-test-report-release-<version>` (90-day retention); the
+  same report is then attached to the published GitHub Release page
+  as the asset `mutation-test-report.txt` (permanent on the release).
+
+To download a CI artefact:
+
+```bash
+# List recent runs — note the RUN_ID in the first column
+gh run list --workflow=mutation-test.yml --limit 5
+
+# Resolve the SHA for that run, then download by exact artefact name
+SHA=$(gh run view <RUN_ID> --json headSha --jq .headSha)
+gh run download <RUN_ID> --name "mutation-test-report-all-${SHA}"
+```
+
+The artefact is the captured stdout of `make mutation-test`.
+`` `LIVED <operator> at <file>:<line>:<col>` `` lines identify
+surviving mutants; cross-reference each against `MUTATION_TESTING.md`
+(repo root) to determine whether it's a genuine regression (kill it
+with a new test) or matches an existing equivalent-mutant exemption.
+
+To verify the workflow itself is detecting surviving mutants — e.g.
+after a gremlins version bump or a `.gremlins.yaml` change — apply a
+deliberately-weak assertion to one of the target files' tests
+(`assert.NotNil(...)` instead of an exact comparison), trigger
+`mutation-test.yml` via `workflow_dispatch`, and confirm the report
+contains LIVED entries.
+
+> **Warning:** the weak assertion MUST NOT be committed. `make check`
+> does not detect weakened assertions — keep the change in a local
+> `git stash` or a throwaway `git worktree`, and revert before
+> opening a PR.
+
+A `workflow_dispatch` run fired while the Sunday scheduled run is
+still in flight waits for the scheduled run to finish before starting
+(`cancel-in-progress: false`); expect up to ~3 hours before results
+are available.
+
 ## Code Standards
 
 The [Google Go Style Guide](https://google.github.io/styleguide/go/)


### PR DESCRIPTION
## Summary

- Wires `make mutation-test*` (landed in #571) into CI via three triggers: standalone weekly + ad-hoc workflow, PR-scope matrix-fan-out, and release gate.
- All 5 ACs of #524 satisfied.

## Three CI modes

1. **`.github/workflows/mutation-test.yml`** (new): `workflow_dispatch` (with single-target choice input) + `cron: '0 4 * * 0'` (Sunday 04:00 UTC). Full suite, 90-day artefact retention.
2. **`ci.yml` PR-scope job**: matrix-fan-out across the per-file targets matching files changed in the PR. The existing `changes` job is extended with a `mutation-targets` JSON-array output that detects whether any of the 6 source files, their test files (any of `_test`, `_boundary_test`, `_property_test`, `_internal_test` suffixes), or `.gremlins.yaml` changed. Empty array → matrix expands to zero jobs → `ci-pass` treats as success. 7-day retention.
3. **`release.yml` gate + attach**: `mutation-test-release` runs the full suite as a release-PR gate (`workflow_dispatch` only; matches existing `fuzz-long`/`api-check` pattern so the push-tag recovery path is not blocked by a 4-hour mutation run). After `goreleaser`, `mutation-test-attach` downloads the artefact and attaches `mutation-test-report.txt` to the published GitHub Release page.

## Refactoring

- Extracted shared diff-base resolution from the existing `code` filter step into a single `Resolve diff base` step that exports `BASE` + `BASE_RESOLVED` to `$GITHUB_ENV`. Eliminates 30-line duplication; both filter steps now consume the same base resolution.
- Updated `download-artifact` SHA pin from v6.0.0 to v8.0.1 (aligned with the version already used elsewhere in the repo).

## Documentation

- `CONTRIBUTING.md` "Reading the CI workflow report" subsection: three CI modes, artefact naming with worked examples, `gh run download` recipe with SHA resolution, weak-assertion verification recipe with safety warning ("MUST NOT be committed"), concurrency note for queued ad-hoc dispatches.

## Test plan

- [x] All three workflow YAMLs parse via `python3 yaml.safe_load`
- [x] Bash regex verified locally — `^format_cef(_(boundary|property|internal))?(_test)?\\.go$` matches the 5 expected file patterns and excludes `format.go` / `format_json.go`
- [x] `make fmt-check`, `make vet`, `make tidy-check` pass (no Go code changes)
- [x] **THIS PR**'s `mutation-test` matrix expands to zero shards (no target files changed) — verifies the empty-matrix path
- [x] Pre-coding consults: devops + test-analyst (verdicts incorporated)
- [x] Post-coding gates: devops, code-reviewer, docs-writer (4 IMPORTANT findings + 1 BLOCKER addressed: `mutation-test-release` properly gated to `workflow_dispatch` to preserve push-tag recovery semantics)

CI workflow scope confirmed by inspection — this PR's diff touches only workflow + docs files, so the new `mutation-test` matrix correctly produces an empty target list and the job result is `skipped` (treated as success by `ci-pass`).

Closes #524