### PR TITLE
security(file): restrict permissions to 0600/0640 (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,68 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Breaking Changes
 
+- **File output permissions restricted to `0o600` (default) or `0o640`
+  (group-readable)** (#436). The flexible `Permissions string`
+  Config field is removed; the YAML `permissions:` key is removed.
+  Replaced by `Config.GroupReadable bool` (YAML: `group_readable:
+  true`). Audit logs are not regular application logs — they contain
+  compliance-critical data subject to SOX/HIPAA/GDPR
+  tamper-resistance — and the prior `0–0o777` flexibility allowed a
+  misconfig to publish audit data world-readable. Two modes are
+  supported: `0o600` (owner only; the strictest default) and
+  `0o640` (owner read/write + group read; for SIEM forwarders
+  running as a separate user in the file's group). World-readable,
+  world-writable, and group-writable modes are unsupported and
+  reject at startup.
+
+  At construction, [`file.New`] now also rejects an existing audit
+  log at the configured path whose on-disk permissions are broader
+  than the target mode, whose setuid/setgid/sticky bits are set, or
+  whose hardlink count exceeds 1 — all are tamper indicators. Errors
+  wrap [`audit.ErrConfigInvalid`].
+
+  **Before**
+  ```yaml
+  outputs:
+    audit_log:
+      type: file
+      config:
+        path: /var/log/audit/events.log
+        permissions: "0600"   # also accepted "0644", "0666", "0777" — silent compliance hazard
+  ```
+
+  **After**
+  ```yaml
+  outputs:
+    audit_log:
+      type: file
+      config:
+        path: /var/log/audit/events.log
+        # Default 0o600 — no field needed.
+  ```
+
+  ```yaml
+  outputs:
+    siem_archive:
+      type: file
+      config:
+        path: /var/log/audit/siem.log
+        group_readable: true   # mode 0o640 for the SIEM forwarder
+  ```
+
+  **Migration**
+
+  | Old YAML | New YAML |
+  |---|---|
+  | `permissions: "0600"` | _omit; default is 0o600_ |
+  | `permissions: "0640"` | `group_readable: true` |
+  | `permissions: "0644"` (or any broader) | unsupported — fix the deployment to `0o600` or `0o640` |
+
+  Operators with existing audit logs at broader modes must `chmod` them
+  before the next startup or the library will refuse to open them.
+  `outputconfig.Load` produces an `unknown field "permissions"` decode
+  error on the legacy key, naming the rejected field for the operator.
+
 - **Collapse output setter interfaces into `audit.FrameworkContext`** (#696).
   The `OutputFactory` signature drops `coreMetrics` and `logger`
   positional parameters and gains all construction-time data via the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -175,7 +175,9 @@ data:
         type: file
         file:
           path: /var/log/myservice/audit.log
-          permissions: "0600"
+          # Default mode is 0o600 (owner only). Set group_readable:
+          # true for 0o640 when a SIEM forwarder runs in the same
+          # group.
           max_size_mb: 100
           max_backups: 5
         hmac:

--- a/docs/file-output.md
+++ b/docs/file-output.md
@@ -157,7 +157,7 @@ for the complete pipeline architecture.
 | `max_size_mb` | int | `100` | 1–10,240 (10 GB) | Rotate when the file reaches this size. Values <= 0 default to 100 |
 | `max_backups` | int | `5` | 0–100 | Rotated backups to retain. 0 = keep all (no count limit). Values <= 0 default to 5 |
 | `max_age_days` | int | `30` | 0–365 | Delete backups older than this. 0 = no age limit. Values <= 0 default to 30 |
-| `permissions` | string | `"0600"` | Octal (0–0777) | File permissions. MUST be quoted in YAML |
+| `group_readable` | bool | `false` | — | If `true`, mode is `0o640` (owner read/write + group read). If absent or `false`, mode is `0o600` (owner only). See [Permissions and Security](#permissions-and-security) for the rationale. |
 | `compress` | bool | `true` | — | Gzip compress rotated backup files |
 | `buffer_size` | int | `10000` | 1–100,000 | Internal async buffer capacity. Events dropped when full |
 
@@ -167,24 +167,35 @@ for the complete pipeline architecture.
 - Parent directory of `path` MUST exist at construction time
 - **Symlinks are rejected** — the parent directory path is resolved at
   construction time and symlinks are rejected to prevent path traversal
-- `permissions` MUST be a valid octal string. Values above `0777` are
-  rejected
-- Group or world-writable permissions (e.g., `0666`, `0777`) produce a
-  `slog` warning
+- An existing audit log at `path` MUST have permissions equal to or
+  narrower than the configured target mode (`0o600` or `0o640`); a
+  broader on-disk mode is rejected with an error wrapping
+  [`audit.ErrConfigInvalid`] (#436)
+- An existing audit log MUST NOT have setuid, setgid, or sticky bits
+  set, and MUST have a hardlink count of 1; both are treated as
+  tamper indicators (#436)
 - `max_size_mb`, `max_backups`, `max_age_days` are rejected if above
   their upper bounds. Zero values default to the documented defaults
 
-### Permissions Quoting
+### Why only two modes (#436)
 
-The `permissions` field MUST be quoted in YAML:
+Audit logs are not regular application logs. They contain
+compliance-critical data — who did what, when, to which resource —
+and are subject to SOX, HIPAA, and GDPR tamper-resistance
+requirements. The library hardcodes two permission modes:
 
-```yaml
-# CORRECT — quoted string, parsed as octal
-permissions: "0600"
+- **`0o600` (default)** — owner read/write only. The strictest mode;
+  use this unless you have a specific reason not to.
+- **`0o640` (`group_readable: true`)** — owner read/write + group
+  read. Required when a SIEM forwarder (Filebeat, Promtail, Fluentd)
+  runs as a separate user in the file's group.
 
-# WRONG — unquoted, YAML parses 0600 as the integer 384
-permissions: 0600
-```
+World-readable, world-writable, or group-writable modes are
+**unsupported** because they undermine compliance: world-readable
+exposes audit data to any user on the host, and write access (group
+or world) defeats append-only-from-a-single-writer integrity.
+Operators needing finer-grained access SHOULD use POSIX ACLs at the
+OS level rather than relax the library's mode.
 
 ## File Rotation
 
@@ -420,7 +431,6 @@ outputs:
       max_size_mb: 500
       max_backups: 20
       max_age_days: 90
-      permissions: "0600"
       compress: true
 ```
 
@@ -437,7 +447,6 @@ outputs:
       max_size_mb: 1000
       max_backups: 100
       max_age_days: 365
-      permissions: "0600"
       compress: true
     hmac:
       enabled: true
@@ -457,10 +466,12 @@ signature to each event, providing evidence of modification.
 | `path must not be empty` | Missing `path` in config | Add the `path` field to the file block |
 | `parent directory does not exist` | Directory not created | Create the directory before starting the application |
 | `symlink rejected` | Parent path contains a symlink | Use a direct path without symlinks |
-| `invalid permissions` | `permissions` value > 0777 | Use a valid octal string like `"0600"` |
+| `existing file permissions … broader than required` | Pre-existing audit log at the configured path has wider permissions than `0o600` (or `0o640` if `group_readable: true`) | `chmod 0600` (or `0640`) the existing file before next startup, or move it aside |
+| `existing file has setuid/setgid/sticky bits set` | Audit log file has special POSIX bits (tamper indicator) | Investigate the cause; if benign, `chmod` to clear the bits before next startup |
+| `existing file has hardlink count` | Audit log shares an inode with another path | Remove the hardlink; the audit log should be a single file with `nlink=1` |
+| `unknown field "permissions"` | Old YAML still uses pre-#436 `permissions:` key | Remove the line (default is `0o600`) or replace with `group_readable: true` for `0o640` |
 | File not rotating | `max_size_mb` too large for event volume | Reduce `max_size_mb` or check disk space |
 | Disk filling up | Too many backups or age limit too high | Reduce `max_backups` and `max_age_days` |
-| `YAML error: 0600 is not a string` | `permissions` not quoted | Quote it: `permissions: "0600"` |
 
 ## Related Documentation
 

--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -89,7 +89,7 @@ outputs:
       max_size_mb: 100             # rotate at this size (default: 100)
       max_backups: 5               # keep this many rotated files (default: 5)
       max_age_days: 30             # delete files older than this (default: 30)
-      permissions: "0600"          # file permissions (default: "0600")
+      group_readable: false        # true → mode 0o640 (default false → 0o600)
       compress: true               # gzip rotated files (default: true)
     route:
       exclude_categories:
@@ -694,7 +694,7 @@ See [Sensitivity Labels](sensitivity-labels.md) for details.
 | `max_size_mb` | `100` | Rotate when file reaches this size in MB. Maximum: 10,240 (10 GB). |
 | `max_backups` | `5` | Number of rotated files to keep. Maximum: 100. |
 | `max_age_days` | `30` | Delete rotated files older than this. Maximum: 365. |
-| `permissions` | `"0600"` | File permissions (octal string, must be quoted). |
+| `group_readable` | `false` | When `true`, mode is `0o640` (owner + group read). Default `false` is `0o600` (owner only). World-readable and group-writable modes are unsupported (#436). |
 | `compress` | `true` | Gzip compress rotated files. |
 | `buffer_size` | `10000` | Internal async buffer capacity. Maximum: 100,000. |
 

--- a/examples/03-file-output/README.md
+++ b/examples/03-file-output/README.md
@@ -44,7 +44,6 @@ outputs:
       path: "./audit.log"
       max_size_mb: 10
       max_backups: 3
-      permissions: "0600"
 ```
 
 The `type: file` tells the library to use the file output module. The
@@ -59,19 +58,8 @@ type-specific settings are nested under a key matching the type name
 | `max_size_mb` | 100 | Rotate when the file exceeds this size. |
 | `max_backups` | 5 | Number of rotated files to keep. |
 | `max_age_days` | 30 | Delete rotated files older than this. |
-| `permissions` | `"0600"` | File permissions (must be quoted — see below). |
+| `group_readable` | `false` | When `true`, mode is `0o640` (owner + group read) for SIEM forwarders running in the file's group. Default `false` is `0o600` (owner only). |
 | `compress` | `true` | Gzip rotated files. |
-
-### Why Permissions Must Be Quoted
-
-```yaml
-permissions: "0600"    # correct
-permissions: 0600      # WRONG — YAML reads this as integer 384
-```
-
-In YAML, an unquoted `0600` is parsed as the integer 384 (octal
-interpretation). The library requires a string to prevent this silent
-misconfiguration.
 
 ### Enabling the File Output Type
 

--- a/examples/03-file-output/outputs.yaml
+++ b/examples/03-file-output/outputs.yaml
@@ -8,4 +8,3 @@ outputs:
       path: "./audit.log"
       max_size_mb: 10
       max_backups: 3
-      permissions: "0600"

--- a/examples/09-multi-output/README.md
+++ b/examples/09-multi-output/README.md
@@ -43,7 +43,6 @@ outputs:
     type: file
     file:
       path: "./audit.log"
-      permissions: "0600"
 
   debug_file:
     enabled: false

--- a/examples/09-multi-output/outputs.yaml
+++ b/examples/09-multi-output/outputs.yaml
@@ -9,7 +9,6 @@ outputs:
     type: file
     file:
       path: "./audit.log"
-      permissions: "0600"
 
   # Disabled outputs are skipped at load time — the output is not
   # created and receives no events. Use this to temporarily turn off

--- a/examples/17-capstone/outputs.yaml
+++ b/examples/17-capstone/outputs.yaml
@@ -44,7 +44,6 @@ outputs:
       max_size_mb: 100
       max_backups: 5
       max_age_days: 90
-      permissions: "0600"
     formatter:
       type: cef
       vendor: "AxonOps"
@@ -70,7 +69,6 @@ outputs:
       max_size_mb: 50
       max_backups: 5
       max_age_days: 90
-      permissions: "0600"
     route:
       include_categories:
         - security

--- a/file/example_test.go
+++ b/file/example_test.go
@@ -32,11 +32,11 @@ func ExampleNew() {
 	defer func() { _ = os.RemoveAll(dir) }()
 
 	out, err := file.New(&file.Config{
-		Path:        filepath.Join(dir, "audit.log"),
-		MaxSizeMB:   100,
-		MaxBackups:  5,
-		MaxAgeDays:  30,
-		Permissions: "0600",
+		Path:       filepath.Join(dir, "audit.log"),
+		MaxSizeMB:  100,
+		MaxBackups: 5,
+		MaxAgeDays: 30,
+		// GroupReadable defaults to false (mode 0o600).
 	})
 	if err != nil {
 		fmt.Println("create error:", err)

--- a/file/file.go
+++ b/file/file.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -93,12 +92,25 @@ type Config struct {
 	// The parent directory must exist when [New] is called.
 	Path string
 
-	// Permissions is the octal file mode string (e.g. "0600") applied
-	// to created files. Empty defaults to "0600" (owner read/write).
-	// Values granting group or world write access produce a slog
-	// warning. Values above 0o777 cause [New] to return an error;
-	// this error does not wrap [audit.ErrConfigInvalid].
-	Permissions string
+	// GroupReadable, when false (the default), creates files readable
+	// only by the owning user (mode 0o600) — the recommended setting
+	// for audit logs. Set true to also allow read access by the file's
+	// group (mode 0o640), used when a SIEM forwarder (Filebeat,
+	// Promtail, Fluentd) runs as a separate user in the file's group.
+	//
+	// No other modes are supported. World-readable or group-writable
+	// audit logs are a security defect: audit data may contain PII,
+	// credentials, or operational details, and the trail must be
+	// append-only from a single writer to preserve tamper-detection.
+	// SOX, HIPAA, and GDPR all require this constraint. Operators
+	// needing finer-grained access should use ACLs at the OS level,
+	// not relax the library's mode.
+	//
+	// At construction, if an existing audit log file's permissions are
+	// broader than the configured target, [New] wraps
+	// [audit.ErrConfigInvalid]; setuid/setgid/sticky bits or a
+	// hardlink count above 1 are also rejected as tamper indicators.
+	GroupReadable bool
 
 	// MaxSizeMB is the maximum size in megabytes of a single log file
 	// before rotation. Zero defaults to 100. Values above [MaxSizeMB]
@@ -219,16 +231,14 @@ func New(cfg *Config, opts ...Option) (*Output, error) { //nolint:gocyclo,cyclop
 		return nil, fmt.Errorf("audit/file: output parent directory %q: %w", parentDir, statErr)
 	}
 
-	perm, err := parsePermissions(cfg.Permissions)
-	if err != nil {
-		return nil, fmt.Errorf("audit/file: output permissions %q: %w", cfg.Permissions, err)
-	}
+	perm := targetMode(cfg.GroupReadable)
 
-	// Warn if permissions grant group or world access to audit data.
-	if perm&0o077 != 0 {
-		logger.Warn("audit/file: output permissions grant group/world access",
-			"path", cfg.Path,
-			"permissions", fmt.Sprintf("%04o", perm))
+	// Reject existing audit log files whose permissions, special
+	// bits, or hardlink count signal tampering. Skipped on non-Unix
+	// platforms (see existing_perms_check_*.go) because os.FileMode
+	// semantics there don't map to the POSIX bits we enforce.
+	if validErr := validateExistingFilePerms(cfg.Path, perm); validErr != nil {
+		return nil, validErr
 	}
 
 	applyFileDefaults(cfg)
@@ -478,21 +488,14 @@ func (f *Output) DestinationKey() string {
 	return f.path
 }
 
-// parsePermissions parses an octal permission string. An empty string
-// defaults to 0600.
-func parsePermissions(s string) (os.FileMode, error) {
-	if s == "" {
-		return 0o600, nil
+// targetMode returns the file mode for an audit log output. The two
+// supported modes are 0o600 (default; owner read/write only) and
+// 0o640 (owner read/write, group read) — see [Config.GroupReadable].
+func targetMode(groupReadable bool) os.FileMode {
+	if groupReadable {
+		return 0o640
 	}
-	v, err := strconv.ParseUint(s, 8, 32)
-	if err != nil {
-		return 0, fmt.Errorf("invalid octal: %w", err)
-	}
-	mode := os.FileMode(v)
-	if mode > 0o777 {
-		return 0, fmt.Errorf("value %04o exceeds maximum 0777", mode)
-	}
-	return mode, nil
+	return 0o600
 }
 
 // applyFileDefaults fills zero-valued rotation and buffer fields with defaults.

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -15,7 +15,6 @@
 package file_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -199,7 +198,7 @@ func TestFileOutput_Name(t *testing.T) {
 	assert.Equal(t, expected, out.Name())
 }
 
-func TestFileOutput_Permissions(t *testing.T) {
+func TestFileOutput_DefaultPermissions_0600(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX permission bits are not honoured on Windows")
 	}
@@ -218,7 +217,7 @@ func TestFileOutput_Permissions(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
-func TestFileOutput_CustomPermissions(t *testing.T) {
+func TestFileOutput_GroupReadable_True_0640(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX permission bits are not honoured on Windows")
 	}
@@ -226,18 +225,17 @@ func TestFileOutput_CustomPermissions(t *testing.T) {
 	path := filepath.Join(dir, "audit.log")
 
 	out, err := file.New(&file.Config{
-		Path:        path,
-		Permissions: "0644",
+		Path:          path,
+		GroupReadable: true,
 	})
 	require.NoError(t, err)
 
 	require.NoError(t, out.Write([]byte("test\n")))
-	// Close to flush async buffer to disk.
 	require.NoError(t, out.Close())
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
 }
 
 func TestFileOutput_DefaultConfig(t *testing.T) {
@@ -274,22 +272,6 @@ func TestFileOutput_InvalidConfig(t *testing.T) {
 			name:    "missing parent directory",
 			cfg:     file.Config{Path: "/nonexistent/dir/audit.log"},
 			wantErr: "parent directory",
-		},
-		{
-			name: "invalid permissions",
-			cfg: file.Config{
-				Path:        filepath.Join(dir, "invalid-perm.log"),
-				Permissions: "not-octal",
-			},
-			wantErr: "permissions",
-		},
-		{
-			name: "permissions out of range",
-			cfg: file.Config{
-				Path:        filepath.Join(dir, "out-of-range.log"),
-				Permissions: "1777",
-			},
-			wantErr: "exceeds maximum",
 		},
 		{
 			name: "MaxSizeMB exceeds limit",
@@ -345,16 +327,58 @@ func TestFileOutput_NegativeMaxSizeMB_DefaultsTo100(t *testing.T) {
 	_ = out.Close()
 }
 
-func TestFileOutput_Permissions0000_Rejected(t *testing.T) {
-	dir := t.TempDir()
-	_, err := file.New(&file.Config{
-		Path:        filepath.Join(dir, "noaccess.log"),
-		Permissions: "0000",
-	})
-	// "0000" is valid octal but the rotation library rejects zero mode.
-	require.Error(t, err)
-	// text-only: rotate/writer.go:411 errors.New, wrapped by file.go:292 — no audit sentinel in the chain.
-	assert.Contains(t, err.Error(), "non-zero")
+// TestFileOutput_ExistingFile_BroaderPerms covers ACs 7-11 of #436:
+// the on-disk permissions of an existing audit log are validated
+// against the configured target mode at construction time.
+//
+//	target = 0o600 (GroupReadable=false)
+//	  existing 0o600 → accept (#8)
+//	  existing 0o640 → reject (group-read not expected, #11)
+//	  existing 0o644 → reject (broader than required, #7)
+//
+//	target = 0o640 (GroupReadable=true)
+//	  existing 0o600 → accept (narrower than required is safe, #9)
+//	  existing 0o640 → accept (#10)
+//	  existing 0o644 → reject (other-read broader)
+func TestFileOutput_ExistingFile_BroaderPerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not honoured on Windows")
+	}
+	cases := []struct {
+		name          string
+		existingPerm  os.FileMode
+		groupReadable bool
+		wantErr       bool
+	}{
+		{"target_0600_existing_0600", 0o600, false, false},
+		{"target_0600_existing_0640_rejected", 0o640, false, true},
+		{"target_0600_existing_0644_rejected", 0o644, false, true},
+		{"target_0640_existing_0600", 0o600, true, false},
+		{"target_0640_existing_0640", 0o640, true, false},
+		{"target_0640_existing_0644_rejected", 0o644, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "audit.log")
+			require.NoError(t, os.WriteFile(path, []byte("pre-existing\n"), tc.existingPerm))
+			require.NoError(t, os.Chmod(path, tc.existingPerm)) // some umasks override WriteFile mode
+
+			out, err := file.New(&file.Config{Path: path, GroupReadable: tc.groupReadable})
+			if tc.wantErr {
+				require.Error(t, err, "expected rejection for %v on target %v",
+					tc.existingPerm, tc.groupReadable)
+				assert.ErrorIs(t, err, audit.ErrConfigInvalid,
+					"existing-perms rejection must wrap audit.ErrConfigInvalid")
+				assert.Contains(t, err.Error(), "broader than required",
+					"error message must explain the rejection cause")
+			} else {
+				require.NoError(t, err, "expected acceptance for %v on target %v",
+					tc.existingPerm, tc.groupReadable)
+				_ = out.Close()
+			}
+		})
+	}
 }
 
 func TestFileOutput_MaxBoundaryValues_Accepted(t *testing.T) {
@@ -1007,53 +1031,12 @@ func BenchmarkFileOutput_Write_WithRotation(b *testing.B) {
 }
 
 // TestFile_ConstructionWarningsRoutedToInjectedLogger verifies that
-// the permission-mode warning emitted during New() routes through
-// the WithDiagnosticLogger-supplied logger rather than slog.Default.
-// Closes #490.
-func TestFile_ConstructionWarningsRoutedToInjectedLogger(t *testing.T) {
-	var buf strings.Builder
-	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
-	injected := slog.New(handler)
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "perm-warning.log")
-
-	// Permission 0o644 grants group read + world read → triggers the
-	// "grants group/world access" warning in file.New.
-	out, err := file.New(&file.Config{
-		Path:        path,
-		Permissions: "0644",
-	}, file.WithDiagnosticLogger(injected))
-	require.NoError(t, err)
-	require.NoError(t, out.Close())
-
-	logged := buf.String()
-	assert.Contains(t, logged, "permissions grant group/world access",
-		"expected permission warning on injected logger, got: %q", logged)
-}
-
-// TestFile_NilDiagnosticLoggerFallsBackToDefault verifies
-// WithDiagnosticLogger(nil) does not nil-deref and falls back to
-// slog.Default for warning emission.
-func TestFile_NilDiagnosticLoggerFallsBackToDefault(t *testing.T) {
-	var buf strings.Builder
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "perm-warning-nil.log")
-
-	out, err := file.New(&file.Config{
-		Path:        path,
-		Permissions: "0644",
-	}, file.WithDiagnosticLogger(nil))
-	require.NoError(t, err)
-	require.NoError(t, out.Close())
-
-	assert.Contains(t, buf.String(), "permissions grant group/world access",
-		"WithDiagnosticLogger(nil) should fall back to slog.Default")
-}
+// (Construction-time permission warnings were removed in #436 along
+// with the flexible Permissions string field; the only configurable
+// modes are now 0o600 and 0o640, neither of which warrants a
+// runtime warning. The injected-vs-default-logger contract for the
+// WithDiagnosticLogger option remains exercised by the writeLoop's
+// async-error path elsewhere in this file.)
 
 // TestNew_NilConfig_ReturnsError verifies that [New] returns a
 // non-nil error when passed a nil *Config (#580). The nil guard
@@ -1190,58 +1173,11 @@ func TestOutputFactory_ZeroContext_NoPanic(t *testing.T) {
 	require.NoError(t, out.Write([]byte(`{"event":"zero"}`+"\n")))
 }
 
-// captureHandler records every slog Record passed through Handle for
-// assertion in factory plumbing tests.
-type captureHandler struct {
-	records []slog.Record
-	mu      sync.Mutex
-}
-
-func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
-func (h *captureHandler) Handle(_ context.Context, r slog.Record) error { //nolint:gocritic // hugeParam: slog.Handler interface contract
-	h.mu.Lock()
-	h.records = append(h.records, r)
-	h.mu.Unlock()
-	return nil
-}
-func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
-func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
-
-func (h *captureHandler) anyContains(s string) bool {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	for i := range h.records {
-		if strings.Contains(h.records[i].Message, s) {
-			return true
-		}
-	}
-	return false
-}
-
-// TestOutputFactory_LoggerReachesOutput verifies that a logger
-// supplied via [audit.FrameworkContext.DiagnosticLogger] reaches the
-// file output and is used to emit the permission-mode warning during
-// construction.
-func TestOutputFactory_LoggerReachesOutput(t *testing.T) {
-	t.Parallel()
-	h := &captureHandler{}
-	logger := slog.New(h)
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "logger-reaches.log")
-	// 0644 grants group/world read → triggers the permission warning.
-	yaml := []byte("path: " + path + "\npermissions: \"0644\"\n")
-
-	factory := audit.LookupOutputFactory("file")
-	require.NotNil(t, factory)
-
-	out, err := factory("logger", yaml, audit.FrameworkContext{DiagnosticLogger: logger})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = out.Close() })
-
-	assert.True(t, h.anyContains("permissions grant group/world access"),
-		"injected logger must capture the permission-mode warning emitted in New")
-}
+// (TestOutputFactory_LoggerReachesOutput and the captureHandler that
+// supported it were removed in #436. The previous form relied on a
+// construction-time perm-mode warning that no longer exists; the
+// injected-logger contract is exercised via the writeLoop's async
+// error path tests in the BDD scenarios for file_output.feature.)
 
 // TestOutputFactory_OutputMetricsReachesOutput verifies that the
 // per-output metrics value supplied via

--- a/file/perms_check_other.go
+++ b/file/perms_check_other.go
@@ -1,0 +1,29 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !unix
+
+package file
+
+import "os"
+
+// validateExistingFilePerms is a no-op on non-Unix platforms: the
+// POSIX permission bits and st_nlink that the Unix variant enforces
+// don't map cleanly onto Windows ACLs or filesystems without a
+// stat-style nlink count. Non-Unix audit log security relies on the
+// host filesystem's native ACL model, which is the operator's
+// responsibility — see docs/file-output.md.
+func validateExistingFilePerms(_ string, _ os.FileMode) error {
+	return nil
+}

--- a/file/perms_check_unix.go
+++ b/file/perms_check_unix.go
@@ -1,0 +1,97 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package file
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/axonops/audit"
+)
+
+// validateExistingFilePerms enforces that, when an audit log file
+// already exists at path, its on-disk permissions and metadata cannot
+// silently widen the configured target mode. Three classes of
+// rejection (#436):
+//
+//  1. Special bits (setuid, setgid, sticky) — never legitimate on an
+//     audit log; treat their presence as a tamper indicator.
+//  2. Hardlink count > 1 — the audit data exists at a second path
+//     under different ownership/perms and would survive a re-chmod
+//     of the configured path.
+//  3. Permissions broader than the target — `existing & ^target != 0`
+//     means existing has at least one bit set that the target does
+//     not. Narrower-or-equal is safe (a 0o600 file with
+//     GroupReadable=true accepts; a 0o640 file with GroupReadable=
+//     false rejects because the group-read bit is broader).
+//
+// Returns nil when the file does not exist (it will be created with
+// the target mode by safeOpen) or when all three checks pass.
+//
+// Note on race window: between this Lstat and the writeLoop's first
+// safeOpen, an attacker with write access could chmod the file
+// broader. Acceptable per the threat model — write access defeats
+// every audit-integrity guarantee — and safeOpen calls f.Chmod(target)
+// on every open, narrowing the window. The startup check exists to
+// fail-loud on misconfiguration, not to defend against an active
+// attacker who already has chmod rights.
+func validateExistingFilePerms(path string, target os.FileMode) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // file doesn't exist yet — will be created with target mode
+		}
+		// Other errors (permission denied on the parent dir, etc.)
+		// fall through to the rotate writer's open path which will
+		// produce its own error. We don't want to double-report.
+		return nil
+	}
+
+	mode := info.Mode()
+
+	// Symlinks are rejected downstream by safeStat/safeOpen via
+	// O_NOFOLLOW. Don't double-report here — and a symlink's own
+	// permissions are 0o777 by convention, which would falsely
+	// trip the broader-than-target check below.
+	if mode&os.ModeSymlink != 0 {
+		return nil
+	}
+
+	// (1) Special bits never legitimate on an audit log.
+	if mode&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 {
+		return fmt.Errorf("audit: file output %q: existing file has setuid/setgid/sticky bits set (mode %v): %w",
+			path, mode, audit.ErrConfigInvalid)
+	}
+
+	// (2) Hardlink count > 1 means the audit data exists under a
+	// second path. Even if we narrow the configured path's perms,
+	// the alternate path retains its own ownership and mode.
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat.Nlink > 1 {
+		return fmt.Errorf("audit: file output %q: existing file has hardlink count %d (must be 1): %w",
+			path, stat.Nlink, audit.ErrConfigInvalid)
+	}
+
+	// (3) Permissions broader than the target.
+	perm := mode.Perm()
+	if perm&^target != 0 {
+		return fmt.Errorf("audit: file output %q: existing file permissions %04o are broader than required %04o: %w",
+			path, perm, target, audit.ErrConfigInvalid)
+	}
+	return nil
+}

--- a/file/register.go
+++ b/file/register.go
@@ -63,13 +63,13 @@ func NewFactory(factory audit.OutputMetricsFactory) audit.OutputFactory {
 // struct. The existing Config struct does not gain yaml tags —
 // this struct is the mapping layer.
 type yamlFileConfig struct { //nolint:govet // fieldalignment: readability preferred over packing
-	Path        string `yaml:"path"`
-	Permissions string `yaml:"permissions"`
-	MaxSizeMB   int    `yaml:"max_size_mb"`
-	MaxBackups  int    `yaml:"max_backups"`
-	MaxAgeDays  int    `yaml:"max_age_days"`
-	Compress    *bool  `yaml:"compress"`
-	BufferSize  *int   `yaml:"buffer_size"`
+	Path          string `yaml:"path"`
+	GroupReadable bool   `yaml:"group_readable"`
+	MaxSizeMB     int    `yaml:"max_size_mb"`
+	MaxBackups    int    `yaml:"max_backups"`
+	MaxAgeDays    int    `yaml:"max_age_days"`
+	Compress      *bool  `yaml:"compress"`
+	BufferSize    *int   `yaml:"buffer_size"`
 }
 
 // intPtrOrDefault returns the pointed-to value if non-nil, or the
@@ -100,13 +100,13 @@ func buildOutput(name string, rawConfig []byte, om audit.OutputMetrics, logger *
 	}
 
 	cfg := Config{
-		Path:        yc.Path,
-		Permissions: yc.Permissions,
-		MaxSizeMB:   yc.MaxSizeMB,
-		MaxBackups:  yc.MaxBackups,
-		MaxAgeDays:  yc.MaxAgeDays,
-		Compress:    yc.Compress,
-		BufferSize:  intPtrOrDefault(yc.BufferSize, DefaultBufferSize),
+		Path:          yc.Path,
+		GroupReadable: yc.GroupReadable,
+		MaxSizeMB:     yc.MaxSizeMB,
+		MaxBackups:    yc.MaxBackups,
+		MaxAgeDays:    yc.MaxAgeDays,
+		Compress:      yc.Compress,
+		BufferSize:    intPtrOrDefault(yc.BufferSize, DefaultBufferSize),
 	}
 
 	opts := []Option{WithDiagnosticLogger(logger)}

--- a/file/register_test.go
+++ b/file/register_test.go
@@ -33,7 +33,8 @@ func TestFileFactory_RegisteredByInit(t *testing.T) {
 func TestFileFactory_ValidConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "audit.log")
-	yaml := []byte("path: " + path + "\npermissions: \"0600\"\n")
+	// Default group_readable: false → mode 0o600 (owner only).
+	yaml := []byte("path: " + path + "\n")
 
 	factory := audit.LookupOutputFactory("file")
 	require.NotNil(t, factory)
@@ -44,6 +45,48 @@ func TestFileFactory_ValidConfig(t *testing.T) {
 
 	assert.Equal(t, "compliance_file", out.Name(), "name should be the YAML-configured name")
 	assert.NoError(t, out.Write([]byte(`{"test":true}`+"\n")))
+}
+
+func TestFileFactory_GroupReadable_True_AppliesMode0640(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+	yaml := []byte("path: " + path + "\ngroup_readable: true\n")
+
+	factory := audit.LookupOutputFactory("file")
+	require.NotNil(t, factory)
+
+	out, err := factory("siem_archive", yaml, audit.FrameworkContext{})
+	require.NoError(t, err)
+	require.NoError(t, out.Write([]byte(`{"x":1}`+"\n")))
+	require.NoError(t, out.Close())
+}
+
+// TestFileFactory_RejectsLegacyPermissionsField verifies that the
+// pre-#436 `permissions:` YAML key produces a clear "unknown field"
+// decode error rather than silently widening file mode.
+func TestFileFactory_RejectsLegacyPermissionsField(t *testing.T) {
+	yaml := []byte(`path: /tmp/x.log
+permissions: "0600"
+`)
+	factory := audit.LookupOutputFactory("file")
+	require.NotNil(t, factory)
+	_, err := factory("legacy", yaml, audit.FrameworkContext{})
+	require.Error(t, err)
+	// Decoder produces an "unknown field" error naming the rejected key.
+	assert.Contains(t, err.Error(), "permissions",
+		"error must name the rejected field so operators know to migrate")
+}
+
+// TestFileFactory_GroupReadable_NotBool_Rejected verifies that a
+// non-bool value for group_readable is rejected by the YAML decoder.
+func TestFileFactory_GroupReadable_NotBool_Rejected(t *testing.T) {
+	yaml := []byte(`path: /tmp/x.log
+group_readable: "yes"
+`)
+	factory := audit.LookupOutputFactory("file")
+	require.NotNil(t, factory)
+	_, err := factory("bad", yaml, audit.FrameworkContext{})
+	require.Error(t, err, "string value for bool field must be rejected")
 }
 
 func TestFileFactory_InvalidConfig_ReturnsError(t *testing.T) {

--- a/outputconfig/testdata/bench_config.yaml
+++ b/outputconfig/testdata/bench_config.yaml
@@ -28,7 +28,6 @@ outputs:
     type: file
     file:
       path: "${AUDIT_TEST_DIR}/audit-archive.log"
-      permissions: "0600"
       max_size_mb: 100
       max_backups: 5
       max_age_days: 90
@@ -47,9 +46,8 @@ outputs:
     file:
       path: "${AUDIT_TEST_DIR}/security.log"
       # Group-readable so operators in the audit group can tail
-      # this file. Exercises the permission-warning code path in
-      # file.New; silenced via WithDiagnosticLogger in the bench.
-      permissions: "0640"
+      # this file (mode 0o640).
+      group_readable: true
       max_size_mb: 50
       max_backups: 3
     route:
@@ -65,7 +63,6 @@ outputs:
     type: file
     file:
       path: "${AUDIT_TEST_DIR}/writes.log"
-      permissions: "0600"
       max_size_mb: 200
     route:
       include_categories:

--- a/outputconfig/testdata/valid_config.yaml
+++ b/outputconfig/testdata/valid_config.yaml
@@ -8,7 +8,6 @@ outputs:
     type: file
     file:
       path: "${AUDIT_TEST_DIR}/audit.log"
-      permissions: "0600"
     route:
       include_categories:
         - write

--- a/tests/bdd/features/file_output.feature
+++ b/tests/bdd/features/file_output.feature
@@ -53,11 +53,23 @@ Feature: File Output
     And I close the auditor
     Then the file should have permissions "0600"
 
-  Scenario: Custom file permissions are applied
-    Given an auditor with file output with permissions "0640"
+  Scenario: Group-readable file output uses 0640
+    Given an auditor with file output that is group-readable
     When I audit event "user_create" with required fields
     And I close the auditor
     Then the file should have permissions "0640"
+
+  Scenario: Existing audit log with broader permissions is rejected
+    Given an existing audit log file with permissions 0644 at the configured path
+    When I try to construct a file output at that path
+    Then the file output construction should fail with an error
+    And the error should wrap audit.ErrConfigInvalid
+    And the error message should contain "broader than required"
+
+  Scenario: Existing audit log with narrower permissions is accepted
+    Given an existing audit log file with permissions 0600 at the configured path
+    When I construct a group-readable file output at that path
+    Then the file output construction should succeed
 
   Scenario: Symlink path is rejected on write — symlink target stays empty
     When I write a single event to a file output configured with a symlink path
@@ -108,10 +120,6 @@ Feature: File Output
 
   Scenario: MaxBackups exceeding limit is rejected
     When I try to create a file output with MaxBackups 200
-    Then the file output construction should fail with an error
-
-  Scenario: Invalid permissions string is rejected
-    When I try to create a file output with permissions "notoctal"
     Then the file output construction should fail with an error
 
   # --- Lifecycle ---

--- a/tests/bdd/steps/file_steps.go
+++ b/tests/bdd/steps/file_steps.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -40,9 +41,10 @@ func registerFileGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^an auditor with file output at a temporary path$`, func() error {
 		return createFileAuditor(tc, file.Config{})
 	})
-	ctx.Step(`^an auditor with file output with permissions "([^"]*)"$`, func(perms string) error {
-		return createFileAuditor(tc, file.Config{Permissions: perms})
+	ctx.Step(`^an auditor with file output that is group-readable$`, func() error {
+		return createFileAuditor(tc, file.Config{GroupReadable: true})
 	})
+	registerFilePermsCheckSteps(ctx, tc)
 	ctx.Step(`^an auditor with file output configured for (\d+) MB max size$`, func(mb int) error {
 		return createFileAuditor(tc, file.Config{MaxSizeMB: mb})
 	})
@@ -103,7 +105,99 @@ func registerFileGivenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 		}
 	})
 	ctx.Step(`^an auditor with no outputs$`, func() error { return createNoOutputAuditor(tc) })
+}
 
+// registerFilePermsCheckSteps registers the BDD step set for #436's
+// existing-file permission validation: pre-create a file with a
+// specific mode, then construct a file output and observe whether
+// New rejects (broader) or accepts (narrower or equal).
+func registerFilePermsCheckSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
+	ctx.Step(`^an existing audit log file with permissions (\d+) at the configured path$`, func(perm int) error {
+		return preCreateFileWithPerms(tc, perm)
+	})
+
+	ctx.Step(`^I try to construct a file output at that path$`, func() error {
+		return tryConstructFileAtCapturedPath(tc, false)
+	})
+
+	ctx.Step(`^I construct a group-readable file output at that path$`, func() error {
+		if err := tryConstructFileAtCapturedPath(tc, true); err != nil {
+			return err
+		}
+		if tc.LastErr != nil {
+			return fmt.Errorf("group-readable construction failed: %w", tc.LastErr)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the file output construction should succeed$`, func() error {
+		if tc.LastErr != nil {
+			return fmt.Errorf("expected success, got error: %w", tc.LastErr)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the error should wrap audit\.ErrConfigInvalid$`, func() error {
+		return assertWrapsErrConfigInvalid(tc.LastErr)
+	})
+
+	ctx.Step(`^the error message should contain "([^"]*)"$`, func(needle string) error {
+		return assertErrorMessageContains(tc.LastErr, needle)
+	})
+}
+
+// preCreateFileWithPerms creates a file at the scenario's configured
+// path with the requested mode (interpreted from Gherkin literal
+// digits as octal — 0600, 0640, 0644).
+func preCreateFileWithPerms(tc *AuditTestContext, perm int) error {
+	dir, err := tc.EnsureFileDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "audit.log")
+	tc.FilePaths["default"] = path
+	mode, parseErr := strconv.ParseUint(fmt.Sprintf("%d", perm), 8, 32)
+	if parseErr != nil {
+		return fmt.Errorf("parse perm %d as octal: %w", perm, parseErr)
+	}
+	if writeErr := os.WriteFile(path, []byte("pre-existing\n"), os.FileMode(mode)); writeErr != nil {
+		return fmt.Errorf("write existing file: %w", writeErr)
+	}
+	// WriteFile may apply umask; chmod explicitly to land the requested mode.
+	if chmodErr := os.Chmod(path, os.FileMode(mode)); chmodErr != nil {
+		return fmt.Errorf("chmod existing file: %w", chmodErr)
+	}
+	return nil
+}
+
+func tryConstructFileAtCapturedPath(tc *AuditTestContext, groupReadable bool) error {
+	path := tc.FilePaths["default"]
+	out, err := file.New(&file.Config{Path: path, GroupReadable: groupReadable})
+	if out != nil {
+		tc.AddCleanup(func() { _ = out.Close() })
+	}
+	tc.LastErr = err
+	return nil
+}
+
+func assertWrapsErrConfigInvalid(err error) error {
+	if err == nil {
+		return fmt.Errorf("no error captured")
+	}
+	if !errors.Is(err, audit.ErrConfigInvalid) {
+		return fmt.Errorf("expected ErrConfigInvalid wrap, got: %w", err)
+	}
+	return nil
+}
+
+func assertErrorMessageContains(err error, needle string) error {
+	if err == nil {
+		return fmt.Errorf("no error captured")
+	}
+	if !strings.Contains(err.Error(), needle) {
+		return fmt.Errorf("expected error to contain %q, got: %s", needle, err.Error())
+	}
+	return nil
 }
 
 func registerFileWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
@@ -132,19 +226,6 @@ func registerFileWhenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 		tc.LastErr = err
 		return nil
 	})
-	ctx.Step(`^I try to create a file output with permissions "([^"]*)"$`, func(perms string) error {
-		dir, dirErr := tc.EnsureFileDir()
-		if dirErr != nil {
-			return dirErr
-		}
-		out, err := file.New(&file.Config{Path: filepath.Join(dir, "test.log"), Permissions: perms})
-		if out != nil {
-			tc.AddCleanup(func() { _ = out.Close() })
-		}
-		tc.LastErr = err
-		return nil
-	})
-
 }
 
 func registerFileThenSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {


### PR DESCRIPTION
## Summary

- Replaces `Config.Permissions string` (accepted 0–0o777) with `Config.GroupReadable bool` (`false` → 0o600 default, `true` → 0o640).
- YAML `permissions:` key removed; `group_readable: true/false` replaces it. Old YAML auto-rejects via the existing `yaml.DisallowUnknownField()` decoder.
- New construction-time validation rejects existing audit logs whose permissions are broader than the target, whose setuid/setgid/sticky bits are set, or whose hardlink count > 1 (per security-reviewer pre-coding consult).
- `//go:build unix` gating for the validation; Windows is a no-op stub (the issue body explicitly scopes Unix-only).
- Breaking change for v0.x; no transitional shim per `feedback_no_backwards_compat`.

## All 13 ACs

| AC | Verification |
|----|---|
| 1 | `New(Config{Path: "x.log"})` creates 0o600 — `TestFileOutput_DefaultPermissions_0600` |
| 2 | `New(Config{..., GroupReadable: true})` creates 0o640 — `TestFileOutput_GroupReadable_True_0640` |
| 3 | `Config.Permissions` field gone — compile-fail proves it (verified by `go vet`) |
| 4 | YAML `permissions: "0600"` returns "unknown field" — `TestFileFactory_RejectsLegacyPermissionsField` |
| 5 | YAML `group_readable: true` sets `Config.GroupReadable` — `TestFileFactory_GroupReadable_True_AppliesMode0640` |
| 6 | YAML `group_readable: "yes"` returns decode error — `TestFileFactory_GroupReadable_NotBool_Rejected` |
| 7 | 0o644 + GroupReadable=false → ErrConfigInvalid + "broader than required" — `TestFileOutput_ExistingFile_BroaderPerms/target_0600_existing_0644_rejected` |
| 8 | 0o600 + GroupReadable=false succeeds — `target_0600_existing_0600` |
| 9 | 0o600 + GroupReadable=true succeeds (narrower-safe) — `target_0640_existing_0600` |
| 10 | 0o640 + GroupReadable=true succeeds — `target_0640_existing_0640` |
| 11 | 0o640 + GroupReadable=false rejects — `target_0600_existing_0640_rejected` |
| 12 | Backup files inherit the configured mode — preserved (rotate's `safeOpen` chmods every open with `cfg.Mode`) |
| 13 | `go test -race` passes locally |

## Test plan

- [x] `make lint` clean (0 issues across all 11 modules)
- [x] `make fmt-check`, `make tidy-check` clean
- [x] `go test -race -count=1 . ./file/...` passes (179s + 1.6s + 2s)
- [x] `BDD_TAGS="@file && ~@docker" go test -tags=integration` passes locally
- [x] Pre-coding consults: api-ergonomics-reviewer (YAML naming + bool default approved), security-reviewer (added setuid/setgid/sticky + nlink rejection per recommendation; symlinks pass through to safeStat)
- [x] `permissions:` field grep'd out of all examples + docs

## Reviewer notes

The pre-coding security-reviewer recommended hardening beyond AC#7 (which only mentioned the broader-perm check). Implemented in this PR:

- **setuid/setgid/sticky reject** — `info.Mode().Perm()` strips bits 9-11, so a 04600 file would silently pass the bare bitwise check. Added explicit `mode&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0` rejection upstream.
- **Hardlink count check** — `Nlink > 1` rejected because a hardlinked path retains independent ownership/perms; narrowing the configured path is meaningless if the data lives at a second link.
- **Race window with safeOpen** — accepted per threat model; `safeOpen` already calls `f.Chmod(target)` on every open, narrowing the window. The startup check exists to fail-loud on misconfig, not defend an attacker who has chmod rights.

Closes #436