### PR TITLE
test: add BDD scenarios for env:// and file:// secrets (#720)

### DIFF
--- a/outputconfig/go.mod
+++ b/outputconfig/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/axonops/audit v0.1.13
 	github.com/axonops/audit/file v0.1.13
 	github.com/axonops/audit/secrets v0.1.13
+	github.com/axonops/audit/secrets/env v0.1.13
+	github.com/axonops/audit/secrets/file v0.1.13
 	github.com/axonops/audit/secrets/openbao v0.1.13
 	github.com/axonops/audit/secrets/vault v0.1.13
 	github.com/cucumber/godog v0.15.1

--- a/outputconfig/go.sum
+++ b/outputconfig/go.sum
@@ -6,6 +6,10 @@ github.com/axonops/audit/iouring v0.0.0-20260504172742-a7311e23b1c6 h1:hSS66oOtq
 github.com/axonops/audit/iouring v0.0.0-20260504172742-a7311e23b1c6/go.mod h1:uOXtOGLXheRF1e3lQrTiCtTY0SipPH94czfKTv5sZsU=
 github.com/axonops/audit/secrets v0.1.13 h1:hT6HTxalLrcUXss1GKE+T//kFxKMFZ5qY9lSaypoOWg=
 github.com/axonops/audit/secrets v0.1.13/go.mod h1:Z00RXS3xRYpPB+UFfnTJpHHjsfQW5L3PH4x+sxlAL0Q=
+github.com/axonops/audit/secrets/env v0.1.13 h1:TEXDFbhP29//jRJ9X8kNz0EZu7NAeCIaf4kNMCVhQa8=
+github.com/axonops/audit/secrets/env v0.1.13/go.mod h1:ApYj1P4x9pKs6eXT3ywpGVu7Ompit9wcJvMswWP9aHg=
+github.com/axonops/audit/secrets/file v0.1.13 h1:Ka0vUZyey8I/X9QdQSwsdTw4SfE+CWXLXcRFAFHYnbA=
+github.com/axonops/audit/secrets/file v0.1.13/go.mod h1:l7/EDGzmlGkm0pmy+G0Zg5Q+s72zeWCuOJP5yUhPv94=
 github.com/axonops/audit/secrets/openbao v0.1.13 h1:C+Rwls8dRKC/Ng9cRfeFwahxBhQrZ5D71MPaUhmZQvA=
 github.com/axonops/audit/secrets/openbao v0.1.13/go.mod h1:pevJ6GlseB40V1yk1X3lJJrshu9BMgyr8/Od1jG4Bg8=
 github.com/axonops/audit/secrets/vault v0.1.13 h1:uYVH296LIKKQJs2VONIRFHwGAQwiZ4D53CcqU53rpKg=

--- a/outputconfig/tests/bdd/features/secret_resolution.feature
+++ b/outputconfig/tests/bdd/features/secret_resolution.feature
@@ -717,3 +717,318 @@ Feature: Secret reference resolution in output configuration
       """
     Then the config load should succeed
     And the HMAC config salt should equal the injection-safety fixture byte-for-byte
+
+  # ---------------------------------------------------------------------------
+  # Scenarios 29–37: real env:// and file:// providers (#720, follow-up to #604)
+  #
+  # Unit tests cover the env / file providers in isolation; these
+  # scenarios prove the providers integrate with outputconfig.Load
+  # end-to-end through the same resolver pipeline used by the mock
+  # provider scenarios above. Both providers are wired by the
+  # registration steps in env_file_secret_steps.go — no mocking of
+  # the audit/secrets/env or audit/secrets/file packages. File
+  # fixtures live in a per-scenario temp dir whose path is exported
+  # as the BDD_SECRETS_DIR env var so ref+file://${BDD_SECRETS_DIR}
+  # expansion works through the standard outputconfig envsubst path.
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # Scenario 29: env:// resolves a set environment variable to its value
+  # ---------------------------------------------------------------------------
+  Scenario: env:// resolves a set environment variable
+    Given an env:// secret provider is registered
+    And the environment variable "BDD_ENV_SECRET_VALUE" is set to "env-secret-value-32-bytes!!!!!!!"
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+env://BDD_ENV_SECRET_VALUE
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should succeed
+    And the HMAC config should have salt "env-secret-value-32-bytes!!!!!!!"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 30: env:// returns a resolve-failure when the variable is unset.
+  # The provider wraps secrets.ErrSecretResolveFailed; the resolver
+  # propagates the diagnostic through outputconfig.Load.
+  # ---------------------------------------------------------------------------
+  Scenario: env:// returns ErrSecretResolveFailed when variable is unset
+    Given an env:// secret provider is registered
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+env://BDD_DEFINITELY_NOT_SET_XYZ_720
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "variable not set"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 31: env:// rejects a #fragment at ParseRef time.
+  # env:// has no key concept; a fragment is a structural error.
+  # ---------------------------------------------------------------------------
+  Scenario: env:// rejects a reference with a #fragment
+    Given an env:// secret provider is registered
+    And the environment variable "BDD_ENV_WITH_FRAGMENT" is set to "ignored"
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+env://BDD_ENV_WITH_FRAGMENT#key
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "env:// must not have a #fragment"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 32: file:// resolves a whole-file secret value.
+  # No #fragment → the entire file content (minus the trailing
+  # newline, per [file.Provider]'s contract) is the resolved value.
+  # ---------------------------------------------------------------------------
+  Scenario: file:// resolves a whole-file secret value
+    Given a file:// secret provider is registered
+    And a file in the temp dir named "salt.txt" with content "file-secret-value-32-bytes!!!!!!"
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+file://${BDD_SECRETS_DIR}/salt.txt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should succeed
+    And the HMAC config should have salt "file-secret-value-32-bytes!!!!!!"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 33: file:// resolves a JSON file via a dotted-fragment path.
+  # The #fragment is parsed as a dotted JSON path; the terminal
+  # scalar string is returned. This mirrors vault/openbao KV-v2
+  # ergonomics for operators who store many secrets in one file.
+  # ---------------------------------------------------------------------------
+  Scenario: file:// resolves a JSON file with dotted-fragment path
+    Given a file:// secret provider is registered
+    And a JSON file in the temp dir named "secrets.json" with content:
+      """
+      {"hmac": {"v1": {"salt": "json-dotted-salt-32-bytes!!!!!!!"}}}
+      """
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+file://${BDD_SECRETS_DIR}/secrets.json#hmac.v1.salt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should succeed
+    And the HMAC config should have salt "json-dotted-salt-32-bytes!!!!!!!"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 34: file:// rejects a relative path at ParseRef time.
+  # Forces operators to make filesystem ownership of secret material
+  # explicit — relative paths depend on process CWD and break the
+  # principle of least surprise.
+  # ---------------------------------------------------------------------------
+  Scenario: file:// rejects a relative path
+    Given a file:// secret provider is registered
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+file://relative/path.txt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "file:// path must be absolute"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 35: file:// rejects a path containing a ".." segment.
+  # Defence-in-depth: even though the trust boundary is operator-
+  # controlled YAML, parent-directory traversal is rejected to
+  # contain damage from a misconfigured config file or a templating
+  # bug that builds the ref string from a less-trusted source.
+  # ---------------------------------------------------------------------------
+  Scenario: file:// rejects a path containing ".."
+    Given a file:// secret provider is registered
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+file://${BDD_SECRETS_DIR}/../escape.txt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing:
+      """
+      path contains ".." segment
+      """
+
+  # ---------------------------------------------------------------------------
+  # Scenario 36: file:// rejects a file exceeding the 1 MiB cap.
+  # Bound on read amplification: a misconfigured ref to /dev/zero
+  # or a multi-GB file must not consume unbounded memory during
+  # config load. The bound is the hardcoded maxFileSize = 1<<20.
+  # ---------------------------------------------------------------------------
+  Scenario: file:// rejects an oversized file
+    Given a file:// secret provider is registered
+    And a file in the temp dir named "huge.txt" with 1048577 bytes of content
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+file://${BDD_SECRETS_DIR}/huge.txt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "file exceeds 1048576 bytes"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 37: file:// follows a Kubernetes-style atomic-swap symlink.
+  # Kubernetes mounts secret volumes as a layered symlink chain:
+  #   <dir>/<name> → <dir>/..data/<name>
+  #   <dir>/..data → <dir>/..2026_..._timestamp_dir
+  # On rotation the kubelet creates a new timestamped dir, then
+  # atomically swaps the ..data symlink. Consumers reading through
+  # the public path observe a single atomic transition. The file
+  # provider MUST follow both indirections so it works under the
+  # standard Kubernetes secret-mount layout.
+  # ---------------------------------------------------------------------------
+  Scenario: file:// follows a Kubernetes-style atomic-swap symlink
+    Given a file:// secret provider is registered
+    And a Kubernetes-style atomic-swap secret named "salt" with content "k8s-atomic-swap-salt-32-bytes!!!"
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+file://${BDD_SECRETS_DIR}/salt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should succeed
+    And the HMAC config should have salt "k8s-atomic-swap-salt-32-bytes!!!"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 38: env:// rejects a variable whose value is an empty string
+  #
+  # An env var that is set but resolves to "" is structurally
+  # distinct from one that is unset entirely. The provider emits a
+  # distinct diagnostic ("resolved to empty value") because operators
+  # commonly leak this case through Helm-template defaulting or
+  # k8s `env` mounts that always emit the key even when unconfigured.
+  # ---------------------------------------------------------------------------
+  Scenario: env:// rejects a variable that resolves to an empty string
+    Given an env:// secret provider is registered
+    And the environment variable "BDD_ENV_EMPTY_VALUE" is set to ""
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+env://BDD_ENV_EMPTY_VALUE
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "resolved to empty value"
+
+  # ---------------------------------------------------------------------------
+  # Scenario 39: file:// rejects a JSON file whose terminal node is non-string
+  #
+  # The dotted-fragment path traversal lands on a JSON value that
+  # is not a string (number, object, array, bool, null). HMAC salts
+  # are byte strings; emitting a coerced "12345" or "true" would
+  # silently break HMAC verification. The provider rejects the load
+  # with a distinctive diagnostic.
+  # ---------------------------------------------------------------------------
+  Scenario: file:// rejects a JSON file whose terminal value is not a string
+    Given a file:// secret provider is registered
+    And a JSON file in the temp dir named "non-string.json" with content:
+      """
+      {"hmac": {"salt": 42}}
+      """
+    And the following output configuration YAML with secret providers:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        audit_log:
+          type: stdout
+          hmac:
+            enabled: true
+            salt:
+              version: v1
+              value: ref+file://${BDD_SECRETS_DIR}/non-string.json#hmac.salt
+            algorithm: HMAC-SHA-256
+      """
+    Then the config load should fail with an error containing "terminal value is not a string"

--- a/outputconfig/tests/bdd/steps/env_file_secret_steps.go
+++ b/outputconfig/tests/bdd/steps/env_file_secret_steps.go
@@ -1,0 +1,159 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Step definitions for env:// and file:// real-provider BDD
+// scenarios (#720). Unlike the mock-provider steps in
+// secret_steps.go, these register the actual
+// audit/secrets/env and audit/secrets/file packages — proving
+// the providers integrate with outputconfig.Load end-to-end.
+
+package steps
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cucumber/godog"
+
+	"github.com/axonops/audit/outputconfig"
+	"github.com/axonops/audit/secrets/env"
+	"github.com/axonops/audit/secrets/file"
+)
+
+// registerEnvFileSecretSteps registers steps that wire the real
+// env:// and file:// secret providers into the outputconfig.Load
+// path.
+func registerEnvFileSecretSteps(ctx *godog.ScenarioContext, tc *TestContext) {
+	ctx.Step(`^an env:// secret provider is registered$`, tc.stepRegisterEnvProvider)
+	ctx.Step(`^a file:// secret provider is registered$`, tc.stepRegisterFileProvider)
+	ctx.Step(`^a file in the temp dir named "([^"]*)" with content "([^"]*)"$`, tc.stepWriteFixtureFile)
+	ctx.Step(`^a file in the temp dir named "([^"]*)" with (\d+) bytes of content$`, tc.stepWriteFixtureFileWithSize)
+	ctx.Step(`^a JSON file in the temp dir named "([^"]*)" with content:$`, tc.stepWriteFixtureJSONFile)
+	ctx.Step(`^a Kubernetes-style atomic-swap secret named "([^"]*)" with content "([^"]*)"$`, tc.stepWriteAtomicSwapSecret)
+}
+
+func (tc *TestContext) stepRegisterEnvProvider() error {
+	tc.LoadOptions = append(tc.LoadOptions, outputconfig.WithSecretProvider(env.New()))
+	return nil
+}
+
+func (tc *TestContext) stepRegisterFileProvider() error {
+	// Eagerly create the per-scenario temp dir and export
+	// BDD_SECRETS_DIR so YAML scenarios referencing
+	// ref+file://${BDD_SECRETS_DIR}/... resolve through the
+	// outputconfig envsubst pass — even scenarios that don't
+	// otherwise create a fixture file (e.g. the "rejects .."
+	// path-traversal scenario, which validates structural
+	// rejection without touching the filesystem).
+	if _, err := tc.ensureSecretsTempDir(); err != nil {
+		return err
+	}
+	tc.LoadOptions = append(tc.LoadOptions, outputconfig.WithSecretProvider(file.New()))
+	return nil
+}
+
+func (tc *TestContext) stepWriteFixtureFile(name, content string) error {
+	dir, err := tc.ensureSecretsTempDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func (tc *TestContext) stepWriteFixtureFileWithSize(name string, size int) error {
+	dir, err := tc.ensureSecretsTempDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, bytes.Repeat([]byte{'x'}, size), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func (tc *TestContext) stepWriteFixtureJSONFile(name string, doc *godog.DocString) error {
+	dir, err := tc.ensureSecretsTempDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(doc.Content), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// stepWriteAtomicSwapSecret builds the layered symlink structure
+// that the Kubernetes kubelet creates when mounting a Secret as a
+// directory:
+//
+//	<dir>/<name>   → ..data/<name>   (public path; symlink)
+//	<dir>/..data   → ..<timestamp>   (atomically swapped on rotation)
+//	<dir>/..<ts>/<name>              (the real file)
+//
+// On rotation the kubelet writes a new timestamped dir, then
+// atomically replaces ..data. file:// must follow both indirections.
+func (tc *TestContext) stepWriteAtomicSwapSecret(name, content string) error {
+	dir, err := tc.ensureSecretsTempDir()
+	if err != nil {
+		return err
+	}
+	// Synthetic versioned dirname mirroring the kubelet AtomicWriter
+	// timestamp format; the literal date is irrelevant to the test.
+	versionDir := filepath.Join(dir, "..0000_00_00_00_00_00.000000000")
+	if err := os.MkdirAll(versionDir, 0o700); err != nil {
+		return fmt.Errorf("create versioned dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, name), []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write versioned file: %w", err)
+	}
+	dataLink := filepath.Join(dir, "..data")
+	if err := os.Symlink(versionDir, dataLink); err != nil {
+		return fmt.Errorf("create ..data symlink: %w", err)
+	}
+	publicLink := filepath.Join(dir, name)
+	if err := os.Symlink(filepath.Join(dataLink, name), publicLink); err != nil {
+		return fmt.Errorf("create public symlink: %w", err)
+	}
+	return nil
+}
+
+// ensureSecretsTempDir returns the per-scenario temp dir for
+// file:// fixtures, creating it on first use. The directory is
+// removed by InitializeScenario's After hook (see steps.go).
+// The path is also exported as the BDD_SECRETS_DIR env var so
+// YAML scenarios can reference fixture files via standard env
+// expansion in ref+file:// URLs.
+func (tc *TestContext) ensureSecretsTempDir() (string, error) {
+	if tc.realSecretsTempDir != "" {
+		return tc.realSecretsTempDir, nil
+	}
+	dir, err := os.MkdirTemp("", "bdd-env-file-*")
+	if err != nil {
+		return "", fmt.Errorf("create secrets temp dir: %w", err)
+	}
+	tc.realSecretsTempDir = dir
+	if err := os.Setenv("BDD_SECRETS_DIR", dir); err != nil {
+		return "", fmt.Errorf("set BDD_SECRETS_DIR: %w", err)
+	}
+	tc.envVarsSet = append(tc.envVarsSet, "BDD_SECRETS_DIR")
+	return dir, nil
+}

--- a/outputconfig/tests/bdd/steps/steps.go
+++ b/outputconfig/tests/bdd/steps/steps.go
@@ -105,9 +105,15 @@ type TestContext struct { //nolint:govet // fieldalignment: readability preferre
 	envVarsSet    []string                  // env vars set by steps, cleaned up in After
 
 	// Real container provider state (for @docker scenarios).
-	realProviderAddr         string
-	realProviderToken        string
-	realProviderCAPath       string
+	realProviderAddr   string
+	realProviderToken  string
+	realProviderCAPath string
+	// realSecretsTempDir is a per-scenario temp dir used by both
+	// the @docker Vault/OpenBao steps (for the extracted CA cert)
+	// and the file:// secret-provider steps (for fixture files).
+	// Mutually exclusive in practice — a scenario uses one provider
+	// family or the other — but both code paths cooperate to set
+	// and to clean up via the After hook below.
 	realSecretsTempDir       string
 	realProviderPendingSeeds map[string]map[string]string
 	realProviderCleanup      []func()
@@ -175,6 +181,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerRealSecretSteps(ctx, tc)
 	registerSecretSteps(ctx, tc)
 	registerSecretsTLSNegativeSteps(ctx, tc)
+	registerEnvFileSecretSteps(ctx, tc)
 }
 
 func registerGivenSteps(ctx *godog.ScenarioContext, tc *TestContext) {
@@ -377,6 +384,14 @@ func registerThenSteps(ctx *godog.ScenarioContext, tc *TestContext) {
 
 	ctx.Step(`^the config load error should contain "([^"]*)"$`, func(substr string) error {
 		return assertError(tc, substr)
+	})
+
+	// Docstring variant: use when the substring contains literal
+	// double-quote characters, which Gherkin's `"..."` step-argument
+	// syntax cannot express (the embedded `\"` escape is not honoured
+	// by godog v0.15).
+	ctx.Step(`^the config load should fail with an error containing:$`, func(doc *godog.DocString) error {
+		return assertError(tc, doc.Content)
 	})
 
 	ctx.Step(`^the loki output formatter should be JSON$`, func() error {


### PR DESCRIPTION
## Summary

Closes #720. Adds 11 BDD scenarios covering the `audit/secrets/env` and `audit/secrets/file` providers end-to-end through `outputconfig.Load`. Promotes both sub-modules from indirect to direct dependencies of `outputconfig` (now possible since v0.1.13 published them).

The 9 scenarios listed in the issue's AC are covered, plus 2 extras for behavioural gaps surfaced during review:

- env://: set, unset, empty-value, fragment-rejection
- file://: whole-file, JSON dotted-fragment, relative-path rejection, ".." rejection, oversize rejection, K8s atomic-swap symlink, non-string JSON terminal

A new docstring-variant step phrase (`the config load should fail with an error containing:`) supports error substrings with embedded double-quote characters (godog v0.15 does not honour `\"` escapes inside Gherkin step arguments).

## Test plan

- [x] `make test-bdd-outputconfig` — all 59 scenarios pass (48 pre-existing + 11 new)
- [x] `make check` — full local gate green
- [ ] CI green
- [ ] issue-closer verification