### PR TITLE
test: extend delivery accounting invariant BDD coverage (#722)

### DIFF
--- a/tests/bdd/features/async_buffer_shutdown.feature
+++ b/tests/bdd/features/async_buffer_shutdown.feature
@@ -88,3 +88,43 @@ Feature: Async Buffer Shutdown
     And I close the auditor
     Then RecordSubmitted should have been called 4 times
     And the delivery accounting invariant should hold
+
+  # Per-counter coverage of the delivery accounting invariant
+  # (#722). The mixed-workload scenario above exercises Successes,
+  # ValidationErrors, and Filtered; the three scenarios below force
+  # OutputErrors, SerializationErrors, and BufferDrops respectively
+  # so every counter in the invariant equation is non-zero in at
+  # least one scenario. Together they kill the tautology risk where
+  # a regression in RecordOutputError, RecordSerializationError, or
+  # RecordBufferDrop would not be caught by the mixed-workload
+  # scenario alone.
+
+  Scenario: Delivery accounting invariant holds when an output Write returns an error
+    Given an auditor with an error output, pipeline metrics, and synchronous delivery
+    When I audit event "user_create" with required fields
+    And I close the auditor
+    Then RecordSubmitted should have been called 1 time
+    And the OutputErrors counter should equal 1
+    And the delivery accounting invariant should hold
+
+  Scenario: Delivery accounting invariant holds when the formatter returns an error
+    Given an auditor with an error-returning formatter, a recording output, pipeline metrics, and synchronous delivery
+    When I audit event "user_create" with required fields
+    And I close the auditor
+    Then RecordSubmitted should have been called 1 time
+    And the SerializationErrors counter should equal 1
+    And the delivery accounting invariant should hold
+
+  # Async delivery is the only mode that exposes BufferDrops; sync
+  # delivery has no buffer, hence no overflow path. The default
+  # behaviour when the queue is full is non-blocking — AuditEvent
+  # returns audit.ErrQueueFull and RecordBufferDrop is incremented
+  # (audit.go:320 doc block). This scenario pins that contract.
+  Scenario: Delivery accounting invariant holds when the async queue overflows
+    Given an auditor with a slow output, pipeline metrics, and async delivery with queue_size 1
+    When I audit 200 events with required fields
+    And I close the auditor
+    Then RecordSubmitted should have been called 200 times
+    And the BufferDrops counter should be at least 1
+    And Successes plus BufferDrops should equal 200
+    And the delivery accounting invariant should hold

--- a/tests/bdd/steps/async_edges_steps.go
+++ b/tests/bdd/steps/async_edges_steps.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cucumber/godog"
 
@@ -150,6 +151,186 @@ func registerAsyncEdgesSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 			return fmt.Errorf(
 				"invariant broken: submitted=%d != successes=%d + output_errors=%d + filtered=%d + validation_errors=%d + serialization_errors=%d + buffer_drops=%d (sum=%d)",
 				m.Submitted, successes, outputErrs, filtered, validation, serial, m.BufferDrops, total)
+		}
+		return nil
+	})
+
+	// --- #722: per-counter coverage for the delivery accounting
+	// invariant. Three new given-steps + four new assertion steps
+	// extend the contract surface so each counter in the invariant
+	// equation is forced non-zero in at least one scenario.
+
+	ctx.Step(`^an auditor with an error output, pipeline metrics, and synchronous delivery$`, func() error {
+		if tc.MockMetrics == nil {
+			tc.MockMetrics = NewMockMetrics()
+		}
+		auditor, err := audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithMetrics(tc.MockMetrics),
+			audit.WithNamedOutput(&errorOutput{}),
+			audit.WithSynchronousDelivery(),
+		)
+		if err != nil {
+			return fmt.Errorf("create auditor: %w", err)
+		}
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
+		return nil
+	})
+
+	ctx.Step(`^an auditor with an error-returning formatter, a recording output, pipeline metrics, and synchronous delivery$`, func() error {
+		if tc.MockMetrics == nil {
+			tc.MockMetrics = NewMockMetrics()
+		}
+		rec := &recordingMockOutput{name: "recording"}
+		auditor, err := audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithMetrics(tc.MockMetrics),
+			audit.WithFormatter(&errorReturningFormatter{}),
+			audit.WithOutputs(rec),
+			audit.WithSynchronousDelivery(),
+		)
+		if err != nil {
+			return fmt.Errorf("create auditor: %w", err)
+		}
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
+		return nil
+	})
+
+	ctx.Step(`^an auditor with a slow output, pipeline metrics, and async delivery with queue_size (\d+)$`, func(queueSize int) error {
+		if tc.MockMetrics == nil {
+			tc.MockMetrics = NewMockMetrics()
+		}
+		// 200 ms per write × queue_size 1. The drain goroutine
+		// dequeues one event then blocks 200 ms inside Write — so
+		// at any instant up to 2 events are in flight (1 in the
+		// queue + 1 held by the drain goroutine). The producer
+		// submits 200 events in sub-millisecond wall time, so
+		// every submit beyond the second hits the queue-full
+		// default branch and is dropped via RecordBufferDrop. The
+		// "at least 1" assertion below is intentionally insensitive
+		// to the configured ShutdownTimeout — Close abandoning
+		// remaining queued events on timeout doesn't change the
+		// result because the producer's drops were recorded at
+		// submit time, not drain time (#722 AC #4).
+		out := &slowMockOutput{delay: 200 * time.Millisecond}
+		auditor, err := audit.New(
+			audit.WithTaxonomy(tc.Taxonomy),
+			audit.WithAppName("test-app"),
+			audit.WithHost("test-host"),
+			audit.WithMetrics(tc.MockMetrics),
+			audit.WithOutputs(out),
+			audit.WithQueueSize(queueSize),
+		)
+		if err != nil {
+			return fmt.Errorf("create auditor: %w", err)
+		}
+		tc.Auditor = auditor
+		tc.AddCleanup(func() { _ = auditor.Close() })
+		return nil
+	})
+
+	ctx.Step(`^I audit (\d+) events with required fields$`, func(n int) error {
+		if tc.Auditor == nil {
+			return errors.New("no auditor configured")
+		}
+		// Use only required fields known to the standard test
+		// taxonomy's user_create event (outcome, actor_id) so the
+		// events pass validation in strict mode and reach the
+		// queue. Unknown fields would be rejected with
+		// ValidationError before enqueue, never producing a
+		// BufferDrop.
+		for i := 0; i < n; i++ {
+			fields := audit.Fields{
+				"actor_id": "u-1",
+				"outcome":  "ok",
+			}
+			// Capture the last error into tc.LastErr so a
+			// regression in the auditor (e.g. ErrLoggerClosed) is
+			// visible to subsequent assertions. ErrQueueFull is
+			// the expected error on overflow and is part of the
+			// contract being tested.
+			tc.LastErr = tc.Auditor.AuditEvent(audit.NewEvent("user_create", fields))
+		}
+		return nil
+	})
+
+	// The four counter assertions below assume the feature scenario
+	// has already executed an explicit "I close the auditor" step.
+	// They MUST NOT call Close themselves: doing so masks scenarios
+	// that forget the explicit close, and conflates "assert" with
+	// "tear down". Cleanup of the auditor is registered via
+	// tc.AddCleanup in each given-step.
+
+	ctx.Step(`^the OutputErrors counter should equal (\d+)$`, func(want int) error {
+		if tc.MockMetrics == nil {
+			return errors.New("no MockMetrics configured")
+		}
+		m := tc.MockMetrics
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		got := 0
+		for _, v := range m.OutputErrors {
+			got += v
+		}
+		if got != want {
+			return fmt.Errorf("OutputErrors: want %d, got %d", want, got)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the SerializationErrors counter should equal (\d+)$`, func(want int) error {
+		if tc.MockMetrics == nil {
+			return errors.New("no MockMetrics configured")
+		}
+		m := tc.MockMetrics
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		got := 0
+		for _, v := range m.SerializationErrs {
+			got += v
+		}
+		if got != want {
+			return fmt.Errorf("SerializationErrors: want %d, got %d", want, got)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the BufferDrops counter should be at least (\d+)$`, func(want int) error {
+		if tc.MockMetrics == nil {
+			return errors.New("no MockMetrics configured")
+		}
+		m := tc.MockMetrics
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.BufferDrops < want {
+			return fmt.Errorf("BufferDrops: want >= %d, got %d", want, m.BufferDrops)
+		}
+		return nil
+	})
+
+	ctx.Step(`^Successes plus BufferDrops should equal (\d+)$`, func(want int) error {
+		if tc.MockMetrics == nil {
+			return errors.New("no MockMetrics configured")
+		}
+		m := tc.MockMetrics
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		successes := 0
+		for k, v := range m.Events {
+			if strings.HasSuffix(k, ":success") {
+				successes += v
+			}
+		}
+		got := successes + m.BufferDrops
+		if got != want {
+			return fmt.Errorf("successes (%d) + buffer_drops (%d) = %d, want %d",
+				successes, m.BufferDrops, got, want)
 		}
 		return nil
 	})


### PR DESCRIPTION
Closes #722.

## Summary

The mixed-workload scenario from #564 pinned the delivery accounting
invariant

    submitted = successes + filtered + validation_errors
              + output_errors + serialization_errors + buffer_drops

but only forced 3 of the 6 counters non-zero. test-analyst flagged
this as a medium tautology risk on PR #564 — a regression in
\`RecordOutputError\`, \`RecordSerializationError\`, or
\`RecordBufferDrop\` would not be caught by the existing scenario.

This PR adds three scenarios, each pinning one previously-zero
counter:

- **OutputErrors path** — sync delivery, single \`errorOutput\`, one
  event. Asserts \`OutputErrors == 1\` and the invariant holds.
- **SerializationErrors path** — sync delivery, single recording
  output, \`errorReturningFormatter\`, one event. Asserts
  \`SerializationErrors == 1\` and the invariant holds.
- **BufferDrops path** — async delivery, \`queue_size 1\`,
  \`slowMockOutput\` blocking 200 ms per write, 200 events. Asserts
  \`BufferDrops >= 1\`, \`Successes + BufferDrops == 200\`, and the
  invariant holds.

Together with the existing scenario, every counter in the invariant
equation is forced non-zero in at least one scenario. Tautology
killed.

## Test plan

- [x] \`make check\` clean (lint, vet, security, GoReleaser)
- [x] \`make test-bdd-core\` passes 5× consecutively (37 s × 5)
- [x] Bug-find during implementation: original step submitted events
      with unknown fields (\`resource_id\`, \`resource_type\`) which
      were rejected by strict-mode validation BEFORE reaching the
      queue, producing 0 BufferDrops. Fixed by using only required
      fields known to the standard test taxonomy.
- [ ] CI green

## Implementation notes

- Reuses existing fakes: \`errorOutput\`, \`errorReturningFormatter\`,
  \`recordingMockOutput\`, \`slowMockOutput\`. No new fake types.
- Counter-assertion steps deliberately do NOT call \`Close\` —
  scenarios invoke the explicit \`I close the auditor\` step first.
  Mixing tear-down into assertions would mask scenarios that forget
  the close.
- No production code touched.