### PR TITLE
chore: add Apache 2.0 license header + repo-wide check (#539)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ permissions:
 #   dependency-review — PR-only, blocks vulnerable-dependency PRs
 #   validate-release — always runs (GoReleaser config check)
 #   hygiene — always runs (make check-static; fmt/tidy/replace/todos/
-#              insecure-skip-verify/example-links/bdd-strict/bench-baseline)
+#              insecure-skip-verify/example-links/bdd-strict/bench-baseline/
+#              license-headers)
 #   lint, test x11, cross-build, examples-build,
 #   security x13, security-verify    — needs: hygiene
 #   integration                      — needs: hygiene

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
        lint-secrets lint-secrets-openbao lint-secrets-vault \
        vet vet-all fmt fmt-check \
        build build-all bench bench-save bench-compare bench-baseline-check coverage \
-       tidy tidy-check verify check-replace check-todos check-example-links check-bdd-strict check-insecure-skip-verify check-static \
+       tidy tidy-check verify check-replace check-todos check-example-links check-bdd-strict check-insecure-skip-verify check-license-headers check-static \
        security release-check api-check check-release-invariants \
        regen-release-docs regen-release-docs-check \
        regen-schema-artifacts regen-schema-artifacts-check \
@@ -578,6 +578,26 @@ check-todos:
 		exit 1; \
 	fi
 
+# Reject any *.go file that lacks the standard Apache 2.0 license
+# header. Generated files (recognised by the standard
+# `// Code generated ... DO NOT EDIT.` marker per `cmd/go` docs)
+# are exempt. The header search window is the first 16 lines so
+# that files starting with build constraints (`//go:build ...`)
+# or a code-generation directive are still recognised. (#539)
+check-license-headers:
+	@MISSING=""; \
+	while IFS= read -r f; do \
+		if ! head -16 "$$f" | grep -qE 'Copyright.*AxonOps|Code generated.*DO NOT EDIT'; then \
+			MISSING="$$MISSING $$f"; \
+		fi; \
+	done < <(find . -name '*.go' -not -path './.git/*' -not -path '*/.scratch/*' -not -path '*/vendor/*' -not -path '*/testdata/*'); \
+	if [ -n "$$MISSING" ]; then \
+		echo "ERROR: .go files missing the Apache 2.0 license header:"; \
+		for f in $$MISSING; do echo "  $$f"; done; \
+		exit 1; \
+	fi
+	@echo "All .go files have the standard license header."
+
 # Reject broken numeric cross-references in example READMEs (e.g.
 # `../05-file-output/` when `examples/05-formatters/` is the actual
 # directory at index 05). Catches drift after example renumbering.
@@ -911,6 +931,7 @@ check-static:
 	for target in fmt-check tidy-check check-todos check-replace \
 	              check-insecure-skip-verify check-example-links \
 	              check-bdd-strict check-sync-comments bench-baseline-check \
+	              check-license-headers \
 	              regen-release-docs-check regen-schema-artifacts-check; do \
 	  echo "==> make $$target"; \
 	  $(MAKE) "$$target" || FAILED="$$FAILED $$target"; \

--- a/tests/bdd/docker/webhook-receiver/main.go
+++ b/tests/bdd/docker/webhook-receiver/main.go
@@ -1,3 +1,17 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Webhook receiver is a test HTTP server that captures audit events
 // for integration and BDD testing. It stores received events in memory
 // and provides endpoints to query, reset, and configure behaviour.


### PR DESCRIPTION
Closes #539.

## Summary

\`tests/bdd/docker/webhook-receiver/main.go\` was the only \`.go\`
file in the repo missing the standard Apache 2.0 license header
required by project policy. Added the header.

Per AC #2, also added a CI check that grep-verifies every \`.go\`
file in the repo has the header — so the gap can't reopen
silently.

## What changed

- \`tests/bdd/docker/webhook-receiver/main.go\` — header added above
  the existing package comment.
- \`Makefile\` — new \`check-license-headers\` target wired into
  \`check-static\`. Scans all \`.go\` files (skipping generated
  files recognised by the \`// Code generated ... DO NOT EDIT.\`
  marker per Go's [generate convention](https://pkg.go.dev/cmd/go#hdr-Generate_Go_files_by_processing_source))
  for the AxonOps copyright line in the first 16 source lines.
  The 16-line window accommodates files starting with build
  constraints (\`//go:build ...\`) above the header (e.g.
  \`loki/tests/integration/loki_test.go\`).
- \`.github/workflows/ci.yml\` — comment-block update naming
  \`license-headers\` in the hygiene job's check list. The hygiene
  job already runs \`make check-static\`, which now includes the
  new check.

## Test plan

- [x] \`make check-license-headers\` clean
- [x] \`make check\` clean (full local gate)
- [x] No new generated-file false positives — explicitly verified
- [ ] CI green