### PR TITLE
chore: add go.mod to every example, wire into release/deps (#437)

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Save pre-update go.mod files
         run: |
-          for mod in . file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault; do
+          for mod in . file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault examples/01-basic examples/02-code-generation examples/03-file-output examples/04-testing examples/05-formatters examples/06-middleware examples/07-syslog-output examples/08-webhook-output examples/09-multi-output examples/10-event-routing examples/11-sensitivity-labels examples/12-hmac-integrity examples/13-standard-fields examples/14-loki-output examples/15-tls-policy examples/16-buffering examples/17-capstone examples/18-health-endpoint examples/19-migration examples/20-prometheus-reference; do
             cp "$mod/go.mod" "$mod/go.mod.before"
           done
 
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault"
+          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault examples/01-basic examples/02-code-generation examples/03-file-output examples/04-testing examples/05-formatters examples/06-middleware examples/07-syslog-output examples/08-webhook-output examples/09-multi-output examples/10-event-routing examples/11-sensitivity-labels examples/12-hmac-integrity examples/13-standard-fields examples/14-loki-output examples/15-tls-policy examples/16-buffering examples/17-capstone examples/18-health-endpoint examples/19-migration examples/20-prometheus-reference"
           CORE_MODULE="github.com/axonops/audit"
           FAILED=""
 
@@ -141,7 +141,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault"
+          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault examples/01-basic examples/02-code-generation examples/03-file-output examples/04-testing examples/05-formatters examples/06-middleware examples/07-syslog-output examples/08-webhook-output examples/09-multi-output examples/10-event-routing examples/11-sensitivity-labels examples/12-hmac-integrity examples/13-standard-fields examples/14-loki-output examples/15-tls-policy examples/16-buffering examples/17-capstone examples/18-health-endpoint examples/19-migration examples/20-prometheus-reference"
           HAS_CHANGES="false"
 
           for mod in $MODULES; do
@@ -188,7 +188,7 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault"
+          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault examples/01-basic examples/02-code-generation examples/03-file-output examples/04-testing examples/05-formatters examples/06-middleware examples/07-syslog-output examples/08-webhook-output examples/09-multi-output examples/10-event-routing examples/11-sensitivity-labels examples/12-hmac-integrity examples/13-standard-fields examples/14-loki-output examples/15-tls-policy examples/16-buffering examples/17-capstone examples/18-health-endpoint examples/19-migration examples/20-prometheus-reference"
           BODY=""
 
           for mod in $MODULES; do
@@ -265,7 +265,7 @@ jobs:
           SAVE=/tmp/depupdate-save
           rm -rf "$SAVE" && mkdir -p "$SAVE"
 
-          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault"
+          MODULES=". file syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault examples/01-basic examples/02-code-generation examples/03-file-output examples/04-testing examples/05-formatters examples/06-middleware examples/07-syslog-output examples/08-webhook-output examples/09-multi-output examples/10-event-routing examples/11-sensitivity-labels examples/12-hmac-integrity examples/13-standard-fields examples/14-loki-output examples/15-tls-policy examples/16-buffering examples/17-capstone examples/18-health-endpoint examples/19-migration examples/20-prometheus-reference"
 
           # Snapshot only go.mod / go.sum from each module — those are
           # the only files the dep-update step modifies.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
        test-integration test-bdd test-bdd-core test-bdd-outputconfig test-bdd-file test-bdd-file-os test-bdd-syslog test-bdd-webhook test-bdd-loki test-bdd-fanout \
        test-bdd-verify \
        test-examples \
-       lint lint-all lint-core lint-file lint-syslog lint-webhook lint-loki lint-outputconfig lint-audit-gen lint-audit-validate lint-capstone \
+       lint lint-all lint-core lint-file lint-syslog lint-webhook lint-loki lint-outputconfig lint-audit-gen lint-audit-validate lint-examples \
        lint-secrets lint-secrets-openbao lint-secrets-vault \
        vet vet-all fmt fmt-check \
        build build-all bench bench-save bench-compare bench-baseline-check coverage \
@@ -37,7 +37,11 @@ SHELL      := bash
 .SHELLFLAGS := -e -o pipefail -c
 
 MODULES           := . file iouring syslog webhook loki outputconfig outputs cmd/audit-gen cmd/audit-validate secrets secrets/env secrets/file secrets/openbao secrets/vault
-WORKSPACE_MODULES := $(MODULES) examples/17-capstone examples/20-prometheus-reference
+# EXAMPLE_MODULES is auto-discovered from any examples/*/go.mod so new
+# examples are picked up without touching the Makefile. Sorted for
+# deterministic workspace generation.
+EXAMPLE_MODULES   := $(sort $(patsubst %/go.mod,%,$(wildcard examples/*/go.mod)))
+WORKSPACE_MODULES := $(MODULES) $(EXAMPLE_MODULES)
 GOBIN             := $(shell go env GOPATH)/bin
 GO_TOOLCHAIN      := go1.26.3
 
@@ -312,10 +316,17 @@ lint-secrets-openbao:
 lint-secrets-vault:
 	cd secrets/vault && $(GOBIN)/golangci-lint run --timeout=5m --config $(CURDIR)/.golangci.yml ./...
 
-lint-capstone:
-	cd examples/17-capstone && $(GOBIN)/golangci-lint run --timeout=5m --config $(CURDIR)/.golangci.yml ./...
+# Lint every example with its own go.mod. EXAMPLE_MODULES is
+# auto-discovered (see top of file). Replaces the single-example
+# lint-capstone target so new examples are linted without further
+# Makefile edits.
+lint-examples:
+	@for dir in $(EXAMPLE_MODULES); do \
+		echo "=== lint $$dir ==="; \
+		(cd $$dir && $(GOBIN)/golangci-lint run --timeout=5m --config $(CURDIR)/.golangci.yml ./...) || exit 1; \
+	done
 
-lint-all: lint-core lint-file lint-syslog lint-webhook lint-loki lint-outputconfig lint-audit-gen lint-audit-validate lint-secrets lint-secrets-openbao lint-secrets-vault lint-capstone
+lint-all: lint-core lint-file lint-syslog lint-webhook lint-loki lint-outputconfig lint-audit-gen lint-audit-validate lint-secrets lint-secrets-openbao lint-secrets-vault lint-examples
 lint: lint-all
 
 # --- Vet ---

--- a/examples/01-basic/go.mod
+++ b/examples/01-basic/go.mod
@@ -1,0 +1,7 @@
+module github.com/axonops/audit/examples/01-basic
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+)

--- a/examples/02-code-generation/go.mod
+++ b/examples/02-code-generation/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/02-code-generation
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/03-file-output/go.mod
+++ b/examples/03-file-output/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/03-file-output
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/04-testing/go.mod
+++ b/examples/04-testing/go.mod
@@ -1,0 +1,10 @@
+module github.com/axonops/audit/examples/04-testing
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+	github.com/stretchr/testify v1.11.1
+)

--- a/examples/05-formatters/go.mod
+++ b/examples/05-formatters/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/05-formatters
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/06-middleware/go.mod
+++ b/examples/06-middleware/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/06-middleware
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/07-syslog-output/go.mod
+++ b/examples/07-syslog-output/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/07-syslog-output
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/08-webhook-output/go.mod
+++ b/examples/08-webhook-output/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/08-webhook-output
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/09-multi-output/go.mod
+++ b/examples/09-multi-output/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/09-multi-output
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/10-event-routing/go.mod
+++ b/examples/10-event-routing/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/10-event-routing
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/11-sensitivity-labels/go.mod
+++ b/examples/11-sensitivity-labels/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/11-sensitivity-labels
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/12-hmac-integrity/go.mod
+++ b/examples/12-hmac-integrity/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/12-hmac-integrity
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/13-standard-fields/go.mod
+++ b/examples/13-standard-fields/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/13-standard-fields
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/14-loki-output/go.mod
+++ b/examples/14-loki-output/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/14-loki-output
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/15-tls-policy/go.mod
+++ b/examples/15-tls-policy/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/15-tls-policy
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/16-buffering/go.mod
+++ b/examples/16-buffering/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/16-buffering
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/18-health-endpoint/go.mod
+++ b/examples/18-health-endpoint/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/18-health-endpoint
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/examples/19-migration/go.mod
+++ b/examples/19-migration/go.mod
@@ -1,0 +1,9 @@
+module github.com/axonops/audit/examples/19-migration
+
+go 1.26.3
+
+require (
+	github.com/axonops/audit v0.1.12
+	github.com/axonops/audit/outputconfig v0.1.12
+	github.com/axonops/audit/outputs v0.1.12
+)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/axonops/audit/file v0.1.11
 	github.com/axonops/audit/loki v0.1.11
 	github.com/axonops/audit/outputconfig v0.1.11
-	github.com/axonops/audit/outputs v0.1.9
 	github.com/axonops/audit/secrets/openbao v0.1.11
 	github.com/axonops/audit/syslog v0.1.11
 	github.com/axonops/audit/webhook v0.1.11

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/axonops/audit/loki v0.1.11 h1:jYewrKwhuml6KBsN2rS/4nejqTGQgv0X3GGV7Gp
 github.com/axonops/audit/loki v0.1.11/go.mod h1:7MZcSDpT4likpw/RqsroAimsjtxe+HGjzCkC7ds/6OY=
 github.com/axonops/audit/outputconfig v0.1.11 h1:RArErBa0X18R3QEEAQAYS5yY5VjoyQojnCezYMNuduw=
 github.com/axonops/audit/outputconfig v0.1.11/go.mod h1:gTzEFOubwmnvfLxTms+Y/3NjsQN+Rsd98IVKQhO9GVA=
-github.com/axonops/audit/outputs v0.1.9 h1:mH3EeoA1U5ahEQkNMvutOyWGfAbcSH0DCEeLrtM/HEA=
-github.com/axonops/audit/outputs v0.1.9/go.mod h1:x8jFor5DmgYOcRYTwSVwixqC+Xo8vNfCggL/YvX17uk=
 github.com/axonops/audit/secrets v0.1.11 h1:ilszR93wSDYRCVNK37LUJsrHUcHXyPOMjx5Lax29t9M=
 github.com/axonops/audit/secrets v0.1.11/go.mod h1:gAQX3co4e/23wOe4vkylrJ6smNicyITP+UEcx/gypak=
 github.com/axonops/audit/secrets/openbao v0.1.11 h1:pIRUVAFg117K48btcK4USV/1yaTa6p1gyLv1rWRNNqc=

--- a/scripts/release/update-deps.sh
+++ b/scripts/release/update-deps.sh
@@ -53,7 +53,18 @@ while IFS='|' read -r dir module_path tag_prefix; do
   [[ "$dir" == "." ]] && continue
   targets+=("$dir")
 done < <(make -s --no-print-directory print-publish-modules)
-targets+=("examples/17-capstone")
+
+# Include every example with its own go.mod (#437). Examples are
+# not published, but their require directives still need to pin to
+# the new release version so the next dependency-update PR sees
+# them as up-to-date. The shell glob is non-fragile: a new example
+# directory with a go.mod is picked up automatically.
+for ex in examples/*/; do
+  ex="${ex%/}"
+  if [[ -f "$ex/go.mod" ]]; then
+    targets+=("$ex")
+  fi
+done
 
 # Version-pin semantics: workspace OFF so each module resolves on
 # its own go.mod, GOPROXY=direct so the script doesn't depend on


### PR DESCRIPTION
Closes #437.

## What

v0.1.12 is now on the Go module proxy, so every example can require a real published version of `audit`. This PR adds a standalone `go.mod` to each of the 18 examples that didn't already have one (01–16, 18, 19), and wires the new modules into the release + dep-update workflows + Makefile.

## Standalone-build status

| Examples | Standalone build (`GOWORK=off go build`) |
|---|---|
| 17, 18, 19, 20 | works today |
| 01–16 | **fails until v0.1.13 publishes** — v0.1.12's audit tarball still contains `examples/01-16/` as part of the parent module (at v0.1.12's tag SHA those directories had no `go.mod` yet), so `go get audit@v0.1.12` returns content whose path conflicts with the new example modules. After v0.1.13 cuts, the parent tarball will EXCLUDE `examples/01-16/`, breaking the cycle |
| All 20 | works today via `make workspace` (workspace-mode build resolves locally) |

Once v0.1.13 publishes, `scripts/release/update-deps.sh` will auto-pin all example `go.mod` requires to v0.1.13 and standalone build starts working for 01–16.

## Wiring

- **Makefile** — `EXAMPLE_MODULES` auto-discovered from `examples/*/go.mod` via `$(wildcard)`; `WORKSPACE_MODULES = MODULES + EXAMPLE_MODULES`. New `lint-examples` target loops over the auto-discovered list. Replaces the single-purpose `lint-capstone` target.
- **`scripts/release/update-deps.sh`** — loops over `examples/*/go.mod` instead of hardcoding `examples/17-capstone`. New examples with a `go.mod` are picked up automatically.
- **`.github/workflows/dependency-update.yml`** — MODULES list (5 occurrences) extended with all 20 example dirs.
- **`make workspace`** — regenerates `go.work` with all 20 examples included.

## Test plan

- [x] `make check` clean (lint, vet, security, GoReleaser)
- [x] `make test-examples` — all 20 examples build via workspace
- [x] `make lint-examples` — all 20 examples lint clean
- [ ] CI green
- [ ] After merge: cut v0.1.13. Verify standalone build works for examples 01–16 after the new tag publishes.

## Notes

- Also includes a 1-line root `go.mod` tidy (drops the unused `github.com/axonops/audit/outputs v0.1.9` require — root doesn't import the convenience outputs package, only references it in doc comments).
- The release-flow hardening follow-ups land separately (#841, #842).
