### PR TITLE
fix(ci): query allow_auto_merge via REST, not gh repo view --json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,7 +418,12 @@ jobs:
           # disabled at the repo level. Catch the misconfiguration
           # here rather than discover it after the workflow times out
           # waiting for a merge that will never happen.
-          allow=$(gh repo view --json autoMergeAllowed --jq '.autoMergeAllowed')
+          #
+          # `gh repo view --json` does not expose this setting (the
+          # GraphQL Repository type has no autoMergeAllowed field).
+          # The setting lives on the REST repo object as
+          # `allow_auto_merge`, so query the REST API directly.
+          allow=$(gh api "/repos/${GITHUB_REPOSITORY}" --jq '.allow_auto_merge')
           if [ "$allow" != "true" ]; then
             echo "::error::Repository setting 'Allow auto-merge' is disabled. Enable it in Settings → General before triggering the release workflow."
             exit 1


### PR DESCRIPTION
Unblocks the v0.1.12 release.

The 'Verify auto-merge is enabled' preflight ran `gh repo view --json autoMergeAllowed --jq '.autoMergeAllowed'`. That field does not exist on the GraphQL `Repository` type that `gh repo view --json` reads, so the command exits non-zero with an 'Unknown JSON field' error.

Under `set -euo pipefail` the entire step fails, surfacing the same way the genuine 'auto-merge is disabled' branch would. Run #4 of v0.1.12 hit this even after I enabled `allow_auto_merge=true` on the repo via the REST API.

Switch to `gh api /repos/${GITHUB_REPOSITORY} --jq '.allow_auto_merge'` which queries the REST repo object where this setting actually lives.