### PR TITLE
security(secrets): redact config substrings in openbao/vault errors (#651)

### DIFF
--- a/secrets/openbao/openbao.go
+++ b/secrets/openbao/openbao.go
@@ -144,6 +144,12 @@ type Provider struct { //nolint:govet // readability over alignment
 // Validates the address (HTTPS required unless [Config.AllowInsecureHTTP]
 // is set), builds the TLS config and HTTP client, but performs no
 // network I/O.
+//
+// Error messages do not echo caller-supplied substrings (the
+// configured address, scheme, or token); the audit/secrets/openbao
+// logger category surfaces the failure class without leakage. Set
+// log-level debug on that category if a deployment-time root cause
+// is needed (#651).
 func New(cfg *Config) (*Provider, error) {
 	// Validate address.
 	if cfg.Address == "" {
@@ -151,10 +157,15 @@ func New(cfg *Config) (*Provider, error) {
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("%w: audit/secrets/openbao: invalid address: %w", audit.ErrConfigInvalid, err)
+		// Do not wrap url.Error — stdlib embeds the full input
+		// address in its error string. The address is operator-
+		// controlled config, not a ref's path/key, but logging it
+		// in error chains still constitutes a leakage vector. See
+		// #651 + the sentinel-injection test in openbao_test.go.
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address is not a valid URL", audit.ErrConfigInvalid)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("%w: audit/secrets/openbao: address must use https (got %q); set AllowInsecureHTTP for local development", audit.ErrConfigInvalid, u.Scheme)
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address must use https; set AllowInsecureHTTP for local development", audit.ErrConfigInvalid)
 	}
 	if u.Host == "" {
 		return nil, fmt.Errorf("%w: audit/secrets/openbao: address has empty host", audit.ErrConfigInvalid)

--- a/secrets/openbao/openbao.go
+++ b/secrets/openbao/openbao.go
@@ -238,10 +238,11 @@ func NewWithHTTPClient(cfg *Config, client *http.Client) (*Provider, error) {
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("%w: audit/secrets/openbao: invalid address: %w", audit.ErrConfigInvalid, err)
+		// See New for the redaction rationale (#651).
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address is not a valid URL", audit.ErrConfigInvalid)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("%w: audit/secrets/openbao: address must use https (got %q); set AllowInsecureHTTP for local development", audit.ErrConfigInvalid, u.Scheme)
+		return nil, fmt.Errorf("%w: audit/secrets/openbao: address must use https; set AllowInsecureHTTP for local development", audit.ErrConfigInvalid)
 	}
 	if u.Host == "" {
 		return nil, fmt.Errorf("%w: audit/secrets/openbao: address has empty host", audit.ErrConfigInvalid)

--- a/secrets/openbao/openbao_test.go
+++ b/secrets/openbao/openbao_test.go
@@ -171,9 +171,24 @@ func TestOpenBaoNew_NeverLeaksInputInErrorMessage(t *testing.T) {
 		}, "embedded_credentials"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run("New_"+tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := openbao.New(tc.cfg)
+			require.Error(t, err)
+			require.ErrorIs(t, err, audit.ErrConfigInvalid)
+			msg := err.Error()
+			assert.NotContains(t, msg, addrSentinel,
+				"address sentinel must not appear in the error: %s", msg)
+			assert.NotContains(t, msg, schemeSentinel,
+				"scheme sentinel must not appear in the error: %s", msg)
+			assert.NotContains(t, msg, tokenSentinel,
+				"token sentinel must not appear in the error: %s", msg)
+		})
+		// NewWithHTTPClient shares the same validation pipeline as
+		// New; assert the same redaction guarantee on its surface.
+		t.Run("NewWithHTTPClient_"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := openbao.NewWithHTTPClient(tc.cfg, http.DefaultClient)
 			require.Error(t, err)
 			require.ErrorIs(t, err, audit.ErrConfigInvalid)
 			msg := err.Error()

--- a/secrets/openbao/openbao_test.go
+++ b/secrets/openbao/openbao_test.go
@@ -136,6 +136,57 @@ func TestNew_RequiresToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "token")
 }
 
+// TestOpenBaoNew_NeverLeaksInputInErrorMessage verifies #651: error
+// messages from openbao.New must not echo caller-supplied substrings.
+// The address parser previously wrapped url.Error directly (which
+// embeds the input URL) and echoed `u.Scheme` via `got %q`; both have
+// been redacted. Sentinel injection across every config-error path
+// catches a regression on either of those leaks.
+func TestOpenBaoNew_NeverLeaksInputInErrorMessage(t *testing.T) {
+	t.Parallel()
+	const (
+		addrSentinel   = "LEAKADDR"
+		schemeSentinel = "leaksentinel"
+		tokenSentinel  = "LEAKTOKEN"
+	)
+	cases := []struct {
+		cfg  *openbao.Config
+		name string
+	}{
+		{&openbao.Config{
+			Address: "://malformed-" + addrSentinel + "%zz",
+			Token:   tokenSentinel,
+		}, "unparseable_address"},
+		{&openbao.Config{
+			Address: schemeSentinel + "://" + addrSentinel + ".invalid",
+			Token:   tokenSentinel,
+		}, "non_https_address_default"},
+		{&openbao.Config{
+			Address: "https://",
+			Token:   tokenSentinel,
+		}, "empty_host"},
+		{&openbao.Config{
+			Address: "https://" + tokenSentinel + "@host." + addrSentinel + ".invalid",
+			Token:   tokenSentinel,
+		}, "embedded_credentials"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := openbao.New(tc.cfg)
+			require.Error(t, err)
+			require.ErrorIs(t, err, audit.ErrConfigInvalid)
+			msg := err.Error()
+			assert.NotContains(t, msg, addrSentinel,
+				"address sentinel must not appear in the error: %s", msg)
+			assert.NotContains(t, msg, schemeSentinel,
+				"scheme sentinel must not appear in the error: %s", msg)
+			assert.NotContains(t, msg, tokenSentinel,
+				"token sentinel must not appear in the error: %s", msg)
+		})
+	}
+}
+
 func TestNew_RejectsEmbeddedCredentials(t *testing.T) {
 	t.Parallel()
 	_, err := openbao.New(&openbao.Config{

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -144,6 +144,12 @@ type Provider struct { //nolint:govet // readability over alignment
 // Validates the address (HTTPS required unless [Config.AllowInsecureHTTP]
 // is set), builds the TLS config and HTTP client, but performs no
 // network I/O.
+//
+// Error messages do not echo caller-supplied substrings (the
+// configured address, scheme, or token); the audit/secrets/vault
+// logger category surfaces the failure class without leakage. Set
+// log-level debug on that category if a deployment-time root cause
+// is needed (#651).
 func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear validation pipeline
 	// Validate address.
 	if cfg.Address == "" {
@@ -151,10 +157,15 @@ func New(cfg *Config) (*Provider, error) { //nolint:gocyclo,cyclop // linear val
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("%w: audit/secrets/vault: invalid address: %w", audit.ErrConfigInvalid, err)
+		// Do not wrap url.Error — stdlib embeds the full input
+		// address in its error string. The address is operator-
+		// controlled config, not a ref's path/key, but logging it
+		// in error chains still constitutes a leakage vector. See
+		// #651 + the sentinel-injection test in vault_test.go.
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address is not a valid URL", audit.ErrConfigInvalid)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("%w: audit/secrets/vault: address must use https (got %q); set AllowInsecureHTTP for local development", audit.ErrConfigInvalid, u.Scheme)
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address must use https; set AllowInsecureHTTP for local development", audit.ErrConfigInvalid)
 	}
 	if u.Host == "" {
 		return nil, fmt.Errorf("%w: audit/secrets/vault: address has empty host", audit.ErrConfigInvalid)

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -241,10 +241,11 @@ func NewWithHTTPClient(cfg *Config, client *http.Client) (*Provider, error) {
 	}
 	u, err := url.Parse(cfg.Address)
 	if err != nil {
-		return nil, fmt.Errorf("%w: audit/secrets/vault: invalid address: %w", audit.ErrConfigInvalid, err)
+		// See New for the redaction rationale (#651).
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address is not a valid URL", audit.ErrConfigInvalid)
 	}
 	if u.Scheme != "https" && !cfg.AllowInsecureHTTP {
-		return nil, fmt.Errorf("%w: audit/secrets/vault: address must use https (got %q); set AllowInsecureHTTP for local development", audit.ErrConfigInvalid, u.Scheme)
+		return nil, fmt.Errorf("%w: audit/secrets/vault: address must use https; set AllowInsecureHTTP for local development", audit.ErrConfigInvalid)
 	}
 	if u.Host == "" {
 		return nil, fmt.Errorf("%w: audit/secrets/vault: address has empty host", audit.ErrConfigInvalid)

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -130,6 +130,57 @@ func TestNew_RequiresToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "token")
 }
 
+// TestVaultNew_NeverLeaksInputInErrorMessage verifies #651: error
+// messages from vault.New must not echo caller-supplied substrings.
+// The address parser previously wrapped url.Error directly (which
+// embeds the input URL) and echoed `u.Scheme` via `got %q`; both have
+// been redacted. Sentinel injection across every config-error path
+// catches a regression on either of those leaks.
+func TestVaultNew_NeverLeaksInputInErrorMessage(t *testing.T) {
+	t.Parallel()
+	const (
+		addrSentinel   = "LEAKADDR"
+		schemeSentinel = "leaksentinel"
+		tokenSentinel  = "LEAKTOKEN"
+	)
+	cases := []struct {
+		cfg  *vault.Config
+		name string
+	}{
+		{&vault.Config{
+			Address: "://malformed-" + addrSentinel + "%zz",
+			Token:   tokenSentinel,
+		}, "unparseable_address"},
+		{&vault.Config{
+			Address: schemeSentinel + "://" + addrSentinel + ".invalid",
+			Token:   tokenSentinel,
+		}, "non_https_address_default"},
+		{&vault.Config{
+			Address: "https://",
+			Token:   tokenSentinel,
+		}, "empty_host"},
+		{&vault.Config{
+			Address: "https://" + tokenSentinel + "@host." + addrSentinel + ".invalid",
+			Token:   tokenSentinel,
+		}, "embedded_credentials"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := vault.New(tc.cfg)
+			require.Error(t, err)
+			require.ErrorIs(t, err, audit.ErrConfigInvalid)
+			msg := err.Error()
+			assert.NotContains(t, msg, addrSentinel,
+				"address sentinel must not appear in the error: %s", msg)
+			assert.NotContains(t, msg, schemeSentinel,
+				"scheme sentinel must not appear in the error: %s", msg)
+			assert.NotContains(t, msg, tokenSentinel,
+				"token sentinel must not appear in the error: %s", msg)
+		})
+	}
+}
+
 func TestNew_RejectsEmbeddedCredentials(t *testing.T) {
 	t.Parallel()
 	_, err := vault.New(&vault.Config{Address: "https://user:pass@vault.example.com", Token: "t"})

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -165,9 +165,24 @@ func TestVaultNew_NeverLeaksInputInErrorMessage(t *testing.T) {
 		}, "embedded_credentials"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run("New_"+tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := vault.New(tc.cfg)
+			require.Error(t, err)
+			require.ErrorIs(t, err, audit.ErrConfigInvalid)
+			msg := err.Error()
+			assert.NotContains(t, msg, addrSentinel,
+				"address sentinel must not appear in the error: %s", msg)
+			assert.NotContains(t, msg, schemeSentinel,
+				"scheme sentinel must not appear in the error: %s", msg)
+			assert.NotContains(t, msg, tokenSentinel,
+				"token sentinel must not appear in the error: %s", msg)
+		})
+		// NewWithHTTPClient shares the same validation pipeline as
+		// New; assert the same redaction guarantee on its surface.
+		t.Run("NewWithHTTPClient_"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := vault.NewWithHTTPClient(tc.cfg, http.DefaultClient)
 			require.Error(t, err)
 			require.ErrorIs(t, err, audit.ErrConfigInvalid)
 			msg := err.Error()


### PR DESCRIPTION
## Summary

- Follow-up to #486. Two construction-time error paths in `secrets/openbao/openbao.go` and `secrets/vault/vault.go` still echoed user-controlled config substrings — `url.Parse(cfg.Address)` failures wrapped stdlib's `url.Error` (which embeds the full input URL), and non-HTTPS rejections echoed `u.Scheme` via `got %q`.
- Both fixed by stripping the `url.Error` wrap and dropping the `%q` scheme echo. The `audit/secrets/openbao` (vault) logger category surfaces the failure class without leakage; the input value never reaches the returned error.
- New `TestOpenBaoNew_NeverLeaksInputInErrorMessage` and `TestVaultNew_NeverLeaksInputInErrorMessage` mirror the existing `TestParseRef_NeverLeaksInputInErrorMessage` sentinel-injection pattern across all four config-error paths.
- Godoc on `openbao.New` / `vault.New` updated to document the redaction guarantee.

## Test plan

- [x] `go test -race -count=1 ./secrets/...` — all packages pass
- [x] `go test -race -count=1 -run "TestOpenBaoNew_NeverLeaksInputInErrorMessage|TestVaultNew_NeverLeaksInputInErrorMessage" ./secrets/...` — new tests pass
- [x] `make lint` clean (0 issues)
- [x] `make fmt-check` clean

## ACs

| AC | Verification |
|----|---|
| 1 — No `%q`/`%s` echoes caller substrings in openbao/vault.go | Grep'd; the only remaining `%q` is the package's own slog log lines (sanitised via existing `sanitizeAddressForLog`) |
| 2 — Sentinel-injection unit tests | `TestOpenBaoNew_NeverLeaksInputInErrorMessage`, `TestVaultNew_NeverLeaksInputInErrorMessage` |

Closes #651