### PR TITLE
docs: add Go Playground incompatibility note (#543)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ for the full table of 31 names, types, and CEF mappings.
 | 🔧 [Troubleshooting](docs/troubleshooting.md) | Common problems and how to fix them |
 | 🔒 [Security Policy](SECURITY.md) | Vulnerability reporting |
 | ⚡ [Benchmarks](BENCHMARKS.md) | Performance baseline, methodology, and side-by-side comparison against [`log/slog`](BENCHMARKS.md#comparison-against-logslog) |
+| 🎮 [Playground note](docs/playground.md) | Why audit examples don't run on play.golang.org, and where to run them instead |
 
 ---
 

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -1,0 +1,38 @@
+[&larr; Back to README](../README.md)
+
+# Running audit examples — why not the Go Playground?
+
+The Go Playground at <https://play.golang.org> is a sandboxed
+environment for sharing snippets of Go code. It does not download
+modules from the public proxy, does not expose a filesystem to
+user code, and does not allow network access. Several of audit's
+hard requirements are incompatible with that sandbox:
+
+- **`go:embed` of generated code.** Most examples use `audit-gen`
+  to produce typed event builders from `taxonomy.yaml`. The
+  generator's output is a real `.go` file in the same package,
+  not a string literal — the Playground's single-file editor
+  cannot reproduce this layout.
+
+- **Filesystem-loaded `outputs.yaml`.** Output configuration is
+  resolved at runtime from a YAML file the operator supplies.
+  The Playground sandbox has no filesystem an operator could
+  populate; in-memory loaders are supported via the
+  [`outputconfig`](https://pkg.go.dev/github.com/axonops/audit/outputconfig)
+  package but are intentionally not the primary path.
+
+- **Multi-module structure.** Outputs that need network I/O
+  (`syslog`, `webhook`, `loki`) live in separate modules. The
+  Playground only resolves the single module of the snippet
+  being run; importing one of those packages would fail at
+  resolve time.
+
+To run the examples, clone the repository and follow the readme
+in any of the [`examples/`](../examples/) directories — the
+shortest is [`examples/01-basic/`](../examples/01-basic/), which
+needs only the core module and a few lines of `main.go`. Every
+other example builds on it incrementally.
+
+If you need a sharable demo that runs in a browser, prefer
+recording a terminal session against `examples/01-basic/` rather
+than a Playground link.


### PR DESCRIPTION
Closes #543.

## Summary

Adds a one-page note explaining why audit examples don't run on
[play.golang.org](https://play.golang.org) and where to run them
instead. Walkthrough decision #18 / master-tracker H-01.

## What changed

- \`docs/playground.md\` — new file. Three-bullet rationale
  (\`go:embed\` of generated code, filesystem-loaded
  \`outputs.yaml\`, multi-module structure for network outputs)
  + pointer to \`examples/01-basic/\` as the simplest local-run
  starting point.
- \`README.md\` — link added to the Documentation table.

## Test plan

- [x] \`make check\` clean (full local gate)
- [x] Markdown links resolve relative to their file location
- [ ] CI green