### PR TITLE
fix(ci): preserve dep-update PR review comments across iterations (#521)

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -246,18 +246,96 @@ jobs:
             echo "*This PR was created automatically by the [nightly dependency update workflow](https://github.com/${{ github.repository }}/actions/workflows/dependency-update.yml).*"
           } > /tmp/pr-body.md
 
-      # --- Create or update the PR ---
+      # --- Commit dep-update on long-lived branch ---
+      #
+      # Replaces peter-evans/create-pull-request, which always
+      # force-pushes. Force-push detaches reviewer line-comments from
+      # their commit SHAs (GitHub marks them "outdated"), which
+      # operators experience as "comments disappeared between runs"
+      # (#521). Append-only commits on a long-lived branch keep
+      # comments anchored to their original commits.
+
+      - name: Commit dep update on long-lived branch
+        id: commit
+        if: steps.changes.outputs.has_changes == 'true'
+        shell: bash
+        run: |
+          set -eo pipefail
+          BRANCH=chore/nightly-dep-update
+          SAVE=/tmp/depupdate-save
+          rm -rf "$SAVE" && mkdir -p "$SAVE"
+
+          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault"
+
+          # Snapshot only go.mod / go.sum from each module — those are
+          # the only files the dep-update step modifies.
+          for mod in $MODULES; do
+            mkdir -p "$SAVE/$mod"
+            cp "$mod/go.mod" "$SAVE/$mod/go.mod"
+            [ -f "$mod/go.sum" ] && cp "$mod/go.sum" "$SAVE/$mod/go.sum" || true
+          done
+
+          # Reset the working tree so we can switch branches cleanly.
+          git reset --hard HEAD
+          git clean -fd
+
+          # Check out target branch — existing on origin if it exists,
+          # otherwise a new branch from current HEAD (main).
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            echo "Checked out existing branch $BRANCH"
+          else
+            git checkout -b "$BRANCH"
+            echo "Created new branch $BRANCH"
+          fi
+
+          # Reapply the snapshotted files on top of the target branch.
+          for mod in $MODULES; do
+            cp "$SAVE/$mod/go.mod" "$mod/go.mod"
+            [ -f "$SAVE/$mod/go.sum" ] && cp "$SAVE/$mod/go.sum" "$mod/go.sum" || true
+          done
+
+          # If the branch already has these exact deps, there is nothing
+          # to push (rare but possible — upstream unchanged since last
+          # successful run).
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No new dep changes vs existing branch — nothing to push"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Stage only go.mod and go.sum across all modules. Avoids
+          # accidentally committing other tree noise.
+          for mod in $MODULES; do
+            git add "$mod/go.mod"
+            [ -f "$mod/go.sum" ] && git add "$mod/go.sum" || true
+          done
+
+          git commit -m "chore(deps): nightly transitive dependency update ($(date -u +%Y-%m-%d))"
+          git push origin "$BRANCH"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Create or update PR
-        if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: chore/nightly-dep-update
-          delete-branch: true
-          title: "chore(deps): nightly transitive dependency update"
-          body-path: /tmp/pr-body.md
-          commit-message: "chore(deps): update transitive Go dependencies"
-          labels: dependencies
-          # If a PR already exists on this branch, it is updated in place.
-          # The branch is force-pushed with the new changes.
+        if: steps.changes.outputs.has_changes == 'true' && steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -eo pipefail
+          BRANCH=chore/nightly-dep-update
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --body-file /tmp/pr-body.md
+            echo "Updated existing PR #$EXISTING in place — review comments preserved"
+          else
+            gh pr create \
+              --head "$BRANCH" \
+              --base main \
+              --title "chore(deps): nightly transitive dependency update" \
+              --body-file /tmp/pr-body.md \
+              --label dependencies
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -391,6 +391,34 @@ in [docs/releasing.md](docs/releasing.md) under "Tag protection";
 that file is the single source of truth, regenerated from the
 canonical `PUBLISH_MODULES` list.
 
+### Nightly dependency-update PR
+
+A scheduled workflow
+([`.github/workflows/dependency-update.yml`](.github/workflows/dependency-update.yml))
+runs daily at 02:00 UTC and posts transitive Go dependency updates
+to a single long-lived PR on the `chore/nightly-dep-update` branch.
+The PR is updated **in place** — new commits are appended on each
+iteration rather than force-pushed — so reviewer line comments stay
+attached to their original commits and remain visible across runs.
+
+Contributors MUST NOT push directly to `chore/nightly-dep-update`.
+The workflow owns the branch exclusively; an external push will
+either be overwritten on the next nightly run or cause the run to
+fail with a non-fast-forward error.
+
+The PR description is refreshed with the latest main-vs-current diff
+on each run; if you have ticked any review checkboxes in the body,
+they will be reset on the next iteration (each day's diff differs,
+so the checklist warrants a fresh look). PR-level conversation
+comments are never reset.
+
+When the PR is **merged with branch deletion**, the next nightly run
+starts a fresh cycle: it creates a new branch from `main` and opens a
+new PR. When the PR is **closed without merging** (or merged without
+branch deletion), the branch persists; the next nightly run appends
+on top and opens a new PR pointing to the same branch. To force a
+clean reset, delete the branch manually.
+
 ## CI Behaviour
 
 The `CI` workflow (`.github/workflows/ci.yml`) detects whether a


### PR DESCRIPTION
## Summary
- Closes #521. Replace `peter-evans/create-pull-request` (which always force-pushes) with a manual git + gh CLI flow that appends commits to a long-lived `chore/nightly-dep-update` branch.
- Reviewer line comments now stay attached to their original commit SHAs across iterations and remain visible (not marked outdated).
- `CONTRIBUTING.md` gains a `Nightly dependency-update PR` subsection documenting the contract.

## Why
peter-evans/create-pull-request synthesises the PR branch from the current working tree on every run and force-pushes — by design. GitHub anchors line-anchored review comments to commit SHAs, so force-push silently marks them outdated and detaches the conversation thread. `delete-branch: true` on the action was a red herring (only fires on PR close).

## What changed
- Replaces the single peter-evans step with two:
  1. **Commit dep update on long-lived branch** — snapshot go.mod/go.sum, reset, fetch + checkout existing branch (or create new from main), reapply, commit, **push without --force**. Skip silently when no diff vs branch HEAD.
  2. **Create or update PR** — `gh pr edit <existing>` or `gh pr create`.
- `CONTRIBUTING.md` adds a subsection under `Branch and Commit Rules` explaining branch ownership, comment preservation, and merge/close cycle behaviour.

## Trade-offs
- PR description (auto-generated body with checklist) is refreshed each run; ticked checkboxes reset. Each day's diff is different, so re-review is warranted anyway.
- The branch may diverge from main if main advances on unrelated commits. Standard PR-merge handles that; conflicts (rare — only go.mod/go.sum touched) require manual resolution. Same as today's force-push behaviour from main HEAD.
- Branch grows over many iterations; maintainer can squash-merge.
- Non-fast-forward push will fail the run loudly rather than silently overwrite — preferred safety property.

## Test plan
- [x] YAML parses (`yaml.safe_load`).
- [x] `make check` → green.
- [x] devops agent gate → SHIP, no findings.
- [x] docs-writer agent gate → content corrected per feedback.
- [x] commit-message-reviewer → PASS.
- [ ] CI on this PR (Hygiene's actionlint validates YAML).
- [ ] Manual smoke test: trigger via `gh workflow run` after merge to confirm the first real-world run creates the PR cleanly.

Closes #521.