### PR TITLE
fix(outputconfig): sanitise unknown-output-type error message

### DIFF
--- a/outputconfig/output.go
+++ b/outputconfig/output.go
@@ -252,10 +252,22 @@ func invokeFactory(name string, f *outputFields, globalAppName, globalHost, glob
 	}
 	if factory == nil {
 		registered := audit.RegisteredOutputTypes()
+		// Only suggest a per-output import path when the type name
+		// looks like a valid Go package path (printable, no spaces,
+		// no control characters). Otherwise, embedding the raw type
+		// name unquoted leaks invalid bytes into the error message
+		// — caught by FuzzOutputConfigLoad on a NUL-containing
+		// input. The %q above still surfaces the offending name to
+		// the operator, just in escaped form.
+		if isValidImportPathSegment(f.typeName) {
+			return nil, fmt.Errorf("output %q: unknown output type %q (registered: [%s]); "+
+				"add import _ \"github.com/axonops/audit/outputs\" for all built-in types "+
+				"(or import _ \"github.com/axonops/audit/%s\" for only this one)",
+				name, f.typeName, strings.Join(registered, ", "), f.typeName)
+		}
 		return nil, fmt.Errorf("output %q: unknown output type %q (registered: [%s]); "+
-			"add import _ \"github.com/axonops/audit/outputs\" for all built-in types "+
-			"(or import _ \"github.com/axonops/audit/%s\" for only this one)",
-			name, f.typeName, strings.Join(registered, ", "), f.typeName)
+			"add import _ \"github.com/axonops/audit/outputs\" for all built-in types",
+			name, f.typeName, strings.Join(registered, ", "))
 	}
 	// Inject global app_name and hostname into syslog config if not already set.
 	injectSyslogGlobals(f, globalAppName, globalHost)
@@ -298,4 +310,28 @@ func invokeFactory(name string, f *outputFields, globalAppName, globalHost, glob
 			name, f.typeName)
 	}
 	return output, nil
+}
+
+// isValidImportPathSegment reports whether s is plausibly a Go
+// package-path segment safe to embed unquoted in an error message.
+// The check rejects empty strings, anything containing whitespace,
+// control characters (NUL/0x7F), backslashes, or double quotes —
+// all of which would either break the suggested `import _ "..."`
+// line or leak invalid bytes into the error message.
+//
+// This is intentionally narrower than the Go spec's actual import
+// path grammar: any plausible audit sub-module name (lowercase
+// letters, digits, hyphen, underscore, slash, dot) is accepted;
+// anything else falls back to a generic error message in
+// invokeFactory.
+func isValidImportPathSegment(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < 0x21 || r == 0x7f || r == '"' || r == '\\' {
+			return false
+		}
+	}
+	return true
 }

--- a/outputconfig/testdata/fuzz/FuzzOutputConfigLoad/9959b3c68d859e06
+++ b/outputconfig/testdata/fuzz/FuzzOutputConfigLoad/9959b3c68d859e06
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("version: 1\napp_name: 0\nhost: 0\noutputs:\n A:\n  type: \x00")


### PR DESCRIPTION
Unblocks the v0.1.12 release. Found by FuzzOutputConfigLoad on
the release workflow's Long Fuzz job (run 25535975492).

## Problem

When a YAML config supplies an output type whose string contains
non-printable characters (e.g. NUL), the "unknown output type"
error message embedded the raw bytes unquoted in the suggested
per-output import path:

\`\`\`
audit/outputconfig: ... (or import _ "github.com/axonops/audit/<RAW_TYPE>" for only this one)
\`\`\`

The fuzz harness's invariant "error message must not contain raw
control bytes" (log-injection defence) fired on the input
\`outputs:\n  A:\n    type: \x00\`.

## Fix

Only emit the "or import for only this one" suggestion when the
type name looks like a plausibly-valid Go package-path segment
— printable ASCII, no whitespace / double quotes / backslashes
/ control bytes. For invalid type names, fall back to the
generic "add import _ outputs" suggestion. The \`%q\`-formatted
\`unknown output type\` line above continues to surface the
offending input to the operator in escaped form.

The failing seed lands at
\`outputconfig/testdata/fuzz/FuzzOutputConfigLoad/9959b3c68d859e06\`
so it becomes a permanent regression test.

## Test plan

- [x] \`go test -run='FuzzOutputConfigLoad/9959b3c68d859e06' .\` passes
- [x] All other fuzz tests in outputconfig + secrets still pass
- [x] \`make check\` clean
- [ ] CI green
- [ ] After merge: re-dispatch v0.1.12 release