### PR TITLE
test: pin sync-delivery validation + filter contracts in BDD (#724)

### DIFF
--- a/tests/bdd/features/sync_delivery.feature
+++ b/tests/bdd/features/sync_delivery.feature
@@ -48,3 +48,36 @@ Feature: Synchronous Delivery
     Given an auditor with synchronous delivery and a recording mock output
     When I audit 100 events from 10 concurrent goroutines
     Then the recording output should have received exactly 100 events
+
+  # Sync-delivery contract: validation runs BEFORE deliverSyncCtx
+  # (audit.go:496-523), and global filter runs BEFORE deliverSyncCtx
+  # (audit.go:458-463). The two scenarios below pin those orderings
+  # at the BDD layer so a refactor that swaps the order is caught
+  # without relying on unit tests alone (#724 — follow-up to #549
+  # test-analyst finding).
+
+  Scenario: Synchronous delivery surfaces validation errors without dispatching to outputs
+    Given an auditor with synchronous delivery and a recording mock output
+    When I try to audit event "unknown_event_type" with required fields
+    Then the audit call should return an error wrapping "ErrUnknownEventType"
+    And the recording output should have received exactly 0 events
+    # Positive control: confirm the recording output is wired correctly
+    # — a valid event must reach it, otherwise the "0 events" assertion
+    # above would pass vacuously even if the output were never registered.
+    When I audit event "user_create" with required fields
+    Then the audit call should return no error
+    And the recording output should have received exactly 1 events
+
+  Scenario: Synchronous delivery honours global filter — disabled category drops event silently
+    Given an auditor with synchronous delivery and a recording mock output
+    When I disable category "write"
+    And I audit event "user_create" with required fields
+    Then the audit call should return no error
+    And the recording output should have received exactly 0 events
+    # Positive control: re-enable the category and audit again. The
+    # output must receive this event — otherwise the "0 events"
+    # assertion above could pass even if the output were never wired.
+    When I enable category "write"
+    And I audit event "user_create" with required fields
+    Then the audit call should return no error
+    And the recording output should have received exactly 1 events


### PR DESCRIPTION
Closes #724.

## Summary

PR #549 added 6 BDD scenarios for sync delivery but did not exercise
two paths flagged by test-analyst: validation-error and
global-filter. Both run BEFORE \`deliverSyncCtx\` in the auditor
(\`audit.go:496-523\` and \`:458-463\` respectively), so a refactor
that swapped check vs deliver on the sync path would not be caught
at the BDD layer.

This PR adds two scenarios to \`tests/bdd/features/sync_delivery.feature\`:

- **"Synchronous delivery surfaces validation errors without dispatching to outputs"**
  — try to audit \`unknown_event_type\`, expect a wrapped
  \`ErrUnknownEventType\`, expect 0 events received.
- **"Synchronous delivery honours global filter — disabled category drops event silently"**
  — disable category \`write\`, audit a write event, expect nil
  error, expect 0 events received.

Each scenario carries a **positive-control tail**: after the
negative assertion, the scenario audits a valid event and asserts
exactly 1 received. The control ensures the recording output is
wired correctly — without it, both negative assertions would pass
vacuously if the output were never registered. (test-analyst
recommendation during the post-coding review.)

## What changed

- \`tests/bdd/features/sync_delivery.feature\` — appended 2 scenarios
  with a header comment explaining the order-of-operations contract
  they pin.

No production code touched. No new step definitions; reuses existing
glue from \`isolation_steps.go\`, \`filter_steps.go\`, and \`audit_steps.go\`.

## Test plan

- [x] \`make test-bdd-core\` passes 5× consecutively (37 s × 5)
- [x] \`make check\` clean (lint, vet, security, GoReleaser)
- [x] Caught one fix during implementation: AC text "And category
      \"write\" is disabled" doesn't match the existing step phrase
      \`I disable category "..."\`. Used the active phrase that
      resolves to \`filter_steps.go:84\`.
- [ ] CI green