### PR TITLE
chore: rename release bot to axonops-audit-release-bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 #
 #   workflow_dispatch (primary path)
 #     - Runs full CI gate, fuzz-long, advisory bench, advisory api-check
-#     - Opens a release PR via the axonops-release-bot GitHub App
+#     - Opens a release PR via the axonops-audit-release-bot GitHub App
 #     - Waits (polling) for PR auto-merge through normal branch
 #       protection — this is what makes branch protection real
 #     - Tags every published module at the merge SHA
@@ -19,7 +19,7 @@
 #       no-ops; tags at a DIFFERENT SHA are aborted as a contamination)
 #     - Runs GoReleaser + verify + invariants
 #
-# All write operations use a token minted from the axonops-release-bot
+# All write operations use a token minted from the axonops-audit-release-bot
 # GitHub App at job start (1-hour TTL; per-job mints). The legacy
 # RELEASE_TOKEN PAT is retired (see CHANGELOG #513). Each job that
 # does git pushes uses persist-credentials:false on checkouts that
@@ -450,8 +450,8 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="release/$PUBLISH_VERSION"
-          git config user.name  "axonops-release-bot[bot]"
-          git config user.email "axonops-release-bot[bot]@users.noreply.github.com"
+          git config user.name  "axonops-audit-release-bot[bot]"
+          git config user.email "axonops-audit-release-bot[bot]@users.noreply.github.com"
 
           # Recreate the branch idempotently. A previous failed run
           # may have left both a branch AND an orphaned open PR on it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -504,7 +504,7 @@ boundaries, and key source files.
 Releases are cut by maintainers. Contributors do not create release tags.
 
 The full release procedure — pre-release checklist, the unified single-tag
-flow, the `axonops-release-bot` GitHub App, the `api-check` gate, proxy
+flow, the `axonops-audit-release-bot` GitHub App, the `api-check` gate, proxy
 verification, and retraction policy — is documented in
 [docs/releasing.md](docs/releasing.md). That file is the single source of
 truth for the release contract.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -303,7 +303,7 @@ so no PR merges without a maintainer's approval.
 
 ### Release-bot GitHub App
 
-The release workflow uses a dedicated GitHub App identity — `axonops-release-bot` —
+The release workflow uses a dedicated GitHub App identity — `axonops-audit-release-bot` —
 instead of a personal access token (PAT). PAT compromise = full account takeover
 across every org the human belongs to; App compromise is scoped to this single
 repository plus the App's explicit permissions.
@@ -329,7 +329,7 @@ installation:
 
 1. **Settings → Developer settings → GitHub Apps → New GitHub App** (on the
    organisation, not personal account).
-2. **GitHub App name**: `axonops-release-bot`.
+2. **GitHub App name**: `axonops-audit-release-bot`.
 3. **Homepage URL**: any URL — `https://github.com/axonops/audit` is fine.
 4. **Webhook URL**: GitHub's form requires a non-empty URL even when webhooks
    are unused. Enter `https://github.com` and **uncheck Active**. The App will
@@ -437,7 +437,7 @@ prevents an unauthorised actor from triggering a release pipeline.
 publish a sub-module release.**
 
 **Allowed actors per rule**: under the unified release flow (#513), the
-canonical creator of release tags is the `axonops-release-bot` App.
+canonical creator of release tags is the `axonops-audit-release-bot` App.
 Each rule's "Restrict who can create matching tags" allow-list MUST
 include the App identity. Maintainers are intentionally **not** on
 the standing allow-list for these patterns — see the rationale in
@@ -545,7 +545,7 @@ The two triggers serve different purposes:
   the same SHA, aborting on SHA mismatch), and runs GoReleaser. It does
   NOT open a release PR. See "Release recovery playbook" below.
 
-The `release.yml` workflow uses the `axonops-release-bot` GitHub App for
+The `release.yml` workflow uses the `axonops-audit-release-bot` GitHub App for
 every write operation; it does not consume a personal access token.
 
 ### `api-check` transition (advisory → blocking)
@@ -1124,7 +1124,7 @@ GitHub), but the proxy cache would still serve the old bytes for existing
 
 - **Do not create release tags.** Every published module's `v*` pattern
   is tag-protected — see "Tag protection" above for the full list.
-  Release tags are created exclusively by the `axonops-release-bot`
+  Release tags are created exclusively by the `axonops-audit-release-bot`
   GitHub App via the `release.yml` workflow.
 - **Do not add `replace` directives to `go.mod` on any branch intended for
   merge.** `replace` directives in published modules break consumer builds.

--- a/scripts/release/tag-all.sh
+++ b/scripts/release/tag-all.sh
@@ -53,8 +53,8 @@ fi
 
 # Configure committer for annotated tags (the message field uses the
 # release-bot identity).
-git config user.name  "axonops-release-bot[bot]"
-git config user.email "axonops-release-bot[bot]@users.noreply.github.com"
+git config user.name  "axonops-audit-release-bot[bot]"
+git config user.email "axonops-audit-release-bot[bot]@users.noreply.github.com"
 
 failed=()
 remaining=()


### PR DESCRIPTION
Per-repo bot identity rather than org-generic. Hardcoded strings in release.yml + tag-all.sh git config must match the App slug exactly, so renaming the App on the GitHub side without this change would orphan release commits.