### PR TITLE
docs: explain blank-import vs WithFactory registration paths (#545)

### DIFF
--- a/docs/output-configuration.md
+++ b/docs/output-configuration.md
@@ -839,12 +839,19 @@ value: "ref+openbao://${BAO_SECRET_PATH:-secret/data/audit/hmac}#salt"
 See [Secret Provider Integration](secrets.md) for URI syntax, provider
 setup, caching, security model, and error reference.
 
-## 🏭 Factory Registry
+## 🏭 Output Factory Registration
 
-Output types must be registered before `Load` can create them.
-Registration happens via a blank import in your application. The
-default — and recommended — path is the convenience package, which
-registers every built-in output (including stdout) in a single line:
+Output types must be registered before `outputconfig.Load` can create
+them from YAML. The library exposes two registration paths; both
+resolve to the same `OutputFactory` contract, but they target
+different scenarios.
+
+### Blank-import (default)
+
+The recommended path for production deployments. Importing the
+convenience umbrella package registers every built-in output —
+`stdout`, `file`, `syslog`, `webhook`, `loki` — via the
+sub-modules' `init()` functions:
 
 ```go
 import _ "github.com/axonops/audit/outputs"
@@ -862,10 +869,58 @@ import (
 )
 ```
 
-Note that `stdout` is also a separate module; if you use
-`type: stdout` without importing `outputs` (or calling
-`audit.MustRegisterOutputFactory("stdout", audit.StdoutFactory())`),
-`Load` returns an error — no output is silently dropped.
+`stdout` is part of the core `github.com/axonops/audit` module, not
+a sub-module. Using `type: stdout` without importing the `outputs`
+umbrella (or calling
+`audit.MustRegisterOutputFactory("stdout", audit.StdoutFactory())`
+directly) causes `Load` to return an error — no output is silently
+dropped.
+
+Double-registration is safe: `audit.RegisterOutputFactory` overwrites
+silently by design, so re-registering the same type name with a
+different factory replaces it without error.
+
+### `WithFactory` (per-call override)
+
+The `outputconfig.WithFactory(typeName, factory)` LoadOption
+registers a factory for a single `Load`/`New`/`NewWithLoad` call,
+without mutating the global registry:
+
+```go
+// customFileFactory is your audit.OutputFactory implementation;
+// yamlBytes is the YAML config (e.g. read from disk or embed).
+result, err := outputconfig.Load(
+    ctx, yamlBytes, taxonomy,
+    outputconfig.WithFactory("file", customFileFactory),
+)
+```
+
+Per-call factories take precedence over globally-registered ones.
+Multiple `WithFactory` calls for the same type name resolve as
+last-wins.
+
+### When to use which
+
+| Scenario | Recommended path |
+|----------|------------------|
+| Default production setup | Blank-import the `outputs` umbrella. |
+| Binary-size optimisation | Blank-import only the sub-modules you reference. |
+| Test code that should not depend on a sub-module's `init()` side effects | `WithFactory` — keeps the test hermetic. The test does not import the sub-module, so its `init()` does not register a real factory and cannot leak into other tests sharing the global registry. |
+| Custom metrics-aware factory for one output type | Blank-import the rest, override that one type with `WithFactory`. |
+| Multiple auditors in one process with different factory bindings | `WithFactory` per call. The global registry stores exactly one factory per type name, so two `RegisterOutputFactory` calls for the same type would have the second overwrite the first; `WithFactory` scopes the binding to one `Load` call so the two auditors do not collide. |
+| Output type not provided by any sub-module (consumer-defined) | Either `audit.RegisterOutputFactory` from your own `init()`, or `WithFactory` per call — the test-vs-production trade-off above applies. |
+| Test cleanup / un-registration between tests | Neither path supports removal. The global registry is append-only (overwrite-with-different-factory works, but there is no `Unregister`). For per-test isolation, prefer `WithFactory` which scopes naturally to the call and never touches the global registry. |
+| Resolution order between `init()` and `WithFactory` | Both are resolved at `Load` time. Blank-import order does not matter as long as every needed factory has been registered by the time `Load` runs. `WithFactory` overrides whatever the global registry holds at that moment. |
+
+The two paths can coexist freely. Blank-import sets up sensible
+defaults at process start; `WithFactory` selectively overrides those
+defaults for a single call.
+
+See:
+- [`audit.RegisterOutputFactory`](https://pkg.go.dev/github.com/axonops/audit#RegisterOutputFactory)
+  — the global-registry entry point invoked by sub-module `init()`s.
+- [`outputconfig.WithFactory`](https://pkg.go.dev/github.com/axonops/audit/outputconfig#WithFactory)
+  — the per-call LoadOption.
 
 ## 📦 Loading Output Configuration
 

--- a/outputconfig/options.go
+++ b/outputconfig/options.go
@@ -93,6 +93,22 @@ func WithOutputMetrics(factory audit.OutputMetricsFactory) LoadOption {
 // WithFactory registers a per-call output factory override for the
 // given type name. Per-call factories take precedence over globally
 // registered factories. Multiple calls for the same type: last wins.
+//
+// # Choosing a registration path
+//
+// WithFactory is one of two registration paths. The other is
+// [github.com/axonops/audit.RegisterOutputFactory] (typically
+// invoked from init() via a blank-import of an output sub-module
+// such as [github.com/axonops/audit/outputs] or
+// [github.com/axonops/audit/file]), which mutates the global
+// registry and applies process-wide.
+//
+// Use WithFactory for tests, per-call overrides, or multiple
+// auditors in one process with different factory bindings. Use
+// RegisterOutputFactory (via blank-import) for default production
+// setup. See the "Output Factory Registration" section of
+// docs/output-configuration.md for full guidance on choosing between
+// them.
 func WithFactory(typeName string, factory audit.OutputFactory) LoadOption {
 	return func(o *loadOptions) {
 		if o.factories == nil {

--- a/registry.go
+++ b/registry.go
@@ -75,6 +75,22 @@ var (
 //
 // Prior to #590 this function panicked directly; the signature change
 // removes the last library-boundary panic in the public API.
+//
+// # Choosing a registration path
+//
+// RegisterOutputFactory is one of two registration paths. The other
+// is [github.com/axonops/audit/outputconfig.WithFactory], which
+// passes a factory as a LoadOption to a single Load call without
+// mutating the global registry. RegisterOutputFactory applies process-wide;
+// WithFactory applies to one Load call only and takes precedence
+// over any globally-registered factory for the same type name.
+//
+// Use RegisterOutputFactory (typically via a blank-import of an
+// output sub-module) for default production setup. Use WithFactory
+// for tests, per-call overrides, or multiple auditors in one process
+// with different factory bindings. See the "Output Factory
+// Registration" section of docs/output-configuration.md for full
+// guidance on choosing between them.
 func RegisterOutputFactory(typeName string, factory OutputFactory) error {
 	if typeName == "" {
 		return fmt.Errorf("%w: RegisterOutputFactory called with empty type name", ErrValidation)


### PR DESCRIPTION
## Summary
- Closes #545. The audit library has two paths for registering output factories: blank-import (`audit.RegisterOutputFactory` via sub-module `init()`) and `outputconfig.WithFactory` (per-call `LoadOption`). Before this PR, only blank-import was documented and there was no cross-reference between the two.
- Restructure `docs/output-configuration.md` § "Factory Registry" into a 3-subsection "Output Factory Registration" with a decision table covering 8 scenarios. Add reciprocal "Choosing a registration path" godoc sections on `RegisterOutputFactory` and `outputconfig.WithFactory`.

## What changed
- `docs/output-configuration.md` — Blank-import / WithFactory / When-to-use-which subsections; pkg.go.dev links at the end.
- `registry.go` — append godoc cross-reference (uses `[bracket]` link syntax for pkg.go.dev resolution).
- `outputconfig/options.go` — expand `WithFactory` godoc with parallel cross-reference.

## Decision table scenarios
1. Default production setup
2. Binary-size optimisation
3. Hermetic tests (avoiding `init()` side effects)
4. Custom metrics-aware factory for one type
5. Multiple auditors per process with different factory bindings
6. Consumer-defined output types
7. Test cleanup / un-registration between tests
8. Resolution order between `init()` and `WithFactory`

## Test plan
- [x] `make check` — green.
- [x] docs-writer agent gate — applied two fixes (factual error: "stdout is its own module" — wrong, stdout lives in core; missing pkg.go.dev bracket link on `registry.go` cross-reference).
- [x] user-guide-reviewer agent gate — applied wording strengthening for test + multiple-auditors scenarios; added test-cleanup and resolution-order rows; clarified identifier provenance in the `WithFactory` code snippet.
- [x] commit-message-reviewer — PASS.

Closes #545.