### PR TITLE
refactor: split dropLimiter per cause in async outputs (#692)

### DIFF
--- a/loki/droplimit.go
+++ b/loki/droplimit.go
@@ -23,9 +23,12 @@ import (
 	"time"
 )
 
-// dropLimiter rate-limits diagnostic slog.Warn calls for buffer-full
-// drop events. The zero value is ready to use — the first drop always
-// triggers a warning.
+// dropLimiter rate-limits diagnostic slog.Warn calls for drop-cause
+// events such as buffer-full or oversized-event-rejected. Each drop
+// cause owns its own dropLimiter (see [Output.dropsOversized] and
+// [Output.dropsBufferFull]) so a burst of one cause does not silence
+// the other in the same window (#692). The zero value is ready to
+// use — the first drop always triggers a warning.
 //
 // dropLimiter is safe for concurrent use.
 type dropLimiter struct {

--- a/loki/loki.go
+++ b/loki/loki.go
@@ -125,10 +125,11 @@ type Output struct { //nolint:govet // fieldalignment: readability preferred
 	// labels. Populated once in New (#696); the atomic.Pointer
 	// indirection is kept because push.go reads on every event and
 	// benefits from a single load over a multi-string copy.
-	fw            atomic.Pointer[frameworkFields]
-	logger        *slog.Logger // immutable after New (#696)
-	drops         dropLimiter  // rate-limits buffer-full warnings
-	maxEventBytes int          // snapshot of cfg.MaxEventBytes — immutable post-construction (#688)
+	fw              atomic.Pointer[frameworkFields]
+	logger          *slog.Logger // immutable after New (#696)
+	dropsOversized  dropLimiter  // rate-limits oversized-event-rejected warnings (#688)
+	dropsBufferFull dropLimiter  // rate-limits buffer-full warnings
+	maxEventBytes   int          // snapshot of cfg.MaxEventBytes — immutable post-construction (#688)
 	// lastDeliveryNanos is the wall-clock UnixNano of the most recent
 	// HTTP 2xx push response. Loki is async — Write only enqueues —
 	// so the timestamp updates from the batch goroutine after the
@@ -265,7 +266,7 @@ func (o *Output) WriteWithMetadata(data []byte, meta audit.EventMetadata) error 
 	}
 
 	if len(data) > o.maxEventBytes {
-		o.drops.record(dropWarnInterval, func(dropped int64) {
+		o.dropsOversized.record(dropWarnInterval, func(dropped int64) {
 			o.logger.Warn("audit: output loki: event rejected (exceeds max_event_bytes)",
 				"event_bytes", len(data),
 				"max_event_bytes", o.maxEventBytes,
@@ -289,7 +290,7 @@ func (o *Output) WriteWithMetadata(data []byte, meta audit.EventMetadata) error 
 	case o.ch <- lokiEntry{data: cp, metadata: meta}:
 		return nil
 	default:
-		o.drops.record(dropWarnInterval, func(dropped int64) {
+		o.dropsBufferFull.record(dropWarnInterval, func(dropped int64) {
 			o.logger.Warn("audit: output loki: event dropped (buffer full)",
 				"dropped", dropped,
 				"buffer_size", cap(o.ch))

--- a/loki/loki_drop_silo_test.go
+++ b/loki/loki_drop_silo_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the per-cause dropLimiter split (#692). The loki Output
+// formerly shared a single `drops` rate-limiter between the
+// oversized-event-rejected path (#688) and the buffer-full path. A
+// burst of one cause silenced the other in the same dropWarnInterval
+// window. After #692 each cause has its own limiter; this test
+// verifies the silos are independent **in both directions** —
+// neither the oversized burst nor the buffer-full burst should
+// silence the other, regardless of which arrives first.
+
+package loki_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit/loki"
+)
+
+// TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Loki
+// asserts that an oversized-reject burst does NOT silence a
+// subsequent buffer-full warn within the same dropWarnInterval, and
+// vice-versa. Each cause has its own dropLimiter as of #692.
+//
+// Pre-#692 either ordering would observe exactly one warn — the
+// first cause saturates the shared limiter; the second cause's warn
+// is silenced. After #692 both warns appear regardless of order.
+//
+// The reverse-order subtest also defends against an asymmetric
+// regression where only one of the two record() call sites is
+// rewired to its dedicated limiter.
+func TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Loki(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		first string // "oversized" or "buffer_full"
+	}{
+		{name: "oversized_first_then_buffer_full", first: "oversized"},
+		{name: "buffer_full_first_then_oversized", first: "buffer_full"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Stall the server so the batch goroutine cannot empty
+			// the internal channel. Once the goroutine takes events
+			// and blocks on POST, subsequent writes accumulate in
+			// the buffer; further writes hit the default branch
+			// and the buffer-full path fires.
+			serverHold := make(chan struct{})
+			srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				<-serverHold
+			}))
+			t.Cleanup(srv.Close)
+
+			buf := &lokiSyncBuf{}
+			logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			const maxBytes = loki.MinMaxEventBytes // 1 KiB
+			const bufferSize = loki.MinBufferSize  // 100 (loki minimum)
+			out, err := loki.New(&loki.Config{
+				URL:                srv.URL + "/loki/api/v1/push",
+				MaxEventBytes:      maxBytes,
+				BufferSize:         bufferSize,
+				BatchSize:          1,
+				FlushInterval:      100 * time.Millisecond,
+				AllowInsecureHTTP:  true,
+				AllowPrivateRanges: true,
+			}, nil, loki.WithDiagnosticLogger(logger))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = out.Close() })
+			// Registered AFTER the constructor so it runs BEFORE
+			// out.Close (t.Cleanup is LIFO). Closing serverHold
+			// unblocks the stalled HTTP handler so out.Close can
+			// drain in finite time.
+			t.Cleanup(func() { close(serverHold) })
+
+			oversized := bytes.Repeat([]byte("X"), maxBytes+1)
+			triggerOversized := func() {
+				for range 5 {
+					_ = out.Write(oversized)
+				}
+			}
+			triggerBufferFull := func() {
+				// 4× the buffer size guarantees at least one write
+				// hits the default branch with the server stalled.
+				for range bufferSize * 4 {
+					_ = out.Write([]byte(`{"n":1}`))
+				}
+			}
+
+			if tt.first == "oversized" {
+				triggerOversized()
+				triggerBufferFull()
+			} else {
+				triggerBufferFull()
+				triggerOversized()
+			}
+
+			logs := buf.String()
+			oversizedWarns := strings.Count(logs, "exceeds max_event_bytes")
+			bufferFullWarns := strings.Count(logs, "buffer full")
+
+			assert.Equal(t, 1, oversizedWarns,
+				"expected exactly one oversized-cause warn; got %d. logs=%s", oversizedWarns, logs)
+			assert.Equal(t, 1, bufferFullWarns,
+				"expected exactly one buffer-full-cause warn — pre-#692 this would be 0 because the shared limiter was already saturated by the other-cause burst. logs=%s",
+				logs)
+		})
+	}
+}

--- a/syslog/droplimit.go
+++ b/syslog/droplimit.go
@@ -23,9 +23,12 @@ import (
 	"time"
 )
 
-// dropLimiter rate-limits diagnostic slog.Warn calls for buffer-full
-// drop events. The zero value is ready to use — the first drop always
-// triggers a warning.
+// dropLimiter rate-limits diagnostic slog.Warn calls for drop-cause
+// events such as buffer-full or oversized-event-rejected. Each drop
+// cause owns its own dropLimiter (see [Output.dropsOversized] and
+// [Output.dropsBufferFull]) so a burst of one cause does not silence
+// the other in the same window (#692). The zero value is ready to
+// use — the first drop always triggers a warning.
 //
 // dropLimiter is safe for concurrent use.
 type dropLimiter struct {

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -192,7 +192,8 @@ type Output struct {
 	appName         string
 	hostname        string
 	writeCount      uint64      // drain-side event counter for RecordQueueDepth sampling
-	drops           dropLimiter // rate-limits buffer-full drop warnings
+	dropsOversized  dropLimiter // rate-limits oversized-event-rejected warnings (#688)
+	dropsBufferFull dropLimiter // rate-limits buffer-full drop warnings
 	mu              sync.Mutex  // protects Close sequence
 	failures        int         // consecutive failure count (writeLoop-only)
 	maxRetry        int
@@ -329,7 +330,7 @@ func (s *Output) enqueue(data []byte, priority srslog.Priority) error {
 	}
 
 	if len(data) > s.maxEventBytes {
-		s.drops.record(dropWarnInterval, func(dropped int64) {
+		s.dropsOversized.record(dropWarnInterval, func(dropped int64) {
 			s.logger.Warn("audit: output syslog: event rejected (exceeds max_event_bytes)",
 				"event_bytes", len(data),
 				"max_event_bytes", s.maxEventBytes,
@@ -347,7 +348,7 @@ func (s *Output) enqueue(data []byte, priority srslog.Priority) error {
 	case s.ch <- syslogEntry{data: cp, priority: priority}:
 		return nil
 	default:
-		s.drops.record(dropWarnInterval, func(dropped int64) {
+		s.dropsBufferFull.record(dropWarnInterval, func(dropped int64) {
 			s.logger.Warn("audit: output syslog: event dropped (buffer full)",
 				"dropped", dropped,
 				"buffer_size", cap(s.ch))

--- a/syslog/syslog_drop_silo_test.go
+++ b/syslog/syslog_drop_silo_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the per-cause dropLimiter split (#692). The syslog Output
+// formerly shared a single `drops` rate-limiter between the
+// oversized-event-rejected path (#688) and the buffer-full path. A
+// burst of one cause silenced the other in the same dropWarnInterval
+// window. After #692 each cause has its own limiter; this test
+// verifies the silos are independent **in both directions** —
+// neither the oversized burst nor the buffer-full burst should
+// silence the other, regardless of which arrives first.
+
+package syslog_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit/syslog"
+)
+
+// syslogSyncBuf wraps bytes.Buffer with a mutex so slog.JSONHandler
+// can safely write concurrently with the test reader.
+type syslogSyncBuf struct {
+	buf bytes.Buffer
+	mu  sync.Mutex
+}
+
+func (s *syslogSyncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syslogSyncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Syslog
+// asserts that an oversized-reject burst does NOT silence a
+// subsequent buffer-full warn within the same dropWarnInterval, and
+// vice-versa. Each cause has its own dropLimiter as of #692.
+//
+// Pre-#692 either ordering would observe exactly one warn — the
+// first cause saturates the shared limiter; the second cause's warn
+// is silenced. After #692 both warns appear regardless of order.
+//
+// The reverse-order subtest also defends against an asymmetric
+// regression where only one of the two record() call sites is
+// rewired to its dedicated limiter.
+func TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Syslog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		first string // "oversized" or "buffer_full"
+	}{
+		{name: "oversized_first_then_buffer_full", first: "oversized"},
+		{name: "buffer_full_first_then_oversized", first: "buffer_full"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Stall the destination so the writeLoop cannot drain
+			// the channel. stallingTCPListener (defined in
+			// syslog_tls_handshake_timeout_test.go) accepts the
+			// connection but never reads, so srslog's send blocks
+			// on the kernel TCP buffer. Subsequent writes fill the
+			// 1-slot internal channel and hit the default branch.
+			addr, stopListener := stallingTCPListener(t)
+			t.Cleanup(stopListener)
+
+			buf := &syslogSyncBuf{}
+			logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			const maxBytes = syslog.MinMaxEventBytes // 1 KiB
+			out, err := syslog.New(&syslog.Config{
+				Network:       "tcp",
+				Address:       addr,
+				BufferSize:    1,
+				FlushInterval: 1 * time.Millisecond,
+				MaxEventBytes: maxBytes,
+			}, syslog.WithDiagnosticLogger(logger))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = out.Close() })
+
+			oversized := bytes.Repeat([]byte("X"), maxBytes+1)
+			triggerOversized := func() {
+				for range 5 {
+					_ = out.Write(oversized)
+				}
+			}
+			triggerBufferFull := func() {
+				// Flood with enough small writes that, with the
+				// destination stalled and BufferSize=1, the channel
+				// fills and at least one write hits the default
+				// branch.
+				for range 200 {
+					_ = out.Write([]byte(`{"n":1}`))
+				}
+			}
+
+			if tt.first == "oversized" {
+				triggerOversized()
+				triggerBufferFull()
+			} else {
+				triggerBufferFull()
+				triggerOversized()
+			}
+
+			logs := buf.String()
+			oversizedWarns := strings.Count(logs, "exceeds max_event_bytes")
+			bufferFullWarns := strings.Count(logs, "buffer full")
+
+			assert.Equal(t, 1, oversizedWarns,
+				"expected exactly one oversized-cause warn; got %d. logs=%s", oversizedWarns, logs)
+			assert.Equal(t, 1, bufferFullWarns,
+				"expected exactly one buffer-full-cause warn — pre-#692 this would be 0 because the shared limiter was already saturated by the other-cause burst. logs=%s",
+				logs)
+		})
+	}
+}

--- a/webhook/droplimit.go
+++ b/webhook/droplimit.go
@@ -23,9 +23,12 @@ import (
 	"time"
 )
 
-// dropLimiter rate-limits diagnostic slog.Warn calls for buffer-full
-// drop events. The zero value is ready to use — the first drop always
-// triggers a warning.
+// dropLimiter rate-limits diagnostic slog.Warn calls for drop-cause
+// events such as buffer-full or oversized-event-rejected. Each drop
+// cause owns its own dropLimiter (see [Output.dropsOversized] and
+// [Output.dropsBufferFull]) so a burst of one cause does not silence
+// the other in the same window (#692). The zero value is ready to
+// use — the first drop always triggers a warning.
 //
 // dropLimiter is safe for concurrent use.
 type dropLimiter struct {

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -113,20 +113,21 @@ func responseHeaderTimeout(t time.Duration) time.Duration {
 //
 // Output is safe for concurrent use.
 type Output struct {
-	metrics       audit.Metrics
-	outputMetrics audit.OutputMetrics // immutable after New (#696)
-	logger        *slog.Logger        // immutable after New (#696)
-	client        *http.Client
-	cancel        context.CancelFunc
-	done          chan struct{}
-	closeCh       chan struct{} // signals batchLoop to drain and exit
-	headers       map[string]string
-	ch            chan []byte
-	url           string
-	name          string      // cached from url.Parse at construction
-	drops         dropLimiter // rate-limits buffer-full warnings
-	flushIvl      time.Duration
-	timeout       time.Duration
+	metrics         audit.Metrics
+	outputMetrics   audit.OutputMetrics // immutable after New (#696)
+	logger          *slog.Logger        // immutable after New (#696)
+	client          *http.Client
+	cancel          context.CancelFunc
+	done            chan struct{}
+	closeCh         chan struct{} // signals batchLoop to drain and exit
+	headers         map[string]string
+	ch              chan []byte
+	url             string
+	name            string      // cached from url.Parse at construction
+	dropsOversized  dropLimiter // rate-limits oversized-event-rejected warnings (#688)
+	dropsBufferFull dropLimiter // rate-limits buffer-full warnings
+	flushIvl        time.Duration
+	timeout         time.Duration
 	// lastDeliveryNanos is the wall-clock UnixNano of the most recent
 	// HTTP 2xx response (post-retry). Webhook is async — Write only
 	// enqueues — so the timestamp updates from the batch goroutine
@@ -238,7 +239,7 @@ func (w *Output) Write(data []byte) error {
 	}
 
 	if len(data) > w.maxEventBytes {
-		w.drops.record(dropWarnInterval, func(dropped int64) {
+		w.dropsOversized.record(dropWarnInterval, func(dropped int64) {
 			w.logger.Warn("audit: output webhook: event rejected (exceeds max_event_bytes)",
 				"event_bytes", len(data),
 				"max_event_bytes", w.maxEventBytes,
@@ -260,7 +261,7 @@ func (w *Output) Write(data []byte) error {
 	case w.ch <- cp:
 		return nil
 	default:
-		w.drops.record(dropWarnInterval, func(dropped int64) {
+		w.dropsBufferFull.record(dropWarnInterval, func(dropped int64) {
 			w.logger.Warn("audit: output webhook: event dropped (buffer full)",
 				"dropped", dropped,
 				"buffer_size", cap(w.ch))

--- a/webhook/webhook_drop_silo_test.go
+++ b/webhook/webhook_drop_silo_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the per-cause dropLimiter split (#692). The webhook Output
+// formerly shared a single `drops` rate-limiter between the
+// oversized-event-rejected path (#688) and the buffer-full path. A
+// burst of one cause silenced the other in the same dropWarnInterval
+// window. After #692 each cause has its own limiter; this test
+// verifies the silos are independent **in both directions** — neither
+// the oversized burst nor the buffer-full burst should silence the
+// other, regardless of which arrives first.
+
+package webhook_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axonops/audit/webhook"
+)
+
+// TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Webhook
+// asserts that an oversized-reject burst does NOT silence a
+// subsequent buffer-full warn within the same dropWarnInterval, and
+// vice-versa. Each cause has its own dropLimiter as of #692.
+//
+// Pre-#692 either ordering would observe exactly one warn — the
+// first cause saturates the shared limiter; the second cause's warn
+// is silenced. After #692 both warns appear regardless of order.
+//
+// The reverse-order subtest also defends against an asymmetric
+// regression where only one of the two record() call sites is
+// rewired to its dedicated limiter.
+func TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Webhook(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		first string // "oversized" or "buffer_full"
+	}{
+		{name: "oversized_first_then_buffer_full", first: "oversized"},
+		{name: "buffer_full_first_then_oversized", first: "buffer_full"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Stall the server so the drain goroutine cannot empty
+			// the internal channel. Once the goroutine takes the
+			// first event and blocks on POST, subsequent writes
+			// accumulate in the 1-slot buffer; further writes hit
+			// the default branch and the buffer-full path fires.
+			serverHold := make(chan struct{})
+			srv := newWebhookTestServer(t, func(_ http.ResponseWriter, _ *http.Request) {
+				<-serverHold
+			})
+
+			buf := &webhookSyncBuf{}
+			logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			const maxBytes = webhook.MinMaxEventBytes // 1 KiB
+			out := newTestWebhookOutputWithOpts(t, srv.url(),
+				[]func(*webhook.Config){func(cfg *webhook.Config) {
+					cfg.MaxEventBytes = maxBytes
+					cfg.BufferSize = 1
+					cfg.BatchSize = 1
+					cfg.FlushInterval = 5 * time.Millisecond
+					cfg.MaxRetries = 0
+				}},
+				[]webhook.Option{webhook.WithDiagnosticLogger(logger)},
+			)
+			// Registered AFTER the constructor so it runs BEFORE
+			// out.Close (t.Cleanup is LIFO). Closing serverHold
+			// unblocks the stalled HTTP handler so out.Close can
+			// drain in finite time.
+			t.Cleanup(func() { close(serverHold) })
+
+			oversized := bytes.Repeat([]byte("X"), maxBytes+1)
+			triggerOversized := func() {
+				for range 5 {
+					_ = out.Write(oversized)
+				}
+			}
+			triggerBufferFull := func() {
+				for range 50 {
+					_ = out.Write([]byte("ok"))
+				}
+			}
+
+			if tt.first == "oversized" {
+				triggerOversized()
+				triggerBufferFull()
+			} else {
+				triggerBufferFull()
+				triggerOversized()
+			}
+
+			logs := buf.String()
+			oversizedWarns := strings.Count(logs, "exceeds max_event_bytes")
+			bufferFullWarns := strings.Count(logs, "buffer full")
+
+			assert.Equal(t, 1, oversizedWarns,
+				"expected exactly one oversized-cause warn; got %d. logs=%s", oversizedWarns, logs)
+			assert.Equal(t, 1, bufferFullWarns,
+				"expected exactly one buffer-full-cause warn — pre-#692 this would be 0 because the shared limiter was already saturated by the other-cause burst. logs=%s",
+				logs)
+		})
+	}
+}


### PR DESCRIPTION
Closes #692.

## Summary

Each of `syslog/syslog.go`, `loki/loki.go`, and `webhook/webhook.go`
formerly shared a single `drops` `dropLimiter` between two distinct
drop causes — oversized-event-rejected (#688) and buffer-full. A
burst of one cause silenced the other within the same
`dropWarnInterval` (10 s) window, and the `dropped` count printed in
each warn conflated the two causes. This was a code-review finding
on #688, deferred for follow-up.

## What changed

- Each `Output` struct now has two unexported `dropLimiter` fields:
  `dropsOversized` (oversized-event-rejected path, #688) and
  `dropsBufferFull` (buffer-full path).
- The two `record(...)` call sites in each output's `Write` /
  `WriteWithMetadata` / `enqueue` are rewired to their dedicated
  limiter.
- `dropLimiter` godoc in each package is updated to reflect the
  broadened use.

No exported API surface changed. No metric semantic changed —
`OutputMetrics.RecordDrop` still fires once per drop regardless of
cause.

## Tests

Three new package-external tests, one per output (named exactly
per the issue's AC #4/#5):

- `TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Syslog`
- `TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Loki`
- `TestDropLimiter_OversizedAndBufferFullSilosAreIndependent_Webhook`

Each test is table-driven across both orderings
(`oversized_first_then_buffer_full` and
`buffer_full_first_then_oversized`) against a stalled destination
(chan-blocked HTTP handler for loki/webhook; existing
`stallingTCPListener` helper for syslog), and asserts **exactly
one** warn per cause in the captured slog output. Pre-#692 either
ordering would observe only one warn total — the symmetric mutation
(rewiring only one of the two record sites) is killed by the
reverse-order subtest.

Verified by:
- 10× race-stress (`go test -race -count=10`) on all three modules — all pass.
- Sanity-flipped one rewire in syslog → test correctly fails with
  `expected 1 actual 0` for buffer-full warn. Reverted.

## Test plan

- [x] `make check` clean (lint, vet, security, GoReleaser)
- [x] `go test -race -count=10` for all three modules — green
- [ ] CI green