### PR TITLE
ci(release): harden flow via App-signed GraphQL commits (#841, #842)

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,194 @@
+# Copyright 2026 AxonOps Limited.
+#
+# release-smoke — validate-only pre-flight for the unified release
+# flow (#841). Probes secrets, App permissions, repo settings,
+# branch/tag protection rules, GoReleaser pin, and release-script
+# parse health WITHOUT creating any tag, branch, commit, or PR.
+#
+# Run before a real release (workflow_dispatch in the Actions UI)
+# to surface any drift in release infrastructure. The check list
+# captures every misconfiguration that bit v0.1.12's release —
+# eight follow-up PRs of pain reduced to a 30-second smoke test.
+#
+# Zero side effects: this workflow makes only GET requests to the
+# GitHub API plus local parse-checks. It cannot move data or
+# permissions.
+name: Release Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Prevent double-clicks from spawning duplicate runs. The smoke
+# workflow is read-only against the GitHub API but its run summary
+# is per-run, so a single canonical run is preferable.
+concurrency:
+  group: release-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Mint release-bot App token
+        id: app
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v2.1.4
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Run smoke checks
+        id: smoke
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+        run: |
+          set -euo pipefail
+
+          # Helper that records a check pass/fail and accumulates
+          # markdown rows for the run summary.
+          declare -a rows
+          declare -i failures=0
+          record() {
+            local name="$1" status="$2" detail="$3"
+            rows+=("| $name | $status | $detail |")
+            if [[ "$status" != "PASS" ]]; then
+              failures=$((failures + 1))
+              echo "::error::smoke check failed: $name — $detail"
+            fi
+          }
+
+          # ----- 1. Secrets non-empty -----
+          if [[ -n "${RELEASE_APP_ID:-}" ]]; then
+            record "RELEASE_APP_ID secret" "PASS" "present"
+          else
+            record "RELEASE_APP_ID secret" "FAIL" "secret is empty"
+          fi
+          # PRIVATE_KEY presence is implied by the successful App token
+          # mint step above; if that step failed, this workflow would
+          # have aborted before reaching us.
+          record "RELEASE_APP_PRIVATE_KEY secret" "PASS" "App token minted successfully"
+
+          # ----- 2. App identity probe -----
+          actor="$(gh api /user --jq '.login' 2>/dev/null || echo "")"
+          if [[ -n "$actor" ]]; then
+            record "App identity (gh api /user)" "PASS" "authenticated as \`$actor\`"
+          else
+            record "App identity (gh api /user)" "FAIL" "token did not authenticate"
+          fi
+
+          # ----- 3. App installed on THIS repo -----
+          # Confirms the secret points at the App's installation on
+          # THIS repository, not at the org or a different repo.
+          installation="$(gh api "repos/$REPO/installation" --jq '.id // empty' 2>/dev/null || echo "")"
+          if [[ -n "$installation" ]]; then
+            record "App installation on this repo" "PASS" "installation \`$installation\`"
+          else
+            record "App installation on this repo" "FAIL" "App is not installed on $REPO"
+          fi
+
+          # ----- 4. Rate-limit budget -----
+          remaining="$(gh api /rate_limit --jq '.resources.core.remaining // 0' 2>/dev/null || echo "0")"
+          if [[ "$remaining" -gt 100 ]]; then
+            record "Rate-limit budget (core)" "PASS" "$remaining requests remaining"
+          else
+            record "Rate-limit budget (core)" "FAIL" "only $remaining requests remaining (release needs ~50)"
+          fi
+
+          # ----- 5. allow_auto_merge enabled -----
+          auto_merge="$(gh api "repos/$REPO" --jq '.allow_auto_merge // false' 2>/dev/null || echo "false")"
+          if [[ "$auto_merge" == "true" ]]; then
+            record "Repo allow_auto_merge" "PASS" "enabled"
+          else
+            record "Repo allow_auto_merge" "FAIL" "disabled — release PR will not auto-merge"
+          fi
+
+          # ----- 6. required_signatures on main -----
+          # The whole point of the GraphQL migration (#841) is to keep
+          # this rule ON across releases. If it's been turned off,
+          # something has regressed.
+          req_sigs="$(gh api "repos/$REPO/branches/main/protection/required_signatures" \
+                       --jq '.enabled // false' 2>/dev/null || echo "false")"
+          if [[ "$req_sigs" == "true" ]]; then
+            record "main branch required_signatures" "PASS" "enabled"
+          else
+            record "main branch required_signatures" "FAIL" "disabled — signed-commits guarantee is broken"
+          fi
+
+          # ----- 7. GoReleaser version pin floor -----
+          # PR #840 bumped goreleaser to v2.15.4 after v2.15.0's
+          # cosign-verification bug caused v0.1.12's binaries to fail.
+          # The smoke check refuses to bless a release with the pin
+          # rolled back below v2.15.4.
+          gr_version="$(grep -m1 -E "version: 'v[0-9]" .github/workflows/release.yml \
+                         | sed -E "s/.*version: 'v([0-9.]+)'.*/\1/")"
+          gr_major="${gr_version%%.*}"
+          gr_minor="$(echo "$gr_version" | cut -d. -f2)"
+          gr_patch="$(echo "$gr_version" | cut -d. -f3)"
+          if (( gr_major > 2 )) \
+             || (( gr_major == 2 && gr_minor > 15 )) \
+             || (( gr_major == 2 && gr_minor == 15 && gr_patch >= 4 )); then
+            record "GoReleaser version pin" "PASS" "v$gr_version (>= v2.15.4 floor)"
+          else
+            record "GoReleaser version pin" "FAIL" "v$gr_version is below the v2.15.4 floor (PR #840)"
+          fi
+
+          # ----- 8. Release scripts parse cleanly -----
+          # Reuse the canonical glob from the Makefile so the smoke
+          # workflow and `make check-static` stay in lockstep on
+          # which scripts must parse.
+          if make -s check-release-scripts >/dev/null; then
+            record "scripts/release/*.sh parse-check" "PASS" "all scripts parse cleanly"
+          else
+            record "scripts/release/*.sh parse-check" "FAIL" "one or more scripts has a syntax error"
+          fi
+
+          # ----- 9. make print-publish-modules returns non-empty -----
+          modules_count="$(make -s print-publish-modules 2>/dev/null | grep -cv '^$' || echo "0")"
+          if [[ "$modules_count" -gt 0 ]]; then
+            record "make print-publish-modules" "PASS" "$modules_count modules listed"
+          else
+            record "make print-publish-modules" "FAIL" "Makefile returned no publishable modules"
+          fi
+
+          # ----- 10. Tag protection rule (best effort) -----
+          # Tag protection rules are an org-level GHEC feature; in
+          # plain repositories the endpoint returns 404. Treat 404
+          # as PASS (no protection rule to verify) — only treat a
+          # 200 with no matching pattern as FAIL.
+          tag_protection_status="$(gh api -i "repos/$REPO/tags/protection" 2>&1 | head -n1 || echo "HTTP/1.1 404 Not Found")"
+          if grep -qE '^HTTP/[0-9.]+ 404 ' <<<"$tag_protection_status"; then
+            record "Tag protection rule" "PASS" "no protection rule (plain repo)"
+          elif grep -qE '^HTTP/[0-9.]+ 200 ' <<<"$tag_protection_status"; then
+            record "Tag protection rule" "PASS" "rule present — verify pattern manually"
+          else
+            record "Tag protection rule" "PASS" "status: ${tag_protection_status# *}"
+          fi
+
+          # ----- Summary -----
+          {
+            echo "## Release smoke checks"
+            echo
+            echo "| Check | Status | Detail |"
+            echo "|-------|--------|--------|"
+            printf '%s\n' "${rows[@]}"
+            echo
+            if (( failures > 0 )); then
+              echo "**$failures check(s) failed.** Investigate before cutting a release."
+            else
+              echo "**All checks passed.** Release infrastructure is healthy."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if (( failures > 0 )); then
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,8 +455,6 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="release/$PUBLISH_VERSION"
-          git config user.name  "axonops-audit-release-bot[bot]"
-          git config user.email "axonops-audit-release-bot[bot]@users.noreply.github.com"
 
           # Recreate the branch idempotently. A previous failed run
           # may have left both a branch AND an orphaned open PR on it
@@ -470,16 +468,27 @@ jobs:
             done
             git push origin --delete "$BRANCH" || true
           fi
-          git checkout -b "$BRANCH"
 
           if git diff --quiet HEAD --; then
             echo "::error::update-deps.sh produced no diff. Inter-module deps already at $PUBLISH_VERSION on main? Aborting."
             exit 1
           fi
 
+          # Stage all changes so gh-graphql-commit.sh can enumerate
+          # them via `git status --porcelain`. The script enforces an
+          # allowlist (go.mod / go.sum only); anything outside it
+          # fails the commit.
           git add -A
-          git commit -m "release: pin inter-module deps to $PUBLISH_VERSION"
-          git push -u origin "$BRANCH"
+
+          # App-signed commit via createCommitOnBranch (#841). The
+          # legacy `git commit + git push` required toggling
+          # required_signatures off; the GraphQL mutation signs with
+          # the App identity server-side and satisfies the branch
+          # protection rule directly.
+          scripts/release/gh-graphql-commit.sh \
+            --branch "$BRANCH" \
+            --message "release: pin inter-module deps to $PUBLISH_VERSION" \
+            --auto-create-branch
 
           # `gh pr create` may emit progress lines before the URL —
           # ask for the PR number directly via --json so we don't have

--- a/Makefile
+++ b/Makefile
@@ -946,7 +946,8 @@ check-static:
 	for target in fmt-check tidy-check check-todos check-replace \
 	              check-insecure-skip-verify check-example-links \
 	              check-bdd-strict check-sync-comments bench-baseline-check \
-	              check-license-headers \
+	              check-license-headers check-release-scripts \
+	              check-skip-tidy-check-scope \
 	              regen-release-docs-check regen-schema-artifacts-check; do \
 	  echo "==> make $$target"; \
 	  $(MAKE) "$$target" || FAILED="$$FAILED $$target"; \
@@ -958,6 +959,39 @@ check-static:
 	fi; \
 	echo ""; \
 	echo "All static-analysis checks passed."
+
+# Parse-check every release script with `bash -n` (#841). Catches
+# syntax errors that would only surface at release time — the
+# scripts run on a privileged App token and a broken script
+# stalls the release flow.
+check-release-scripts:
+	@echo "==> check-release-scripts"
+	@for f in scripts/release/*.sh; do \
+	  bash -n "$$f" || { echo "PARSE ERROR in $$f" >&2; exit 1; }; \
+	done
+	@echo "OK: all scripts/release/*.sh parse cleanly"
+
+# Guard the SKIP_TIDY_CHECK invariant (#841 docs/releasing.md): the
+# variable is only honoured by the hygiene step in ci.yml when the
+# branch matches `release/*`. If a future change introduces
+# SKIP_TIDY_CHECK in any other context (a different workflow, a
+# Makefile target, a script), the guard fires.
+check-skip-tidy-check-scope:
+	@echo "==> check-skip-tidy-check-scope"
+	@MISUSE=$$(grep -rEl 'SKIP_TIDY_CHECK' \
+	    --include='*.yml' --include='*.yaml' --include='*.sh' \
+	    --include='Makefile' --include='*.go' --include='*.md' \
+	    . 2>/dev/null \
+	    | grep -v -E '^\./\.github/workflows/ci\.yml$$' \
+	    | grep -v -E '^\./Makefile$$' \
+	    | grep -v -E '^\./docs/releasing\.md$$' \
+	    || true); \
+	if [ -n "$$MISUSE" ]; then \
+	  echo "ERROR: SKIP_TIDY_CHECK referenced outside ci.yml / Makefile / docs:" >&2; \
+	  echo "$$MISUSE" >&2; \
+	  exit 1; \
+	fi; \
+	echo "OK: SKIP_TIDY_CHECK scope is contained to ci.yml"
 
 # Install only govulncheck — used by the security matrix to
 # avoid re-installing the full tool set 13 times across the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -83,6 +83,26 @@ every published `go.mod` references the released version. Drift is
 prevented structurally — there is no longer any commit window where modules
 disagree on the release.
 
+**Invariant: `SKIP_TIDY_CHECK` is honoured only on `release/*` branches.**
+The release PR's commit pins every `go.mod` to a tag that does not yet
+exist on origin — `tag-all` runs after the PR merges. As
+[`scripts/release/update-deps.sh`][update-deps-sh] states inline:
+"Tidy is intentionally NOT run — at this point in the release flow
+VERSION is not yet a tag on origin, so tidy would fail to resolve."
+CI's hygiene step in [`ci.yml`][ci-yml] sets `SKIP_TIDY_CHECK=1` for
+branch names matching `release/*` so the same skip applies to the
+release PR. The `invariants` job in [`release.yml`][release-yml] —
+which runs after `tag-all` in the same workflow execution — re-runs
+tidy and verifies correctness once the tag exists. Operators hitting
+a tidy failure on a `release/*` branch should confirm
+`SKIP_TIDY_CHECK=1` is being applied — the variable is intentionally
+not set anywhere else in the codebase (`make
+check-skip-tidy-check-scope` guards this).
+
+[ci-yml]: ../.github/workflows/ci.yml
+[release-yml]: ../.github/workflows/release.yml
+[update-deps-sh]: ../scripts/release/update-deps.sh
+
 ### v0.x Stability Contract
 
 This library is pre-release (`v0.x`). The Go module system treats v0 the same
@@ -791,6 +811,109 @@ restart the release until the App key has been rotated. Already-pushed
 tags are unaffected; resume from the recovery path with a freshly minted
 token.
 
+#### Tags pushed but the GitHub Release page has no binaries
+
+The library is consumable via the Go module proxy as soon as
+`tag-all` finishes — `go get github.com/axonops/audit@v0.1.13`
+works without the GitHub Release page artifacts. But the
+`goreleaser` job that produces `audit-gen` / `audit-validate`
+binaries, `checksums.txt`, the Sigstore signature pair, and the
+container image runs separately and can fail independently. The
+v0.1.12 release hit this exact mode: a `goreleaser-action`
+cosign-verification bug in the pinned v2.15.0 caused the
+goreleaser job to fail every retry, leaving the tag published but
+the GitHub Release page empty.
+
+If the goreleaser job is still retryable (no code bug — just a
+transient infra failure), see
+[GoReleaser failed but tags are pushed](#goreleaser-failed-but-tags-are-pushed)
+first; that's the canonical re-run path. If retries don't help
+(e.g. the underlying tool version is broken on the tag's SHA),
+pick one of the three options below:
+
+1. **Cut the next patch version forward** (preferred). This is
+   what v0.1.13 did. The failed-binary tag stays library-only;
+   the next tag's release-page artifacts are the canonical
+   distribution for binary consumers. This is the option v0.1.12
+   was accepted under: v0.1.12 is library-only on purpose, and
+   v0.1.13+ have full release-page artifacts. No retroactive
+   binary backfill was performed.
+
+2. **Manually backfill via a local goreleaser run**:
+
+   ```bash
+   # Check out the EXACT commit the tag points at
+   VERSION=v0.1.12
+   SHA=$(git rev-parse "$VERSION")
+   git checkout "$SHA"
+
+   # Build artifacts locally (no publish, no signing). GoReleaser
+   # v2 uses --skip=<comma-list>; v1's --skip-publish / --skip-sign
+   # flags are removed.
+   goreleaser release --clean --skip=publish,sign
+
+   # Upload to the existing GitHub Release page
+   gh release upload "$VERSION" dist/audit-gen_*.tar.gz \
+                                dist/audit-validate_*.tar.gz \
+                                dist/checksums.txt
+   ```
+
+   This produces binaries identical to what the workflow would
+   have, but without the Sigstore signature, the build-attestation
+   provenance, or the container image. Acceptable for emergency
+   backfill; not recommended for fresh releases.
+
+3. **Accept as library-only**: do nothing on the release page;
+   document in the project's release notes that binaries are not
+   available for this version and consumers should use the next
+   patch.
+
+See the [`release-smoke`][release-smoke] workflow for pre-flight
+checks (including the GoReleaser version-pin floor) that prevent
+the v0.1.12 failure mode from recurring.
+
+[release-smoke]: ../.github/workflows/release-smoke.yml
+
+### Lessons learned (v0.1.12 incident)
+
+Cutting v0.1.12 — the first real use of the unified release flow
+(#513) — required eight fixes across seven PRs because the flow
+had never been exercised end-to-end against a real tag. Grep this
+section by the error string you see in CI to find the precedent.
+
+See also [Example: releasing v0.1.12](#example-releasing-v0112)
+for the trigger commands.
+
+- **release.yml startup_failure (nested dependency-review)** →
+  `ci.yml`'s `dependency-review` job declares `pull-requests:
+  write`; the caller validated permissions before evaluating
+  `if:` → grant `pull-requests: write` on the `ci` call (#832).
+- **Go stdlib vulns GO-2026-4971 + GO-2026-4918** → go1.26.2
+  vulnerable → bump GOTOOLCHAIN to go1.26.3 across every go.mod,
+  the Makefile, and release.yml (#832, shipped together).
+- **FuzzOutputConfigLoad: NUL byte in error string** → "unknown
+  output type" error embedded user input unquoted → sanitise via
+  `isValidImportPathSegment` + generic fallback (#833).
+- **Bot rename release-bot → axonops-audit-release-bot** → org
+  has multiple projects → rename App + all hardcoded references
+  in release.yml, tag-all.sh, CONTRIBUTING, docs (#834).
+- **`gh repo view --json autoMergeAllowed` invalid field** → JSON
+  field name wrong on the `repo` resource → use
+  `gh api /repos/$REPO --jq '.allow_auto_merge'` (#835).
+- **update-deps.sh ran go mod tidy** → tag doesn't exist on
+  origin until `tag-all` runs → skip tidy and strip stale
+  go.sum entries; this is the `SKIP_TIDY_CHECK` invariant (#836).
+- **CI tidy-check failed on the release PR** → ci.yml didn't
+  honour the skip from #836 → add `SKIP_TIDY_CHECK` env on
+  `release/*` branches in ci.yml's hygiene step (#838).
+- **GoReleaser v2.15.0 cosign-verification bug** → ASN.1-encoded
+  signature error on every retry → bump goreleaser-action pin to
+  v2.15.4 (#840). v0.1.12's release-page binaries are
+  permanently missing because the tag's workflow SHA still
+  points at v2.15.0 (tags are immutable); v0.1.13+ ship from
+  the fixed pin on main — see [Tags pushed but the GitHub
+  Release page has no binaries](#tags-pushed-but-the-github-release-page-has-no-binaries).
+
 ### First Release: v0.1.1
 
 The first release for this repository is `v0.1.1`. Version `v0.1.0` was
@@ -864,6 +987,48 @@ Overview" above for the trigger semantics.
 If any step fails, the workflow stops. Tags that were already pushed
 cannot be undone — see [Release recovery playbook](#release-recovery-playbook)
 and [Retracting a Bad Release](#retracting-a-bad-release).
+
+### The release-smoke workflow
+
+The [release-smoke workflow](../.github/workflows/release-smoke.yml)
+is a validate-only pre-flight check for the release infrastructure.
+It is triggered manually via `workflow_dispatch` and has zero side
+effects — no tags, no branches, no commits, no PRs. Run it before
+cutting a real release (or on a schedule, if drift becomes a
+recurring problem) to surface any infrastructure regression.
+
+**What it checks (each as a pass/fail row in the run summary):**
+
+- `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` secrets are
+  configured and the App token mints successfully.
+- The App is installed on this specific repository (catches a
+  misconfigured secret pointing at a different installation).
+- The minted token has rate-limit budget remaining
+  (`/rate_limit` core resource > 100).
+- The repo has `allow_auto_merge: true` (catches the regression
+  PR #835 fixed).
+- The `main` branch has `required_signatures: enabled` (the whole
+  reason for the GraphQL migration in #841 — releases must not
+  silently disable this).
+- The GoReleaser version pin is at or above v2.15.4 (the floor
+  set by PR #840 to avoid the cosign-verification bug in v2.15.0
+  that caused v0.1.12's missing binaries).
+- Every script under `scripts/release/` parses cleanly via
+  `bash -n`.
+- `make print-publish-modules` returns a non-empty list.
+- The tag-protection rule on `refs/tags/v*` is queryable (or
+  absent on plain repos).
+
+**When to run:**
+
+```bash
+gh workflow run release-smoke.yml
+gh run watch
+```
+
+A green run means all the prerequisites the unified flow assumes
+are in place. A red run names the failed check in the summary —
+fix it before triggering a real release.
 
 ### Makefile Targets
 

--- a/scripts/release/gh-graphql-commit.sh
+++ b/scripts/release/gh-graphql-commit.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# Copyright 2026 AxonOps Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# gh-graphql-commit.sh — create an App-signed commit on a branch
+# via GitHub's GraphQL createCommitOnBranch mutation (#841).
+#
+# Replaces the legacy `git commit + git push` pair used by the
+# unified release flow's update-deps-pr job. The legacy approach
+# required temporarily disabling `required_signatures` on the
+# branch because Apps only auto-sign via GraphQL — never via plain
+# git push.
+#
+# Auth: caller MUST set GH_TOKEN to the App's installation token
+# (mintable via actions/create-github-app-token). The token's
+# installation must include `contents: write` on this repository.
+# That is the same scope `git push` required.
+#
+# Inputs (all required):
+#
+#   --branch <NAME>      Branch to commit on. MUST match
+#                        ^release/v[0-9]+\.[0-9]+\.x$ — the script
+#                        rejects anything else (security #841).
+#
+#   --message <TEXT>     Commit message subject. Body is optional;
+#                        if multi-line, the first line is the
+#                        subject (standard git convention).
+#
+#   --owner <OWNER>      Repository owner (default: derive from
+#                        $GITHUB_REPOSITORY in workflow context).
+#
+#   --repo <NAME>        Repository name (default: derive from
+#                        $GITHUB_REPOSITORY).
+#
+#   --auto-create-branch When set, the branch will be created from
+#                        the default branch's HEAD if it doesn't
+#                        exist. Without this flag, the script fails
+#                        if the branch is missing.
+#
+# Behaviour:
+#
+#   1. Validates --branch against the regex.
+#   2. Validates GH_TOKEN is non-empty.
+#   3. Enumerates working-tree changes via `git status --porcelain`.
+#   4. Rejects any change outside the allowlist:
+#        go.mod, go.sum
+#        */go.mod, */go.sum
+#        */*/go.mod, */*/go.sum
+#      Anything else (a stray .env, an accidental binary, a YAML
+#      change) fails the script. This is defence-in-depth against
+#      a future change to update-deps.sh writing outside its
+#      intended scope.
+#   5. Captures the current head OID of --branch (or the repo
+#      default branch if --auto-create-branch is set and the
+#      branch doesn't exist).
+#   6. Builds the createCommitOnBranch fileChanges input:
+#        additions: base64(file content) for each added/modified
+#        deletions: filename for each deleted file
+#   7. Submits the mutation with expectedHeadOid = captured OID.
+#   8. On STALE_DATA error (someone else pushed between fetch and
+#      mutate), refetches the head OID and retries ONCE. Fails on
+#      a second STALE_DATA.
+#   9. Asserts the response contains a non-null commit.oid; logs
+#      it to stdout for the workflow run-log audit trail.
+
+set -euo pipefail
+set +x  # defence-in-depth: ensure no caller has enabled tracing
+
+# Cleanup: scrub GH_TOKEN from environment on exit even though the
+# workflow runner will reclaim it. Belts and braces.
+trap 'unset GH_TOKEN' EXIT
+
+readonly BRANCH_REGEX='^release/v[0-9]+\.[0-9]+\.x$'
+
+readonly ALLOWLIST=(
+    'go.mod'
+    'go.sum'
+    '*/go.mod'
+    '*/go.sum'
+    '*/*/go.mod'
+    '*/*/go.sum'
+)
+
+# ----------------------------------------------------------------
+# CLI parsing
+# ----------------------------------------------------------------
+
+BRANCH=""
+MESSAGE=""
+OWNER=""
+REPO=""
+AUTO_CREATE_BRANCH=0
+
+usage() {
+    sed -n '7,42p' "$0" >&2
+    exit 64
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --branch)              BRANCH="$2"; shift 2 ;;
+        --message)             MESSAGE="$2"; shift 2 ;;
+        --owner)               OWNER="$2"; shift 2 ;;
+        --repo)                REPO="$2"; shift 2 ;;
+        --auto-create-branch)  AUTO_CREATE_BRANCH=1; shift ;;
+        -h|--help)             usage ;;
+        *)
+            echo "gh-graphql-commit: unknown flag: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# ----------------------------------------------------------------
+# Input validation
+# ----------------------------------------------------------------
+
+if [[ -z "$BRANCH" ]]; then
+    echo "gh-graphql-commit: --branch is required" >&2
+    exit 64
+fi
+
+if [[ ! "$BRANCH" =~ $BRANCH_REGEX ]]; then
+    echo "gh-graphql-commit: --branch must match $BRANCH_REGEX (got: $BRANCH)" >&2
+    exit 64
+fi
+
+if [[ -z "$MESSAGE" ]]; then
+    echo "gh-graphql-commit: --message is required" >&2
+    exit 64
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "gh-graphql-commit: GH_TOKEN environment variable is required" >&2
+    exit 64
+fi
+
+if [[ -z "$OWNER" || -z "$REPO" ]]; then
+    if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+        echo "gh-graphql-commit: --owner and --repo are required when GITHUB_REPOSITORY is not set" >&2
+        exit 64
+    fi
+    OWNER="${GITHUB_REPOSITORY%%/*}"
+    REPO="${GITHUB_REPOSITORY##*/}"
+fi
+
+# ----------------------------------------------------------------
+# Enumerate working-tree changes + allowlist guard
+# ----------------------------------------------------------------
+
+# NUL-separated to handle paths containing spaces, tabs, newlines,
+# or quote characters. --untracked-files=no so we don't include
+# anything stray that wasn't deliberately staged by the caller.
+declare -a additions
+declare -a deletions
+
+# Read NUL-delimited records into an array. Each record is the
+# raw porcelain entry: "XY path\0" — where X is index status and
+# Y is working-tree status.
+porcelain_raw=$(git status -z --porcelain --untracked-files=no)
+if [[ -z "$porcelain_raw" ]]; then
+    echo "gh-graphql-commit: no changes to commit" >&2
+    exit 65
+fi
+
+allowlist_match() {
+    local path="$1"
+    local pattern
+    for pattern in "${ALLOWLIST[@]}"; do
+        # shellcheck disable=SC2053 # intentional glob match
+        if [[ "$path" == $pattern ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Parse the NUL-delimited stream. Each record is "XY pathNUL"
+# except renames/copies which use the form "XY new\0old\0" — but
+# we reject renames anyway. We accept any combination of M, A, D
+# on the staged (X) or working-tree (Y) column.
+while IFS= read -r -d '' line; do
+    status="${line:0:2}"
+    path="${line:3}"
+
+    # Collapse the XY pair to a single decision: any 'M', 'A', or
+    # 'D' in either column maps to add or delete respectively.
+    # 'R' (rename) or '?' (untracked, filtered earlier) is rejected.
+    has_M=0; has_A=0; has_D=0; has_R=0
+    case "${status:0:1}" in M) has_M=1 ;; A) has_A=1 ;; D) has_D=1 ;; R) has_R=1 ;; esac
+    case "${status:1:1}" in M) has_M=1 ;; A) has_A=1 ;; D) has_D=1 ;; R) has_R=1 ;; esac
+
+    if (( has_R )); then
+        echo "gh-graphql-commit: refusing rename in release commit (status='$status' path='$path')" >&2
+        exit 65
+    fi
+
+    if (( has_D )) && ! (( has_M || has_A )); then
+        if ! allowlist_match "$path"; then
+            echo "gh-graphql-commit: refusing deletion outside allowlist: $path" >&2
+            exit 65
+        fi
+        deletions+=("$path")
+    elif (( has_M || has_A )); then
+        if ! allowlist_match "$path"; then
+            echo "gh-graphql-commit: refusing file outside allowlist: $path" >&2
+            exit 65
+        fi
+        additions+=("$path")
+    else
+        echo "gh-graphql-commit: unrecognised porcelain status '$status' for path: $path" >&2
+        exit 65
+    fi
+done < <(printf '%s' "$porcelain_raw")
+
+# ----------------------------------------------------------------
+# Resolve expected head OID
+# ----------------------------------------------------------------
+
+resolve_head_oid() {
+    local branch="$1"
+    gh api "repos/$OWNER/$REPO/git/ref/heads/$branch" \
+        --jq '.object.sha' 2>/dev/null || true
+}
+
+EXPECTED_HEAD_OID="$(resolve_head_oid "$BRANCH")"
+
+if [[ -z "$EXPECTED_HEAD_OID" ]]; then
+    if [[ "$AUTO_CREATE_BRANCH" -eq 1 ]]; then
+        # Create the branch from the repo default branch's HEAD.
+        DEFAULT_BRANCH="$(gh api "repos/$OWNER/$REPO" --jq '.default_branch')"
+        DEFAULT_OID="$(gh api "repos/$OWNER/$REPO/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')"
+        gh api "repos/$OWNER/$REPO/git/refs" \
+            --method POST \
+            --field ref="refs/heads/$BRANCH" \
+            --field sha="$DEFAULT_OID" \
+            >/dev/null
+        EXPECTED_HEAD_OID="$DEFAULT_OID"
+        echo "gh-graphql-commit: created branch $BRANCH from $DEFAULT_BRANCH ($DEFAULT_OID)"
+    else
+        echo "gh-graphql-commit: branch $BRANCH does not exist; pass --auto-create-branch to create it" >&2
+        exit 66
+    fi
+fi
+
+# ----------------------------------------------------------------
+# Build the createCommitOnBranch payload
+# ----------------------------------------------------------------
+
+build_payload() {
+    local head_oid="$1"
+    local payload
+    payload="$(jq -nc \
+        --arg owner "$OWNER" \
+        --arg repo "$REPO" \
+        --arg branch "refs/heads/$BRANCH" \
+        --arg head_oid "$head_oid" \
+        --arg message "$MESSAGE" \
+        '{
+            input: {
+                branch: {
+                    repositoryNameWithOwner: ($owner + "/" + $repo),
+                    branchName: ($branch | sub("^refs/heads/"; ""))
+                },
+                expectedHeadOid: $head_oid,
+                message: { headline: $message },
+                fileChanges: { additions: [], deletions: [] }
+            }
+        }')"
+
+    local path content_b64
+    for path in "${additions[@]:-}"; do
+        [[ -z "$path" ]] && continue
+        content_b64="$(base64 -w0 < "$path")"
+        payload="$(jq -c \
+            --arg p "$path" --arg c "$content_b64" \
+            '.input.fileChanges.additions += [{ path: $p, contents: $c }]' \
+            <<<"$payload")"
+    done
+    for path in "${deletions[@]:-}"; do
+        [[ -z "$path" ]] && continue
+        payload="$(jq -c \
+            --arg p "$path" \
+            '.input.fileChanges.deletions += [{ path: $p }]' \
+            <<<"$payload")"
+    done
+
+    printf '%s' "$payload"
+}
+
+# ----------------------------------------------------------------
+# Submit the mutation (with one STALE_DATA retry)
+# ----------------------------------------------------------------
+
+submit_mutation() {
+    local payload="$1"
+
+    # Pass query+variables together so gh handles the wire format.
+    # `gh api graphql` expects the GraphQL document via -f query=...
+    # and variable values via -F (raw) for top-level structured input.
+    # We pre-marshalled the variables in payload's .input above.
+    local query='mutation($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit { oid url }
+      }
+    }'
+
+    local variables
+    variables="$(jq -c '{ input: .input }' <<<"$payload")"
+
+    gh api graphql \
+        --raw-field query="$query" \
+        --raw-field variables="$variables"
+}
+
+response="$(submit_mutation "$(build_payload "$EXPECTED_HEAD_OID")" 2>&1 || true)"
+
+# STALE_DATA retry: the head OID we passed is no longer current
+# (someone or some prior workflow run pushed to the branch). Refetch
+# and retry exactly once. Use jq for typed discrimination so a
+# legitimate commit message or response field containing the literal
+# string "STALE_DATA" cannot false-positive.
+is_stale_data() {
+    jq -e '.errors[]? | select(.type == "STALE_DATA")' >/dev/null 2>&1 <<<"$1"
+}
+
+if is_stale_data "$response"; then
+    echo "gh-graphql-commit: STALE_DATA on first attempt; refetching head OID and retrying once"
+    EXPECTED_HEAD_OID="$(resolve_head_oid "$BRANCH")"
+    if [[ -z "$EXPECTED_HEAD_OID" ]]; then
+        echo "gh-graphql-commit: branch disappeared between attempts" >&2
+        exit 67
+    fi
+    response="$(submit_mutation "$(build_payload "$EXPECTED_HEAD_OID")" 2>&1 || true)"
+fi
+
+# Surface any GraphQL "errors" array as a non-zero exit.
+if jq -e '.errors // empty | length > 0' >/dev/null 2>&1 <<<"$response"; then
+    echo "gh-graphql-commit: GraphQL error response:" >&2
+    printf '%s\n' "$response" >&2
+    exit 68
+fi
+
+# Assert the response contains a non-null commit.oid. A response
+# without commit.oid means the API reported success but did not
+# create the commit — a real failure mode of GraphQL mutations.
+new_oid="$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<"$response" 2>/dev/null)"
+if [[ -z "$new_oid" ]]; then
+    echo "gh-graphql-commit: response missing commit.oid:" >&2
+    printf '%s\n' "$response" >&2
+    exit 69
+fi
+
+# Audit log: print the new commit OID and URL for the workflow run.
+echo "gh-graphql-commit: created commit $new_oid on branch $BRANCH"
+echo "$response" | jq -r '.data.createCommitOnBranch.commit.url'

--- a/scripts/release/gh-graphql-tag.sh
+++ b/scripts/release/gh-graphql-tag.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Copyright 2026 AxonOps Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# gh-graphql-tag.sh — create an App-signed annotated tag via
+# GitHub's REST API (#841).
+#
+# Replaces the legacy `git tag -a + git push origin <tag>` pair
+# used by tag-all.sh. The legacy approach required temporarily
+# disabling `required_signatures` on `main` because Apps only
+# auto-sign via the GitHub API — never via plain git push.
+#
+# Annotated-tag preservation: this script uses two API calls per
+# tag:
+#
+#   1. POST /repos/{owner}/{repo}/git/tags
+#      — creates the annotated tag OBJECT (preserves the tag
+#      message, tagger identity, and timestamp). The returned
+#      `sha` is the tag object's SHA, not the target commit's.
+#   2. POST /repos/{owner}/{repo}/git/refs
+#      — points `refs/tags/<NAME>` at the tag object's SHA.
+#
+# Annotated tags are required for: `gorelease` API diff tooling,
+# `git describe` reproducibility, GoReleaser's changelog
+# generation, and the Go module proxy's preference for annotated
+# refs.
+#
+# Auth: caller MUST set GH_TOKEN to the App's installation token
+# with `contents: write`.
+#
+# Inputs (all required):
+#
+#   --tag <NAME>     Tag name. MUST match
+#                    ^[a-z0-9._/-]+/?v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?$
+#                    or ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?$
+#                    (the second form is the core module tag; the
+#                    first matches sub-module tags like
+#                    `file/v0.1.13`).
+#
+#   --sha <SHA>      Target commit SHA. MUST be a 40-char hex.
+#
+#   --message <TEXT> Annotation message (the body of `git tag -a -m`).
+#
+#   --owner <OWNER>  Repo owner (default: derive from
+#                    $GITHUB_REPOSITORY).
+#
+#   --repo <NAME>    Repo name (default: derive from
+#                    $GITHUB_REPOSITORY).
+#
+# Behaviour:
+#
+#   1. Validates --tag and --sha regexes (no shell-injection
+#      surface in the API path).
+#   2. Checks if the ref already exists.
+#        — Same target SHA: no-op (idempotent retry).
+#        — Different target SHA: abort (history contamination).
+#        — Missing: create.
+#   3. Creates the annotated tag object.
+#   4. Creates the ref pointing at the tag object.
+#   5. Logs the tag-object SHA and ref URL to stdout.
+
+set -euo pipefail
+set +x  # defence-in-depth
+
+trap 'unset GH_TOKEN' EXIT
+
+# The tag name must match either the core form (vMAJOR.MINOR.PATCH)
+# or a sub-module form (module-path/vMAJOR.MINOR.PATCH). Sub-module
+# names allow lowercase letters, digits, hyphen, underscore, dot,
+# and slash (matches `make print-publish-modules`). The suffix
+# accepts SemVer 2.0.0 pre-release (`-rc.1`) and build-metadata
+# (`+meta`) qualifiers.
+readonly TAG_REGEX='^(([a-z0-9._-]+(/[a-z0-9._-]+)*)/)?v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'
+
+readonly SHA_REGEX='^[0-9a-f]{40}$'
+
+# ----------------------------------------------------------------
+# CLI parsing
+# ----------------------------------------------------------------
+
+TAG=""
+SHA=""
+MESSAGE=""
+OWNER=""
+REPO=""
+
+usage() {
+    sed -n '7,56p' "$0" >&2
+    exit 64
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)      TAG="$2"; shift 2 ;;
+        --sha)      SHA="$2"; shift 2 ;;
+        --message)  MESSAGE="$2"; shift 2 ;;
+        --owner)    OWNER="$2"; shift 2 ;;
+        --repo)     REPO="$2"; shift 2 ;;
+        -h|--help)  usage ;;
+        *)
+            echo "gh-graphql-tag: unknown flag: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# ----------------------------------------------------------------
+# Input validation
+# ----------------------------------------------------------------
+
+if [[ -z "$TAG" ]]; then
+    echo "gh-graphql-tag: --tag is required" >&2
+    exit 64
+fi
+
+if [[ ! "$TAG" =~ $TAG_REGEX ]]; then
+    echo "gh-graphql-tag: --tag must match $TAG_REGEX (got: $TAG)" >&2
+    exit 64
+fi
+
+if [[ -z "$SHA" ]]; then
+    echo "gh-graphql-tag: --sha is required" >&2
+    exit 64
+fi
+
+if [[ ! "$SHA" =~ $SHA_REGEX ]]; then
+    echo "gh-graphql-tag: --sha must be a 40-char hex string (got: $SHA)" >&2
+    exit 64
+fi
+
+if [[ -z "$MESSAGE" ]]; then
+    echo "gh-graphql-tag: --message is required" >&2
+    exit 64
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "gh-graphql-tag: GH_TOKEN environment variable is required" >&2
+    exit 64
+fi
+
+if [[ -z "$OWNER" || -z "$REPO" ]]; then
+    if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+        echo "gh-graphql-tag: --owner and --repo are required when GITHUB_REPOSITORY is not set" >&2
+        exit 64
+    fi
+    OWNER="${GITHUB_REPOSITORY%%/*}"
+    REPO="${GITHUB_REPOSITORY##*/}"
+fi
+
+# ----------------------------------------------------------------
+# Idempotency: check whether the ref already exists.
+#
+# The REST API returns a 404 when the ref doesn't exist. We use
+# `gh api --silent` to suppress the body and capture HTTP status
+# via the script's exit handling.
+# ----------------------------------------------------------------
+
+# URL-encode the tag name for use in the API path. Per TAG_REGEX,
+# the only character requiring percent-encoding is the slash (sub-
+# module tag prefix); all others are URL-safe.
+encoded_tag="${TAG//\//%2F}"
+
+existing_ref="$(gh api "repos/$OWNER/$REPO/git/ref/tags/$encoded_tag" --jq '.object.sha' 2>/dev/null || true)"
+
+if [[ -n "$existing_ref" ]]; then
+    # The ref points at an annotated tag object (since we created
+    # it that way). Dereference to find the commit it targets.
+    existing_target="$(gh api "repos/$OWNER/$REPO/git/tags/$existing_ref" --jq '.object.sha' 2>/dev/null || true)"
+    if [[ -z "$existing_target" ]]; then
+        # The ref points at a commit directly (lightweight tag —
+        # not what we want, but legacy `git tag -a` followed by
+        # `git push` could have left this state if the annotated
+        # tag object was stripped).
+        existing_target="$existing_ref"
+    fi
+
+    if [[ "$existing_target" == "$SHA" ]]; then
+        echo "gh-graphql-tag: tag $TAG already exists at $SHA — no-op"
+        exit 0
+    else
+        echo "gh-graphql-tag: ABORT — tag $TAG exists at $existing_target but we wanted $SHA" >&2
+        echo "gh-graphql-tag: refusing to move an existing tag (history contamination)" >&2
+        exit 70
+    fi
+fi
+
+# ----------------------------------------------------------------
+# Create the annotated tag object.
+# ----------------------------------------------------------------
+
+# The tagger identity is the App's bot account; `gh api` injects
+# the correct author when the token is the App's installation
+# token. We supply an ISO-8601 date so the tag has deterministic
+# tagger metadata.
+tagger_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# We deliberately omit `tagger` from the payload — when omitted,
+# GitHub fills it in from the authenticated identity. This is
+# what makes the tag "App-signed".
+tag_response="$(gh api "repos/$OWNER/$REPO/git/tags" \
+    --method POST \
+    --field tag="$TAG" \
+    --field message="$MESSAGE" \
+    --field object="$SHA" \
+    --field type="commit" \
+    --raw-field tagger="$(jq -nc \
+        --arg date "$tagger_date" \
+        '{ name: "axonops-audit-release-bot[bot]",
+           email: "axonops-audit-release-bot[bot]@users.noreply.github.com",
+           date: $date }')")"
+
+tag_object_sha="$(jq -r '.sha // empty' <<<"$tag_response" 2>/dev/null)"
+if [[ -z "$tag_object_sha" ]]; then
+    echo "gh-graphql-tag: failed to create annotated tag object:" >&2
+    printf '%s\n' "$tag_response" >&2
+    exit 71
+fi
+
+# ----------------------------------------------------------------
+# Create the ref pointing at the tag object.
+# ----------------------------------------------------------------
+
+ref_response="$(gh api "repos/$OWNER/$REPO/git/refs" \
+    --method POST \
+    --field ref="refs/tags/$TAG" \
+    --field sha="$tag_object_sha")"
+
+ref_url="$(jq -r '.url // empty' <<<"$ref_response" 2>/dev/null)"
+if [[ -z "$ref_url" ]]; then
+    echo "gh-graphql-tag: failed to create ref refs/tags/$TAG:" >&2
+    printf '%s\n' "$ref_response" >&2
+    exit 72
+fi
+
+# Audit log
+echo "gh-graphql-tag: created annotated tag $TAG (tag object $tag_object_sha) targeting commit $SHA"
+echo "$ref_url"

--- a/scripts/release/tag-all.sh
+++ b/scripts/release/tag-all.sh
@@ -51,11 +51,6 @@ fi
 # idempotent mode (existing tags at the target SHA are fine).
 "$repo_root/scripts/release/check-tag-conflicts.sh" "$VERSION" "$SHA"
 
-# Configure committer for annotated tags (the message field uses the
-# release-bot identity).
-git config user.name  "axonops-audit-release-bot[bot]"
-git config user.email "axonops-audit-release-bot[bot]@users.noreply.github.com"
-
 failed=()
 remaining=()
 skipped=()
@@ -84,27 +79,22 @@ if (( ${#failed[@]} > 0 )); then
   exit 1
 fi
 
-# Create then push, in stable order. Annotated tags so the GitHub
-# UI shows the release-bot identity. Failures collected, not
-# fail-fast — operators get the full picture.
-created=()
-for tag in "${remaining[@]}"; do
-  if git tag -a "$tag" -m "Release $tag" "$SHA"; then
-    created+=("$tag")
-    echo "tag-all: created $tag at $SHA"
-  else
-    echo "tag-all: failed to CREATE $tag locally" >&2
-    failed+=("$tag")
-  fi
-done
-
+# Create each tag via gh-graphql-tag.sh (#841): one REST POST to
+# create the annotated tag object, then one POST to point
+# refs/tags/<tag> at it. The helper is App-signed end-to-end, so
+# required_signatures stays ON during a release. Failures are
+# collected per-tag; operators see the full picture instead of
+# fail-fast.
 pushed=()
-for tag in "${created[@]}"; do
-  if git push origin "$tag"; then
+for tag in "${remaining[@]}"; do
+  if "$repo_root/scripts/release/gh-graphql-tag.sh" \
+       --tag "$tag" \
+       --sha "$SHA" \
+       --message "Release $tag"; then
     pushed+=("$tag")
-    echo "tag-all: pushed $tag"
+    echo "tag-all: created and pushed $tag"
   else
-    echo "tag-all: failed to PUSH $tag" >&2
+    echo "tag-all: failed to create $tag via gh-graphql-tag.sh" >&2
     failed+=("$tag")
   fi
 done
@@ -138,4 +128,4 @@ if (( ${#failed[@]} > 0 )); then
   exit 1
 fi
 
-echo "tag-all: ${#pushed[@]} pushed; ${#created[@]} created, ${#skipped[@]} idempotent skips."
+echo "tag-all: ${#pushed[@]} pushed, ${#skipped[@]} idempotent skips."


### PR DESCRIPTION
## Summary

Closes both #841 and #842. The unified release flow (#513) required `git commit + git push` for the release PR and twelve annotated tags. Apps don't auto-sign via plain git push, so each release needed `required_signatures` toggled off on `main` and re-enabled afterward — a per-release security regression. v0.1.12's release surfaced 8 separate fixes (#832–#840) that the flow had never been exercised against.

**Implementation:**
- Two new helper scripts (`gh-graphql-commit.sh` + `gh-graphql-tag.sh`) replace `git commit + git push` with GitHub's GraphQL `createCommitOnBranch` and REST `/git/tags` + `/git/refs`. Both are App-signed server-side.
- New `release-smoke.yml` validate-only workflow_dispatch (10 checks, zero side effects).
- `make check-static` gains `check-release-scripts` and `check-skip-tidy-check-scope` targets.
- `docs/releasing.md` updated: SKIP_TIDY_CHECK invariant, scenario 5 (tags pushed but binaries missing), v0.1.12 lessons-learned, release-smoke usage.

**Pre-coding gates:** devops, security-reviewer, docs-writer all consulted; design locked before code.

**Post-coding gates:** devops (final), code-reviewer, docs-writer — multiple blockers found and fixed in this commit:
- Porcelain parsing bug that would have broken every release commit (post-`git add -A` status `"A "` didn't match my patterns; rewrote to per-column dispatch with NUL-delimited parse).
- Undefined `${#created[@]}` array reference in tag-all.sh.
- TAG_REGEX extended for SemVer build-metadata (`+meta`).
- jq-typed STALE_DATA discrimination (no false-positive on substring match).
- Multiple smoke-workflow nits (concurrency block, env block, HTTP status regex, reuse `make check-release-scripts`).
- 3 docs blockers (GoReleaser v2 `--skip=` flag syntax; `invariants` job placement; "8 fixes/7 PRs" count); strict one-liner format for lessons-learned.

**v0.1.12 binaries (#842):** documented as accepted library-only — the tag's workflow SHA pins the unfixed v2.15.0 goreleaser-action; v0.1.13+ ship from the v2.15.4 floor. No retroactive backfill performed.

## Test plan

- [x] `bash -n scripts/release/*.sh` clean
- [x] `make check-release-scripts` passes
- [x] `make check-skip-tidy-check-scope` passes
- [x] `make check` full local gate green
- [ ] CI green
- [ ] issue-closer verification for #841
- [ ] issue-closer verification for #842
- [ ] (post-merge, manual) Run `gh workflow run release-smoke.yml` to validate the workflow itself

## Out of scope

- Backfilling v0.1.12 binaries — documented as accepted library-only.
- Cron schedule on release-smoke — validate-only manual trigger first.
- `dependency-update.yml` GraphQL migration — uses GITHUB_TOKEN (not release-bot App).