### PR TITLE
fix(release): skip go mod tidy in update-deps; strip stale go.sum

### DIFF
--- a/scripts/release/update-deps.sh
+++ b/scripts/release/update-deps.sh
@@ -9,9 +9,11 @@
 #
 # Reads the canonical module list from `make print-publish-modules`.
 # Iterates every published module and rewrites its `require` directive
-# for every OTHER published module to `@VERSION`. Then runs `go mod
-# tidy` with `GOWORK=off GOPROXY=direct GONOSUMCHECK=...` matching the
-# existing release.yml semantics.
+# for every OTHER published module to `@VERSION`. Stale go.sum entries
+# for those paths are stripped so the next `go mod download` after the
+# new tag publishes re-populates them with the correct hash. Tidy is
+# intentionally NOT run — at this point in the release flow VERSION
+# is not yet a tag on origin, so tidy would fail to resolve.
 #
 # Also updates `examples/17-capstone/go.mod` (it's not published, but
 # its dependency pins move with the release).
@@ -53,16 +55,25 @@ while IFS='|' read -r dir module_path tag_prefix; do
 done < <(make -s --no-print-directory print-publish-modules)
 targets+=("examples/17-capstone")
 
-# go mod tidy semantics matching the existing release.yml: workspace
-# off (so each module resolves on its own go.mod), GOPROXY=direct
-# (fetches new versions from GitHub even before the proxy has indexed
-# them), and GONOSUMCHECK / GONOSUMDB so the sumdb doesn't refuse a
-# version that hasn't been seen yet.
+# Version-pin semantics: workspace OFF so each module resolves on
+# its own go.mod, GOPROXY=direct so the script doesn't depend on
+# the proxy having indexed the previous release, GOFLAGS=-mod=mod
+# so `go mod edit` can rewrite the require directives.
+#
+# The chicken-and-egg: at this point in the release flow, the
+# new tag (e.g. v0.1.12) does NOT yet exist on origin — it's
+# created by the `tag-all-modules` job AFTER this PR auto-merges
+# (release.yml:553-...). So `go mod tidy` would fail trying to
+# resolve every inter-module require@VERSION. Skip tidy and
+# manually drop any stale go.sum entries for the inter-module
+# axonops/audit paths; the CI job that runs on the release PR
+# operates in workspace mode (`make workspace`) and resolves
+# inter-module deps locally, so a missing-checksum is not an
+# error there. The first downstream consumer that fetches
+# v$VERSION populates a fresh entry in their own go.sum.
 export GOWORK=off
 export GOPROXY=direct
-export GONOSUMCHECK=github.com/axonops/audit
-export GONOSUMDB=github.com/axonops/audit
-export GOFLAGS=-mod=mod  # update mode required for go mod edit + tidy
+export GOFLAGS=-mod=mod
 
 for target in "${targets[@]}"; do
   if [[ ! -f "$target/go.mod" ]]; then
@@ -81,11 +92,18 @@ for target in "${targets[@]}"; do
     if grep -qE "^[[:space:]]*${path}[[:space:]]v[0-9]" go.mod; then
       go mod edit -require "${path}@${VERSION}"
       echo "  pinned $path → $VERSION"
+      # Strip any existing go.sum entries for this path so they
+      # don't reference the previous version's hash. The first
+      # `go mod download` after the new tag publishes will re-add
+      # the correct entries.
+      if [[ -f go.sum ]]; then
+        # Match the path at the start of the line followed by space
+        # — same anchoring as above.
+        sed -i "/^${path//\//\\/} /d" go.sum
+      fi
     fi
   done
 
-  go mod tidy
-  echo "  tidied."
   popd >/dev/null
 done
 


### PR DESCRIPTION
Unblocks the v0.1.12 release. **Fifth fix in a row** for the unified release flow (#513) — turns out it was never actually exercised end-to-end before today.

## Timeline

- v0.1.11 tagged 2026-04-18 via the **legacy three-tier flow**.
- Unified-flow PR #769 merged 2026-04-29.
- v0.1.12 is the first attempted use of the new flow. So far it's hit:
  1. `pull-requests: write` permission missing on release.yml's `ci:` job (PR #832).
  2. Go toolchain on 1.26.2 — two new stdlib vulns (PR #832).
  3. `FuzzOutputConfigLoad` finding a real bug in outputconfig error formatting (PR #833).
  4. Bot rename + missing GitHub App secrets — manual.
  5. `gh repo view --json autoMergeAllowed` is not a valid field (PR #835).
  6. **This**: `go mod tidy` in `update-deps.sh` fails because v$VERSION is not yet tagged on origin.

## Problem

`update-deps.sh` runs at the start of the release flow, **before** the new tag is created (the tag is placed at the merge SHA in the `tag-all-modules` job AFTER this script's PR auto-merges). The script's pinning loop is:

```bash
go mod edit -require axonops/audit@v$VERSION
go mod tidy   # fails: 'reading github.com/axonops/audit/go.mod at revision v0.1.12: unknown revision v0.1.12'
```

## Fix

Skip tidy. Strip stale `go.sum` entries for the pinned paths so they don't reference the previous version's hash. The release PR's CI runs in workspace mode (`make workspace`) and resolves inter-module deps locally, so missing-checksum isn't a build error.

Minimum change to unblock the release. The README/PR body for the release PR also acknowledges this as a temporary patch — a follow-up issue should harden the design (pre-tag at release-PR commit + tidy, or post-tag tidy step).

## Test plan

- [x] Dry-run `bash scripts/release/update-deps.sh v0.1.99-test` succeeds locally
- [x] `make check` clean
- [ ] CI green
- [ ] After merge: re-dispatch v0.1.12 release