### PR TITLE
feat(webhook): derive Content-Type from formatter, add BDD (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Breaking
+
+- The [`audit.Formatter`](https://pkg.go.dev/github.com/axonops/audit#Formatter)
+  interface gains a `ContentType() string` method. Built-in
+  formatters implement it (`JSONFormatter` → `application/x-ndjson`,
+  `CEFFormatter` → `text/plain`). Third-party `Formatter`
+  implementations must add a one-line method returning the MIME
+  type of the bytes they emit. The library is pre-release; no
+  back-compat shim. (#463)
+
+### Added
+
+- New optional output interface
+  [`audit.ContentTypeSetter`](https://pkg.go.dev/github.com/axonops/audit#ContentTypeSetter).
+  The auditor invokes `SetContentType` on every output that
+  implements it at construction time, passing the result of the
+  output's effective formatter's `ContentType()`. HTTP outputs
+  (webhook) use this to set the request Content-Type header
+  correctly per formatter — previously hardcoded to
+  `application/x-ndjson` even when the formatter was CEF. Loki
+  does not implement this interface because its Content-Type is
+  fixed at `application/json` for the Loki push API. (#463)
+- 7 new BDD scenarios in `tests/bdd/features/webhook_batching.feature`
+  validating the wire-level batched payload structure for both
+  JSON and CEF formatters: NDJSON line count + parseability,
+  per-event marker order, trailing-newline invariant, single- and
+  multi-event CEF bodies with `CEF:0|` prefix, Content-Type
+  assertions for JSON and CEF (including a negative assertion
+  for the CEF→NDJSON Content-Type bug that this change fixes).
+  (#463)
+
+### Fixed
+
+- Webhook output: when a `CEFFormatter` was configured, the
+  request `Content-Type` header still claimed
+  `application/x-ndjson`, lying to the receiver. The header now
+  reflects the formatter's declared type (`text/plain` for CEF).
+  Operators who need a different MIME type can still override via
+  the output's `headers` configuration. (#463)
+
 ### Changed
 
 - Core now depends on `github.com/axonops/syncmap v1.0.0` for the

--- a/audit.go
+++ b/audit.go
@@ -267,6 +267,7 @@ func (a *Auditor) applyConstructionDefaults() {
 		a.timezone = time.Now().Location().String()
 	}
 	a.propagateFrameworkFields()
+	a.propagateContentTypes()
 }
 
 // Logger returns the diagnostic logger configured via

--- a/audit_dedup_test.go
+++ b/audit_dedup_test.go
@@ -115,6 +115,8 @@ func (f *cacheTestFmt) Format(_ time.Time, _ string, _ audit.Fields, _ *audit.Ev
 	return []byte("data"), nil
 }
 
+func (f *cacheTestFmt) ContentType() string { return "application/x-ndjson" }
+
 func TestFormatCache_PutGet(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/audit_exclusion_test.go
+++ b/audit_exclusion_test.go
@@ -43,6 +43,8 @@ func (e *exclusionErrorFormatter) Format(_ time.Time, _ string, _ audit.Fields, 
 	return []byte(`{"ok":true}` + "\n"), nil
 }
 
+func (e *exclusionErrorFormatter) ContentType() string { return "application/x-ndjson" }
+
 // TestFormatWithExclusion_ErrorPath verifies that when Format returns an error
 // through the formatWithExclusion path (sensitivity label stripping), the
 // event is dropped and the serialization error is recorded in metrics.

--- a/docs/webhook-output.md
+++ b/docs/webhook-output.md
@@ -187,7 +187,25 @@ Each HTTP request body contains one JSON object per line:
 {"timestamp":"...","event_type":"user_create","severity":5,...}\n
 ```
 
-The Content-Type header is `application/x-ndjson`.
+The Content-Type header is `application/x-ndjson` for the default
+[`JSONFormatter`](https://pkg.go.dev/github.com/axonops/audit#JSONFormatter).
+When a different formatter is configured on the output, the
+Content-Type follows that formatter's declared type. The library
+discovers this via [`Formatter.ContentType()`](https://pkg.go.dev/github.com/axonops/audit#Formatter)
+and propagates it to the webhook at auditor construction.
+
+| Formatter | `Content-Type` |
+|-----------|----------------|
+| [`JSONFormatter`](https://pkg.go.dev/github.com/axonops/audit#JSONFormatter) | `application/x-ndjson` |
+| [`CEFFormatter`](https://pkg.go.dev/github.com/axonops/audit#CEFFormatter) | `text/plain` |
+| Custom `Formatter` | Whatever the implementation returns from `ContentType()` |
+
+The CEF wire format is one CEF record per line, newline-separated,
+matching the convention accepted by ArcSight SmartConnector and
+Splunk HEC raw endpoints. Operators sending CEF to a receiver that
+demands a different MIME type can override Content-Type via the
+output's `headers` configuration — operator-supplied headers take
+precedence over the formatter's default.
 
 NDJSON is:
 - **Streamable** — receivers can process lines as they arrive
@@ -328,7 +346,7 @@ Each POST request contains:
 
 | Header | Value |
 |--------|-------|
-| `Content-Type` | `application/x-ndjson` |
+| `Content-Type` | Formatter-driven (`application/x-ndjson` for JSON, `text/plain` for CEF — see [Wire Format](#wire-format)) |
 | Custom headers | From `headers:` config |
 
 Body: one JSON object per line (NDJSON), terminated with `\n`.

--- a/drain.go
+++ b/drain.go
@@ -330,6 +330,34 @@ func (a *Auditor) propagateFrameworkFields() {
 	}
 }
 
+// propagateContentTypes informs each output that implements
+// [ContentTypeSetter] of the MIME type of the bytes its effective
+// formatter emits. Called once at auditor construction, after
+// [propagateFrameworkFields], before any event is dispatched.
+//
+// HTTP-based outputs (notably [webhook.Output]) use the value to
+// populate the request Content-Type header so receivers can
+// correctly parse CEF text vs. JSON streams. Outputs that don't
+// care (file, stdout, syslog, Loki) simply omit the interface and
+// are skipped.
+//
+// The webhook's batchLoop may already be running when this
+// propagation fires; implementations MUST use atomic/synchronised
+// storage for the field per the contract on [ContentTypeSetter].
+func (a *Auditor) propagateContentTypes() {
+	for _, oe := range a.entries {
+		setter, ok := oe.output.(ContentTypeSetter)
+		if !ok {
+			continue
+		}
+		f := oe.effectiveFormatter(a.formatter)
+		if f == nil {
+			continue
+		}
+		setter.SetContentType(f.ContentType())
+	}
+}
+
 // formatWithExclusion serialises an event with sensitivity-labelled
 // fields excluded. It bypasses the format cache because different
 // outputs may exclude different label sets.

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -557,6 +557,8 @@ func (p *panicFormatter) Format(_ time.Time, _ string, _ audit.Fields, _ *audit.
 	panic("formatter panic")
 }
 
+func (p *panicFormatter) ContentType() string { return "application/x-ndjson" }
+
 func TestFanout_PanicInOutputWrite_OtherOutputsStillReceive(t *testing.T) {
 	panicOut := &panicOnWriteOutput{MockOutput: *testhelper.NewMockOutput("panicker")}
 	survivor := testhelper.NewMockOutput("survivor")
@@ -666,6 +668,8 @@ type errorFormatter struct{}
 func (e *errorFormatter) Format(_ time.Time, _ string, _ audit.Fields, _ *audit.EventDef, _ *audit.FormatOptions) ([]byte, error) {
 	return nil, fmt.Errorf("format failed")
 }
+
+func (e *errorFormatter) ContentType() string { return "application/x-ndjson" }
 
 func TestFanout_ErrorFormatter_DoesNotBlockDefaultFormatter(t *testing.T) {
 	goodOut := testhelper.NewMockOutput("good")

--- a/format.go
+++ b/format.go
@@ -150,6 +150,26 @@ type Formatter interface {
 	// A non-nil error causes the event to be dropped and
 	// [Metrics.RecordSerializationError] to be called.
 	Format(ts time.Time, eventType string, fields Fields, def *EventDef, opts *FormatOptions) ([]byte, error)
+
+	// ContentType returns the MIME type of the bytes emitted by
+	// [Formatter.Format]. HTTP-based outputs use this value as the
+	// request Content-Type header. Implementations MUST return a
+	// stable, non-empty value (the library reads it once at
+	// construction time and propagates it to outputs via
+	// [ContentTypeSetter.SetContentType]).
+	//
+	// Examples: the built-in [JSONFormatter] returns
+	// "application/x-ndjson"; [CEFFormatter] returns "text/plain"
+	// (CEF has no IANA-registered media type — text/plain is the
+	// convention accepted by ArcSight SmartConnector and Splunk
+	// HEC).
+	//
+	// The value MUST satisfy the RFC 9110 §5.5 field-value grammar
+	// — no CRLF, no NUL, no non-printable control characters.
+	// [ContentTypeSetter.SetContentType] validates and rejects unsafe
+	// values at auditor construction; the HTTP transport applies its
+	// own validation downstream as defence in depth.
+	ContentType() string
 }
 
 // bufferedFormatter is an internal optimisation interface: built-in

--- a/format_cef.go
+++ b/format_cef.go
@@ -257,6 +257,14 @@ const maxCEFHeaderField = 255
 // cefSeverityStrings avoids per-event strconv.Itoa for severity (0-10).
 var cefSeverityStrings = [11]string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
 
+// ContentType implements [Formatter.ContentType]. CEF has no
+// IANA-registered media type; "text/plain" is the de-facto
+// convention accepted by ArcSight SmartConnector and Splunk HEC
+// raw endpoints. Operators sending CEF to a receiver that demands
+// a specific value can override the Content-Type via the output's
+// headers config.
+func (cf *CEFFormatter) ContentType() string { return "text/plain" }
+
 // Format serialises a single audit event as a CEF line. The returned
 // slice is owned by the caller (defensive copy from the pooled buffer).
 //

--- a/format_json.go
+++ b/format_json.go
@@ -95,6 +95,13 @@ type JSONFormatter struct {
 	OmitEmpty bool
 }
 
+// ContentType implements [Formatter.ContentType]. JSONFormatter emits
+// newline-delimited JSON; the MIME type "application/x-ndjson" is
+// the [NDJSON spec](https://github.com/ndjson/ndjson-spec) convention
+// and is accepted by every webhook receiver that supports streaming
+// JSON.
+func (jf *JSONFormatter) ContentType() string { return "application/x-ndjson" }
+
 // Format serialises a single audit event as a JSON line. The returned
 // slice is owned by the caller (defensive copy from the pooled buffer).
 //

--- a/format_test.go
+++ b/format_test.go
@@ -921,6 +921,8 @@ func (s *stubFormatter) Format(ts time.Time, eventType string, fields audit.Fiel
 	return s.fn(ts, eventType, fields, def)
 }
 
+func (s *stubFormatter) ContentType() string { return "application/x-ndjson" }
+
 func TestLogger_DefaultJSONFormatter(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
 	auditor, err := audit.New(

--- a/output.go
+++ b/output.go
@@ -138,6 +138,39 @@ type MetadataWriter interface {
 	WriteWithMetadata(data []byte, meta EventMetadata) error
 }
 
+// ContentTypeSetter is an optional interface implemented by outputs
+// that need to know the MIME type of the bytes their associated
+// formatter emits. HTTP-based outputs (notably [webhook.Output])
+// use it to set the request Content-Type header without having to
+// pin themselves to a specific formatter.
+//
+// The library calls SetContentType once at auditor construction
+// time, after each output has been bound to its effective formatter
+// and after [FrameworkFieldSetter.SetFrameworkFields] propagation,
+// but BEFORE any event is dispatched. Outputs that do not care
+// about Content-Type simply omit the method.
+//
+// Implementations MUST treat SetContentType as a one-shot
+// configuration call from a non-I/O goroutine. Use
+// [sync/atomic.Pointer] or equivalent if a concurrent reader (the
+// output's background write goroutine) could observe the field
+// before the auditor's construction goroutine writes it — otherwise
+// the initialisation is a data race per the Go memory model.
+//
+// Implementations SHOULD validate the value (reject empty strings,
+// CRLF, control characters) and return early on bad input rather
+// than panicking — a malformed Content-Type ultimately surfaces as
+// an HTTP-transport error per request, which is recoverable.
+//
+// Outputs whose wire format is fixed independently of the
+// formatter (e.g., Loki's JSON push API, where the envelope is
+// always "application/json" regardless of the inner log-line
+// formatter) MUST NOT implement this interface — the library will
+// not call SetContentType on them.
+type ContentTypeSetter interface {
+	SetContentType(contentType string)
+}
+
 // FrameworkContext carries auditor-wide framework metadata into
 // output constructors so the first connection / first request can
 // use the correct app_name, host, timezone, and pid. Construction-

--- a/postfield_property_test.go
+++ b/postfield_property_test.go
@@ -116,6 +116,8 @@ func (noopFormatter) Format(ts time.Time, eventType string, fields Fields, def *
 	return nil, nil
 }
 
+func (noopFormatter) ContentType() string { return "application/x-ndjson" }
+
 // TestAppendPostFieldsJSONInto_PropertyEqualsSequentialInPlace is
 // the byte-equality proof for the #508 batch in-place JSON path.
 // Rapid generates random JSON-formatted bases and random PostField

--- a/tests/bdd/features/webhook_batching.feature
+++ b/tests/bdd/features/webhook_batching.feature
@@ -1,0 +1,103 @@
+@core @webhook-batching
+Feature: Webhook batched payload structure for JSON and CEF (#463)
+  As a library consumer, I want the webhook output to produce a
+  wire body whose structure matches its declared Content-Type:
+  newline-delimited JSON for the JSON formatter, newline-delimited
+  CEF lines for the CEF formatter. The receiver should be able to
+  parse the batch back without guessing the format.
+
+  Background:
+    Given a standard test taxonomy
+
+  # ---------------------------------------------------------------------------
+  # JSON formatter — NDJSON wire structure
+  # ---------------------------------------------------------------------------
+
+  Scenario: Multi-event NDJSON batch has exactly N parseable JSON lines
+    Given a local body-capturing webhook receiver
+    And an auditor with webhook output to the body-capture receiver, batch size 3
+    When I audit 3 uniquely marked batching events
+    And I close the batching auditor
+    Then the body-capture receiver should have at least 1 request within 5 seconds
+    And the most recent body-capture request body should have exactly 3 NDJSON lines
+    And the most recent body-capture request body should end with a newline
+
+  Scenario: NDJSON line order preserves submission order
+    Given a local body-capturing webhook receiver
+    And an auditor with webhook output to the body-capture receiver, batch size 3
+    When I audit 3 uniquely marked batching events
+    And I close the batching auditor
+    Then the body-capture receiver should have at least 1 request within 5 seconds
+    And line 1 of the body-capture body should contain marker "m1"
+    And line 2 of the body-capture body should contain marker "m2"
+    And line 3 of the body-capture body should contain marker "m3"
+
+  Scenario: Default formatter sends application/x-ndjson Content-Type
+    Given a local body-capturing webhook receiver
+    And an auditor with webhook output to the body-capture receiver, batch size 1
+    When I audit 1 uniquely marked batching events
+    And I close the batching auditor
+    Then the body-capture receiver should have at least 1 request within 5 seconds
+    And the most recent body-capture request Content-Type should be "application/x-ndjson"
+
+  # ---------------------------------------------------------------------------
+  # CEF formatter — text/plain wire structure (#463)
+  # ---------------------------------------------------------------------------
+
+  Scenario: Single-event CEF body has one CEF line
+    Given a local body-capturing webhook receiver
+    And an auditor with webhook output to the body-capture receiver using CEF formatter, batch size 1
+    When I audit 1 uniquely marked batching events
+    And I close the batching auditor
+    Then the body-capture receiver should have at least 1 request within 5 seconds
+    And the most recent body-capture request body should have exactly 1 CEF lines
+    And the most recent body-capture request body should end with a newline
+
+  Scenario: Multi-event CEF batch has exactly N CEF lines
+    Given a local body-capturing webhook receiver
+    And an auditor with webhook output to the body-capture receiver using CEF formatter, batch size 3
+    When I audit 3 uniquely marked batching events
+    And I close the batching auditor
+    Then the body-capture receiver should have at least 1 request within 5 seconds
+    And the most recent body-capture request body should have exactly 3 CEF lines
+    And the most recent body-capture request body should end with a newline
+
+  Scenario: CEF formatter sends text/plain Content-Type
+    Given a local body-capturing webhook receiver
+    And an auditor with webhook output to the body-capture receiver using CEF formatter, batch size 1
+    When I audit 1 uniquely marked batching events
+    And I close the batching auditor
+    Then the body-capture receiver should have at least 1 request within 5 seconds
+    And the most recent body-capture request Content-Type should be "text/plain"
+
+  Scenario: CEF formatter does not send application/x-ndjson Content-Type
+    Given a local body-capturing webhook receiver
+    And an auditor with webhook output to the body-capture receiver using CEF formatter, batch size 1
+    When I audit 1 uniquely marked batching events
+    And I close the batching auditor
+    Then the body-capture receiver should have at least 1 request within 5 seconds
+    And the most recent body-capture request Content-Type should not be "application/x-ndjson"
+
+  # ---------------------------------------------------------------------------
+  # Lifecycle edge cases
+  # ---------------------------------------------------------------------------
+
+  Scenario: Close with no audited events sends no request
+    Given a local body-capturing webhook receiver
+    And an auditor with webhook output to the body-capture receiver, batch size 10
+    When I close the batching auditor
+    Then the body-capture receiver should have exactly 0 requests
+
+  # ---------------------------------------------------------------------------
+  # Multi-output Content-Type isolation
+  # ---------------------------------------------------------------------------
+
+  Scenario: JSON and CEF webhook outputs send distinct Content-Types
+    Given two local body-capturing webhook receivers
+    And an auditor with two webhook outputs: receiver A using JSON, receiver B using CEF, batch size 1
+    When I audit 1 uniquely marked batching events
+    And I close the batching auditor
+    Then receiver A should have at least 1 request within 5 seconds
+    And receiver B should have at least 1 request within 5 seconds
+    And the most recent receiver A request Content-Type should be "application/x-ndjson"
+    And the most recent receiver B request Content-Type should be "text/plain"

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -55,10 +55,11 @@ type AuditTestContext struct { //nolint:govet // fieldalignment: readability pre
 	SymlinkTargetPath string            // file.Output symlink-safety scenarios — real path behind the symlink
 
 	// Docker infrastructure.
-	WebhookURL    string // "http://localhost:8080"
-	LokiURL       string // "http://localhost:3100"
-	TLSReceiver   any    // *tlsWebhookReceiver for HTTPS webhook tests
-	LocalReceiver any    // *localWebhookReceiver or *localLokiReceiver for SSRF/redirect/retry tests
+	WebhookURL     string // "http://localhost:8080"
+	LokiURL        string // "http://localhost:3100"
+	TLSReceiver    any    // *tlsWebhookReceiver for HTTPS webhook tests
+	LocalReceiver  any    // *localWebhookReceiver or *localLokiReceiver for SSRF/redirect/retry tests
+	LocalReceiverB any    // secondary local webhook receiver (used by #463 fan-out scenarios)
 
 	// Middleware state.
 	TestServer   *httptest.Server
@@ -164,6 +165,7 @@ func (tc *AuditTestContext) Reset() {
 	tc.AuditDuration = 0
 	tc.TLSReceiver = nil
 	tc.LocalReceiver = nil
+	tc.LocalReceiverB = nil
 	tc.cleanups = nil
 	tc.ScenarioName = ""
 }
@@ -230,6 +232,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerMetricsSteps(ctx, tc)
 	registerSyslogSteps(ctx, tc)
 	registerWebhookSteps(ctx, tc)
+	registerWebhookBatchingSteps(ctx, tc)
 	registerFanoutSteps(ctx, tc)
 	registerMiddlewareSteps(ctx, tc)
 	RegisterMultiCatSteps(ctx, tc)

--- a/tests/bdd/steps/fanout_steps.go
+++ b/tests/bdd/steps/fanout_steps.go
@@ -665,12 +665,16 @@ func (p *panicFormatter) Format(_ time.Time, _ string, _ audit.Fields, _ *audit.
 	panic("intentional panic in formatter")
 }
 
+func (p *panicFormatter) ContentType() string { return "application/x-ndjson" }
+
 // errorReturningFormatter returns an error on every Format call (no panic).
 type errorReturningFormatter struct{}
 
 func (e *errorReturningFormatter) Format(_ time.Time, _ string, _ audit.Fields, _ *audit.EventDef, _ *audit.FormatOptions) ([]byte, error) {
 	return nil, fmt.Errorf("intentional format error")
 }
+
+func (e *errorReturningFormatter) ContentType() string { return "application/x-ndjson" }
 
 // devNullOutput discards all writes.
 type devNullOutput struct{}

--- a/tests/bdd/steps/webhook_batching_steps.go
+++ b/tests/bdd/steps/webhook_batching_steps.go
@@ -1,0 +1,491 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+// Step definitions for #463 — wire-level batched payload validation
+// (JSON NDJSON + CEF text). Uses a purpose-built local httptest
+// receiver that preserves the raw request body and headers per
+// request, which the docker webhook-receiver does not (it
+// JSON-decodes a single value per request — fine for single-event
+// assertions, useless for body-structure assertions).
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/webhook"
+)
+
+// capturedRequest snapshots the body and headers of one POST.
+type capturedRequest struct {
+	When        time.Time
+	ContentType string
+	Body        []byte
+}
+
+// bodyCaptureReceiver is a local HTTP server that captures the raw
+// body and Content-Type of every POST it receives, in order. Unlike
+// the docker webhook-receiver (which decodes one JSON value per
+// request), this server preserves the wire bytes verbatim so tests
+// can assert NDJSON line structure, CEF line structure, and the
+// exact Content-Type header value.
+type bodyCaptureReceiver struct {
+	server   *httptest.Server
+	requestC chan struct{}
+	requests []capturedRequest
+	mu       sync.Mutex
+}
+
+func newBodyCaptureReceiver() *bodyCaptureReceiver {
+	r := &bodyCaptureReceiver{requestC: make(chan struct{}, 1024)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /events", func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			http.Error(w, "read body: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		r.mu.Lock()
+		r.requests = append(r.requests, capturedRequest{
+			Body:        body,
+			ContentType: req.Header.Get("Content-Type"),
+			When:        time.Now(),
+		})
+		r.mu.Unlock()
+		select {
+		case r.requestC <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	r.server = httptest.NewServer(mux)
+	return r
+}
+
+func (r *bodyCaptureReceiver) url() string { return r.server.URL + "/events" }
+
+func (r *bodyCaptureReceiver) close() { r.server.Close() }
+
+// waitForRequests blocks until at least n requests are captured or
+// timeout elapses. Returns true on success.
+func (r *bodyCaptureReceiver) waitForRequests(n int, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		r.mu.Lock()
+		count := len(r.requests)
+		r.mu.Unlock()
+		if count >= n {
+			return true
+		}
+		select {
+		case <-r.requestC:
+		case <-deadline:
+			return false
+		}
+	}
+}
+
+// snapshot returns a copy of the captured requests in order.
+func (r *bodyCaptureReceiver) snapshot() []capturedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]capturedRequest, len(r.requests))
+	copy(out, r.requests)
+	return out
+}
+
+// registerWebhookBatchingSteps registers steps for #463. Wires
+// the bodyCaptureReceiver lifecycle to the test context via
+// tc.LocalReceiver so cleanup runs at the end of every scenario.
+//
+//nolint:gocognit,gocyclo,cyclop // BDD step registration — many small step closures, low per-step complexity.
+func registerWebhookBatchingSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
+	ctx.Step(`^a local body-capturing webhook receiver$`, func() error {
+		rcv := newBodyCaptureReceiver()
+		tc.LocalReceiver = rcv
+		tc.AddCleanup(rcv.close)
+		return nil
+	})
+
+	ctx.Step(`^an auditor with webhook output to the body-capture receiver, batch size (\d+)$`, func(batchSize int) error {
+		return setupBatchingAuditor(tc, batchSize, nil)
+	})
+
+	ctx.Step(`^an auditor with webhook output to the body-capture receiver using CEF formatter, batch size (\d+)$`, func(batchSize int) error {
+		cefFmt := &audit.CEFFormatter{Vendor: "Test", Product: "BDD", Version: "1.0"}
+		return setupBatchingAuditor(tc, batchSize, cefFmt)
+	})
+
+	ctx.Step(`^I audit (\d+) uniquely marked batching events$`, func(n int) error {
+		for i := 1; i <= n; i++ {
+			err := tc.Auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+				"outcome":   "success",
+				"actor_id":  fmt.Sprintf("actor-%d", i),
+				"marker":    fmt.Sprintf("m%d", i),
+				"target_id": fmt.Sprintf("user-%d", i),
+			}))
+			if err != nil {
+				return fmt.Errorf("audit event %d: %w", i, err)
+			}
+		}
+		return nil
+	})
+
+	ctx.Step(`^I close the batching auditor$`, func() error {
+		if tc.Auditor == nil {
+			return nil
+		}
+		return tc.Auditor.Close()
+	})
+
+	ctx.Step(`^the body-capture receiver should have at least (\d+) request within (\d+) seconds$`, func(n, secs int) error {
+		rcv, ok := tc.LocalReceiver.(*bodyCaptureReceiver)
+		if !ok || rcv == nil {
+			return fmt.Errorf("no body-capture receiver in scope")
+		}
+		if !rcv.waitForRequests(n, time.Duration(secs)*time.Second) {
+			return fmt.Errorf("expected at least %d requests, got %d after %d seconds", n, len(rcv.snapshot()), secs)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the most recent body-capture request body should have exactly (\d+) NDJSON lines$`, func(n int) error {
+		body, err := latestBody(tc)
+		if err != nil {
+			return err
+		}
+		lines := splitNDJSON(body)
+		if len(lines) != n {
+			return fmt.Errorf("expected %d NDJSON lines, got %d (body=%q)", n, len(lines), body)
+		}
+		for i, line := range lines {
+			var v map[string]any
+			if err := json.Unmarshal(line, &v); err != nil {
+				return fmt.Errorf("line %d not valid JSON (line=%q): %w", i+1, line, err)
+			}
+		}
+		return nil
+	})
+
+	ctx.Step(`^the most recent body-capture request body should have exactly (\d+) CEF lines$`, func(n int) error {
+		body, err := latestBody(tc)
+		if err != nil {
+			return err
+		}
+		// Independent CEF line splitter — do NOT call the formatter to
+		// parse, otherwise we'd be re-asserting what we built.
+		lines := splitNonEmptyLines(body)
+		if len(lines) != n {
+			return fmt.Errorf("expected %d CEF lines, got %d (body=%q)", n, len(lines), body)
+		}
+		for i, line := range lines {
+			if !bytes.HasPrefix(line, []byte("CEF:0|")) {
+				return fmt.Errorf("line %d does not start with \"CEF:0|\" (line=%q)", i+1, line)
+			}
+		}
+		return nil
+	})
+
+	ctx.Step(`^the most recent body-capture request body should end with a newline$`, func() error {
+		body, err := latestBody(tc)
+		if err != nil {
+			return err
+		}
+		if len(body) == 0 || body[len(body)-1] != '\n' {
+			return fmt.Errorf("body does not end with newline (body=%q)", body)
+		}
+		return nil
+	})
+
+	ctx.Step(`^line (\d+) of the body-capture body should contain marker "([^"]*)"$`, func(lineN int, marker string) error {
+		body, err := latestBody(tc)
+		if err != nil {
+			return err
+		}
+		lines := splitNDJSON(body)
+		if lineN < 1 || lineN > len(lines) {
+			return fmt.Errorf("line %d out of range (have %d lines)", lineN, len(lines))
+		}
+		if !bytes.Contains(lines[lineN-1], []byte(`"marker":"`+marker+`"`)) {
+			return fmt.Errorf("line %d does not contain marker %q (line=%q)", lineN, marker, lines[lineN-1])
+		}
+		return nil
+	})
+
+	ctx.Step(`^the most recent body-capture request Content-Type should be "([^"]*)"$`, func(want string) error {
+		req, err := latestRequest(tc)
+		if err != nil {
+			return err
+		}
+		if req.ContentType != want {
+			return fmt.Errorf("Content-Type: got %q, want %q", req.ContentType, want)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the most recent body-capture request Content-Type should not be "([^"]*)"$`, func(notWant string) error {
+		req, err := latestRequest(tc)
+		if err != nil {
+			return err
+		}
+		if req.ContentType == notWant {
+			return fmt.Errorf("Content-Type should not be %q but it is", notWant)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the body-capture receiver should have exactly (\d+) requests$`, func(n int) error {
+		rcv, ok := tc.LocalReceiver.(*bodyCaptureReceiver)
+		if !ok || rcv == nil {
+			return fmt.Errorf("no body-capture receiver in scope")
+		}
+		// Empty-close: give the goroutine a brief window to confirm
+		// it did NOT make a request. 500 ms is generous given the
+		// 50 ms flush interval below.
+		time.Sleep(500 * time.Millisecond)
+		got := len(rcv.snapshot())
+		if got != n {
+			return fmt.Errorf("expected exactly %d requests, got %d", n, got)
+		}
+		return nil
+	})
+
+	// Multi-output (#463) — Content-Type isolation between two webhook
+	// outputs on the same auditor, one JSON one CEF.
+	ctx.Step(`^two local body-capturing webhook receivers$`, func() error {
+		a := newBodyCaptureReceiver()
+		b := newBodyCaptureReceiver()
+		tc.LocalReceiver = a
+		tc.LocalReceiverB = b
+		tc.AddCleanup(a.close)
+		tc.AddCleanup(b.close)
+		return nil
+	})
+
+	ctx.Step(`^an auditor with two webhook outputs: receiver A using JSON, receiver B using CEF, batch size (\d+)$`, func(batchSize int) error {
+		return setupDualBatchingAuditor(tc, batchSize)
+	})
+
+	ctx.Step(`^receiver A should have at least (\d+) request within (\d+) seconds$`, func(n, secs int) error {
+		rcv, ok := tc.LocalReceiver.(*bodyCaptureReceiver)
+		if !ok || rcv == nil {
+			return fmt.Errorf("no receiver A in scope")
+		}
+		if !rcv.waitForRequests(n, time.Duration(secs)*time.Second) {
+			return fmt.Errorf("receiver A: expected at least %d requests, got %d", n, len(rcv.snapshot()))
+		}
+		return nil
+	})
+
+	ctx.Step(`^receiver B should have at least (\d+) request within (\d+) seconds$`, func(n, secs int) error {
+		rcv, ok := tc.LocalReceiverB.(*bodyCaptureReceiver)
+		if !ok || rcv == nil {
+			return fmt.Errorf("no receiver B in scope")
+		}
+		if !rcv.waitForRequests(n, time.Duration(secs)*time.Second) {
+			return fmt.Errorf("receiver B: expected at least %d requests, got %d", n, len(rcv.snapshot()))
+		}
+		return nil
+	})
+
+	ctx.Step(`^the most recent receiver A request Content-Type should be "([^"]*)"$`, func(want string) error {
+		return assertReceiverContentType(tc.LocalReceiver, "A", want)
+	})
+
+	ctx.Step(`^the most recent receiver B request Content-Type should be "([^"]*)"$`, func(want string) error {
+		return assertReceiverContentType(tc.LocalReceiverB, "B", want)
+	})
+}
+
+func assertReceiverContentType(holder any, label, want string) error {
+	rcv, ok := holder.(*bodyCaptureReceiver)
+	if !ok || rcv == nil {
+		return fmt.Errorf("no receiver %s in scope", label)
+	}
+	reqs := rcv.snapshot()
+	if len(reqs) == 0 {
+		return fmt.Errorf("receiver %s captured no requests", label)
+	}
+	got := reqs[len(reqs)-1].ContentType
+	if got != want {
+		return fmt.Errorf("receiver %s Content-Type: got %q, want %q", label, got, want)
+	}
+	return nil
+}
+
+// setupDualBatchingAuditor wires one auditor with two webhook
+// outputs — one using the default JSON formatter pointed at
+// receiver A, one using CEFFormatter pointed at receiver B.
+// Validates the per-output Content-Type isolation invariant.
+func setupDualBatchingAuditor(tc *AuditTestContext, batchSize int) error {
+	rcvA, ok := tc.LocalReceiver.(*bodyCaptureReceiver)
+	if !ok || rcvA == nil {
+		return fmt.Errorf("receiver A not configured")
+	}
+	rcvB, ok := tc.LocalReceiverB.(*bodyCaptureReceiver)
+	if !ok || rcvB == nil {
+		return fmt.Errorf("receiver B not configured")
+	}
+	if tc.Taxonomy == nil {
+		tax, err := audit.ParseTaxonomyYAML([]byte(routingTaxonomyYAML))
+		if err != nil {
+			return fmt.Errorf("parse taxonomy: %w", err)
+		}
+		tc.Taxonomy = tax
+	}
+
+	mkOut := func(url string) (*webhook.Output, error) {
+		return webhook.New(&webhook.Config{
+			URL:                url,
+			AllowInsecureHTTP:  true,
+			AllowPrivateRanges: true,
+			BatchSize:          batchSize,
+			FlushInterval:      50 * time.Millisecond,
+			Timeout:            5 * time.Second,
+			MaxRetries:         1,
+			BufferSize:         1000,
+		}, nil)
+	}
+
+	outA, err := mkOut(rcvA.url())
+	if err != nil {
+		return fmt.Errorf("create webhook A: %w", err)
+	}
+	tc.AddCleanup(func() { _ = outA.Close() })
+
+	outB, err := mkOut(rcvB.url())
+	if err != nil {
+		return fmt.Errorf("create webhook B: %w", err)
+	}
+	tc.AddCleanup(func() { _ = outB.Close() })
+
+	cefFmt := &audit.CEFFormatter{Vendor: "Test", Product: "BDD", Version: "1.0"}
+	auditor, err := audit.New(
+		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithNamedOutput(outA),
+		audit.WithNamedOutput(outB, audit.WithOutputFormatter(cefFmt)),
+	)
+	if err != nil {
+		return fmt.Errorf("create auditor: %w", err)
+	}
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
+	return nil
+}
+
+// setupBatchingAuditor builds an auditor with a single webhook
+// output pointing at the body-capture receiver. The webhook output
+// is constructed with a tight flush_interval so close() drains
+// promptly.
+func setupBatchingAuditor(tc *AuditTestContext, batchSize int, formatter audit.Formatter) error {
+	rcv, ok := tc.LocalReceiver.(*bodyCaptureReceiver)
+	if !ok || rcv == nil {
+		return fmt.Errorf("no body-capture receiver in scope; add the Given step first")
+	}
+	if tc.Taxonomy == nil {
+		tax, err := audit.ParseTaxonomyYAML([]byte(routingTaxonomyYAML))
+		if err != nil {
+			return fmt.Errorf("parse taxonomy: %w", err)
+		}
+		tc.Taxonomy = tax
+	}
+
+	out, err := webhook.New(&webhook.Config{
+		URL:                rcv.url(),
+		AllowInsecureHTTP:  true,
+		AllowPrivateRanges: true,
+		BatchSize:          batchSize,
+		FlushInterval:      50 * time.Millisecond,
+		Timeout:            5 * time.Second,
+		MaxRetries:         1,
+		BufferSize:         1000,
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("create webhook: %w", err)
+	}
+	tc.AddCleanup(func() { _ = out.Close() })
+
+	var outputOpts []audit.OutputOption
+	if formatter != nil {
+		outputOpts = append(outputOpts, audit.WithOutputFormatter(formatter))
+	}
+	opts := []audit.Option{
+		audit.WithTaxonomy(tc.Taxonomy),
+		audit.WithAppName("test-app"),
+		audit.WithHost("test-host"),
+		audit.WithNamedOutput(out, outputOpts...),
+	}
+	auditor, err := audit.New(opts...)
+	if err != nil {
+		return fmt.Errorf("create auditor: %w", err)
+	}
+	tc.Auditor = auditor
+	tc.AddCleanup(func() { _ = auditor.Close() })
+	return nil
+}
+
+// latestBody returns the most recent request body from the body-
+// capture receiver, or an error if none has been captured.
+func latestBody(tc *AuditTestContext) ([]byte, error) {
+	req, err := latestRequest(tc)
+	if err != nil {
+		return nil, err
+	}
+	return req.Body, nil
+}
+
+func latestRequest(tc *AuditTestContext) (capturedRequest, error) {
+	rcv, ok := tc.LocalReceiver.(*bodyCaptureReceiver)
+	if !ok || rcv == nil {
+		return capturedRequest{}, fmt.Errorf("no body-capture receiver in scope")
+	}
+	reqs := rcv.snapshot()
+	if len(reqs) == 0 {
+		return capturedRequest{}, fmt.Errorf("no requests captured yet")
+	}
+	return reqs[len(reqs)-1], nil
+}
+
+// splitNDJSON splits an NDJSON body into non-empty lines stripped of
+// their trailing \n.
+func splitNDJSON(body []byte) [][]byte {
+	return splitNonEmptyLines(body)
+}
+
+func splitNonEmptyLines(body []byte) [][]byte {
+	if len(body) == 0 {
+		return nil
+	}
+	parts := bytes.Split(body, []byte("\n"))
+	out := make([][]byte, 0, len(parts))
+	for _, p := range parts {
+		if len(bytes.TrimSpace(p)) == 0 {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/webhook/doc.go
+++ b/webhook/doc.go
@@ -24,12 +24,16 @@
 //
 // # Batching and Delivery
 //
-// Events are buffered in memory and flushed as newline-delimited JSON
-// (application/x-ndjson) when the batch reaches [Config.BatchSize]
-// events or [Config.FlushInterval] elapses. Failed batches are retried with exponential backoff up to
-// [Config.MaxRetries] times. Delivery semantics are at-least-once:
-// a batch may be delivered more than once if the server accepts the
-// payload but the acknowledgement is lost.
+// Events are buffered in memory and flushed using the Content-Type
+// reported by the output's configured formatter — application/x-ndjson
+// for the built-in [audit.JSONFormatter], text/plain for [audit.CEFFormatter],
+// or whatever a third-party Formatter declares via
+// [audit.Formatter.ContentType]. The batch flushes when it reaches
+// [Config.BatchSize] events or [Config.FlushInterval] elapses. Failed
+// batches are retried with exponential backoff up to [Config.MaxRetries]
+// times. Delivery semantics are at-least-once: a batch may be delivered
+// more than once if the server accepts the payload but the
+// acknowledgement is lost.
 //
 // # Construction
 //

--- a/webhook/http.go
+++ b/webhook/http.go
@@ -159,7 +159,7 @@ func (w *Output) doPost(ctx context.Context, body []byte) (bool, error) {
 		return false, fmt.Errorf("audit/webhook: request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/x-ndjson")
+	req.Header.Set("Content-Type", w.effectiveContentType())
 	for k, v := range w.headers {
 		req.Header.Set(k, v)
 	}

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -47,10 +47,24 @@ const dropWarnInterval = 10 * time.Second
 
 // Compile-time assertions.
 var (
-	_ audit.Output           = (*Output)(nil)
-	_ audit.DeliveryReporter = (*Output)(nil)
-	_ audit.DestinationKeyer = (*Output)(nil)
+	_ audit.Output            = (*Output)(nil)
+	_ audit.DeliveryReporter  = (*Output)(nil)
+	_ audit.DestinationKeyer  = (*Output)(nil)
+	_ audit.ContentTypeSetter = (*Output)(nil)
 )
+
+// defaultContentType is the request Content-Type used by [Output]
+// when no [audit.ContentTypeSetter.SetContentType] call has fired
+// (i.e., the webhook was constructed outside an auditor for unit
+// tests). Matches the body shape produced by the default
+// [audit.JSONFormatter].
+const defaultContentType = "application/x-ndjson"
+
+// maxContentTypeLen caps the Content-Type header value to defend
+// against an adversarial formatter returning an absurd string.
+// HTTP header values have no formal upper bound, but 256 covers
+// every realistic media-type + parameter combination.
+const maxContentTypeLen = 256
 
 // errRedirectBlocked is returned by the http.Client's CheckRedirect
 // function. It is checked in doPost to classify redirect errors as
@@ -112,6 +126,8 @@ func responseHeaderTimeout(t time.Duration) time.Duration {
 // but returns 5xx due to a timeout. Receivers SHOULD be idempotent.
 //
 // Output is safe for concurrent use.
+//
+//nolint:govet // fieldalignment: readability preferred — fields grouped by lifecycle (#463)
 type Output struct {
 	metrics         audit.Metrics
 	outputMetrics   audit.OutputMetrics // immutable after New (#696)
@@ -133,6 +149,14 @@ type Output struct {
 	// doPostWithRetry. Read/written only by doPostWithRetry in the
 	// batchLoop goroutine; no synchronisation needed.
 	retryHint time.Duration
+	// contentType holds the request Content-Type as decided by the
+	// formatter via [audit.ContentTypeSetter]. The auditor's
+	// construction goroutine writes it once; the batchLoop reads it
+	// on every doPost. The two goroutines have no synchronisation
+	// edge between them at startup (batchLoop is started in New
+	// BEFORE audit.New calls SetContentType), so atomic storage is
+	// mandatory. A nil pointer means "use [defaultContentType]".
+	contentType atomic.Pointer[string]
 	// lastDeliveryNanos is the wall-clock UnixNano of the most recent
 	// HTTP 2xx response (post-retry). Webhook is async — Write only
 	// enqueues — so the timestamp updates from the batch goroutine
@@ -336,6 +360,75 @@ func (w *Output) ReportsDelivery() bool { return true }
 // frozen. Implements [audit.LastDeliveryReporter] (#753).
 func (w *Output) LastDeliveryNanos() int64 {
 	return w.lastDeliveryNanos.Load()
+}
+
+// SetContentType implements [audit.ContentTypeSetter]. The auditor
+// calls this once at construction time with the result of
+// [audit.Formatter.ContentType] from the effective per-output
+// formatter, before any event is dispatched.
+//
+// Validation rejects (silently — auditor construction continues):
+//   - empty strings
+//   - values exceeding [maxContentTypeLen]
+//   - any string failing [net/http/internal/ascii.IsPrint] equivalent
+//     validation against the [RFC 9110] field-value grammar
+//     (i.e., contains CR, LF, NUL, or non-printable bytes).
+//
+// A rejected value leaves the previous Content-Type in place (or
+// [defaultContentType] if SetContentType has never been called).
+// This protects against a hostile or misbehaving formatter — the
+// HTTP transport would reject the malformed value at request-send
+// time anyway, but failing early at construction surfaces the bug
+// in a single log line rather than per-request errors.
+//
+// Operator override: a `Content-Type` entry in the output's
+// `headers` config (passed via [Config.Headers]) takes precedence
+// over the value installed here. The request pipeline sets
+// Content-Type from this field first, then applies operator
+// headers — so an operator who must send (e.g.) `application/json`
+// to a strict CEF receiver can still do so.
+func (w *Output) SetContentType(ct string) {
+	if ct == "" || len(ct) > maxContentTypeLen || !isValidContentType(ct) {
+		w.logger.Warn("audit: output webhook: rejected invalid Content-Type from formatter",
+			"value_length", len(ct))
+		return
+	}
+	w.contentType.Store(&ct)
+}
+
+// effectiveContentType returns the Content-Type to use on the
+// outbound POST: the value set via [Output.SetContentType], or
+// [defaultContentType] when the webhook was constructed outside
+// an auditor (e.g. unit tests).
+func (w *Output) effectiveContentType() string {
+	if p := w.contentType.Load(); p != nil {
+		return *p
+	}
+	return defaultContentType
+}
+
+// isValidContentType is a conservative byte-level check matching the
+// RFC 9110 §5.5 field-value grammar: visible ASCII plus space and
+// horizontal tab, no control characters (excluding HTAB), no
+// CR/LF/NUL. Sufficient for header-value safety; a stricter
+// media-type-grammar check would be over-engineering — the HTTP
+// transport applies its own validation downstream.
+func isValidContentType(ct string) bool {
+	// Iterate raw bytes via index — ranging over the string would yield
+	// runes after UTF-8 decoding. Header values are byte-grammars per
+	// RFC 9110 §5.5.
+	for i := range len(ct) {
+		b := ct[i]
+		// HTAB (0x09) and visible ASCII (0x20..0x7E) only. Reject
+		// every other byte including DEL, CR, LF, NUL.
+		if b == 0x09 {
+			continue
+		}
+		if b < 0x20 || b > 0x7E {
+			return false
+		}
+	}
+	return true
 }
 
 // Name returns the human-readable identifier for this output.


### PR DESCRIPTION
## Summary

- Adds `audit.Formatter.ContentType() string` (BREAKING for third-party `Formatter` implementations — one-line addition required).
- Adds `audit.ContentTypeSetter` optional interface for outputs that need to know the wire-format Content-Type of the bytes their formatter emits.
- `JSONFormatter.ContentType()` → `"application/x-ndjson"`, `CEFFormatter.ContentType()` → `"text/plain"`.
- Webhook output now reads the per-formatter Content-Type via `atomic.Pointer[string]` (race-safe across audit goroutine writer vs batchLoop reader) and uses it for outbound POST headers. Fixes the latent bug where a CEF-formatted webhook would send `Content-Type: application/x-ndjson`.
- Loki output does NOT implement the new interface — its push API envelope is fixed JSON regardless of formatter.
- 9 new BDD scenarios validating wire-level batched payload structure for both formats (line count, parseability, line order, trailing newline, Content-Type assertions, empty-close, JSON+CEF fan-out isolation).
- Compile-time interface assertion in webhook (`_ audit.ContentTypeSetter = (*Output)(nil)`).
- Validation in `SetContentType` rejects empty, over-length, and non-printable Content-Type values.

## Test plan

- [x] `make check` green (fmt, vet, lint, test, build, tidy-check, security)
- [x] `make test-bdd-core` green — all 9 new scenarios pass, no existing-scenario regressions
- [x] Race-detector clean (`go test -race` on core + webhook)
- [x] Pre-coding consults: api-ergonomics-reviewer, code-reviewer, test-analyst, security-reviewer (all approved with notes applied)
- [x] Post-coding gates: code-reviewer (IMPORTANT + 2 NITs applied), security-reviewer (0 findings), api-ergonomics-reviewer (approved), test-analyst (2 MEDIUM gaps both applied), docs-writer (2 FAILs both applied), go-quality (READY)
- [ ] CI green
- [ ] issue-closer REPORT-ONLY for #463

## Files changed (20)

Core: `format.go`, `format_json.go`, `format_cef.go`, `output.go`, `drain.go`, `audit.go`.
Webhook: `webhook/webhook.go`, `webhook/http.go`, `webhook/doc.go`.
BDD: new `tests/bdd/features/webhook_batching.feature`, new `tests/bdd/steps/webhook_batching_steps.go`, `tests/bdd/steps/context.go`, `tests/bdd/steps/fanout_steps.go`.
Test mocks: `audit_dedup_test.go`, `audit_exclusion_test.go`, `postfield_property_test.go`, `format_test.go`, `fanout_test.go` — each gains a one-line `ContentType()` on its mock formatter.
Docs: `docs/webhook-output.md`, `CHANGELOG.md`.

Closes #463.