### PR TITLE
refactor: value-typed EventRoute.IncludeCategories (#867 part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Breaking
 
+- [`audit.EventRoute.IncludeCategories`](https://pkg.go.dev/github.com/axonops/audit#EventRoute)
+  changes from `map[string]*SeverityRange` to
+  `map[string]SeverityRange` (value type, not pointer). The
+  canonical "no severity constraint for this category" value
+  changes from `nil` (typed-nil pointer) to `SeverityRange{}`
+  (zero-value struct). Inner fields `MinSeverity *int` and
+  `MaxSeverity *int` remain as pointers (sentinel-nil = no
+  bound). YAML configuration is unchanged. The library is
+  pre-release; no back-compat shim. (#867 part 1)
 - The [`audit.Formatter`](https://pkg.go.dev/github.com/axonops/audit#Formatter)
   interface gains a `ContentType() string` method. Built-in
   formatters implement it (`JSONFormatter` → `application/x-ndjson`,

--- a/audit_benchmark_test.go
+++ b/audit_benchmark_test.go
@@ -371,10 +371,10 @@ func BenchmarkAudit_FanOut_FilteredOutputs(b *testing.B) {
 		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out1), // receives all events
 		audit.WithNamedOutput(out2, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 		})), // receives only write events
 		audit.WithNamedOutput(out3, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 		})), // receives only security events — filters schema_register
 	)
 	if err != nil {

--- a/audit_concurrency_test.go
+++ b/audit_concurrency_test.go
@@ -102,7 +102,7 @@ func TestLogger_ThreeWayRace_AuditSetRouteClose(t *testing.T) {
 			defer wg.Done()
 			for range 5 {
 				_ = auditor.SetOutputRoute("test", &audit.EventRoute{
-					IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+					IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 				})
 				_ = auditor.SetOutputRoute("test", &audit.EventRoute{})
 			}

--- a/audit_filter_test.go
+++ b/audit_filter_test.go
@@ -335,7 +335,7 @@ func TestLogger_MultiCategory_IncludeRoute(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 		})),
 	)
 	require.NoError(t, err)

--- a/docs/event-routing.md
+++ b/docs/event-routing.md
@@ -264,15 +264,15 @@ Routes can be modified at runtime without restarting the auditor:
 ```go
 // Restrict an output to security events only.
 err := auditor.SetOutputRoute("siem", &audit.EventRoute{
-    IncludeCategories: map[string]*audit.SeverityRange{
-        "security": nil, // any severity
+    IncludeCategories: map[string]audit.SeverityRange{
+        "security": {}, // zero value — any severity
     },
 })
 
 // Restrict to high-severity security events.
 sev7 := 7
 err = auditor.SetOutputRoute("siem", &audit.EventRoute{
-    IncludeCategories: map[string]*audit.SeverityRange{
+    IncludeCategories: map[string]audit.SeverityRange{
         "security": {MinSeverity: &sev7},
     },
 })

--- a/example_test.go
+++ b/example_test.go
@@ -323,7 +323,7 @@ func ExampleNewStdoutOutput() {
 func ExampleEventRoute_include() {
 	// Include mode: only security events are delivered to this output.
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 	}
 	fmt.Println("empty:", route.IsEmpty())
 	// Output: empty: false
@@ -333,6 +333,22 @@ func ExampleEventRoute_exclude() {
 	// Exclude mode: all events except reads are delivered.
 	route := audit.EventRoute{
 		ExcludeCategories: []string{"read"},
+	}
+	fmt.Println("empty:", route.IsEmpty())
+	// Output: empty: false
+}
+
+func ExampleEventRoute_perCategorySeverity() {
+	// Per-category severity: the value's SeverityRange constrains
+	// each included category independently. The zero value
+	// SeverityRange{} means "no severity constraint" — the
+	// category is included at every severity.
+	sev7 := 7
+	route := audit.EventRoute{
+		IncludeCategories: map[string]audit.SeverityRange{
+			"security": {MinSeverity: &sev7}, // sev 7+ only
+			"read":     {},                   // all severities
+		},
 	}
 	fmt.Println("empty:", route.IsEmpty())
 	// Output: empty: false
@@ -373,7 +389,7 @@ func ExampleAuditor_SetOutputRoute() {
 
 	// Restrict output to security events only at runtime.
 	if err := auditor.SetOutputRoute("stdout", &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 	}); err != nil {
 		fmt.Println("route error:", err)
 		return

--- a/fanout.go
+++ b/fanout.go
@@ -81,8 +81,8 @@ func (oe *outputEntry) effectiveFormatter(defaultFmt Formatter) Formatter {
 
 // setRoute atomically replaces the output's event route. The route is
 // deep-copied into a new EventRoute to prevent the caller from
-// mutating backing arrays, the IncludeCategories map, or any
-// *SeverityRange values after the call returns.
+// mutating backing arrays, the IncludeCategories map, or the inner
+// *int pointers of any SeverityRange values after the call returns.
 func (oe *outputEntry) setRoute(route *EventRoute) {
 	cp := &EventRoute{
 		IncludeCategories: cloneIncludeCategories(route.IncludeCategories),
@@ -97,8 +97,9 @@ func (oe *outputEntry) setRoute(route *EventRoute) {
 }
 
 // getRoute returns a deep copy of the output's current event route.
-// Both the IncludeCategories map and every *SeverityRange value are
-// freshly allocated so the caller cannot mutate the stored route.
+// The IncludeCategories map is freshly allocated and every
+// SeverityRange value's inner *int pointers are deep-copied so the
+// caller cannot mutate the stored route.
 func (oe *outputEntry) getRoute() EventRoute {
 	route := oe.route.Load()
 	if route == nil {
@@ -115,20 +116,16 @@ func (oe *outputEntry) getRoute() EventRoute {
 }
 
 // cloneIncludeCategories returns a deep copy of an IncludeCategories
-// map: the outer map is freshly allocated, and every non-nil
-// *SeverityRange is also freshly allocated with its own *int
-// pointers. A nil input returns nil.
-func cloneIncludeCategories(in map[string]*SeverityRange) map[string]*SeverityRange {
+// map: the outer map is freshly allocated, and every value's inner
+// *int pointers (MinSeverity, MaxSeverity) are deep-copied. A nil
+// input returns nil.
+func cloneIncludeCategories(in map[string]SeverityRange) map[string]SeverityRange {
 	if in == nil {
 		return nil
 	}
-	out := make(map[string]*SeverityRange, len(in))
+	out := make(map[string]SeverityRange, len(in))
 	for k, v := range in {
-		if v == nil {
-			out[k] = nil
-			continue
-		}
-		out[k] = &SeverityRange{
+		out[k] = SeverityRange{
 			MinSeverity: copyIntPtr(v.MinSeverity),
 			MaxSeverity: copyIntPtr(v.MaxSeverity),
 		}

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -77,13 +77,13 @@ func TestFanout_RouteFiltering(t *testing.T) {
 	}{
 		{
 			name:      "include category matches",
-			route:     audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"security": nil}},
+			route:     audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"security": {}}},
 			events:    []string{"user_create", "auth_failure"},
 			wantCount: 1, // only auth_failure
 		},
 		{
 			name:      "include category no match",
-			route:     audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"security": nil}},
+			route:     audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"security": {}}},
 			events:    []string{"user_create", "user_get"},
 			wantCount: 0,
 		},
@@ -96,7 +96,7 @@ func TestFanout_RouteFiltering(t *testing.T) {
 		{
 			name: "include union matches category and event type",
 			route: audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+				IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 				IncludeEventTypes: []string{"auth_failure"},
 			},
 			events:    []string{"user_create", "auth_failure", "user_get"},
@@ -207,7 +207,7 @@ func TestFanout_BootstrapValidation_UnknownCategory(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"nonexistent": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"nonexistent": {}},
 		})),
 	)
 	require.Error(t, err)
@@ -222,7 +222,7 @@ func TestFanout_BootstrapValidation_MixedMode(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 			ExcludeCategories: []string{"read"},
 		})),
 	)
@@ -248,7 +248,7 @@ func TestFanout_SetOutputRoute(t *testing.T) {
 
 	// Set route to security only.
 	require.NoError(t, auditor.SetOutputRoute("routed", &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 	}))
 
 	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_delete", audit.Fields{"outcome": "success"})))
@@ -274,7 +274,7 @@ func TestFanout_SetOutputRoute_DoesNotAffectOtherOutputs(t *testing.T) {
 
 	// Restrict A to security only.
 	require.NoError(t, auditor.SetOutputRoute("a", &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 	}))
 
 	require.NoError(t, auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{"outcome": "success"})))
@@ -313,7 +313,7 @@ func TestFanout_SetOutputRoute_InvalidRoute(t *testing.T) {
 	t.Cleanup(func() { _ = auditor.Close() })
 
 	err = auditor.SetOutputRoute("test", &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"bogus": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"bogus": {}},
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, audit.ErrConfigInvalid)
@@ -328,7 +328,7 @@ func TestFanout_ClearOutputRoute(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 		})),
 	)
 	require.NoError(t, err)
@@ -360,7 +360,7 @@ func TestFanout_ClearOutputRoute_UnknownOutput(t *testing.T) {
 
 func TestFanout_OutputRoute(t *testing.T) {
 	out := testhelper.NewMockOutput("test")
-	route := audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"security": nil}}
+	route := audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"security": {}}}
 	auditor, err := audit.New(
 		audit.WithTaxonomy(testhelper.TestTaxonomy()),
 		audit.WithAppName("test-app"),
@@ -377,7 +377,7 @@ func TestFanout_OutputRoute(t *testing.T) {
 	// Mutating the returned route must not affect the stored route.
 	// Map form (#193): inserting a new key on the returned map must
 	// not be observable on a subsequent OutputRoute() call.
-	got.IncludeCategories["write"] = nil
+	got.IncludeCategories["write"] = audit.SeverityRange{}
 	got2, err := auditor.OutputRoute("test")
 	require.NoError(t, err)
 	assert.Len(t, got2.IncludeCategories, 1, "stored route should not be mutated")
@@ -411,11 +411,11 @@ func TestFanout_OutputRoute_ReflectsSetAndClear(t *testing.T) {
 	t.Cleanup(func() { _ = auditor.Close() })
 
 	// Set a route.
-	newRoute := audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"write": nil}}
+	newRoute := audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"write": {}}}
 	require.NoError(t, auditor.SetOutputRoute("test", &newRoute))
 	got, err := auditor.OutputRoute("test")
 	require.NoError(t, err)
-	assert.Equal(t, map[string]*audit.SeverityRange{"write": nil}, got.IncludeCategories)
+	assert.Equal(t, map[string]audit.SeverityRange{"write": {}}, got.IncludeCategories)
 
 	// Clear.
 	require.NoError(t, auditor.ClearOutputRoute("test"))
@@ -449,7 +449,7 @@ func TestFanout_ConcurrentSetRouteAndAudit(t *testing.T) {
 		defer wg.Done()
 		for range 50 {
 			_ = auditor.SetOutputRoute("concurrent", &audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+				IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 			})
 			_ = auditor.ClearOutputRoute("concurrent")
 		}
@@ -482,7 +482,7 @@ func TestFanout_GlobalFilterTakesPrecedence(t *testing.T) {
 		audit.WithAppName("test-app"),
 		audit.WithHost("test-host"),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 		})),
 	)
 	require.NoError(t, err)
@@ -627,7 +627,7 @@ func TestFanout_PerOutputRouteFilter_MetricsRecordFiltered(t *testing.T) {
 		audit.WithHost("test-host"),
 		audit.WithMetrics(metrics),
 		audit.WithNamedOutput(out, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 		})),
 	)
 	require.NoError(t, err)
@@ -766,8 +766,8 @@ func TestFanout_AllExcludeRoute_ZeroDeliveries(t *testing.T) {
 // independently — no leakage from one output's filter into
 // another's. (#565 G10).
 func TestFanout_IncludeExclude_MultipleOutputs_Independence(t *testing.T) {
-	writeOnly := &audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"write": nil}}
-	securityOnly := &audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"security": nil}}
+	writeOnly := &audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"write": {}}}
+	securityOnly := &audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"security": {}}}
 	out1 := testhelper.NewMockOutput("write-only")
 	out2 := testhelper.NewMockOutput("security-only")
 	auditor, err := audit.New(

--- a/filter.go
+++ b/filter.go
@@ -27,8 +27,8 @@ import (
 // scale (0-10). Used as the value type of
 // [EventRoute.IncludeCategories] to express per-category severity
 // thresholds in a route. A nil pointer in either field disables that
-// side of the bound; a nil *SeverityRange (or a *SeverityRange with
-// both fields nil) means "no severity constraint" for the associated
+// side of the bound; the zero value SeverityRange{} (both inner
+// pointers nil) means "no severity constraint" for the associated
 // category.
 type SeverityRange struct {
 	// MinSeverity is the inclusive lower bound on CEF severity
@@ -61,9 +61,10 @@ type SeverityRange struct {
 // the event:
 //
 //   - If the event's category is a key in [EventRoute.IncludeCategories],
-//     the value's [SeverityRange] applies. A nil value means "no
-//     severity constraint for this category", and route-level
-//     [EventRoute.MinSeverity]/[EventRoute.MaxSeverity] are NOT applied.
+//     the value's [SeverityRange] applies. The zero value
+//     SeverityRange{} means "no severity constraint for this
+//     category", and route-level [EventRoute.MinSeverity] /
+//     [EventRoute.MaxSeverity] are NOT applied.
 //   - Else if the event's type is in [EventRoute.IncludeEventTypes],
 //     the route-level severity bounds apply.
 //   - Else (no include categories or event types — the severity-only
@@ -74,10 +75,11 @@ type SeverityRange struct {
 type EventRoute struct {
 	// IncludeCategories maps category names to per-category severity
 	// filters. Presence of a key allows events in that category; the
-	// value (when non-nil) further restricts by severity. A nil value
-	// means "all severities allowed for this category". Mutually
-	// exclusive with ExcludeCategories and ExcludeEventTypes.
-	IncludeCategories map[string]*SeverityRange
+	// value's [SeverityRange] optionally restricts by severity. The
+	// zero value SeverityRange{} means "all severities allowed for
+	// this category". Mutually exclusive with ExcludeCategories and
+	// ExcludeEventTypes.
+	IncludeCategories map[string]SeverityRange
 
 	// IncludeEventTypes lists event type names to allow. Events whose
 	// type is in this list are delivered using the route-level
@@ -159,9 +161,9 @@ func ValidateEventRoute(route *EventRoute, taxonomy *Taxonomy) error {
 	slices.Sort(cats)
 	for _, cat := range cats {
 		f := route.IncludeCategories[cat]
-		if f == nil {
-			continue
-		}
+		// Zero-value SeverityRange{} (both inner pointers nil) means
+		// "no severity constraint" — validateSeverityRange returns
+		// nil for that input, so no special case is needed here.
 		ctx := fmt.Sprintf("EventRoute category %q", cat)
 		if err := validateSeverityRange(f.MinSeverity, f.MaxSeverity, ctx); err != nil {
 			return err
@@ -220,7 +222,7 @@ func checkCategories(unknown, cats []string, taxonomy *Taxonomy) []string {
 // iteration is non-deterministic in Go — the caller (validateRouteEntries)
 // sorts the resulting unknown slice before formatting the error so the
 // error message is reproducible.
-func checkCategoryMap(unknown []string, cats map[string]*SeverityRange, taxonomy *Taxonomy) []string {
+func checkCategoryMap(unknown []string, cats map[string]SeverityRange, taxonomy *Taxonomy) []string {
 	for cat := range cats {
 		if _, ok := taxonomy.Categories[cat]; !ok {
 			unknown = append(unknown, fmt.Sprintf("category %q", cat))
@@ -299,13 +301,13 @@ func MatchesRoute(route *EventRoute, eventType, category string, severity int) b
 	}
 
 	if route.isIncludeMode() {
-		// Category-key match wins; the per-category filter (or nil)
+		// Category-key match wins; the per-category filter
 		// determines severity entirely — route-level severity does
-		// not apply to category matches.
+		// not apply to category matches. The zero-value
+		// SeverityRange{} flows through checkSeverity(nil, nil, _)
+		// which returns true, so no special-case nil branch is
+		// needed.
 		if filter, ok := route.IncludeCategories[category]; ok {
-			if filter == nil {
-				return true
-			}
 			return checkSeverity(filter.MinSeverity, filter.MaxSeverity, severity)
 		}
 		// Event-type fallback uses route-level severity.

--- a/filter_property_test.go
+++ b/filter_property_test.go
@@ -98,7 +98,7 @@ func genFilterOps(rt *rapid.T) []filterOp {
 			op.route = &audit.EventRoute{}
 			if rapid.Bool().Draw(rt, "include_categories") {
 				cat := rapid.SampledFrom(categories).Draw(rt, "include_cat")
-				op.route.IncludeCategories = map[string]*audit.SeverityRange{cat: nil}
+				op.route.IncludeCategories = map[string]audit.SeverityRange{cat: {}}
 			}
 		case opClearOutputRoute:
 			op.output = rapid.SampledFrom(outputs).Draw(rt, "output")
@@ -181,11 +181,11 @@ func formatRoute(r *audit.EventRoute) string {
 		" exclude_evts=" + joinSorted(r.ExcludeEventTypes)
 }
 
-// joinSortedMap collapses a map[string]*audit.SeverityRange to a
+// joinSortedMap collapses a map[string]audit.SeverityRange to a
 // deterministic "[a,b,c]" string of the keys. Per-category severity
 // ranges are not part of the property-test domain today; if a future
 // op introduces them, extend this to include the range too.
-func joinSortedMap(m map[string]*audit.SeverityRange) string {
+func joinSortedMap(m map[string]audit.SeverityRange) string {
 	if len(m) == 0 {
 		return "[]"
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestEventRoute_IsEmpty(t *testing.T) {
 	assert.True(t, (&audit.EventRoute{}).IsEmpty())
-	assert.False(t, (&audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"write": nil}}).IsEmpty())
+	assert.False(t, (&audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"write": {}}}).IsEmpty())
 	assert.False(t, (&audit.EventRoute{ExcludeEventTypes: []string{"auth_failure"}}).IsEmpty())
 }
 
@@ -44,7 +44,7 @@ func TestValidateEventRoute(t *testing.T) {
 		},
 		{
 			name:  "valid include categories",
-			route: audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"write": nil, "security": nil}},
+			route: audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"write": {}, "security": {}}},
 		},
 		{
 			name:  "valid include event types",
@@ -61,7 +61,7 @@ func TestValidateEventRoute(t *testing.T) {
 		{
 			name: "valid include categories and event types",
 			route: audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+				IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 				IncludeEventTypes: []string{"auth_failure"},
 			},
 		},
@@ -75,7 +75,7 @@ func TestValidateEventRoute(t *testing.T) {
 		{
 			name: "mixed include and exclude categories",
 			route: audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+				IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 				ExcludeCategories: []string{"read"},
 			},
 			wantErr: "either include or exclude, not both",
@@ -83,7 +83,7 @@ func TestValidateEventRoute(t *testing.T) {
 		{
 			name: "mixed include categories and exclude event types",
 			route: audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+				IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 				ExcludeEventTypes: []string{"auth_failure"},
 			},
 			wantErr: "either include or exclude, not both",
@@ -98,7 +98,7 @@ func TestValidateEventRoute(t *testing.T) {
 		},
 		{
 			name:    "unknown include category",
-			route:   audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"nonexistent": nil}},
+			route:   audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"nonexistent": {}}},
 			wantErr: "unknown taxonomy entries",
 		},
 		{
@@ -151,14 +151,14 @@ func TestMatchesRoute(t *testing.T) {
 		// Include mode — categories.
 		{
 			name:      "include category match",
-			route:     audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"security": nil}},
+			route:     audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"security": {}}},
 			eventType: "auth_failure",
 			category:  "security",
 			want:      true,
 		},
 		{
 			name:      "include category no match",
-			route:     audit.EventRoute{IncludeCategories: map[string]*audit.SeverityRange{"security": nil}},
+			route:     audit.EventRoute{IncludeCategories: map[string]audit.SeverityRange{"security": {}}},
 			eventType: "user_create",
 			category:  "write",
 			want:      false,
@@ -182,7 +182,7 @@ func TestMatchesRoute(t *testing.T) {
 		{
 			name: "include union category match",
 			route: audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+				IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 				IncludeEventTypes: []string{"auth_failure"},
 			},
 			eventType: "user_create",
@@ -192,7 +192,7 @@ func TestMatchesRoute(t *testing.T) {
 		{
 			name: "include union event type match",
 			route: audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+				IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 				IncludeEventTypes: []string{"auth_failure"},
 			},
 			eventType: "auth_failure",
@@ -202,7 +202,7 @@ func TestMatchesRoute(t *testing.T) {
 		{
 			name: "include union no match",
 			route: audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+				IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 				IncludeEventTypes: []string{"auth_failure"},
 			},
 			eventType: "config_get",
@@ -296,7 +296,7 @@ func BenchmarkMatchesRoute(b *testing.B) {
 
 	b.Run("include_categories", func(b *testing.B) {
 		route := audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"write": nil, "security": nil, "admin": nil, "read": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"write": {}, "security": {}, "admin": {}, "read": {}},
 		}
 		b.ResetTimer()
 		b.ReportAllocs()
@@ -328,11 +328,11 @@ func BenchmarkMatchesRoute(b *testing.B) {
 	})
 
 	b.Run("include_20_categories", func(b *testing.B) {
-		cats := make(map[string]*audit.SeverityRange, 20)
+		cats := make(map[string]audit.SeverityRange, 20)
 		for i := 0; i < 20; i++ {
-			cats[fmt.Sprintf("category_%02d", i)] = nil
+			cats[fmt.Sprintf("category_%02d", i)] = audit.SeverityRange{}
 		}
-		cats["write"] = nil // ensure the match key is present
+		cats["write"] = audit.SeverityRange{} // ensure the match key is present
 		route := audit.EventRoute{IncludeCategories: cats}
 		b.ResetTimer()
 		b.ReportAllocs()

--- a/outputconfig/outputconfig_test.go
+++ b/outputconfig/outputconfig_test.go
@@ -124,7 +124,7 @@ func TestLoad_FileWithRoute(t *testing.T) {
 	// Second output: file with route
 	assert.Equal(t, "audit_log", result.OutputMetadata()[1].Name)
 	require.NotNil(t, result.OutputMetadata()[1].Route)
-	assert.Equal(t, map[string]*audit.SeverityRange{"write": nil, "security": nil}, result.OutputMetadata()[1].Route.IncludeCategories)
+	assert.Equal(t, map[string]audit.SeverityRange{"write": {}, "security": {}}, result.OutputMetadata()[1].Route.IncludeCategories)
 }
 
 func TestLoad_MultipleOutputs(t *testing.T) {

--- a/outputconfig/route.go
+++ b/outputconfig/route.go
@@ -22,10 +22,10 @@ import (
 )
 
 // yamlSeverityRange is the YAML representation of a per-category
-// severity filter. An empty YAML mapping (`{}`) unmarshals to a
-// non-nil *yamlSeverityRange with both fields nil; buildRoute
-// normalises this to a nil *audit.SeverityRange so consumers have
-// exactly one canonical "no filter" value.
+// severity filter. An empty YAML mapping (`{}`) or an explicit `~`
+// / null unmarshals to a zero-value audit.SeverityRange (both inner
+// pointers nil) so "no severity constraint for this category" is
+// represented by a single canonical value.
 type yamlSeverityRange struct {
 	MinSeverity *int `yaml:"min_severity"`
 	MaxSeverity *int `yaml:"max_severity"`
@@ -76,20 +76,20 @@ func buildRoute(name string, raw any, taxonomy *audit.Taxonomy) (*audit.EventRou
 
 // convertIncludeCategories translates the parsed YAML map to the
 // audit package's typed map. An empty inline mapping (`{}`) or an
-// explicit `~` / null is normalised to a nil *audit.SeverityRange —
-// there is exactly one canonical "no filter" value so equality and
-// golden-file tests are stable.
-func convertIncludeCategories(in map[string]*yamlSeverityRange) map[string]*audit.SeverityRange {
+// explicit `~` / null becomes a zero-value audit.SeverityRange —
+// the canonical "no severity constraint" representation that
+// flows through MatchesRoute without a special case.
+func convertIncludeCategories(in map[string]*yamlSeverityRange) map[string]audit.SeverityRange {
 	if in == nil {
 		return nil
 	}
-	out := make(map[string]*audit.SeverityRange, len(in))
+	out := make(map[string]audit.SeverityRange, len(in))
 	for cat, yf := range in {
-		if yf == nil || (yf.MinSeverity == nil && yf.MaxSeverity == nil) {
-			out[cat] = nil
+		if yf == nil {
+			out[cat] = audit.SeverityRange{}
 			continue
 		}
-		out[cat] = &audit.SeverityRange{
+		out[cat] = audit.SeverityRange{
 			MinSeverity: yf.MinSeverity,
 			MaxSeverity: yf.MaxSeverity,
 		}

--- a/per_category_severity_test.go
+++ b/per_category_severity_test.go
@@ -36,8 +36,8 @@ import (
 func TestPerCat_ModeA_AnySeverityPasses(t *testing.T) {
 	t.Parallel()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
-			"security": nil,
+		IncludeCategories: map[string]audit.SeverityRange{
+			"security": {},
 		},
 	}
 	// Category match with nil filter passes regardless of severity.
@@ -59,7 +59,7 @@ func TestPerCat_ModeA_AnySeverityPasses(t *testing.T) {
 func TestPerCat_ModeB_MinOnly(t *testing.T) {
 	t.Parallel()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(7)},
 		},
 	}
@@ -79,7 +79,7 @@ func TestPerCat_ModeB_MinOnly(t *testing.T) {
 func TestPerCat_ModeB_MaxOnly(t *testing.T) {
 	t.Parallel()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"read": {MaxSeverity: intPtr(3)},
 		},
 	}
@@ -99,7 +99,7 @@ func TestPerCat_ModeB_MaxOnly(t *testing.T) {
 func TestPerCat_ModeB_MinAndMax(t *testing.T) {
 	t.Parallel()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(4), MaxSeverity: intPtr(7)},
 		},
 	}
@@ -120,9 +120,9 @@ func TestPerCat_ModeB_MixedFilters(t *testing.T) {
 	t.Parallel()
 	// security ≥ 7, read any severity.
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(7)},
-			"read":     nil,
+			"read":     {},
 		},
 	}
 	// Security: only ≥7 passes.
@@ -145,8 +145,8 @@ func TestPerCat_RouteLevelDoesNotApplyToCategoryMatch(t *testing.T) {
 	// Route-level min=9, but the category has a nil filter → all
 	// severities pass for category matches.
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
-			"security": nil,
+		IncludeCategories: map[string]audit.SeverityRange{
+			"security": {},
 		},
 		MinSeverity: intPtr(9),
 	}
@@ -161,7 +161,7 @@ func TestPerCat_RouteLevelAppliesToEventTypeMatch(t *testing.T) {
 	// admin_action event-type, route-level min=5 applies ONLY to the
 	// event-type fallback path.
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(7)},
 		},
 		IncludeEventTypes: []string{"admin_action"},
@@ -194,28 +194,27 @@ func TestPerCat_ModeC_SeverityOnly(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Empty {} vs absent vs nil pointer — semantic equivalence
+// Presence vs absence — key-in-map is the include signal
 // ---------------------------------------------------------------------------
 
-func TestPerCat_NilFilter_EquivalentToEmptyStruct(t *testing.T) {
+func TestPerCat_AbsentKey_DoesNotMatch(t *testing.T) {
 	t.Parallel()
-	// Both forms should behave identically: "all severities pass for
-	// this category". The library normalises empty filters to nil at
-	// parse time (see outputconfig.convertIncludeCategories), but
-	// programmatic construction can produce either. Both must match.
-	nilForm := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
-	}
-	emptyForm := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
-			"security": {}, // non-nil pointer with both bounds nil
+	// Presence of a key in IncludeCategories is the include signal;
+	// the zero-value SeverityRange{} means "no severity constraint".
+	// An absent category key must NOT match the route; a present
+	// zero-value key MUST match at every severity.
+	route := audit.EventRoute{
+		IncludeCategories: map[string]audit.SeverityRange{
+			"security": {}, // present, zero value
 		},
 	}
 	for sev := 0; sev <= 10; sev++ {
-		nilGot := audit.MatchesRoute(&nilForm, "auth_failure", "security", sev)
-		emptyGot := audit.MatchesRoute(&emptyForm, "auth_failure", "security", sev)
-		assert.Equal(t, nilGot, emptyGot,
-			"nil filter and empty-struct filter must behave identically; sev=%d", sev)
+		// Present key — all severities pass.
+		assert.True(t, audit.MatchesRoute(&route, "auth_failure", "security", sev),
+			"present zero-value key must match every severity; sev=%d", sev)
+		// Absent key — never matches regardless of severity.
+		assert.False(t, audit.MatchesRoute(&route, "user_create", "write", sev),
+			"absent key must not match; sev=%d", sev)
 	}
 }
 
@@ -227,7 +226,7 @@ func TestPerCat_Validation_OutOfRangeMin(t *testing.T) {
 	t.Parallel()
 	tax := testhelper.TestTaxonomy()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(11)},
 		},
 	}
@@ -244,7 +243,7 @@ func TestPerCat_Validation_OutOfRangeMax(t *testing.T) {
 	t.Parallel()
 	tax := testhelper.TestTaxonomy()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MaxSeverity: intPtr(-1)},
 		},
 	}
@@ -258,7 +257,7 @@ func TestPerCat_Validation_MinGreaterThanMax(t *testing.T) {
 	t.Parallel()
 	tax := testhelper.TestTaxonomy()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(8), MaxSeverity: intPtr(3)},
 		},
 	}
@@ -273,8 +272,8 @@ func TestPerCat_Validation_UnknownCategory(t *testing.T) {
 	t.Parallel()
 	tax := testhelper.TestTaxonomy()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
-			"nonexistent": nil,
+		IncludeCategories: map[string]audit.SeverityRange{
+			"nonexistent": {},
 		},
 	}
 	err := audit.ValidateEventRoute(&route, tax)
@@ -290,7 +289,7 @@ func TestPerCat_Validation_DeterministicErrorOrder(t *testing.T) {
 	// iterates sorted keys and returns on the first failure.
 	tax := testhelper.TestTaxonomy()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"zzz_unknown": {MinSeverity: intPtr(11)},
 			"security":    {MinSeverity: intPtr(11)},
 		},
@@ -321,24 +320,25 @@ func TestPerCat_RoundTrip_DeepClonePreservesSeverityRange(t *testing.T) {
 	t.Cleanup(func() { _ = auditor.Close() })
 
 	original := &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(7), MaxSeverity: intPtr(9)},
-			"read":     nil,
+			"read":     {},
 		},
 	}
 	require.NoError(t, auditor.SetOutputRoute("test", original))
 
 	got, err := auditor.OutputRoute("test")
 	require.NoError(t, err)
+	require.Len(t, got.IncludeCategories, 2,
+		"both keys must round-trip; absent keys would also return a zero-value SeverityRange from the map")
 	require.Contains(t, got.IncludeCategories, "security")
-	require.NotNil(t, got.IncludeCategories["security"])
 	require.NotNil(t, got.IncludeCategories["security"].MinSeverity)
 	assert.Equal(t, 7, *got.IncludeCategories["security"].MinSeverity)
 	require.NotNil(t, got.IncludeCategories["security"].MaxSeverity)
 	assert.Equal(t, 9, *got.IncludeCategories["security"].MaxSeverity)
-	// Nil filter for "read" survives the round-trip.
+	// Zero-value SeverityRange for "read" survives the round-trip.
 	require.Contains(t, got.IncludeCategories, "read")
-	assert.Nil(t, got.IncludeCategories["read"])
+	assert.Equal(t, audit.SeverityRange{}, got.IncludeCategories["read"])
 
 	// Mutating the returned route's SeverityRange must not affect
 	// the stored route. This is the core deep-clone invariant.
@@ -366,7 +366,7 @@ func TestPerCat_RoundTrip_CallerMutationOfInputCannotCorrupt(t *testing.T) {
 	// after SetOutputRoute returns must NOT change the stored value.
 	min7 := 7
 	original := &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: &min7},
 		},
 	}
@@ -375,7 +375,7 @@ func TestPerCat_RoundTrip_CallerMutationOfInputCannotCorrupt(t *testing.T) {
 	// Mutation #1: the SAME *int pointee.
 	min7 = 99
 	// Mutation #2: insert a new key into the caller's map.
-	original.IncludeCategories["new_cat"] = nil
+	original.IncludeCategories["new_cat"] = audit.SeverityRange{}
 
 	got, err := auditor.OutputRoute("test")
 	require.NoError(t, err)
@@ -394,11 +394,11 @@ func TestPerCat_RoundTrip_CallerMutationOfInputCannotCorrupt(t *testing.T) {
 func BenchmarkMatchesRoute_PerCategorySeverity(b *testing.B) {
 	// Mode B — Per-category severity gating, the new capability.
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security":   {MinSeverity: intPtr(7)},
 			"compliance": {MinSeverity: intPtr(5)},
 			"write":      {MinSeverity: intPtr(3)},
-			"read":       nil,
+			"read":       {},
 		},
 	}
 	b.ResetTimer()
@@ -412,11 +412,11 @@ func BenchmarkMatchesRoute_MixedNilAndFilter(b *testing.B) {
 	// Worst branch-predictor case: some categories with nil filter,
 	// some with thresholds, calls alternate between the two paths.
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(7)},
-			"read":     nil,
+			"read":     {},
 			"write":    {MinSeverity: intPtr(3)},
-			"admin":    nil,
+			"admin":    {},
 		},
 	}
 	categories := []string{"security", "read", "write", "admin"}

--- a/severity_routing_test.go
+++ b/severity_routing_test.go
@@ -120,7 +120,7 @@ func TestMatchesRoute_MinAndMaxSeverity_Reject(t *testing.T) {
 func TestMatchesRoute_SeverityWithCategoryFilter(t *testing.T) {
 	t.Parallel()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			"security": {MinSeverity: intPtr(6)},
 		},
 	}
@@ -149,7 +149,7 @@ func TestMatchesRoute_SeverityWithCategoryFilter(t *testing.T) {
 func TestMatchesRoute_RouteLevelSeverity_DoesNotApplyToCategoryMatch(t *testing.T) {
 	t.Parallel()
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 		MinSeverity:       intPtr(6), // applies only to event-type matches
 	}
 	got := audit.MatchesRoute(&route, "auth_failure", "security", 3)
@@ -221,7 +221,7 @@ func TestMatchesRoute_NilSeverity_NoFilter(t *testing.T) {
 	// Include-mode route with nil severity pointers: only the category
 	// filter applies; severity plays no role.
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 		// MinSeverity and MaxSeverity are nil (zero value).
 	}
 
@@ -504,7 +504,7 @@ func TestSetRoute_NilSeverityPointersPreserved(t *testing.T) {
 
 	// Set a route that has no severity constraints.
 	route := &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 		// MinSeverity and MaxSeverity intentionally nil.
 	}
 	require.NoError(t, auditor.SetOutputRoute("nil-sev", route))
@@ -812,7 +812,7 @@ func TestValidateEventRoute_SeverityWithMixedIncludeExclude(t *testing.T) {
 	tax := testhelper.TestTaxonomy()
 
 	route := audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{"write": nil},
+		IncludeCategories: map[string]audit.SeverityRange{"write": {}},
 		ExcludeCategories: []string{"read"},
 		MinSeverity:       intPtr(3),
 		MaxSeverity:       intPtr(8),
@@ -870,7 +870,7 @@ func BenchmarkMatchesRoute_Severity(b *testing.B) {
 	b.Run("include_categories_with_severity", func(b *testing.B) {
 		// Category include filter combined with severity range.
 		route := audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"write": nil, "security": nil, "admin": nil, "read": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"write": {}, "security": {}, "admin": {}, "read": {}},
 			MinSeverity:       intPtr(5),
 			MaxSeverity:       intPtr(9),
 		}
@@ -886,9 +886,9 @@ func BenchmarkMatchesRoute_Severity(b *testing.B) {
 		// category's SeverityRange. Event in matching category but
 		// below the per-cat min → rejected on filter deref.
 		route := audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{
+			IncludeCategories: map[string]audit.SeverityRange{
 				"write":    {MinSeverity: intPtr(9)},
-				"security": nil,
+				"security": {},
 			},
 		}
 		b.ResetTimer()
@@ -902,9 +902,9 @@ func BenchmarkMatchesRoute_Severity(b *testing.B) {
 		// Per-category severity (#193): event in matching category and
 		// above the per-cat min → passes via the per-cat fast path.
 		route := audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{
+			IncludeCategories: map[string]audit.SeverityRange{
 				"write":    {MinSeverity: intPtr(5)},
-				"security": nil,
+				"security": {},
 			},
 		}
 		b.ResetTimer()

--- a/tests/bdd/steps/fanout_steps.go
+++ b/tests/bdd/steps/fanout_steps.go
@@ -73,16 +73,16 @@ events:
 `
 
 // includeCats builds an EventRoute.IncludeCategories map from a list
-// of category names with nil SeverityRange (the "no severity filter"
-// shorthand). Used throughout the fanout step definitions to keep
-// the call sites concise.
-func includeCats(names ...string) map[string]*audit.SeverityRange {
+// of category names with zero-value SeverityRange (the "no severity
+// filter" shorthand). Used throughout the fanout step definitions
+// to keep the call sites concise.
+func includeCats(names ...string) map[string]audit.SeverityRange {
 	if len(names) == 0 {
 		return nil
 	}
-	m := make(map[string]*audit.SeverityRange, len(names))
+	m := make(map[string]audit.SeverityRange, len(names))
 	for _, n := range names {
-		m[n] = nil
+		m[n] = audit.SeverityRange{}
 	}
 	return m
 }

--- a/tests/bdd/steps/severity_routing_steps.go
+++ b/tests/bdd/steps/severity_routing_steps.go
@@ -186,7 +186,7 @@ func createPerCategorySeverityRoutedAuditor(tc *AuditTestContext, cat string, mi
 		return fmt.Errorf("create stdout: %w", err)
 	}
 	route := &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			cat: {MinSeverity: minSev, MaxSeverity: maxSev},
 		},
 	}
@@ -250,7 +250,7 @@ func tryPerCategoryAuditorCreation(tc *AuditTestContext, cat string, minSev, max
 		return fmt.Errorf("create stdout: %w", err)
 	}
 	route := &audit.EventRoute{
-		IncludeCategories: map[string]*audit.SeverityRange{
+		IncludeCategories: map[string]audit.SeverityRange{
 			cat: {MinSeverity: minSev, MaxSeverity: maxSev},
 		},
 	}
@@ -306,7 +306,7 @@ func registerSeverityRuntimeSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 				return fmt.Errorf("auditor not created")
 			}
 			route := &audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{
+				IncludeCategories: map[string]audit.SeverityRange{
 					cat: {MinSeverity: &minSev},
 				},
 			}
@@ -324,7 +324,7 @@ func registerSeverityRuntimeSteps(ctx *godog.ScenarioContext, tc *AuditTestConte
 				return fmt.Errorf("create stdout: %w", err)
 			}
 			route := &audit.EventRoute{
-				IncludeCategories: map[string]*audit.SeverityRange{cat: nil},
+				IncludeCategories: map[string]audit.SeverityRange{cat: {}},
 				MinSeverity:       &minSev,
 			}
 			auditor, lErr := audit.New(

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -244,7 +244,7 @@ func TestFanOut_EventRouting(t *testing.T) {
 		audit.WithHost("test-host"),
 		audit.WithNamedOutput(fileOut), // all events
 		audit.WithNamedOutput(webhookOut, audit.WithRoute(&audit.EventRoute{
-			IncludeCategories: map[string]*audit.SeverityRange{"security": nil},
+			IncludeCategories: map[string]audit.SeverityRange{"security": {}},
 		})), // security only
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

PR-1 of two-PR fix for spike #867 (matchesRoute include_categories +112% regression).

This PR changes the public API of `audit.EventRoute.IncludeCategories` from a pointer-valued map to a value-typed map:

```go
// before
IncludeCategories map[string]*SeverityRange

// after
IncludeCategories map[string]SeverityRange
```

Inner `MinSeverity *int` / `MaxSeverity *int` stay as pointers (sentinel-nil = no bound). The canonical "no severity constraint" form flips from typed-nil pointer to `SeverityRange{}` zero value. YAML config is unchanged.

**This PR alone does not recover the perf baseline** — see the bench data below. The actual perf fix lands in PR-2 (inline `[4]string + [4]SeverityRange` fast path + mode-byte peephole). PR-1 is the prerequisite refactor that PR-2 builds on.

## Why split into two PRs

The Plan-agent reviewing the spike strategy recommended this split:
1. **PR-1 is high blast radius (144 call sites updated)** — better as a focused refactor that can be reverted independently if the API change misbehaves.
2. **PR-2 is internal** — no public API surface change, only filter.go internals.

## Bench data (10 iterations, AMD Ryzen 7950X)

| Benchmark | Pre-PR-1 | Post-PR-1 | Δ |
|---|---:|---:|---:|
| `MatchesRoute/include_categories` | 6.80 ns | 6.80 ns | flat |
| `MatchesRoute_Severity/include_categories_with_severity` | ~6.6 ns | ~7.0 ns | within noise |
| `MatchesRoute_Severity/per_category_severity_accept` | ~7.05 ns | ~7.28 ns | within noise |

The expected ~1.5 ns recovery from "no pointer chase + no nil branch" is offset by the 16-byte value-type vs 8-byte pointer in the map. Net: flat. PR-2's inline arrays eliminate the map machinery entirely (`aeshashbody`, `mapaccess2_faststr`, `getWithoutKeySmallFastStr`) for the common N≤4 case.

## Agent review trail

- **Pre-coding**: api-ergonomics-reviewer approved the value-type swap, rejected Option F (packed `[2]int16`). code-reviewer approved cloneIncludeCategories simplification + test-migration mechanics.
- **Post-coding**: code-reviewer (2 IMPORTANT fixed — tautological test replaced with meaningful absent-vs-present semantics, stale comments updated). test-analyst (LOW only — tightened `Len` assertion). security-reviewer (no findings).
- **Quality gate**: go-quality all six checks pass (fmt, vet, lint, tidy, replace, todos).

## Test plan

- [x] `go test -race -count=1 ./...` core + every sub-module passes (~10 min total)
- [x] `BDD_TAGS="@core && ~@docker" go test -race -count=1 -tags=integration ./tests/bdd/...` core BDD passes (33 s)
- [x] `make check` — all six checks pass
- [x] Bench delta captured and documented above
- [x] New godoc example `ExampleEventRoute_perCategorySeverity` added in example_test.go

## Out of scope (PR-2)

- Inline `[4]string + [4]SeverityRange` arrays on `EventRoute`
- `routeMode` discriminator byte + `MatchesRoute` switch rewrite
- ADR 0007 `matchesroute-perf.md`
- `BenchmarkMatchesRoute_LargeInclude` with N=4/5/16/32 subtests
- Cold-CPU baseline regeneration

Refs #867