### PR TITLE
ci: add post-release examples-verify workflow (#438)

### DIFF
--- a/.github/workflows/release-examples-verify.yml
+++ b/.github/workflows/release-examples-verify.yml
@@ -1,0 +1,311 @@
+# Post-release verification of every example module against the
+# PUBLISHED proxy.golang.org versions. Closes #438.
+#
+# Runs after a GitHub Release is published. For each example under
+# examples/*, copies the example outside the workspace, bumps every
+# github.com/axonops/audit* require to the released tag, runs
+# go mod tidy + go build + (when tests exist) go test. Any failures
+# are aggregated into a single dedup'd GitHub issue per release.
+#
+# Does NOT block the release — fires after publication.
+name: Release Examples Verify
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Tag to verify (e.g. v0.1.13)"
+        required: true
+
+# One run per release tag. Re-runs queue rather than cancel so the
+# dedup search in the report job sees a stable issue state.
+concurrency:
+  group: release-examples-verify-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  GOPROXY: https://proxy.golang.org,direct
+  GOSUMDB: sum.golang.org
+
+jobs:
+  # preflight resolves the version, validates its format, enumerates
+  # the examples, and waits for proxy.golang.org to have indexed every
+  # published module at the target version.
+  preflight:
+    name: Preflight (enumerate + proxy ready)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      # Checkout the released tag so the matrix enumeration and the
+      # `make print-example-modules` call see the same examples that
+      # were in the tree at release time — not whatever drifted into
+      # main since.
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.version }}
+
+      - name: Resolve and validate version
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG:-$INPUT_VERSION}"
+          if [[ -z "$VERSION" ]]; then
+            echo "preflight: no version (no release tag and no workflow_dispatch input)" >&2
+            exit 2
+          fi
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.\-]+)?$ ]]; then
+            echo "preflight: invalid version format: $VERSION" >&2
+            exit 2
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Enumerate examples (matrix)
+        id: matrix
+        run: |
+          set -euo pipefail
+          mapfile -t examples < <(make print-example-modules | xargs -n1 basename)
+          if [[ ${#examples[@]} -eq 0 ]]; then
+            echo "preflight: no examples discovered" >&2
+            exit 2
+          fi
+          # jq -nc '$ARGS.positional' guarantees valid JSON escaping.
+          matrix=$(printf '%s\n' "${examples[@]}" | jq -Rcn '[inputs]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "preflight: ${#examples[@]} examples: ${examples[*]}"
+
+      - name: Wait for proxy.golang.org to index every module
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Probe every published module at $VERSION. Retry up to
+          # 6 times with 30s backoff (~3 min total) — proxy indexing
+          # is usually instant post-release but can lag briefly.
+          mapfile -t entries < <(make print-publish-modules)
+          for entry in "${entries[@]}"; do
+            module="$(echo "$entry" | cut -d'|' -f2)"
+            echo "::group::probe $module@$VERSION"
+            ok=""
+            for attempt in 1 2 3 4 5 6; do
+              if GOWORK=off GOPROXY="$GOPROXY" GOSUMDB="$GOSUMDB" \
+                  go list -m "$module@$VERSION" >/dev/null 2>&1; then
+                echo "  attempt $attempt: indexed"
+                ok=1
+                break
+              fi
+              echo "  attempt $attempt: not yet indexed, sleeping 30s"
+              sleep 30
+            done
+            echo "::endgroup::"
+            if [[ -z "$ok" ]]; then
+              echo "preflight: proxy did not index $module@$VERSION after 6 attempts" >&2
+              exit 1
+            fi
+          done
+
+  # verify-example builds one example in isolation against the
+  # published proxy versions. fail-fast: false so one breakage
+  # doesn't mask the other 19.
+  verify-example:
+    name: Verify ${{ matrix.example }}
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        example: ${{ fromJSON(needs.preflight.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.version }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Copy example out of the workspace
+        env:
+          EXAMPLE: ${{ matrix.example }}
+        run: |
+          set -euo pipefail
+          DST="$RUNNER_TEMP/verify-$EXAMPLE"
+          mkdir -p "$DST"
+          cp -r "examples/$EXAMPLE"/. "$DST"/
+          echo "DST=$DST" >> "$GITHUB_ENV"
+
+      - name: Bump audit deps to ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/scripts/release/bump-example-deps.sh" \
+              "$DST" "${{ needs.preflight.outputs.version }}"
+
+      - name: go mod tidy
+        run: |
+          set -euo pipefail
+          cd "$DST"
+          GOWORK=off go mod tidy 2>&1 | tee tidy.log
+
+      - name: go build ./...
+        run: |
+          set -euo pipefail
+          cd "$DST"
+          GOWORK=off go build ./... 2>&1 | tee build.log
+
+      - name: go test ./...
+        run: |
+          set -euo pipefail
+          cd "$DST"
+          # No conditional — `go test ./...` on a module with no
+          # _test.go prints "? <pkg> [no test files]" and exits 0.
+          GOWORK=off go test ./... 2>&1 | tee test.log
+
+      - name: Capture failure log
+        if: failure()
+        env:
+          EXAMPLE: ${{ matrix.example }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## ${EXAMPLE} — verification failed"
+            echo
+            for log in tidy.log build.log test.log; do
+              if [[ -f "$DST/$log" ]]; then
+                echo "### $log"
+                echo '```'
+                tail -80 "$DST/$log"
+                echo '```'
+                echo
+              fi
+            done
+          } > "$RUNNER_TEMP/failure-${EXAMPLE}.md"
+
+      - name: Upload failure log
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-log-${{ matrix.example }}
+          path: ${{ runner.temp }}/failure-${{ matrix.example }}.md
+          retention-days: 14
+          if-no-files-found: ignore
+
+  # report aggregates the matrix outcome. If any example failed,
+  # create or update a single GitHub issue per release tag.
+  report:
+    name: Report
+    needs: [preflight, verify-example]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: always()
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.version }}
+
+      - name: Download all failure logs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: build-log-*
+          path: ${{ runner.temp }}/failures
+          merge-multiple: true
+
+      - name: Build summary table
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+          MATRIX_RESULT: ${{ needs.verify-example.result }}
+        run: |
+          set -euo pipefail
+          {
+            echo "# Release examples verification — $VERSION"
+            echo
+            echo "Matrix outcome: **$MATRIX_RESULT**"
+            echo
+            echo "## Per-example status"
+            echo
+            mapfile -t examples < <(make print-example-modules | xargs -n1 basename)
+            for ex in "${examples[@]}"; do
+              if [[ -f "$RUNNER_TEMP/failures/failure-${ex}.md" ]]; then
+                echo "- ❌ $ex"
+              else
+                echo "- ✅ $ex"
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create or update tracking issue on failure
+        if: needs.verify-example.result == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EXPECTED_TITLE: examples post-release verification failed for ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Build body. `shopt -s nullglob` makes the failure-*.md
+          # glob expand to nothing when no failure artefacts exist,
+          # avoiding the literal-pattern-iteration trap.
+          shopt -s nullglob
+          body_file="$RUNNER_TEMP/issue-body.md"
+          {
+            echo "Post-release verification of the example modules"
+            echo "failed for release **$VERSION**."
+            echo
+            echo "Workflow run: $RUN_URL"
+            echo
+            echo "## Failing examples"
+            echo
+            for f in "$RUNNER_TEMP"/failures/failure-*.md; do
+              cat "$f"
+            done
+            echo
+            echo "_Auto-filed by .github/workflows/release-examples-verify.yml._"
+          } > "$body_file"
+
+          # Dedup: look for an existing open issue with the exact title.
+          # `in:title` limits the search to titles only (body matches
+          # would pollute the dedup). The `select(.title==env.EXPECTED_TITLE)`
+          # jq filter reads EXPECTED_TITLE from the gh subprocess's env,
+          # which inherits from the step's `env:` block — exact-match
+          # guarantees we never re-use an unrelated issue, while the
+          # broader `--search` makes the GitHub-side query cheap.
+          existing=$(gh issue list \
+            --search "examples post-release verification failed in:title" \
+            --state open \
+            --label ci/cd \
+            --json number,title \
+            --jq '.[] | select(.title==env.EXPECTED_TITLE) | .number' \
+            | head -n1)
+
+          if [[ -n "$existing" ]]; then
+            echo "Appending comment to existing issue #$existing"
+            gh issue comment "$existing" --body-file "$body_file"
+          else
+            echo "Creating new issue"
+            gh issue create \
+              --title "$EXPECTED_TITLE" \
+              --body-file "$body_file" \
+              --label bug,ci/cd
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   reflects the formatter's declared type (`text/plain` for CEF).
   Operators who need a different MIME type can still override via
   the output's `headers` configuration. (#463)
+- Makefile `test-examples` target was a hard-coded list of 20
+  example directories that drifted out of sync with `examples/`
+  every time a new example was added (the issue body for #438
+  cited "17 examples" when there were 20 — same drift bug).
+  Now driven from the auto-discovered `EXAMPLE_MODULES` variable
+  so future example additions need zero Makefile change. (#438)
+
+### CI
+
+- New workflow `.github/workflows/release-examples-verify.yml`
+  fires on `release: published` (and `workflow_dispatch` for
+  manual backfill). For each example under `examples/*`,
+  copies it outside the workspace, bumps every
+  `github.com/axonops/audit*` require to the published tag via
+  `scripts/release/bump-example-deps.sh`, runs `go mod tidy +
+  go build` and `go test` if any `*_test.go` files exist.
+  Failures aggregated into one dedup'd GitHub issue per release
+  tag — so a broken example surfaces immediately as a tracked
+  bug rather than as a silent first-impression failure for the
+  next consumer doing `go get`. Does NOT block the release;
+  runs after publication. (#438)
+- New `make verify-examples-published VERSION=v0.1.13` target
+  reproduces the CI workflow locally for any published tag —
+  same script, same flow, same exit code. Lets a maintainer
+  smoke a release before tagging. (#438)
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -265,21 +265,60 @@ test-bdd-secrets:
 test-bdd-verify:
 	./scripts/verify-bdd-coverage.sh
 
-# Example compilation tests (no runtime — examples are documentation)
+# Example compilation tests (no runtime — examples are documentation).
+# Driven from EXAMPLE_MODULES (line 43) so new examples are picked up
+# without touching the Makefile. The previous hard-coded list drifted
+# behind reality — issue #438 cited "17 examples" when there were 20.
 test-examples:
-	@for dir in examples/01-basic examples/02-code-generation \
-	            examples/03-file-output examples/04-formatters \
-	            examples/05-standard-fields examples/06-syslog-output \
-	            examples/07-webhook-output examples/08-loki-output \
-	            examples/09-multi-output examples/10-event-routing \
-	            examples/11-sensitivity-labels examples/12-hmac-integrity \
-	            examples/13-tls-policy examples/14-buffering \
-	            examples/15-middleware examples/16-health-endpoint \
-	            examples/17-testing examples/18-migration \
-	            examples/19-prometheus-reference examples/20-capstone; do \
+	@for dir in $(EXAMPLE_MODULES); do \
 		echo "=== build $$dir ==="; \
 		(cd $$dir && go build -o /dev/null .) || exit 1; \
 	done
+
+# print-example-modules emits EXAMPLE_MODULES one entry per line for
+# shell-script consumption (.github/workflows/release-examples-verify.yml).
+# Mirrors print-publish-modules.
+.PHONY: print-example-modules
+print-example-modules:
+	@$(foreach e,$(EXAMPLE_MODULES),printf '%s\n' '$(e)';)
+
+# verify-examples-published — local equivalent of
+# .github/workflows/release-examples-verify.yml. Iterates every example,
+# copies to a tmpdir, bumps every github.com/axonops/audit* require to
+# VERSION via scripts/release/bump-example-deps.sh, runs go mod tidy +
+# go build + (if tests exist) go test. Lets a maintainer reproduce the
+# post-release CI gate against any published tag locally.
+#
+# Usage:
+#   VERSION=v0.1.13 make verify-examples-published
+.PHONY: verify-examples-published
+verify-examples-published:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "verify-examples-published: VERSION must be set (e.g. VERSION=v0.1.13)"; \
+		exit 2; \
+	fi
+	@scripts_dir="$(CURDIR)/scripts/release"; \
+	base=$$(mktemp -d -t verify-examples-XXXXXX); \
+	trap 'rm -rf "$$base"' EXIT INT TERM; \
+	failed=""; \
+	for src in $(EXAMPLE_MODULES); do \
+		echo "=== verify-published $$src @ $(VERSION) ==="; \
+		dst="$$base/$$(basename $$src)"; \
+		mkdir -p "$$dst"; \
+		cp -r "$$src"/. "$$dst"/; \
+		( \
+			cd "$$dst" && \
+			"$$scripts_dir/bump-example-deps.sh" "$$dst" "$(VERSION)" && \
+			GOWORK=off go mod tidy && \
+			GOWORK=off go build ./... && \
+			GOWORK=off go test ./... \
+		) || failed="$$failed $$src"; \
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo "verify-examples-published: FAILED for:$$failed"; \
+		exit 1; \
+	fi; \
+	echo "verify-examples-published: all examples passed"
 
 # --- Linting ---
 

--- a/scripts/release/bump-example-deps.sh
+++ b/scripts/release/bump-example-deps.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# bump-example-deps.sh — bump every github.com/axonops/audit* require
+# line in an example's go.mod to a given VERSION via `go get`. Used by
+# .github/workflows/release-examples-verify.yml and by the local
+# `make verify-examples-published` target to simulate a consumer
+# doing `go get` after a release.
+#
+# Usage:
+#   scripts/release/bump-example-deps.sh <EXAMPLE_DIR> <VERSION>
+#
+# Example:
+#   scripts/release/bump-example-deps.sh /tmp/verify-09-multi-output v0.1.13
+#
+# Notes:
+#   * Uses `go get <mod>@<version>` (not `go mod edit -require`) so the
+#     proxy is actually hit and go.sum is updated — exactly what a real
+#     consumer's first `go get` does.
+#   * Forces GOWORK=off so a stray go.work outside the target dir does
+#     NOT shadow the published versions with local replacements.
+#   * Validates VERSION format to protect against injection via the
+#     workflow's workflow_dispatch input.
+set -euo pipefail
+
+readonly EXAMPLE_DIR="${1:-}"
+readonly VERSION="${2:-}"
+
+if [[ -z "$EXAMPLE_DIR" || -z "$VERSION" ]]; then
+  echo "Usage: $0 <EXAMPLE_DIR> <VERSION>" >&2
+  exit 2
+fi
+if [[ ! -d "$EXAMPLE_DIR" ]]; then
+  echo "bump-example-deps: not a directory: $EXAMPLE_DIR" >&2
+  exit 2
+fi
+if [[ ! -f "$EXAMPLE_DIR/go.mod" ]]; then
+  echo "bump-example-deps: no go.mod in: $EXAMPLE_DIR" >&2
+  exit 2
+fi
+if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.\-]+)?$ ]]; then
+  echo "bump-example-deps: invalid version format: $VERSION" >&2
+  exit 2
+fi
+
+# Collect every audit-module require line. The regex requires a
+# version column on the same line — this skips comment lines like
+# "// github.com/axonops/audit/foo: deprecated" that would otherwise
+# match the prefix pattern.
+mapfile -t modules < <(
+  awk '/^[[:space:]]*github\.com\/axonops\/audit[a-z0-9\/_-]*[[:space:]]+v[0-9]/ {print $1}' \
+    "$EXAMPLE_DIR/go.mod" | sort -u
+)
+
+if [[ ${#modules[@]} -eq 0 ]]; then
+  echo "bump-example-deps: no github.com/axonops/audit requires in $EXAMPLE_DIR/go.mod" >&2
+  exit 0
+fi
+
+echo "bump-example-deps: bumping ${#modules[@]} modules in $EXAMPLE_DIR to $VERSION"
+cd "$EXAMPLE_DIR"
+
+# Disable workspace so the bumped versions are honoured, not shadowed
+# by any go.work in a parent directory.
+export GOWORK=off
+# Force fresh proxy fetch on every invocation — verifies the proxy
+# actually has the version, not just the local module cache.
+export GOFLAGS="-mod=mod${GOFLAGS:+ $GOFLAGS}"
+
+# Single `go get` call with every module pinned at the same version.
+# Doing them one-by-one risked transitive resolution pinning the base
+# module to @latest while a sub-module was being bumped.
+args=()
+for mod in "${modules[@]}"; do
+  args+=("$mod@$VERSION")
+done
+echo "  go get ${args[*]}"
+go get "${args[@]}"
+
+echo "bump-example-deps: done"


### PR DESCRIPTION
## Summary

Closes #438 — adds a post-release CI workflow that verifies every example module against the PUBLISHED proxy.golang.org versions and auto-files an issue if any break.

## Why

A broken example discovered by a new consumer doing `go get` is a terrible first impression. The existing release.yml `verify` job only checks that one aggregate `main.go` (importing all modules) compiles — it doesn't catch per-example breakage. This workflow fills that gap.

**Does NOT block the release** — fires after publication.

## Pipeline

1. **preflight**: validate version regex, enumerate examples via `make print-example-modules`, probe `proxy.golang.org` with bounded retry (6 × 30s) until every published module is indexed at the released version.
2. **verify-example**: 20-way matrix (`fail-fast: false`). Each leg checks out the release tag, copies the example to `$RUNNER_TEMP`, runs `bump-example-deps.sh`, `go mod tidy`, `go build`, `go test`. Failures upload a markdown artefact.
3. **report**: aggregates artefacts into a summary table and, if any failed, creates or updates a tracking issue with the exact title `examples post-release verification failed for $VERSION`. Dedup via `in:title` search + exact-match jq filter — re-runs of the same version append a comment.

## Drive-by fix

`Makefile` `test-examples` was a hardcoded 20-line list — drifted to "17" in #438's issue body (exactly the bug). Rewrote to iterate `$(EXAMPLE_MODULES)` so future examples are picked up automatically. New `make verify-examples-published VERSION=v0.1.13` target lets maintainers reproduce the workflow locally.

## Agent review trail

| Stage | Agent | Findings |
|---|---|---|
| Pre-coding | devops | Trigger choice, proxy readiness probe, action permissions, env vars |
| Post-coding | devops | **3 CRITICAL** (action SHA drift) + **5 FAIL** (in:title search, env-export contract, checkout pinning, nullglob, GOFLAGS, single go-get) — all fixed |
| Post-coding | code-reviewer | **3 IMPORTANT** (Makefile trap for tmpdir cleanup, fragile find\|head\|grep, awk pattern hardening) — all fixed |
| Post-coding | go-quality | All six checks pass |
| Pre-commit | commit-message-reviewer | Subject reworded from noun phrase to imperative |

## Test plan

- [x] `make print-example-modules` enumerates 20 examples correctly
- [x] `make test-examples` (rewritten) builds all 20 cleanly
- [x] `make release-check` validates GoReleaser config
- [x] `make check` — all six checks pass
- [ ] After merge: manual `workflow_dispatch` against an existing release tag (e.g. v0.1.13) to validate end-to-end before the next real release

## Files

- `.github/workflows/release-examples-verify.yml` (new, 325 lines)
- `scripts/release/bump-example-deps.sh` (new, 80 lines)
- `Makefile` (rewrite + 2 new targets)
- `CHANGELOG.md` (Fixed + new CI section)

Closes #438