### PR TITLE
ci: adopt setup-audit composite action in dep-update + security-scan (#520)

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -40,11 +40,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      # Single setup story: pulls in setup-go, make workspace, the
+      # ~/go/bin tool cache (keyed by scripts/tool-versions.txt), and
+      # make install-tools. Tools are installed unconditionally up front
+      # so the smoke-test path below stays a flat sequence; cache hits
+      # make this ~5–10 s on no-change runs (#520).
+      - name: Set up audit toolchain
+        uses: ./.github/actions/setup-audit
         with:
-          go-version-file: go.mod
-          cache: true
+          install-tools: 'true'
 
       - name: Save pre-update go.mod files
         run: |
@@ -154,21 +158,7 @@ jobs:
       # --- Smoke test: verify updated deps do not break the build ---
       # Runs vet, lint, unit tests, and cross-build on the updated tree.
       # Full integration/BDD tests run when CI triggers on the PR.
-
-      - name: Set up go.work
-        if: steps.changes.outputs.has_changes == 'true'
-        run: make workspace
-
-      - name: Cache Go tools
-        if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/go/bin
-          key: go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
-
-      - name: Install tools
-        if: steps.changes.outputs.has_changes == 'true'
-        run: make install-tools
+      # (Toolchain is set up unconditionally above by setup-audit.)
 
       - name: Smoke test — vet
         if: steps.changes.outputs.has_changes == 'true'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,23 +22,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      # Single setup story: setup-go, make workspace, ~/go/bin tool
+      # cache keyed by scripts/tool-versions.txt, and make install-tools
+      # in one step. Replaces the inline duplicate that drifted to a
+      # Makefile-based cache key (#520).
+      - name: Set up audit toolchain
+        uses: ./.github/actions/setup-audit
         with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Set up go.work
-        run: make workspace
-
-      - name: Cache Go tools
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/go/bin
-          key: go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
-
-      - name: Install tools
-        run: make install-tools
+          install-tools: 'true'
 
       - name: Run govulncheck
         id: scan


### PR DESCRIPTION
## Summary
- Closes #520. Adopt the existing `setup-audit` composite action (added by PR #759) in `dependency-update.yml` and `security-scan.yml` — the two workflow files that were missed when ci.yml was migrated.
- Net **-19 LOC** across the two files (-35 / +16); ~30 LOC of duplicated setup ceremony eliminated.
- Quiet correctness fix: cache key drift `hashFiles('Makefile')` → `hashFiles('scripts/tool-versions.txt')`. The Makefile key would not invalidate on tool-version bumps, so operators could land a version bump and see the old binary restored from cache.

## Why
The issue's original framing — "4 jobs in ci.yml duplicate setup-go + workspace + install-tools" — was overtaken by PR #759 which extracted the pattern into `setup-audit` and migrated every ci.yml job. The duplication that remained was in two outlier workflows, plus the cache-key drift that crept in there.

## Architectural note
The issue body proposed a `workflow_call` reusable workflow. That is wrong for this use case: reusable workflows spawn a separate runner, so the installed Go binary, populated `~/go/bin` cache, and `go.work` would not propagate back to the caller. Composite actions run as steps inside the caller's job and share the runner's filesystem; the existing `setup-audit` is the correct primitive. User-approved scope decision.

## Out of scope
- `release.yml` — 8 bespoke `setup-go` invocations with variations (no `make workspace`, benchstat-only install, api-check minimal). Migrating would require extending setup-audit's input contract.
- `goreleaser.yml` — 1 manual `setup-go + workspace` block. Same reason.
- `mutation-test.yml` — already uses setup-audit.

## Test plan
- [x] YAML parses (`yaml.safe_load` both files).
- [x] `make check` → green.
- [x] devops agent gate → SHIPPABLE, no findings.
- [x] CI on this PR (validates YAML via Hygiene's actionlint).

Closes #520.