### PR TITLE
docs: surface v1.0.0 features in existing examples

### DIFF
--- a/examples/01-basic/README.md
+++ b/examples/01-basic/README.md
@@ -173,6 +173,20 @@ asynchronously and `Close()` drains the buffer before finishing.
 This is normal — `Close()` guarantees all buffered events are
 delivered before it returns.
 
+## When to Graduate from DevTaxonomy
+
+`DevTaxonomy()` accepts any event type with any fields. That's
+deliberate — it lets you explore the library without authoring a
+schema first. But every guarantee the library provides (typo
+rejection, required-field enforcement, sensitivity labelling,
+CEF severity resolution) requires a real taxonomy.
+
+The next example — [02-code-generation](../02-code-generation/) —
+shows how to author a `taxonomy.yaml` and generate typed event
+builders so the schema is enforced at compile time. The 4-step
+migration recipe is in
+[`docs/taxonomy-validation.md`](../../docs/taxonomy-validation.md#migrating-from-devtaxonomy-to-a-strict-taxonomy).
+
 ## Further Reading
 
 - [Taxonomy Validation](../../docs/taxonomy-validation.md) — how the library validates events

--- a/examples/02-code-generation/README.md
+++ b/examples/02-code-generation/README.md
@@ -8,6 +8,13 @@ Define your audit events in a YAML file, generate type-safe Go
 constants, and configure outputs in a separate YAML file. This is the
 recommended workflow for audit — all subsequent examples follow it.
 
+> **Coming from example 01?** If you started with
+> `audit.DevTaxonomy()`, this example is the migration target. Take
+> the event types you've been emitting, list them in
+> `taxonomy.yaml` with their required fields, regenerate, and swap
+> the `WithTaxonomy(...)` call. The full 4-step recipe lives in
+> [`docs/taxonomy-validation.md`](../../docs/taxonomy-validation.md#migrating-from-devtaxonomy-to-a-strict-taxonomy).
+
 ## What You'll Learn
 
 - Why audit events are defined in YAML and embedded in the binary

--- a/examples/03-file-output/README.md
+++ b/examples/03-file-output/README.md
@@ -59,6 +59,46 @@ type-specific settings are nested under a key matching the type name
 | `max_age_days` | 30 | Delete rotated files older than this. |
 | `group_readable` | `false` | When `true`, mode is `0o640` (owner + group read) for SIEM forwarders running in the file's group. Default `false` is `0o600` (owner only). |
 | `compress` | `true` | Gzip rotated files. |
+| `fsync_each_batch` | `false` | When `true`, each batched write is `writev(2)` + `fsync(2)`. See [Durability vs Throughput](#durability-vs-throughput) below. |
+
+### Durability vs Throughput
+
+By default the file output writes events to the OS page cache and
+lets the kernel flush to disk on its own schedule. This is fast
+but creates a brief window where a crash (kernel panic, power
+loss, container OOM-kill of the writer's host) can lose the most
+recent batch. For compliance use cases that require each event be
+on stable storage before the next acknowledgement, set:
+
+```yaml
+file:
+  path: "./audit.log"
+  fsync_each_batch: true   # see #678
+```
+
+With `fsync_each_batch: true`, every flushed batch becomes
+`writev(2) + fsync(2)`. The drain goroutine's throughput is then
+bounded by the disk's fsync latency:
+
+- Rotational disks: ~5–50 ms per batch.
+- Local SSD: ~0.1–2 ms per batch.
+- Network filesystems (NFS, EFS): highly variable; benchmark before
+  enabling.
+
+The sustained event rate is approximately
+`batch_size / (writev_latency + fsync_latency)`. For a 256-event
+batch on an SSD this is still tens of thousands of events per
+second — well above most audit workloads — but the latency floor
+matters for back-pressure tuning. See `BENCHMARKS.md` for figures
+on your platform.
+
+**Partial guarantee.** `fsync_each_batch: true` fsyncs the audit
+log file, but does NOT fsync the parent directory. After a crash
+during log rotation the post-rotation file's directory entry may
+not yet be on disk. For directory-level durability, mount the
+audit-log directory with `dirsync` (Linux), or accept that the
+rotated tail may not survive a crash that hits at exactly the
+rotation moment.
 
 ### Enabling the File Output Type
 

--- a/examples/03-file-output/outputs.yaml
+++ b/examples/03-file-output/outputs.yaml
@@ -8,3 +8,5 @@ outputs:
       path: "./audit.log"
       max_size_mb: 10
       max_backups: 3
+      # fsync_each_batch: false  # default — see README "Durability
+      #                          #   vs Throughput" before flipping to true

--- a/examples/06-syslog-output/README.md
+++ b/examples/06-syslog-output/README.md
@@ -182,6 +182,27 @@ message. For audit logging, `local0` through `local7` are recommended
 Full list: `kern`, `user`, `mail`, `daemon`, `auth`, `syslog`, `lpr`,
 `news`, `uucp`, `cron`, `authpriv`, `ftp`, `local0`–`local7`.
 
+### Fail-Fast on Startup (#286)
+
+The syslog output verifies connectivity at construction time by
+default. `audit.New` returns a wrapped error if the configured
+address is unreachable, the TLS handshake fails, or the
+verification budget elapses — surfacing the misconfiguration at
+application start-up instead of as silent event loss on the first
+flush.
+
+```yaml
+syslog:
+  network: "tcp+tls"
+  address: "siem.example.com:6514"
+  verify_on_startup: true                 # default — fail at New()
+  verify_on_startup_timeout: 5s           # default — budget for dial + handshake
+```
+
+Set `verify_on_startup: false` for sidecar deployments where the
+SIEM may come up after the application, or for short-lived CLI
+tools that must start regardless of receiver availability.
+
 ### Automatic Reconnection
 
 If the syslog server becomes unavailable, the output automatically

--- a/examples/07-webhook-output/README.md
+++ b/examples/07-webhook-output/README.md
@@ -80,6 +80,33 @@ line, with a newline (`\n`) separator. The HTTP body looks like:
 This format is efficient (no wrapping array), streamable, and widely
 supported by log aggregators (Elasticsearch, Loki, Datadog, etc.).
 
+### Content-Type Tracks the Formatter (#463)
+
+The default JSON formatter sends `Content-Type: application/x-ndjson`.
+If you switch the webhook to a CEF formatter, the wire body becomes
+newline-separated CEF records and the `Content-Type` automatically
+flips to `text/plain` — the convention accepted by ArcSight
+SmartConnector and Splunk HEC raw endpoints.
+
+```yaml
+audit_webhook:
+  type: webhook
+  formatter:
+    type: cef
+    vendor: "MyCompany"
+    product: "MyApp"
+    version: "1.0"
+  webhook:
+    url: "https://logs.example.com/audit"
+    # request Content-Type becomes "text/plain" automatically
+```
+
+Operators whose receiver demands a specific MIME type can override
+via the `headers:` config — operator headers take precedence over
+the formatter's default. See
+[docs/webhook-output.md](../../docs/webhook-output.md#ndjson-format)
+for the full table.
+
 ### Batch Triggers
 
 Events are buffered internally and flushed as a batch when ANY of these
@@ -133,6 +160,26 @@ This example uses `allow_private_ranges: true` and
 - **Always use HTTPS** — `allow_insecure_http` MUST NOT be `true`
 - **Keep SSRF protection enabled** — only disable for local dev/testing
 
+### Fail-Fast on Startup (#286)
+
+The webhook output verifies connectivity at construction time by
+default. `audit.New` returns a wrapped error if the URL is
+unreachable, the TLS handshake fails, the SSRF policy rejects
+the host, or the verification budget elapses — surfacing the
+misconfiguration at application start-up instead of as silent
+event loss on the first flush.
+
+```yaml
+webhook:
+  url: "https://ingest.example.com/audit"
+  verify_on_startup: true                 # default — fail at New()
+  verify_on_startup_timeout: 5s           # default — budget for dial + handshake
+```
+
+Set `verify_on_startup: false` for sidecar deployments where the
+receiver may come up after the application, or for short-lived
+CLI tools that must start regardless of receiver availability.
+
 ### Retry with Backoff
 
 When the webhook endpoint returns an error, the output retries with
@@ -141,7 +188,7 @@ exponential backoff:
 | Response | Action |
 |----------|--------|
 | **2xx** | Success — batch delivered |
-| **429** (Too Many Requests) | Retry with backoff |
+| **429** (Too Many Requests) | Retry with backoff, honouring the `Retry-After` response header (capped at 30 s, delta-seconds form only — see #291) |
 | **5xx** (Server Error) | Retry with backoff |
 | **4xx** (Client Error, not 429) | No retry — batch dropped (configuration or auth problem) |
 | **Redirect** (3xx) | Rejected — SSRF protection blocks redirects |

--- a/examples/08-loki-output/README.md
+++ b/examples/08-loki-output/README.md
@@ -473,6 +473,26 @@ curl -H 'X-Scope-OrgID: example' 'http://localhost:3100/loki/api/v1/query_range?
 
 Without the header, Loki returns 401 Unauthorized.
 
+## Fail-Fast on Startup (#286)
+
+The Loki output verifies connectivity to the push API at
+construction time by default. `audit.New` returns a wrapped
+error if the URL is unreachable, the TLS handshake fails, the
+auth credentials are rejected, or the verification budget
+elapses — surfacing the misconfiguration at application start-up
+instead of as silent event loss on the first flush.
+
+```yaml
+loki:
+  url: "http://loki:3100/loki/api/v1/push"
+  verify_on_startup: true                 # default — fail at New()
+  verify_on_startup_timeout: 5s           # default — budget for dial + handshake
+```
+
+Set `verify_on_startup: false` for sidecar deployments where Loki
+may come up after the application, or for short-lived CLI tools
+that must start regardless of receiver availability.
+
 ## Troubleshooting
 
 | Problem | Cause | Fix |

--- a/examples/10-event-routing/README.md
+++ b/examples/10-event-routing/README.md
@@ -131,10 +131,20 @@ events that won't be delivered.
 ### Severity-Based Routing
 
 Each output's route can filter by severity level (0-10). This
-example's `outputs.yaml` includes a `critical_alerts` output with
-`min_severity: 7`. Below are the three routing modes you can use:
+example's `outputs.yaml` demonstrates four routing shapes:
 
-**Category only** — filter by category, all severity levels:
+- **No route** — `console` receives every event.
+- **Mode A — category only** — `security_log` and `writes_log`.
+- **Mode B — per-category severity** (#193) — `audit_feed`
+  carries different thresholds per category in a single route
+  (security ≥ 7 AND every read event).
+- **Mode C — severity-only catch-all** — `critical_alerts`
+  routes any event at severity ≥ 7 regardless of category.
+
+The Mode B form is the v1.0.0 addition (#193); see the inline
+comments in `outputs.yaml` and the per-mode snippets below.
+
+**Mode A — category only** — filter by category, all severity levels:
 ```yaml
   security_log:
     type: file
@@ -144,7 +154,7 @@ example's `outputs.yaml` includes a `critical_alerts` output with
       include_categories: {security: {}}
 ```
 
-**Category with per-category severity** (#193) — each included
+**Mode B — per-category severity** (#193) — each included
 category can carry its own severity bound. The bound goes **inside**
 the category mapping value, not at the route level. A category
 match never falls back to route-level severity — to constrain a
@@ -160,7 +170,7 @@ category by severity, place the bound inside its mapping:
           min_severity: 7   # only security events at severity >= 7
 ```
 
-**Severity only** — filter by severity regardless of category. This
+**Mode C — severity-only** — filter by severity regardless of category. This
 is the PagerDuty use case — route all high-severity events to an
 alerting webhook:
 ```yaml
@@ -209,7 +219,7 @@ All three events appear on stdout (all events). Each file contains only
 the events matching its route:
 
 ```
-INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=4 synchronous=false
+INFO audit: auditor created queue_size=10000 shutdown_timeout=5s validation_mode=strict outputs=5 synchronous=false
 INFO audit: shutdown started
 ... (stdout shows all three events)
 INFO audit: shutdown complete duration=...
@@ -220,15 +230,22 @@ INFO audit: shutdown complete duration=...
 --- writes.log ---
 {"timestamp":"...","event_type":"user_create","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"alice","outcome":"success","event_category":"write"}
 
+--- audit-feed.log ---
+{"timestamp":"...","event_type":"user_read","severity":5,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"outcome":"success","event_category":"read"}
+{"timestamp":"...","event_type":"auth_failure","severity":8,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"unknown","outcome":"failure","event_category":"security"}
+
 --- critical.log ---
 {"timestamp":"...","event_type":"auth_failure","severity":8,"app_name":"example","host":"localhost","timezone":"Local","pid":...,"actor_id":"unknown","outcome":"failure","event_category":"security"}
 ```
 
-The `user_read` event doesn't appear in any file — no route includes
-the `read` category, and its severity (5) is below the critical
-threshold (7). The `auth_failure` event appears in both `security.log`
-(category route) and `critical.log` (severity route) — it matches both
-independently.
+`audit-feed.log` shows Mode B in action: the `user_read` event lands
+because the `read` category accepts every severity, while the
+severity-8 `auth_failure` clears the `min_severity: 7` bound on the
+`security` category mapping. The severity-5 `user_read` is below
+the threshold for `critical.log` (Mode C wants ≥ 7), so it does not
+appear there. `auth_failure` appears in `security.log` (Mode A
+category match) and `critical.log` (Mode C severity-only match) —
+each route is evaluated independently.
 
 ## Further Reading
 

--- a/examples/10-event-routing/main.go
+++ b/examples/10-event-routing/main.go
@@ -60,11 +60,13 @@ func main() {
 	// Show filtered output.
 	printFile("security.log")
 	printFile("writes.log")
+	printFile("audit-feed.log")
 	printFile("critical.log")
 
 	// Clean up.
 	_ = os.Remove("./security.log")
 	_ = os.Remove("./writes.log")
+	_ = os.Remove("./audit-feed.log")
 	_ = os.Remove("./critical.log")
 }
 

--- a/examples/10-event-routing/outputs.yaml
+++ b/examples/10-event-routing/outputs.yaml
@@ -2,9 +2,12 @@ version: 1
 app_name: example
 host: localhost
 outputs:
+  # No route — receives every event.
   console:
     type: stdout
 
+  # Mode A — category only. All severities for the listed
+  # categories. Empty inline mapping `{}` = no severity filter.
   security_log:
     type: file
     file:
@@ -21,6 +24,24 @@ outputs:
       include_categories:
         write: {}
 
+  # Mode B — per-category severity (#193). Each included category
+  # can carry its own min_severity / max_severity inside the
+  # mapping value. Route-level severity is NOT applied to category
+  # matches — to constrain a category, put the bound inside its
+  # mapping. Here: security events only at sev >= 7, every read
+  # event regardless of severity.
+  audit_feed:
+    type: file
+    file:
+      path: "./audit-feed.log"
+    route:
+      include_categories:
+        security:
+          min_severity: 7
+        read: {}
+
+  # Mode C — severity-only catch-all. No category filter; any
+  # event at sev >= 7 lands here.
   critical_alerts:
     type: file
     file:


### PR DESCRIPTION
## Summary

Six v1.0.0 features are callable via the public API but were not demonstrated in any example after the example reorder (#863). This PR extends six existing examples to surface them — no new directories.

| Feature | Example | What changed |
|--------|---------|--------------|
| Per-category severity (#193) | 10-event-routing | New \`audit_feed\` output demonstrating Mode B; four-mode intro paragraph; subheadings aligned to Mode A/B/C labels; \`main.go\` prints and cleans up the new log file; Expected Output regenerated |
| Webhook Retry-After (#291) | 07-webhook-output | Retry table row noting the 30 s cap and delta-seconds form |
| Webhook Content-Type per formatter (#463) | 07-webhook-output | New "Content-Type Tracks the Formatter" subsection with CEF formatter YAML and override semantics |
| File \`fsync_each_batch\` (#678) | 03-file-output | New "Durability vs Throughput" subsection with latency table (rotational / SSD) and \`dirsync\` caveat |
| Startup verification (#286) | 06-syslog-output, 07-webhook-output, 08-loki-output | New "Fail-Fast on Startup" subsection in all three with \`verify_on_startup\` + \`verify_on_startup_timeout\` YAML |
| DevTaxonomy → typed migration | 01-basic, 02-code-generation | "When to Graduate" subsection in 01 pointing at 02; "Coming from example 01?" callout in 02 linking the 4-step recipe in \`docs/taxonomy-validation.md\` |

Pure docs/config extension on already-reviewed example surfaces. No public API changes. The only Go code change is two added lines in \`examples/10-event-routing/main.go\` to print and clean up \`audit-feed.log\`.

## Test plan

- [x] \`make test-examples\` — all 20 examples build clean
- [x] \`make check\` — full local quality gate passed
- [x] \`go run .\` in 10-event-routing — observed audit-feed.log matches the Expected Output prose
- [x] user-guide-reviewer agent — caught \`startup_verification_timeout\` (wrong key), \`push_url\` (wrong key in loki snippet), and stale Expected Output / main.go in 10-event-routing — all fixed
- [x] docs-writer agent — caught the dead \`#wire-format\` anchor in 07 (now \`#ndjson-format\`) and the field-name bug — all fixed
- [x] commit-message-reviewer — passed

Refs #193, #291, #463, #678, #286