### PR TITLE
chore(deps): adopt axonops/syncmap fork in filterState (#158)

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -9,7 +9,7 @@ grateful to their authors and contributors.
 |---------|---------|-----------|----------|
 | [github.com/goccy/go-yaml](https://github.com/goccy/go-yaml) | MIT | Masaaki Goshima | YAML parsing for taxonomy and output configuration |
 | [github.com/axonops/srslog](https://github.com/axonops/srslog) | BSD-3-Clause | 2015 Rackspace | RFC 5424 syslog client (fork of [gravwell/srslog](https://github.com/gravwell/srslog)) |
-| [github.com/rgooding/go-syncmap](https://github.com/rgooding/go-syncmap) | Apache-2.0 | Richard Gooding | Generic `sync.Map` for lock-free category lookups |
+| [github.com/axonops/syncmap](https://github.com/axonops/syncmap) | Apache-2.0 | 2023 Richard Gooding; 2026 AxonOps Limited | Generic `sync.Map` for lock-free category lookups (fork of [rgooding/go-syncmap](https://github.com/rgooding/go-syncmap)) |
 
 ## Test Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Core now depends on `github.com/axonops/syncmap v1.0.0` for the
+  `filterState` lock-free category/event-type lookups, replacing the
+  15-line inlined `syncMapBool` wrapper added in #588. The fork is
+  AxonOps-controlled (Apache 2.0, signed releases, CI / CodeQL /
+  Dependabot / SECURITY.md) so the supply-chain acceptance criteria
+  tracked by #158 are self-imposed rather than requested upstream.
+  Hot-path benchmark `BenchmarkFilterCheck` is unchanged within
+  noise (16.74 ns → 16.72 ns, p=0.841). Upstream attribution is
+  preserved in the fork's NOTICE.
+
 ## [0.1.13] - 2026-05-12
 
 Mostly release-engineering and example-hygiene. No library API changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -485,9 +485,17 @@ skip on docs-only PRs.
 ## Dependencies
 
 Dependencies are kept minimal. The core library depends on
-`github.com/goccy/go-yaml` (taxonomy parsing) and `go-syncmap` (lock-free
-category lookups). Output modules carry their own dependencies
-(e.g., `github.com/axonops/srslog` for syslog).
+`github.com/goccy/go-yaml` (taxonomy parsing) and
+`github.com/axonops/syncmap` (generic, type-safe wrapper around
+`sync.Map` for the lock-free filter-state hot path). Output
+modules carry their own dependencies — `github.com/axonops/srslog`
+for syslog, etc.
+
+Both runtime dependencies are AxonOps-controlled forks of
+their upstream projects, which lets us self-impose the supply-chain
+acceptance criteria (CI, CodeQL, Dependabot, SECURITY.md, signed
+releases, CLA) that #158 originally tracked as upstream feature
+requests. Upstream attribution lives in the forks' `NOTICE` files.
 
 Before adding a new dependency, file an issue to discuss it. Forbidden
 in core: Prometheus, OpenTelemetry, any logging framework, any config

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ license details.
 
 - [github.com/goccy/go-yaml](https://github.com/goccy/go-yaml) — YAML parsing (MIT)
 - [github.com/axonops/srslog](https://github.com/axonops/srslog) — RFC 5424 syslog (BSD-3-Clause)
-- [github.com/rgooding/go-syncmap](https://github.com/rgooding/go-syncmap) — Generic sync.Map (Apache-2.0)
+- [github.com/axonops/syncmap](https://github.com/axonops/syncmap) — Generic sync.Map (Apache-2.0), fork of [rgooding/go-syncmap](https://github.com/rgooding/go-syncmap)
 
 ---
 

--- a/filter.go
+++ b/filter.go
@@ -18,8 +18,9 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"sync/atomic"
+
+	"github.com/axonops/syncmap"
 )
 
 // SeverityRange is an inclusive [Min, Max] severity bound on the CEF
@@ -341,46 +342,23 @@ func inSet(set map[string]struct{}, fallback []string, key string) bool {
 	return slices.Contains(fallback, key)
 }
 
-// syncMapBool is a minimal generic wrapper over [sync.Map] with
-// string keys and bool values — the exact shape filterState
-// needs. Inlined here (~15 lines) rather than depending on a
-// third-party wrapper: CLAUDE.md mandates minimal dependencies,
-// and a single-purpose hot-path type shouldn't carry supply-chain
-// risk. Ref: #588.
-type syncMapBool struct {
-	m sync.Map
-}
-
-// Load returns the value stored in the map for key, and true if
-// present. Not-present returns false, false — the "val zero,
-// ok=false" shape used everywhere in sync.Map wrappers.
-func (s *syncMapBool) Load(key string) (val, ok bool) {
-	v, ok := s.m.Load(key)
-	if !ok {
-		return false, false
-	}
-	b, _ := v.(bool)
-	return b, true
-}
-
-// Store sets the value for a key.
-func (s *syncMapBool) Store(key string, value bool) {
-	s.m.Store(key, value)
-}
-
 // filterState tracks which categories and individual event types are
 // enabled. It is safe for concurrent use — reads are lock-free via
-// syncMapBool (backed by sync.Map internally).
+// [syncmap.SyncMap] (backed by [sync.Map] internally). The
+// AxonOps-controlled fork of [github.com/rgooding/go-syncmap] is
+// used so the dependency's supply chain (CI, CodeQL, SECURITY.md,
+// signed releases) is under the same engineering controls as audit
+// itself (#158).
 type filterState struct {
 	// enabledCategories tracks the enabled state of each category.
 	// Reads are lock-free for stable keys after initial population.
-	enabledCategories syncMapBool
+	enabledCategories syncmap.SyncMap[string, bool]
 
 	// eventOverrides tracks per-event-type overrides. A true value
 	// forces the event to be enabled regardless of its category; a
 	// false value forces it disabled. Events not in this map inherit
 	// their category's state.
-	eventOverrides syncMapBool
+	eventOverrides syncmap.SyncMap[string, bool]
 
 	// hasEventOverrides is set when EnableEvent or DisableEvent is
 	// called. Guards the eventOverrides.Load on the hot path —

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/axonops/audit/secrets/openbao v0.1.11
 	github.com/axonops/audit/syslog v0.1.11
 	github.com/axonops/audit/webhook v0.1.11
+	github.com/axonops/syncmap v1.0.0
 	github.com/cucumber/godog v0.15.1
 	github.com/goccy/go-yaml v1.19.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/axonops/audit/webhook v0.1.11 h1:ybsP4yuIQIUZPjqoare5m49cHWTEzl5Uc456
 github.com/axonops/audit/webhook v0.1.11/go.mod h1:5/exBCN81VkoFO8bqOUV31I2qTyBR1pO73gY1hBDW2w=
 github.com/axonops/srslog v1.0.1 h1:TucvspQNxwL18w3xo9r3p+ulxJ5ltR8S9DalDTYDfA4=
 github.com/axonops/srslog v1.0.1/go.mod h1:KmR9aaV5bdRj/WE95Nzfwwed8MKdDpjFCcFO5syaJWg=
+github.com/axonops/syncmap v1.0.0 h1:LioA4tccTuYsMG+i4XeJJ9tXsoxrbdiLCxUrUmQuN5o=
+github.com/axonops/syncmap v1.0.0/go.mod h1:UzPuU30i9SaKB5xYEbkYuuuXcy1yrasWfv+1oZnuVCs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cucumber/gherkin/go/v26 v26.2.0 h1:EgIjePLWiPeslwIWmNQ3XHcypPsWAHoMCz/YEBKP4GI=
 github.com/cucumber/gherkin/go/v26 v26.2.0/go.mod h1:t2GAPnB8maCT4lkHL99BDCVNzCh1d7dBhCLt150Nr/0=


### PR DESCRIPTION
## Summary

- Core now depends on `github.com/axonops/syncmap v1.0.0`, replacing the 15-line inlined `syncMapBool` wrapper added in #588.
- The fork is an AxonOps-controlled rebuild of `rgooding/go-syncmap` (Apache 2.0, zero runtime deps). The supply-chain acceptance criteria originally tracked by #158 (CI, CodeQL, Dependabot, SECURITY.md, signed releases, CLA) are now self-imposed at the fork repo rather than requested upstream. Upstream attribution preserved in the fork's NOTICE.
- The fork's `Load(K) → (V, bool)` and `Store(K, V)` API matches the inlined wrapper exactly — every call site in `filter.go` is unchanged.

## Hot-path benchmarks (benchstat against main)

```
BenchmarkFilterCheck-32                  16.74n  →  16.72n     ~ (p=0.841)
BenchmarkFilterCheck_Parallel-32          1.041n →   1.058n    ~ (p=0.056)
BenchmarkFilterCheck_ReadWriteContention  1.037n →   1.047n    ~ (p=0.381)
BenchmarkAudit-32                       420.1n   → 414.8n      ~ (p=0.421)
BenchmarkAudit_Parallel-32               80.43n  →  81.99n     ~ (p=0.310)
```

Zero allocation regressions on every hot-path benchmark.

## Test plan

- [x] `make check` green
- [x] benchstat vs main: hot path flat (table above)
- [x] Pre-coding consults: code-reviewer, security-reviewer, performance-reviewer — all approved
- [x] Post-coding gates: code-reviewer (3 IMPORTANT applied), security-reviewer (0 CRITICAL/HIGH/MEDIUM), performance-reviewer (SHIP), go-quality (READY)
- [ ] CI green
- [ ] issue-closer REPORT-ONLY for #158

## Files changed (7)

- `filter.go` — drop `syncMapBool` type+methods; switch fields to `syncmap.SyncMap[string, bool]`.
- `go.mod` / `go.sum` — add `github.com/axonops/syncmap v1.0.0`.
- `CONTRIBUTING.md`, `README.md`, `ACKNOWLEDGEMENTS.md` — name the fork, preserve upstream attribution.
- `CHANGELOG.md` — Unreleased entry.

Closes #158.