### PR TITLE
test: parallelise audit_*_test.go + enrich BDD step errors (#570)

### DIFF
--- a/audit_acceptance_test.go
+++ b/audit_acceptance_test.go
@@ -59,6 +59,7 @@ func (s *slowOutput) Close() error {
 func (s *slowOutput) Name() string { return "slow" }
 
 func TestDrainLoop_SlowOutput_DoesNotBlockOthers(t *testing.T) {
+	t.Parallel()
 	// A slow output must not prevent a fast output from receiving events.
 	slow := &slowOutput{delay: 100 * time.Millisecond}
 	fast := testhelper.NewMockOutput("fast")
@@ -85,6 +86,7 @@ func TestDrainLoop_SlowOutput_DoesNotBlockOthers(t *testing.T) {
 }
 
 func TestDrainLoop_AllOutputsAsync_NoSequentialBlocking(t *testing.T) {
+	t.Parallel()
 	// Verify two async outputs both receive events.
 	outA := testhelper.NewMockOutput("output-a")
 	outB := testhelper.NewMockOutput("output-b")
@@ -113,6 +115,7 @@ func TestDrainLoop_AllOutputsAsync_NoSequentialBlocking(t *testing.T) {
 }
 
 func TestCoreMetrics_RecordSubmitted_CalledPerAuditEvent(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	metrics := testhelper.NewMockMetrics()
 
@@ -139,6 +142,7 @@ func TestCoreMetrics_RecordSubmitted_CalledPerAuditEvent(t *testing.T) {
 }
 
 func TestCoreMetrics_RecordSubmitted_CalledBeforeFiltering(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	metrics := testhelper.NewMockMetrics()
 
@@ -170,6 +174,7 @@ func TestCoreMetrics_RecordSubmitted_CalledBeforeFiltering(t *testing.T) {
 }
 
 func TestCoreMetrics_RecordQueueDepth_SampledEveryNEvents(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	metrics := testhelper.NewMockMetrics()
 

--- a/audit_benchmark_test.go
+++ b/audit_benchmark_test.go
@@ -496,6 +496,7 @@ func TestDropLimiter_TotalConservedAcrossWindows(t *testing.T) {
 }
 
 func TestLogger_DisableEvent_UncategorisedEvent(t *testing.T) {
+	t.Parallel()
 	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{

--- a/audit_completeness_test.go
+++ b/audit_completeness_test.go
@@ -31,6 +31,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
+	t.Parallel()
 	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{
@@ -87,6 +88,7 @@ func TestLogger_Audit_FieldCompleteness_AllFieldsPresent(t *testing.T) {
 }
 
 func TestLogger_Audit_FieldCompleteness_OmittedOptionalFieldsAbsent(t *testing.T) {
+	t.Parallel()
 	tax := &audit.Taxonomy{
 		Version: 1,
 		Categories: map[string]*audit.CategoryDef{

--- a/audit_concurrency_test.go
+++ b/audit_concurrency_test.go
@@ -33,6 +33,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
@@ -69,6 +70,7 @@ func TestLogger_ConcurrentWritesAndClose(t *testing.T) {
 }
 
 func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
@@ -123,6 +125,7 @@ func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Handle_AuditAfterClose(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
@@ -152,6 +155,7 @@ func TestLogger_Handle_AuditAfterClose(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_ConcurrentAudit(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -174,6 +178,7 @@ func TestLogger_ConcurrentAudit(t *testing.T) {
 }
 
 func TestLogger_ConcurrentFilterMutation(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -199,6 +204,7 @@ func TestLogger_ConcurrentFilterMutation(t *testing.T) {
 }
 
 func TestLogger_ConcurrentClose(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(

--- a/audit_ctx_test.go
+++ b/audit_ctx_test.go
@@ -182,6 +182,7 @@ func BenchmarkEventHandle_AuditContext_Background(b *testing.B) {
 // a regression that allows N+1 events through, or rejects the
 // Nth, would surface here. (#565 G11).
 func TestLogger_OverflowPolicy_ExactCapacity(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 
 	// QueueSize 1 with a blocking output: the drain goroutine
@@ -233,6 +234,7 @@ func TestLogger_OverflowPolicy_ExactCapacity(t *testing.T) {
 // missing increments would mislead operators about backpressure
 // pressure. (#565 G11).
 func TestLogger_Audit_QueueFull_MetricsIncrement(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 
 	out := &blockingOutput{name: "blocking", blockCh: make(chan struct{})}
@@ -274,6 +276,7 @@ func TestLogger_Audit_QueueFull_MetricsIncrement(t *testing.T) {
 // contract: an explicit Close on a non-blocking pipeline never
 // drops events. (#565 G1).
 func TestLogger_Close_DrainCompletesBeforeTimeout(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("drainable")
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
@@ -308,6 +311,7 @@ func TestLogger_Close_DrainCompletesBeforeTimeout(t *testing.T) {
 // "zero defaults to DefaultShutdownTimeout" — a more permissive
 // interpretation that this test pins. (#565 G1).
 func TestLogger_Close_ZeroShutdownTimeout(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("zero-timeout")
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),
@@ -331,6 +335,7 @@ func TestLogger_Close_ZeroShutdownTimeout(t *testing.T) {
 // per the documented contract — verify the actual behaviour).
 // (#565 G1).
 func TestLogger_New_WithDisabledCategoryAtBoot(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("after-disable")
 	auditor, err := audit.New(
 		audit.WithValidationMode(audit.ValidationPermissive),

--- a/audit_dedup_test.go
+++ b/audit_dedup_test.go
@@ -44,6 +44,7 @@ func (d *destKeyOutput) DestinationKey() string {
 }
 
 func TestWithOutputs_DuplicateDestination_ReturnsError(t *testing.T) {
+	t.Parallel()
 	o1 := &destKeyOutput{name: "out1", key: "/var/log/audit.log"}
 	o2 := &destKeyOutput{name: "out2", key: "/var/log/audit.log"}
 	_, err := audit.New(
@@ -58,6 +59,7 @@ func TestWithOutputs_DuplicateDestination_ReturnsError(t *testing.T) {
 }
 
 func TestWithNamedOutput_DuplicateDestination_ReturnsError(t *testing.T) {
+	t.Parallel()
 	o1 := &destKeyOutput{name: "out1", key: "localhost:514"}
 	o2 := &destKeyOutput{name: "out2", key: "localhost:514"}
 	_, err := audit.New(
@@ -73,6 +75,7 @@ func TestWithNamedOutput_DuplicateDestination_ReturnsError(t *testing.T) {
 }
 
 func TestWithOutputs_EmptyDestinationKey_NoCollision(t *testing.T) {
+	t.Parallel()
 	// Outputs returning empty DestinationKey opt out of dedup.
 	o1 := &destKeyOutput{name: "out1", key: ""}
 	o2 := &destKeyOutput{name: "out2", key: ""}
@@ -87,6 +90,7 @@ func TestWithOutputs_EmptyDestinationKey_NoCollision(t *testing.T) {
 }
 
 func TestWithOutputs_MixedTypes_NoFalsePositive(t *testing.T) {
+	t.Parallel()
 	// destKeyOutput + MockOutput (no DestinationKeyer) should not collide.
 	o1 := &destKeyOutput{name: "keyed", key: "/var/log/audit.log"}
 	o2 := testhelper.NewMockOutput("unkeyed")
@@ -112,6 +116,7 @@ func (f *cacheTestFmt) Format(_ time.Time, _ string, _ audit.Fields, _ *audit.Ev
 }
 
 func TestFormatCache_PutGet(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		formatters int
@@ -124,6 +129,7 @@ func TestFormatCache_PutGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			fc := &audit.FormatCacheForTest{}
 			fmts := make([]*cacheTestFmt, tt.formatters)
 			for i := range fmts {
@@ -145,6 +151,7 @@ func TestFormatCache_PutGet(t *testing.T) {
 }
 
 func TestFormatCache_NilData(t *testing.T) {
+	t.Parallel()
 	fc := &audit.FormatCacheForTest{}
 	f := &cacheTestFmt{id: 1}
 
@@ -167,6 +174,8 @@ func TestFormatCache_NilData(t *testing.T) {
 // `go test` — benchmarks only fail via benchstat, which is not on
 // the `make check` path.
 func TestFormatCache_FillsArraySlots_ZeroMapAllocs(t *testing.T) {
+	// Intentionally NOT t.Parallel(): testing.AllocsPerRun panics
+	// when called from a parallel test.
 	// Pre-allocate one distinct formatter instance per cache slot.
 	// Pointer identity is what the cache keys on, so each &cacheTestFmt{}
 	// produces a distinct key regardless of field values.

--- a/audit_filter_test.go
+++ b/audit_filter_test.go
@@ -31,6 +31,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestLogger_EnableCategory(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -45,6 +46,7 @@ func TestLogger_EnableCategory(t *testing.T) {
 }
 
 func TestLogger_DisableCategory(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -67,6 +69,7 @@ func TestLogger_DisableCategory(t *testing.T) {
 }
 
 func TestLogger_EnableEvent_OverridesCategory(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -92,6 +95,7 @@ func TestLogger_EnableEvent_OverridesCategory(t *testing.T) {
 }
 
 func TestLogger_DisableEvent_OverridesCategory(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -118,6 +122,7 @@ func TestLogger_DisableEvent_OverridesCategory(t *testing.T) {
 }
 
 func TestLogger_Filter_InvalidCategory(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -134,6 +139,7 @@ func TestLogger_Filter_InvalidCategory(t *testing.T) {
 }
 
 func TestLogger_MultiCategory_DeliveredPerCategory(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 
 	// Create a taxonomy where auth_failure is in both security and access.
@@ -166,6 +172,7 @@ func TestLogger_MultiCategory_DeliveredPerCategory(t *testing.T) {
 }
 
 func TestLogger_MultiCategory_DisableOneCategory(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 
 	tax := &audit.Taxonomy{
@@ -200,6 +207,7 @@ func TestLogger_MultiCategory_DisableOneCategory(t *testing.T) {
 }
 
 func TestLogger_MultiCategory_DisableAllCategories(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 
 	tax := &audit.Taxonomy{
@@ -238,6 +246,7 @@ func TestLogger_MultiCategory_DisableAllCategories(t *testing.T) {
 }
 
 func TestLogger_Uncategorised_DeliveredToUnroutedOutput(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 
 	// data_export is not in any category.
@@ -269,6 +278,7 @@ func TestLogger_Uncategorised_DeliveredToUnroutedOutput(t *testing.T) {
 }
 
 func TestLogger_MultiCategory_EnableEventOverride(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 
 	tax := &audit.Taxonomy{
@@ -306,6 +316,7 @@ func TestLogger_MultiCategory_EnableEventOverride(t *testing.T) {
 }
 
 func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 
 	tax := &audit.Taxonomy{
@@ -340,6 +351,7 @@ func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 }
 
 func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
+	t.Parallel()
 	out := testhelper.NewMockOutput("test")
 
 	tax := &audit.Taxonomy{
@@ -373,6 +385,7 @@ func TestLogger_MultiCategory_ExcludeRoute(t *testing.T) {
 }
 
 func TestLogger_Filter_InvalidEvent(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)

--- a/audit_handle_test.go
+++ b/audit_handle_test.go
@@ -31,6 +31,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestLogger_Handle_Valid(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -42,6 +43,7 @@ func TestLogger_Handle_Valid(t *testing.T) {
 }
 
 func TestLogger_Handle_Error(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -53,6 +55,7 @@ func TestLogger_Handle_Error(t *testing.T) {
 }
 
 func TestLogger_MustHandle_Valid(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -64,6 +67,7 @@ func TestLogger_MustHandle_Valid(t *testing.T) {
 }
 
 func TestLogger_MustHandle_Panics(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -172,6 +176,7 @@ func TestEventHandle_Metadata_ReadOnlyContract(t *testing.T) {
 }
 
 func TestLogger_Handle_Audit(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)

--- a/audit_lifecycle_test.go
+++ b/audit_lifecycle_test.go
@@ -32,6 +32,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_EventDelivered(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -46,6 +47,7 @@ func TestLogger_Audit_EventDelivered(t *testing.T) {
 }
 
 func TestLogger_Audit_BufferFull(t *testing.T) {
+	t.Parallel()
 
 	metrics := testhelper.NewMockMetrics()
 
@@ -105,6 +107,7 @@ func (b *blockingOutput) Close() error { return nil }
 func (b *blockingOutput) Name() string { return b.name }
 
 func TestLogger_Close_DrainsEvents(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
@@ -130,6 +133,7 @@ func TestLogger_Close_DrainsEvents(t *testing.T) {
 }
 
 func TestLogger_Close_Idempotent(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
@@ -145,6 +149,7 @@ func TestLogger_Close_Idempotent(t *testing.T) {
 }
 
 func TestLogger_Audit_AfterClose(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
@@ -164,6 +169,7 @@ func TestLogger_Audit_AfterClose(t *testing.T) {
 }
 
 func TestLogger_Close_ShutdownTimeout(t *testing.T) {
+	t.Parallel()
 
 	// Use a blocking output that never unblocks combined with a very
 	// short drain timeout. Close should return within a bounded time
@@ -197,6 +203,7 @@ func TestLogger_Close_ShutdownTimeout(t *testing.T) {
 }
 
 func TestLogger_Close_OutputError(t *testing.T) {
+	t.Parallel()
 
 	out := &errorOutput{name: "bad", closeErr: errors.New("close failed")}
 	auditor, err := audit.New(
@@ -227,6 +234,7 @@ func (e *errorOutput) Close() error         { return e.closeErr }
 func (e *errorOutput) Name() string         { return e.name }
 
 func TestLogger_Close_MultipleOutputErrors(t *testing.T) {
+	t.Parallel()
 	errAlpha := errors.New("alpha broke")
 	errBeta := errors.New("beta broke")
 
@@ -255,6 +263,7 @@ func TestLogger_Close_MultipleOutputErrors(t *testing.T) {
 }
 
 func TestLogger_Close_AllOutputsCloseCalledOnError(t *testing.T) {
+	t.Parallel()
 	// Verify output B's Close() is called even when output A's Close() fails.
 	outA := &errorOutput{name: "fail-first", closeErr: errors.New("first fail")}
 	outB := testhelper.NewMockOutput("second")

--- a/audit_metadata_test.go
+++ b/audit_metadata_test.go
@@ -701,6 +701,7 @@ func TestMetadataWriter_CachedAssertion_Correct(t *testing.T) {
 }
 
 func TestTimezoneAlwaysPopulated(t *testing.T) {
+	t.Parallel()
 	// Create an auditor with NO timezone config — it should auto-detect.
 	tax := &audit.Taxonomy{
 		Version: 1,
@@ -732,6 +733,7 @@ func TestTimezoneAlwaysPopulated(t *testing.T) {
 }
 
 func TestTimezoneAutoDetect(t *testing.T) {
+	t.Parallel()
 	tax := &audit.Taxonomy{
 		Version: 1,
 		Events:  map[string]*audit.EventDef{"test_event": {}},
@@ -764,6 +766,7 @@ func TestTimezoneAutoDetect(t *testing.T) {
 }
 
 func TestTimezoneOverride(t *testing.T) {
+	t.Parallel()
 	tax := &audit.Taxonomy{
 		Version: 1,
 		Events:  map[string]*audit.EventDef{"test_event": {}},

--- a/audit_metrics_test.go
+++ b/audit_metrics_test.go
@@ -32,6 +32,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestAudit_UnknownEventType_RecordsValidationError(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out,
@@ -45,6 +46,7 @@ func TestAudit_UnknownEventType_RecordsValidationError(t *testing.T) {
 }
 
 func TestAudit_MissingRequiredField_RecordsValidationError(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out,
@@ -58,6 +60,7 @@ func TestAudit_MissingRequiredField_RecordsValidationError(t *testing.T) {
 }
 
 func TestAudit_UnknownFieldStrict_RecordsValidationError(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(
@@ -82,6 +85,7 @@ func TestAudit_UnknownFieldStrict_RecordsValidationError(t *testing.T) {
 }
 
 func TestAudit_FilteredEvent_RecordsFiltered(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out,
@@ -97,6 +101,7 @@ func TestAudit_FilteredEvent_RecordsFiltered(t *testing.T) {
 }
 
 func TestAudit_FilteredEventOverride_RecordsFiltered(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out,
@@ -117,6 +122,7 @@ func TestAudit_FilteredEventOverride_RecordsFiltered(t *testing.T) {
 }
 
 func TestProcessEntry_SerializationError_RecordsMetric(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 	out := testhelper.NewMockOutput("test")
 	badFormatter := &stubFormatter{
@@ -150,6 +156,7 @@ func TestProcessEntry_SerializationError_RecordsMetric(t *testing.T) {
 }
 
 func TestEmitShutdown_BufferFull_RecordsBufferDrop(t *testing.T) {
+	t.Parallel()
 	metrics := testhelper.NewMockMetrics()
 	out := &blockingOutput{name: "stuck", blockCh: make(chan struct{})}
 	t.Cleanup(func() { close(out.blockCh) })
@@ -181,6 +188,7 @@ func TestEmitShutdown_BufferFull_RecordsBufferDrop(t *testing.T) {
 }
 
 func TestAudit_NilMetrics_NoPanic(t *testing.T) {
+	t.Parallel()
 	// Verify that all metrics paths handle nil metrics without panic,
 	// including the async serialization error path in processEntry.
 	badFormatter := &stubFormatter{
@@ -244,6 +252,7 @@ var _ audit.DeliveryReporter = (*deliveryReporterOutput)(nil)
 var _ audit.Output = (*deliveryReporterOutput)(nil)
 
 func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
+	t.Parallel()
 	// When an output satisfies DeliveryReporter and ReportsDelivery()
 	// returns true, the core auditor must NOT call RecordDelivery on success.
 	metrics := testhelper.NewMockMetrics()
@@ -275,6 +284,7 @@ func TestWriteToOutput_DeliveryReporter_SuccessSkipsCoreMetrics(t *testing.T) {
 }
 
 func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
+	t.Parallel()
 	// When a DeliveryReporter output fails on Write, the core auditor must
 	// NOT call RecordDelivery or RecordOutputError — the output is responsible.
 	metrics := testhelper.NewMockMetrics()
@@ -310,6 +320,7 @@ func TestWriteToOutput_DeliveryReporter_ErrorSkipsCoreMetrics(t *testing.T) {
 }
 
 func TestWriteToOutput_NonDeliveryReporter_SuccessRecordsCoreMetrics(t *testing.T) {
+	t.Parallel()
 	// A plain output (not DeliveryReporter) must have RecordDelivery(success)
 	// called by the core auditor on a successful write.
 	metrics := testhelper.NewMockMetrics()
@@ -369,6 +380,7 @@ func TestIsZeroValue_NumericTypeBranches_Direct(t *testing.T) {
 }
 
 func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
+	t.Parallel()
 	// Exercises the int32, float32, uint, uint64 branches in isZeroValue
 	// via the OmitEmpty path through the JSON formatter.
 	out := testhelper.NewMockOutput("test")
@@ -434,6 +446,7 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Use a fresh output per subtest to avoid event ordering issues.
 			subOut := testhelper.NewMockOutput("sub-" + tt.name)
 			subLogger, err := audit.New(
@@ -470,6 +483,7 @@ func TestLogger_Audit_OmitEmpty_NumericTypeBranches(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_MetricsRecordSuccess(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test-out")
 	metrics := testhelper.NewMockMetrics()
@@ -490,6 +504,7 @@ func TestLogger_Audit_MetricsRecordSuccess(t *testing.T) {
 }
 
 func TestLogger_Audit_MetricsRecordOutputError(t *testing.T) {
+	t.Parallel()
 
 	metrics := testhelper.NewMockMetrics()
 	out := &errorWriteOutput{name: "bad-write"}

--- a/audit_misc_test.go
+++ b/audit_misc_test.go
@@ -35,6 +35,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_MultipleOutputs(t *testing.T) {
+	t.Parallel()
 
 	out1 := testhelper.NewMockOutput("out1")
 	out2 := testhelper.NewMockOutput("out2")
@@ -64,6 +65,7 @@ func TestLogger_Audit_MultipleOutputs(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_OmitEmptyNonZeroIncluded(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
@@ -87,6 +89,7 @@ func TestLogger_Audit_OmitEmptyNonZeroIncluded(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_FuncFieldOmitEmpty(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
@@ -118,6 +121,7 @@ func TestLogger_Audit_FuncFieldOmitEmpty(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Close_ShutdownEventDroppedOnFullBuffer(t *testing.T) {
+	t.Parallel()
 
 	out := &blockingOutput{name: "stuck", blockCh: make(chan struct{})}
 	t.Cleanup(func() { close(out.blockCh) })
@@ -151,6 +155,7 @@ func TestLogger_Close_ShutdownEventDroppedOnFullBuffer(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_AllCategoriesEnabledByDefault(t *testing.T) {
+	t.Parallel()
 
 	tax := &audit.Taxonomy{
 		Version:    1,
@@ -182,6 +187,7 @@ func TestLogger_Audit_AllCategoriesEnabledByDefault(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_NoOutputs(t *testing.T) {
+	t.Parallel()
 
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
@@ -204,6 +210,7 @@ func TestLogger_Audit_NoOutputs(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNew_QueueSizeExceedsMax(t *testing.T) {
+	t.Parallel()
 	_, err := audit.New(
 		audit.WithQueueSize(audit.MaxQueueSize+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
@@ -216,6 +223,7 @@ func TestNew_QueueSizeExceedsMax(t *testing.T) {
 }
 
 func TestNew_ShutdownTimeoutExceedsMax(t *testing.T) {
+	t.Parallel()
 	_, err := audit.New(
 		audit.WithShutdownTimeout(audit.MaxShutdownTimeout+1),
 		audit.WithTaxonomy(testhelper.ValidTaxonomy()),
@@ -232,6 +240,7 @@ func TestNew_ShutdownTimeoutExceedsMax(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_OmitEmptyZeroInt(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithOmitEmpty(), audit.WithValidationMode(audit.ValidationPermissive))
@@ -261,6 +270,7 @@ func TestLogger_Audit_OmitEmptyZeroInt(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_UnsupportedFieldValueType_Permissive_CoercesAndDelivers(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationPermissive))
@@ -291,6 +301,7 @@ func TestLogger_Audit_UnsupportedFieldValueType_Permissive_CoercesAndDelivers(t 
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_NilFieldsNoRequiredFields(t *testing.T) {
+	t.Parallel()
 
 	// Create a taxonomy with an event that has no required fields.
 	tax := &audit.Taxonomy{

--- a/audit_pool_internal_test.go
+++ b/audit_pool_internal_test.go
@@ -32,6 +32,12 @@ import (
 // `returnFieldsToPool` calls `clear()` before `Put()` on the non-drop
 // path.
 func TestFieldsPool_DropsOversizedMap_NotReused(t *testing.T) {
+	// Intentionally NOT t.Parallel(): all three TestFieldsPool_* tests
+	// read and assert exact deltas on the package-global
+	// [fieldsPoolDrops] counter. Parallelisation would let one test's
+	// drop bump leak into another test's before/after window, causing
+	// flakes that the race detector cannot surface (atomic counters
+	// are race-free; the race here is logical, not data).
 	before := fieldsPoolDrops.Load()
 
 	// Build a map beyond the threshold.
@@ -51,6 +57,8 @@ func TestFieldsPool_DropsOversizedMap_NotReused(t *testing.T) {
 // at or under the threshold — protects against a regression that
 // over-eagerly discards every map.
 func TestFieldsPool_KeepsSmallMap(t *testing.T) {
+	// Intentionally NOT t.Parallel(): see comment on
+	// TestFieldsPool_DropsOversizedMap_NotReused.
 	before := fieldsPoolDrops.Load()
 
 	small := make(Fields, 4)
@@ -65,6 +73,8 @@ func TestFieldsPool_KeepsSmallMap(t *testing.T) {
 
 // TestFieldsPool_NilIsNoop verifies the nil-safety contract.
 func TestFieldsPool_NilIsNoop(t *testing.T) {
+	// Intentionally NOT t.Parallel(): see comment on
+	// TestFieldsPool_DropsOversizedMap_NotReused.
 	before := fieldsPoolDrops.Load()
 	returnFieldsToPool(nil)
 	after := fieldsPoolDrops.Load()

--- a/audit_validation_test.go
+++ b/audit_validation_test.go
@@ -32,6 +32,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_ValidCall(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -52,6 +53,7 @@ func TestLogger_Audit_ValidCall(t *testing.T) {
 }
 
 func TestLogger_Audit_MissingRequiredField(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -69,6 +71,7 @@ func TestLogger_Audit_MissingRequiredField(t *testing.T) {
 }
 
 func TestLogger_Audit_MissingSingleRequiredField(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -83,6 +86,7 @@ func TestLogger_Audit_MissingSingleRequiredField(t *testing.T) {
 }
 
 func TestLogger_Audit_UnknownEventType(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -96,6 +100,7 @@ func TestLogger_Audit_UnknownEventType(t *testing.T) {
 }
 
 func TestLogger_Audit_UnknownFieldStrict(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -114,6 +119,7 @@ func TestLogger_Audit_UnknownFieldStrict(t *testing.T) {
 }
 
 func TestLogger_Audit_UnknownFieldWarn(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationWarn))
@@ -130,6 +136,7 @@ func TestLogger_Audit_UnknownFieldWarn(t *testing.T) {
 }
 
 func TestLogger_Audit_UnknownFieldPermissive(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationPermissive))
@@ -525,6 +532,7 @@ func TestWithStandardFieldDefaults_SatisfiesRequired(t *testing.T) {
 }
 
 func TestLogger_Audit_NilFields(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -539,6 +547,7 @@ func TestLogger_Audit_NilFields(t *testing.T) {
 }
 
 func TestLogger_Audit_DisabledCategory(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -559,6 +568,7 @@ func TestLogger_Audit_DisabledCategory(t *testing.T) {
 }
 
 func TestLogger_Audit_OptionalFields(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -581,6 +591,7 @@ func TestLogger_Audit_OptionalFields(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_TimestampAutoPopulated(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -602,6 +613,7 @@ func TestLogger_Audit_TimestampAutoPopulated(t *testing.T) {
 }
 
 func TestLogger_Audit_EventTypeAutoPopulated(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)
@@ -618,6 +630,7 @@ func TestLogger_Audit_EventTypeAutoPopulated(t *testing.T) {
 }
 
 func TestLogger_Audit_ConsumerTimestampOverwritten(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithValidationMode(audit.ValidationPermissive))
@@ -640,6 +653,7 @@ func TestLogger_Audit_ConsumerTimestampOverwritten(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLogger_Audit_OmitEmptyTrue(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out, audit.WithOmitEmpty())
@@ -659,6 +673,7 @@ func TestLogger_Audit_OmitEmptyTrue(t *testing.T) {
 }
 
 func TestLogger_Audit_OmitEmptyFalse(t *testing.T) {
+	t.Parallel()
 
 	out := testhelper.NewMockOutput("test")
 	auditor := newTestAuditor(t, out)

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -105,6 +105,15 @@ type AuditTestContext struct { //nolint:govet // fieldalignment: readability pre
 	// Cleanup functions run in AfterScenario (LIFO order).
 	cleanups []func()
 	mu       sync.Mutex
+
+	// ScenarioName is the name of the running scenario, captured by
+	// the Before hook for use by the step-error enrichment hook
+	// (#570 AC#3). Safe without a mutex only because the BDD runner
+	// uses Concurrency: 1 (see tests/bdd/bdd_test.go); if that ever
+	// changes, this field must move onto context.Context with a
+	// typed key, since steps within different scenarios would
+	// otherwise race on it.
+	ScenarioName string
 }
 
 // AddCleanup registers a cleanup function to run after the scenario.
@@ -156,6 +165,7 @@ func (tc *AuditTestContext) Reset() {
 	tc.TLSReceiver = nil
 	tc.LocalReceiver = nil
 	tc.cleanups = nil
+	tc.ScenarioName = ""
 }
 
 // EnsureFileDir creates a temp directory for file outputs if not already set.
@@ -181,6 +191,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 
 	ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
 		tc.Reset()
+		tc.ScenarioName = sc.Name
 		// Reset webhook receiver if Docker is available (ignore errors
 		// for non-Docker scenarios).
 		_ = resetWebhookReceiver(tc.WebhookURL)
@@ -194,6 +205,17 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		}
 		tc.Cleanup()
 		return ctx, nil
+	})
+
+	// Step-error enrichment hook (#570 AC#3). When a step fails,
+	// godog's default failure log shows only the underlying error.
+	// Wrap it with scenario+step context so CI logs are diagnosable
+	// without local repro.
+	ctx.StepContext().After(func(ctx context.Context, st *godog.Step, status godog.StepResultStatus, err error) (context.Context, error) {
+		if err == nil {
+			return ctx, nil
+		}
+		return ctx, fmt.Errorf("scenario %q step %q: %w", tc.ScenarioName, st.Text, err)
 	})
 
 	// Register all step definitions.


### PR DESCRIPTION
## Summary

Closes #570.

- Adds `t.Parallel()` to ~99 Test functions across 14 `audit_*_test.go`
  files at the repository root. Two clusters are intentionally kept
  non-parallel (with comments explaining why):
  - The three `TestFieldsPool_*` tests in `audit_pool_internal_test.go`
    assert exact deltas on the package-global `fieldsPoolDrops`
    counter; a parallel sibling could bump it between their before
    /after `Load()`s.
  - `TestFormatCache_FillsArraySlots_ZeroMapAllocs` calls
    `testing.AllocsPerRun`, which panics when invoked from a parallel
    test.
- Adds an `AfterStep` hook in `tests/bdd/steps/context.go` that wraps
  non-nil step errors with scenario+step context. CI failure logs
  now show `scenario "X" step "Y": <underlying err>` instead of just
  the bare error from godog. The scenario name is captured in the
  existing `Before` hook on a new `ScenarioName` field of
  `AuditTestContext`; this is safe without a mutex only because the
  runner uses `Concurrency: 1`, and that invariant is documented in
  the field's godoc.

`hmac_internal_test.go` was already compliant — confirmed during
implementation; no changes needed.

## Test plan

- [x] `go test -race -count=1` (root) — green
- [x] `go test -race -count=10` on concurrency-heavy tests — green
- [x] `make check` — clean (lint, vet, tests, security, goreleaser)
- [x] `tests/bdd` compiles
- [ ] CI green