### PR TITLE
chore: cut v0.1.12 release-prep — CHANGELOG conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-05-07
+
 > See [`docs/v1-changes.md`](docs/v1-changes.md) for a consolidated
 > Before/After reference table of every public-API rename, YAML
 > field rename, signature change, removal, and new error sentinel


### PR DESCRIPTION
Release-prep for v0.1.12. Per \`docs/releasing.md\` pre-release
checklist, the existing \`## [Unreleased]\` section in
\`CHANGELOG.md\` is converted to \`## [0.1.12] - 2026-05-07\`
ahead of triggering the release workflow. A new empty
\`[Unreleased]\` section is left at the top per Keep a Changelog
convention.

## What's NOT in this PR

- No code changes.
- No example \`go.mod\` additions (#437 still requires this PR's
  release to ship first per the chicken-and-egg analysis on
  that issue).
- No inter-module \`go.mod\` pinning — the release workflow
  auto-opens a separate PR for that.

## Pre-release checklist (lightweight items I can verify)

- [x] CI green on \`main\` (last 4 PRs all merged green)
- [x] \`make check\` passes locally
- [x] \`make check-replace\` — no replace directives
- [x] \`make tidy-check\` — clean
- [ ] \`make api-check\` — skipped on dirty tree; CI will run on merge

## Pre-release items requiring stable hardware (your action)

- [ ] \`make bench-save\` — refresh \`bench-baseline.txt\` on stable hardware
- [ ] \`make soak\` — 12-hour mixed-output soak (#573); paste summary into
      \`BENCHMARKS.md\` "Release Soak-Test Summary"

## After this PR merges

Trigger the release workflow:

\`\`\`bash
gh workflow run release.yml -f version=v0.1.12 -f api_check_blocking=false
\`\`\`

The workflow opens a release PR pinning every inter-module \`go.mod\`
to v0.1.12, you approve, auto-merge fires, the bot creates the
twelve annotated tags. After publishing, #437 work resumes.

## Test plan

- [x] \`make check\` clean
- [ ] CI green on this PR