### PR TITLE
docs: document Dependency Review CI job and security-check split (#631)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,25 @@ jobs:
             echo "Mutation-test targets: ${JSON}"
           fi
 
+  # PR-only supply-chain guard. `actions/dependency-review-action`
+  # diffs the PR's go.mod / go.sum changes against the GitHub
+  # Advisory Database (GHAS) and fails the check if the diff
+  # introduces a HIGH-severity advisory in any added or upgraded
+  # module. It complements `make security` (govulncheck × every
+  # published module — see the `security:` matrix below): govulncheck
+  # tracks Go-vuln-DB CVEs that are reachable from imported symbols
+  # in the existing tree, while this job catches GHAS advisories on
+  # new or bumped modules at PR time, often before the Go vuln DB
+  # has indexed them. It is also the only check that can enforce
+  # license-policy or supply-chain blocklists if we ever configure
+  # `deny-licenses` / `deny-packages`.
+  #
+  # Deliberately NOT in `ci-pass.needs:` (see comment on `ci-pass`
+  # below) — the job is `if: github.event_name == 'pull_request'`
+  # and would otherwise mark every push run as `skipped`. Removing
+  # this job would not weaken the merge gate, but would lose the
+  # only PR-time GHAS coverage and the only license-policy hook.
+  #
   # Requires Dependency Graph enabled in repo settings:
   # https://github.com/axonops/audit/settings/security_analysis
   dependency-review:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -959,7 +959,41 @@ action — every job consumes it via `uses: ./.github/actions/setup-audit`.
 The cache key hashes `scripts/tool-versions.txt` so version bumps are
 the only thing that invalidate the cache.
 
+### Security checks in CI
 
+Three CI-time supply-chain controls run in this repository. Each plays
+a distinct role; together they cover known-vuln detection, import
+reachability, license policy, and update propagation. Removing any one
+opens a coverage gap that the others do not fill.
+
+| Tool | Where it runs | Trigger | What it blocks | Threshold |
+|------|---------------|---------|----------------|-----------|
+| `actions/dependency-review-action` (pinned to v4.9.0) | `dependency-review:` job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) | every pull request to `main` | a PR whose `go.mod`/`go.sum` diff introduces an advisory in the [GitHub Advisory Database](https://github.com/advisories) at or above the configured severity | `fail-on-severity: high` |
+| `govulncheck` (run via `make security` / `make security-one MOD=...`) | `security:` matrix in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) (one job per published module — root, `file`, `iouring`, `syslog`, `webhook`, `loki`, `outputconfig`, `outputs`, `cmd/audit-gen`, `cmd/audit-validate`, `secrets`, `secrets/env`, `secrets/file`, `secrets/openbao`, `secrets/vault`); the same target also runs in [`.github/workflows/security-scan.yml`](../.github/workflows/security-scan.yml) | every push and pull request that touches code; weekly cron at `0 6 * * 1`; manual dispatch | a build whose imported symbols reach a CVE in the [Go vulnerability database](https://pkg.go.dev/vuln/) | any vulnerability flagged by `govulncheck` (no severity gate) |
+| Dependabot | [`.github/dependabot.yml`](../.github/dependabot.yml) | continuous (GitHub-managed) | nothing directly — opens version-bump and security-fix PRs against every module directory listed in the config | n/a (open-PR mechanism, not a gate) |
+
+The split is intentional. `dependency-review` is the only PR-time
+check against GHAS — a broader and often more current advisory feed
+than the Go vulnerability database, and the only place we can enforce
+`deny-licenses` or `deny-packages` if a license-policy or supply-chain
+blocklist is added later. `govulncheck` is the only tool that performs
+import-reachability analysis, so it surfaces "your code actually calls
+into a vulnerable function" rather than "a vulnerable version is in
+the graph". Dependabot is the only mechanism that opens update PRs.
+
+If a PR is failing `Test - Dependency Review`, read the check
+annotation for the GHSA ID and the affected module, then either bump
+the dependency to a fixed version (Dependabot will usually open such a
+PR independently within hours) or, if the advisory is a false positive
+for our usage, allow it via `allow-ghsas:` on the action's `with:`
+block — and document the rationale in the PR description.
+
+A weekly run of `security-scan.yml` opens a tracking issue
+automatically on every run where `make security` exits non-zero —
+this includes CVEs that are already known but not yet resolved, so
+expect duplicate issues until the underlying vulnerability is
+fixed. Resolve them promptly: each one represents a CVE in code we
+already ship, not a hypothetical "new dependency" risk.
 
 ### The pipefail bug class
 


### PR DESCRIPTION
Closes #631.

## Summary

Spike outcome: **RETAIN** the `dependency-review` job in
`.github/workflows/ci.yml`. The PR adds (a) a 16-line block comment
above the job in `ci.yml` describing its role, and (b) a new
"Security checks in CI" subsection in `docs/releasing.md` covering
all three CI-time supply-chain controls. No workflow logic or
configuration is changed — the job stays at `fail-on-severity: high`.

## Current configuration (verbatim)

```yaml
dependency-review:
  name: Test - Dependency Review
  runs-on: ubuntu-latest
  permissions:
    contents: read
    pull-requests: write   # action posts a PR comment on findings
  timeout-minutes: 5
  if: github.event_name == 'pull_request'
  steps:
    - name: Checkout
      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

    - name: Dependency Review
      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
      with:
        fail-on-severity: high
```

No configuration changes proposed.

## Coverage matrix

| Finding class | `dependency-review` | `govulncheck` | Dependabot |
|---|:-:|:-:|:-:|
| Known CVE in direct dep (in Go vuln DB) | yes | yes (if imported symbol called) | yes (security PR) |
| Known CVE in direct dep (in GHAS, not yet in Go vuln DB) | **yes** | no | yes (security PR) |
| Known CVE in transitive dep | yes | yes (if imported symbol reaches) | yes (security PR) |
| Yanked module version | partial (via GHAS) | yes | yes |
| **License-policy violation** (if configured) | **yes** | no | no |
| **Denied package / supply-chain blocklist** (if configured) | **yes** | no | no |
| Vulnerable symbol actually called by us | no | yes | no |
| Version update PR (non-security) | no | no | yes |

## Decision: RETAIN

Two cells of the matrix are uniquely covered by `dependency-review`:

1. **GHAS-only advisories.** GitHub Advisory Database often lists a
   Go advisory before it lands in the Go vulnerability database that
   `govulncheck` consults. Removing this job loses the only PR-time
   tool that catches that window.
2. **License/blocklist policy.** Even though `deny-licenses` and
   `deny-packages` are not currently configured, this is the only
   place where they could be added in future. `govulncheck` and
   Dependabot have no equivalent capability.

Cost is effectively zero: PR-only `if`, 5-minute timeout,
deliberately excluded from `ci-pass.needs:` (`ci.yml:735`) so
removing it would not affect the merge gate either way. Retention
is the lower-risk path; the documentation gap was the actual issue.

## What this PR changes

- `.github/workflows/ci.yml` — 16-line comment block above the
  `dependency-review:` job naming what it checks, what it blocks,
  why it co-exists with `make security`, and the `ci-pass` exclusion
  rationale. Configuration unchanged.
- `docs/releasing.md` — new `### Security checks in CI` subsection
  inside `## For Maintainers: CI Health`, between `### Job
  dependency graph` and `### The pipefail bug class`. Three-row
  table + role-split rationale + triage paragraph for failing
  dependency-review checks.

## Test plan

- [x] `make check` — clean (lint, vet, security scan, GoReleaser
      check)
- [ ] CI green on this PR
- [ ] AC #8 / #7 verification — throwaway draft PR demonstrating
      the job blocks a HIGH-severity CVE bump in the root `go.mod`
      AND in a sub-module's `go.mod` (filed separately, linked
      from the close comment of #631)