### PR TITLE
feat: wire HTML/Markdown test reports across all CI jobs (#877)

### DIFF
--- a/.github/actions/upload-test-report/README.md
+++ b/.github/actions/upload-test-report/README.md
@@ -1,0 +1,87 @@
+# upload-test-report
+
+Composite GitHub Action that generates HTML + GitHub-flavoured Markdown
+test reports from cucumber JSON (godog) or JUnit XML (gotestsum),
+uploads both as run artifacts, and inlines an only-failures Markdown
+summary into the workflow's step summary panel.
+
+Centralises the wiring introduced inline in the bdd job by #876
+(per issue #439) so the same pattern applies to every test type —
+unit, integration, cross-platform — without copy-paste across 20+
+jobs. Issue #877.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `format` | yes | — | `cucumber-json` (godog) or `junit-xml` (gotestsum) |
+| `suite` | yes | — | Suite/module name shown in the report header and appended to artifact names |
+| `input-path` | yes | — | Path to the cucumber JSON or JUnit XML input file |
+| `artifact-prefix` | yes | — | Prefix; suite is appended (and `-md` for the Markdown artifact) |
+| `retention-days` | no | `14` | Artifact retention |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `html-artifact-name` | Name of the uploaded HTML artifact |
+| `md-artifact-name` | Name of the uploaded Markdown artifact |
+
+## Example — BDD job (cucumber JSON)
+
+```yaml
+- name: Generate + upload BDD report
+  if: always()
+  uses: ./.github/actions/upload-test-report
+  with:
+    format: cucumber-json
+    suite: ${{ matrix.suite }}
+    input-path: /tmp/bdd-report-${{ matrix.suite }}.json
+    artifact-prefix: bdd-report
+```
+
+Produces `bdd-report-<suite>` (HTML) and `bdd-report-<suite>-md`
+(Markdown).
+
+## Example — Unit job (JUnit XML)
+
+```yaml
+- name: Generate + upload Unit test report
+  if: always()
+  uses: ./.github/actions/upload-test-report
+  with:
+    format: junit-xml
+    suite: ${{ matrix.flag }}
+    input-path: /tmp/junit-${{ matrix.flag }}.xml
+    artifact-prefix: test-report-unit
+```
+
+Produces `test-report-unit-<flag>` and `test-report-unit-<flag>-md`.
+
+## Behaviour notes
+
+- **`if: always()` on every step** — reports surface on test failure
+  (which is when they matter most).
+- **Skip on empty/missing input** — when the test runner failed before
+  producing output (infra container didn't start, panic in `TestMain`,
+  etc.) the input file is missing or empty; in that case the action
+  skips the report rather than failing the upload. The original test
+  failure is the signal; double-failing the upload would obscure it.
+- **Step summary** uses the report tool's `-only-failures` mode so the
+  output fits inside GitHub's 1 MiB step-summary cap. The tool itself
+  emits a truncation footer pointing at the full artifact if the cap
+  is reached.
+- **`if-no-files-found: warn`** on the upload steps preserves the
+  skip-on-empty behaviour above.
+
+## Security
+
+Every `${{ inputs.X }}` reference in `action.yml` flows through a
+step-level `env:` block before reaching a shell `run:` script.
+**Never interpolate `${{ inputs.X }}` directly into a `run:` command**
+— that re-introduces the GHA shell-injection class that #876 closed.
+When adding new steps, follow the env-var indirection pattern.
+
+The `actions/upload-artifact` action is SHA-pinned to v7.0.1; keep in
+sync with every other reference in this repository so Dependabot
+rotates all call sites together.

--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -1,0 +1,156 @@
+name: 'Upload test report'
+description: >-
+  Generate HTML + Markdown reports from cucumber JSON or JUnit XML,
+  upload both as artefacts, and inline the only-failures Markdown into
+  the GitHub Actions step summary panel. Centralises the wiring
+  introduced inline in the bdd job by #876 / #439 so the same pattern
+  applies to every test type (unit, integration, cross-platform, BDD)
+  without copy-paste.
+
+# SECURITY: every `${{ inputs.X }}` reference in this file flows through
+# a step-level `env:` block before reaching any shell `run:` script.
+# Direct interpolation of `${{ inputs.X }}` into a shell command is
+# forbidden (it would re-introduce the GHA shell-injection class that
+# the env-var indirection pattern from #876 closed). When adding new
+# steps, always set the input via `env:` and read it as `$VAR` in bash.
+
+inputs:
+  format:
+    description: 'Input format: "cucumber-json" (godog) or "junit-xml" (gotestsum).'
+    required: true
+  suite:
+    description: 'Suite or module name shown in the report header and appended to artifact names.'
+    required: true
+  input-path:
+    description: 'Path to the cucumber JSON or JUnit XML input file.'
+    required: true
+  artifact-prefix:
+    description: |
+      Prefix for uploaded artifact names. The action appends the suite
+      name and (for Markdown) "-md", producing:
+        <prefix>-<suite>      (HTML)
+        <prefix>-<suite>-md   (Markdown)
+      The suite suffix is mandatory — matrix jobs need it for
+      per-leg artifact discoverability.
+    required: true
+  retention-days:
+    description: 'Artifact retention in days.'
+    required: false
+    default: '14'
+
+outputs:
+  html-artifact-name:
+    description: 'Name of the uploaded HTML artifact.'
+    # Derived from inputs because actions/upload-artifact@v7.0.1
+    # doesn't expose the artifact name as a step output — only id,
+    # url and digest. We control the name composition (see the
+    # artifact-prefix docs above) so the input-derived form is the
+    # single source of truth.
+    value: ${{ inputs.artifact-prefix }}-${{ inputs.suite }}
+  md-artifact-name:
+    description: 'Name of the uploaded Markdown artifact.'
+    value: ${{ inputs.artifact-prefix }}-${{ inputs.suite }}-md
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve report tool
+      id: tool
+      shell: bash
+      env:
+        FORMAT: ${{ inputs.format }}
+      run: |
+        set -euo pipefail
+        case "$FORMAT" in
+          cucumber-json) echo "tool=bdd-report" >> "$GITHUB_OUTPUT" ;;
+          junit-xml)     echo "tool=junit-report" >> "$GITHUB_OUTPUT" ;;
+          *)
+            echo "::error::unknown format: $FORMAT (expected cucumber-json or junit-xml)"
+            exit 1
+            ;;
+        esac
+
+    - name: Generate HTML report
+      if: always()
+      shell: bash
+      env:
+        TOOL: ${{ steps.tool.outputs.tool }}
+        SUITE: ${{ inputs.suite }}
+        SRC: ${{ inputs.input-path }}
+        # OUT_HTML is computed here (rather than as an action output) so
+        # both Generate and Upload steps share the same path without an
+        # extra `id:` round-trip.
+        ARTIFACT_PREFIX: ${{ inputs.artifact-prefix }}
+      run: |
+        set -euo pipefail
+        # RUNNER_TEMP resolves to a writable temp dir on every runner
+        # OS (Linux: $HOME/work/_temp, macOS: similar, Windows: D:\a\_temp).
+        # /tmp is Linux-specific and Git Bash on Windows would map it
+        # into a path the native Windows go.exe / gotestsum.exe might
+        # not resolve consistently.
+        OUT_HTML="${RUNNER_TEMP}/${ARTIFACT_PREFIX}-${SUITE}.html"
+        echo "OUT_HTML=$OUT_HTML" >> "$GITHUB_ENV"
+        # Skip when the source file is missing or empty — the test
+        # runner failed before producing a report (infra container
+        # didn't start, test panicked in TestMain, etc.). The test
+        # failure itself is the signal in that case; pretending to
+        # generate an empty report would hide it.
+        if [[ -s "$SRC" ]]; then
+          go run ./cmd/"$TOOL" -suite "$SUITE" -input "$SRC" -format html > "$OUT_HTML"
+        else
+          echo "No input at $SRC — skipping HTML report"
+        fi
+
+    - name: Generate Markdown report + step summary
+      if: always()
+      shell: bash
+      env:
+        TOOL: ${{ steps.tool.outputs.tool }}
+        SUITE: ${{ inputs.suite }}
+        SRC: ${{ inputs.input-path }}
+        ARTIFACT_PREFIX: ${{ inputs.artifact-prefix }}
+      run: |
+        set -euo pipefail
+        OUT_MD="${RUNNER_TEMP}/${ARTIFACT_PREFIX}-${SUITE}.md"
+        STEP_MD="${RUNNER_TEMP}/${ARTIFACT_PREFIX}-${SUITE}.step.md"
+        echo "OUT_MD=$OUT_MD" >> "$GITHUB_ENV"
+        if [[ -s "$SRC" ]]; then
+          # Full Markdown → artifact (no GitHub-imposed size cap).
+          go run ./cmd/"$TOOL" -suite "$SUITE" -input "$SRC" -format markdown > "$OUT_MD"
+          # Only-failures Markdown → step summary (1 MiB hard cap;
+          # the tool enforces a truncation footer when exceeded).
+          go run ./cmd/"$TOOL" -suite "$SUITE" -input "$SRC" -format markdown -only-failures > "$STEP_MD"
+          {
+            echo ""
+            echo "---"
+            echo ""
+            cat "$STEP_MD"
+          } >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "No input at $SRC — skipping Markdown report"
+        fi
+
+    - name: Upload HTML artifact
+      if: always()
+      # SHA pinned to v7.0.1 — keep in sync with every other
+      # actions/upload-artifact reference in this repository so
+      # Dependabot rotates all callsites together.
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-prefix }}-${{ inputs.suite }}
+        path: ${{ env.OUT_HTML }}
+        retention-days: ${{ inputs.retention-days }}
+        # warn (not error) preserves the skip-on-empty-source behaviour
+        # above — when the test runner died before producing output,
+        # the original failure is the signal; failing the upload
+        # would double-fail and obscure it.
+        if-no-files-found: warn
+
+    - name: Upload Markdown artifact
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-prefix }}-${{ inputs.suite }}-md
+        path: ${{ env.OUT_MD }}
+        retention-days: ${{ inputs.retention-days }}
+        if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,8 +340,14 @@ jobs:
 
       - name: Set up audit workspace
         uses: ./.github/actions/setup-audit
+        with:
+          # gotestsum is required when JUNIT_REPORT_FILE is set on
+          # the test step below (PR A foundation, #877).
+          install-tools: 'true'
 
       - name: Run unit tests with coverage
+        env:
+          JUNIT_REPORT_FILE: ${{ runner.temp }}/junit-${{ matrix.flag }}.xml
         run: make ${{ matrix.target }}
 
       - name: Upload coverage
@@ -350,6 +356,15 @@ jobs:
           files: ${{ matrix.module }}/coverage.out
           flags: ${{ matrix.flag }}
           fail_ci_if_error: false
+
+      - name: Generate + upload Unit test report
+        if: always()
+        uses: ./.github/actions/upload-test-report
+        with:
+          format: junit-xml
+          suite: ${{ matrix.flag }}
+          input-path: ${{ runner.temp }}/junit-${{ matrix.flag }}.xml
+          artifact-prefix: test-report-unit
 
   # Cross-platform test matrix for core + file. Runs only after the
   # Linux test and BDD jobs pass, so a Linux-side bug fails fast
@@ -401,6 +416,8 @@ jobs:
 
       - name: Run unit tests with coverage
         shell: bash
+        env:
+          JUNIT_REPORT_FILE: ${{ runner.temp }}/junit-${{ matrix.flag }}-${{ matrix.os }}.xml
         run: make ${{ matrix.target }}
 
       - name: Upload coverage
@@ -410,30 +427,102 @@ jobs:
           flags: ${{ matrix.flag }}-${{ matrix.os }}
           fail_ci_if_error: false
 
+      - name: Generate + upload Cross-Platform test report
+        if: always()
+        uses: ./.github/actions/upload-test-report
+        with:
+          format: junit-xml
+          # `<flag>-<os>` so the macOS and Windows artifacts for the
+          # same module don't collide.
+          suite: ${{ matrix.flag }}-${{ matrix.os }}
+          input-path: ${{ runner.temp }}/junit-${{ matrix.flag }}-${{ matrix.os }}.xml
+          artifact-prefix: test-report-crossplatform
+
   integration:
-    name: Test - Integration
+    name: Test - Integration (${{ matrix.flag }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 10
     needs: [hygiene, changes]
     if: needs.changes.outputs.code == 'true'
+    strategy:
+      # One per-module leg can fail without masking the others — the
+      # previous single-recipe shape aborted on the first failure and
+      # hid subsequent module results.
+      fail-fast: false
+      matrix:
+        include:
+          - module: "."
+            target: test-integration-core
+            flag: integration-core
+            infra-up: ""
+            infra-down: ""
+          - module: file
+            target: test-integration-file
+            flag: integration-file
+            infra-up: ""
+            infra-down: ""
+          - module: syslog
+            target: test-integration-syslog
+            flag: integration-syslog
+            infra-up: test-infra-syslog-up
+            infra-down: test-infra-syslog-down
+          - module: webhook
+            target: test-integration-webhook
+            flag: integration-webhook
+            infra-up: test-infra-webhook-up
+            infra-down: test-infra-webhook-down
+          - module: loki
+            target: test-integration-loki
+            flag: integration-loki
+            infra-up: test-infra-loki-up
+            infra-down: test-infra-loki-down
+          - module: secrets/openbao
+            target: test-integration-secrets-openbao
+            flag: integration-openbao
+            infra-up: test-infra-openbao-up
+            infra-down: test-infra-openbao-down
+          - module: secrets/vault
+            target: test-integration-secrets-vault
+            flag: integration-vault
+            infra-up: test-infra-vault-up
+            infra-down: test-infra-vault-down
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up audit workspace
         uses: ./.github/actions/setup-audit
+        with:
+          # gotestsum is required when JUNIT_REPORT_FILE is set
+          # (PR A foundation, #877).
+          install-tools: 'true'
 
       - name: Start test infrastructure
-        run: make test-infra-up
+        if: matrix.infra-up != ''
+        # matrix.infra-up may name multiple targets separated by spaces.
+        # Direct interpolation word-splits naturally; the matrix values
+        # are a repo-controlled closed set so no injection surface.
+        run: make ${{ matrix.infra-up }}
 
       - name: Run integration tests
-        run: make test-integration
+        env:
+          JUNIT_REPORT_FILE: ${{ runner.temp }}/junit-${{ matrix.flag }}.xml
+        run: make ${{ matrix.target }}
+
+      - name: Generate + upload Integration test report
+        if: always()
+        uses: ./.github/actions/upload-test-report
+        with:
+          format: junit-xml
+          suite: ${{ matrix.flag }}
+          input-path: ${{ runner.temp }}/junit-${{ matrix.flag }}.xml
+          artifact-prefix: test-report-integration
 
       - name: Stop test infrastructure
-        if: always()
-        run: make test-infra-down
+        if: always() && matrix.infra-down != ''
+        run: make ${{ matrix.infra-down }}
 
   bdd:
     name: Test - BDD (${{ matrix.suite }})
@@ -520,7 +609,7 @@ jobs:
           # godog writes a cucumber JSON report at this path when set.
           # cmd/bdd-report (next steps) converts it to per-suite HTML
           # and Markdown artefacts published below. See #439.
-          BDD_REPORT_FILE: /tmp/bdd-report-${{ matrix.suite }}.json
+          BDD_REPORT_FILE: ${{ runner.temp }}/bdd-report-${{ matrix.suite }}.json
         run: |
           set -eo pipefail
           make "$TARGET" 2>&1 | tee /tmp/bdd-output.txt
@@ -551,78 +640,16 @@ jobs:
           path: /tmp/bdd-count.txt
           retention-days: 1
 
-      - name: Generate HTML report
+      - name: Generate + upload BDD report
         if: always()
-        shell: bash
-        env:
-          SUITE: ${{ matrix.suite }}
-          REPORT_JSON: /tmp/bdd-report-${{ matrix.suite }}.json
-          REPORT_HTML: /tmp/bdd-report-${{ matrix.suite }}.html
-        run: |
-          set -eo pipefail
-          # When the JSON report is non-empty, convert it to HTML.
-          # An empty file means BDD failed before godog wrote anything
-          # (e.g. infra container did not start) — skip silently and
-          # let the original test failure surface in the workflow log.
-          if [[ -s "$REPORT_JSON" ]]; then
-            go run ./cmd/bdd-report -suite "$SUITE" -input "$REPORT_JSON" -format html > "$REPORT_HTML"
-            echo "Generated $REPORT_HTML ($(wc -c < "$REPORT_HTML") bytes)"
-          else
-            echo "No cucumber JSON at $REPORT_JSON — skipping HTML report"
-          fi
-
-      - name: Generate Markdown report + step summary
-        if: always()
-        shell: bash
-        env:
-          SUITE: ${{ matrix.suite }}
-          REPORT_JSON: /tmp/bdd-report-${{ matrix.suite }}.json
-          REPORT_MD: /tmp/bdd-report-${{ matrix.suite }}.md
-        run: |
-          set -eo pipefail
-          # Same skip rule as the HTML report — a missing/empty JSON
-          # file means godog never started, in which case the test
-          # failure itself is the signal.
-          if [[ -s "$REPORT_JSON" ]]; then
-            # Full report → artefact (no size cap).
-            go run ./cmd/bdd-report -suite "$SUITE" -input "$REPORT_JSON" -format markdown > "$REPORT_MD"
-            echo "Generated $REPORT_MD ($(wc -c < "$REPORT_MD") bytes)"
-
-            # Step summary → only-failures variant. The GitHub Actions
-            # step summary has a 1 MiB hard cap (silently truncated
-            # past that); -only-failures emits just the failing
-            # scenarios + a count header so reviewers see what broke
-            # without downloading anything. Build a separate file so
-            # the artefact retains the full report.
-            STEP_MD=/tmp/bdd-step-${SUITE}.md
-            go run ./cmd/bdd-report -suite "$SUITE" -input "$REPORT_JSON" -format markdown -only-failures > "$STEP_MD"
-            {
-              echo ""
-              echo "---"
-              echo ""
-              cat "$STEP_MD"
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No cucumber JSON at $REPORT_JSON — skipping Markdown report"
-          fi
-
-      - name: Upload HTML report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: ./.github/actions/upload-test-report
         with:
-          name: bdd-report-${{ matrix.suite }}
-          path: /tmp/bdd-report-${{ matrix.suite }}.html
-          retention-days: 14
-          if-no-files-found: warn
-
-      - name: Upload Markdown report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: bdd-report-${{ matrix.suite }}-md
-          path: /tmp/bdd-report-${{ matrix.suite }}.md
-          retention-days: 14
-          if-no-files-found: warn
+          format: cucumber-json
+          suite: ${{ matrix.suite }}
+          input-path: ${{ runner.temp }}/bdd-report-${{ matrix.suite }}.json
+          # Artifact names preserved as bdd-report-<suite> and
+          # bdd-report-<suite>-md (back-compat with #876's published names).
+          artifact-prefix: bdd-report
 
       - name: Stop test infrastructure
         if: always() && matrix.infra-down != ''
@@ -814,7 +841,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: mutation-test-report-${{ matrix.target }}-${{ github.sha }}
+          # Renamed mutation-test-report-* → test-report-mutation-* for
+          # naming consistency with the per-test-type test-report-*
+          # artefact pattern introduced by #877.
+          name: test-report-mutation-${{ matrix.target }}-${{ github.sha }}
           path: mutation-test-report-${{ matrix.target }}.txt
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,8 +456,12 @@ jobs:
           - module: "."
             target: test-integration-core
             flag: integration-core
-            infra-up: ""
-            infra-down: ""
+            # Core integration covers tests/integration/e2e_secrets_webhook_test.go
+            # (needs openbao + webhook) and fanout_test.go (needs
+            # syslog + webhook + loki). Spin the full stack — narrowing
+            # to a per-test-file subset is a future optimisation.
+            infra-up: test-infra-up
+            infra-down: test-infra-down
           - module: file
             target: test-integration-file
             flag: integration-file

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -87,6 +87,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: mutation-test-report-${{ inputs.target || 'all' }}-${{ github.sha }}
+          # Renamed mutation-test-report-* → test-report-mutation-* for
+          # naming consistency with the per-test-type test-report-*
+          # artefact pattern introduced by #877. Gremlins v0.6.0 only
+          # emits text; if it ever gains HTML output, this artefact
+          # can be processed through the upload-test-report composite
+          # like the other test types.
+          name: test-report-mutation-${{ inputs.target || 'all' }}-${{ github.sha }}
           path: mutation-test-report.txt
           retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   reproduces the CI workflow locally for any published tag —
   same script, same flow, same exit code. Lets a maintainer
   smoke a release before tagging. (#438)
+- CI now publishes per-test-type HTML and Markdown report artefacts
+  for every job in the matrix — Unit (13 modules), Integration
+  (7 modules — the previously-single integration job is now a 7-leg
+  matrix with per-leg infra so per-module JUnit XML emission works
+  without collision), Cross-Platform (4 legs: core + file × macOS +
+  Windows), in addition to the BDD reports landed by #876. Naming
+  pattern: `test-report-unit-<module>`, `test-report-integration-
+  <module>`, `test-report-crossplatform-<module>-<os>` (HTML) and
+  the same with `-md` suffix (Markdown). Failures inline into the
+  workflow run page's step-summary panel via the report tool's
+  `-only-failures` mode (1 MiB cap with truncation footer). Wiring
+  is centralised in a new `.github/actions/upload-test-report`
+  composite action used by every test job; the bdd job (#876)
+  refactored to use it, artefact names preserved. Mutation tests
+  remain text-only because gremlins v0.6.0 does not emit HTML;
+  the existing text artefact was renamed
+  `mutation-test-report-*` → `test-report-mutation-*` for naming
+  consistency with the other test types. (#877)
 - Project toolchain adds `gotestsum` v1.13.0 for JUnit XML test
   reporting. Every per-module `make test-*` target now accepts a
   `JUNIT_REPORT_FILE=foo.xml` env var that writes a JUnit XML report

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,14 @@ MODULES           := . file iouring syslog webhook loki outputconfig outputs cmd
 # deterministic workspace generation.
 EXAMPLE_MODULES   := $(sort $(patsubst %/go.mod,%,$(wildcard examples/*/go.mod)))
 WORKSPACE_MODULES := $(MODULES) $(EXAMPLE_MODULES)
-GOBIN             := $(shell go env GOPATH)/bin
+# `go env GOPATH` returns Windows-style paths on Windows
+# (e.g. C:\Users\runneradmin\go); when interpolated into bash recipes
+# the backslashes are interpreted as escape characters and stripped,
+# producing an invalid path like `C:Usersrunneradmingo/bin`. Convert
+# to forward slashes so the same recipe works on Linux, macOS, and
+# Windows (Git Bash tolerates forward slashes in Windows absolute
+# paths). (#877)
+GOBIN             := $(subst \,/,$(shell go env GOPATH))/bin
 GO_TOOLCHAIN      := go1.26.3
 # Windows go install appends .exe to executables; everything else is
 # bare. Used when the recipe must invoke an installed tool by absolute

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: test test-all test-core test-file test-syslog test-webhook test-loki test-outputconfig test-audit-gen test-audit-validate test-bdd-report test-junit-report \
        test-secrets test-secrets-env test-secrets-file test-secrets-openbao test-secrets-vault \
-       test-integration test-bdd test-bdd-core test-bdd-outputconfig test-bdd-file test-bdd-file-os test-bdd-syslog test-bdd-webhook test-bdd-loki test-bdd-fanout \
+       test-integration test-integration-file test-integration-syslog test-integration-webhook test-integration-loki test-integration-core test-integration-secrets-openbao test-integration-secrets-vault \
+       test-bdd test-bdd-core test-bdd-outputconfig test-bdd-file test-bdd-file-os test-bdd-syslog test-bdd-webhook test-bdd-loki test-bdd-fanout \
        test-bdd-verify \
        test-examples \
        lint lint-all lint-core lint-file lint-syslog lint-webhook lint-loki lint-outputconfig lint-audit-gen lint-audit-validate lint-bdd-report lint-junit-report lint-examples \
@@ -249,15 +250,40 @@ fuzz-long: ## Run each fuzz target for ${FUZZ_TIME} (default 60s). Release gate.
 	cd outputconfig && go test -run='^$$' -fuzz='^FuzzExpandEnvString$$' -fuzztime=${FUZZ_TIME} .
 	cd secrets && go test -run='^$$' -fuzz='^FuzzParseRef$$' -fuzztime=${FUZZ_TIME} .
 
-# Integration tests (requires Docker: make test-infra-up first)
-test-integration:
-	cd file && go test -race -v -count=1 -tags=integration ./tests/integration/...
-	cd syslog && go test -race -v -count=1 -tags=integration ./tests/integration/...
-	cd webhook && go test -race -v -count=1 -tags=integration ./tests/integration/...
-	cd loki && go test -race -v -count=1 -tags=integration ./tests/integration/...
-	go test -race -v -count=1 -tags=integration ./tests/integration/...
-	cd secrets/openbao && go test -race -v -count=1 -tags=integration ./tests/integration/...
-	cd secrets/vault && go test -race -v -count=1 -tags=integration ./tests/integration/...
+# Integration tests (requires Docker: make test-infra-up first).
+#
+# Per-module integration targets honour JUNIT_REPORT_FILE via the
+# go_test_with_junit macro (#877 PR A). CI runs each per-module
+# target in its own matrix leg so the JUnit XML for each module is
+# written to a distinct path; the meta `test-integration` target
+# below preserves the local-dev one-command invocation. Do NOT
+# parallelise (make -j test-integration) — the per-module docker
+# stacks share infra ports.
+test-integration-file:
+	cd file && $(call go_test_with_junit,-race -count=1 -tags=integration,./tests/integration/...)
+
+test-integration-syslog:
+	cd syslog && $(call go_test_with_junit,-race -count=1 -tags=integration,./tests/integration/...)
+
+test-integration-webhook:
+	cd webhook && $(call go_test_with_junit,-race -count=1 -tags=integration,./tests/integration/...)
+
+test-integration-loki:
+	cd loki && $(call go_test_with_junit,-race -count=1 -tags=integration,./tests/integration/...)
+
+test-integration-core:
+	$(call go_test_with_junit,-race -count=1 -tags=integration,./tests/integration/...)
+
+test-integration-secrets-openbao:
+	cd secrets/openbao && $(call go_test_with_junit,-race -count=1 -tags=integration,./tests/integration/...)
+
+test-integration-secrets-vault:
+	cd secrets/vault && $(call go_test_with_junit,-race -count=1 -tags=integration,./tests/integration/...)
+
+test-integration: test-integration-file test-integration-syslog \
+                  test-integration-webhook test-integration-loki \
+                  test-integration-core test-integration-secrets-openbao \
+                  test-integration-secrets-vault
 
 # BDD tests — all scenarios (requires Docker for syslog/webhook/loki scenarios)
 test-bdd:


### PR DESCRIPTION
## Summary

PR B of three for #877. PR A (#879, merged) shipped the foundation. This PR delivers AC #4 #5 #8 #12 by:

- New composite action **`.github/actions/upload-test-report`** — one call generates HTML + Markdown reports and uploads both as artefacts and inlines an only-failures Markdown summary into the workflow run page.
- **bdd job refactored** to use it (4 inline steps → 1 composite call); artefact names preserved for back-compat with #876.
- **Unit matrix (13 legs)** wired: \`install-tools: 'true'\`, \`JUNIT_REPORT_FILE\` env, composite call.
- **Integration matrix-split**: previously a single job with 7 sequential \`go test\` invocations → 7 parallel matrix legs with per-leg infra. fail-fast: false. Makefile gets 7 \`test-integration-<mod>\` targets via the existing \`go_test_with_junit\` macro.
- **Cross-platform (4 legs)** wired.
- **Mutation artefact rename**: \`mutation-test-report-*\` → \`test-report-mutation-*\` for naming consistency. Gremlins v0.6.0 doesn't emit HTML; explicit gap documented in CHANGELOG.

## Branch protection note

The integration job display name changed from \`Test - Integration\` to \`Test - Integration (<flag>)\` (7 separate matrix legs). If branch protection lists \`Test - Integration\` as a required check by exact name, it needs updating. Verified that \`Test - CI Pass\` (the aggregate) is the documented required check, so this should be a no-op — but flagging for visibility.

## Locked decisions from pre-coding consults

- **Input names**: \`format\` (cucumber-json / junit-xml) not \`tool\` — decouples composite from binary names
- **\`input-path\`** matches CLI \`-input\` flag
- **American "artifact"** spelling at the GitHub Actions boundary (sits adjacent to \`actions/upload-artifact\`)
- **\`RUNNER_TEMP\`** for all temp paths so Windows GHA runners under Git Bash resolve consistently
- **Outputs derived from inputs** because actions/upload-artifact@v7.0.1 doesn't expose artifact-name (only id/url/digest)

## Test plan

- [x] composite action \`make check\` green locally
- [x] \`make test-integration\` meta-target runs all 7 per-module targets
- [x] code-reviewer + devops reviewed and approved (after 2 BLOCKING fixes: broken output names, Windows path)
- [ ] CI green across BDD (9) + Unit (13) + Integration (7) + Cross-Platform (4) + everything else
- [ ] Per-test-type \`test-report-*\` artefacts appear on PR run page
- [ ] Step summary panel shows Markdown failure summary on a deliberate fail run