### PR TITLE
docs: polish README quickstart so every step is self-contained (#467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Documentation
 
+- Polish the README quickstart so every step is followable
+  without scrolling to other sections (#467). The Step 3 → Step 4
+  transition now explains what `audit-gen` emits (`NewXxxEvent`
+  constructors plus `.SetXxx` setters, including the 31 reserved
+  standard fields). The main.go snippet now carries a
+  `//go:generate` directive so `go generate ./...` regenerates
+  after taxonomy changes, matching `examples/02-code-generation`.
+  Inline comments at the `outputconfig.New` call, the
+  `NewUserCreateEvent` / `SetTargetID` call, the `_ "outputs"`
+  blank import, and the discarded `audittest.NewQuick` return
+  signpost where each name comes from and what each line is for.
+  The sample JSON output is now internally consistent (all
+  literal example values instead of mixing placeholders and
+  literals). No API changes; documentation only.
 - Add `llms.txt` and `llms-full.txt` at the repo root following
   the llmstxt.org specification, exposing the library
   documentation to AI coding assistants and IDE-integrated RAG

--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ go run github.com/axonops/audit/cmd/audit-gen \
   -input taxonomy.yaml -output audit_generated.go -package main
 ```
 
+`audit-gen` writes `audit_generated.go` next to your `main.go`.
+Each event in the taxonomy becomes a typed constructor —
+`NewUserCreateEvent(actorID, outcome)` here, with required fields
+as parameters — plus `.SetXxx()` setters for optional fields.
+Setters for [reserved standard fields](#reserved-standard-fields)
+like `target_id`, `source_ip`, and `reason` are also generated, no
+taxonomy declaration needed. See
+[docs/code-generation.md](docs/code-generation.md) for the full
+generated surface.
+
+The same command appears as a `//go:generate` directive in
+`main.go` below, so after taxonomy edits you can re-run it with
+`go generate ./...`.
+
 ### 4️⃣ Wire it up and emit events (`main.go`)
 
 ```go
@@ -96,13 +110,15 @@ import (
     "log"
 
     "github.com/axonops/audit/outputconfig"
-    _ "github.com/axonops/audit/outputs"
+    _ "github.com/axonops/audit/outputs" // registers stdout/file/syslog/webhook/loki factories
 )
 
+//go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
 func main() {
+    // outputconfig.New: ctx, embedded taxonomy bytes, runtime outputs.yaml path.
     auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml")
     if err != nil {
         log.Fatal(err)
@@ -110,6 +126,8 @@ func main() {
     defer func() { _ = auditor.Close() }()
 
     if err := auditor.AuditEvent(
+        // target_id is a reserved standard field — generator emits
+        // a setter even though it isn't declared in taxonomy.yaml.
         NewUserCreateEvent("alice", "success").SetTargetID("user-42"),
     ); err != nil {
         log.Printf("audit: %v", err)
@@ -131,6 +149,8 @@ import (
 )
 
 func TestCreateUser_EmitsAudit(t *testing.T) {
+    // NewQuick returns (*Auditor, *Recorder, *MetricsRecorder); the
+    // metrics recorder is unused here.
     auditor, events, _ := audittest.NewQuick(t, "user_create")
     _ = auditor.AuditEvent(NewUserCreateEvent("alice", "success"))
     events.RequireEvent(t, "user_create")
@@ -144,7 +164,7 @@ func TestCreateUser_EmitsAudit(t *testing.T) {
 `go run .` prints one JSON event to stdout (default formatter):
 
 ```json
-{"timestamp":"...","event_type":"user_create","severity":3,"app_name":"my-service","host":"<your-host>","timezone":"UTC","pid":12345,"actor_id":"alice","outcome":"success","target_id":"user-42","event_category":"write"}
+{"timestamp":"2026-01-15T09:00:00.000Z","event_type":"user_create","severity":3,"app_name":"my-service","host":"inventory-01","timezone":"UTC","pid":12345,"actor_id":"alice","outcome":"success","target_id":"user-42","event_category":"write"}
 ```
 
 > 📐 **Field order is deterministic** — framework fields first, then required and optional fields (alphabetical), then extra fields, then `event_category`. See [JSON format → Field Order](docs/json-format.md#field-order).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -386,6 +386,20 @@ go run github.com/axonops/audit/cmd/audit-gen \
   -input taxonomy.yaml -output audit_generated.go -package main
 ```
 
+`audit-gen` writes `audit_generated.go` next to your `main.go`.
+Each event in the taxonomy becomes a typed constructor —
+`NewUserCreateEvent(actorID, outcome)` here, with required fields
+as parameters — plus `.SetXxx()` setters for optional fields.
+Setters for [reserved standard fields](#reserved-standard-fields)
+like `target_id`, `source_ip`, and `reason` are also generated, no
+taxonomy declaration needed. See
+[docs/code-generation.md](docs/code-generation.md) for the full
+generated surface.
+
+The same command appears as a `//go:generate` directive in
+`main.go` below, so after taxonomy edits you can re-run it with
+`go generate ./...`.
+
 ### 4️⃣ Wire it up and emit events (`main.go`)
 
 ```go
@@ -397,13 +411,15 @@ import (
     "log"
 
     "github.com/axonops/audit/outputconfig"
-    _ "github.com/axonops/audit/outputs"
+    _ "github.com/axonops/audit/outputs" // registers stdout/file/syslog/webhook/loki factories
 )
 
+//go:generate go run github.com/axonops/audit/cmd/audit-gen -input taxonomy.yaml -output audit_generated.go -package main
 //go:embed taxonomy.yaml
 var taxonomyYAML []byte
 
 func main() {
+    // outputconfig.New: ctx, embedded taxonomy bytes, runtime outputs.yaml path.
     auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml")
     if err != nil {
         log.Fatal(err)
@@ -411,6 +427,8 @@ func main() {
     defer func() { _ = auditor.Close() }()
 
     if err := auditor.AuditEvent(
+        // target_id is a reserved standard field — generator emits
+        // a setter even though it isn't declared in taxonomy.yaml.
         NewUserCreateEvent("alice", "success").SetTargetID("user-42"),
     ); err != nil {
         log.Printf("audit: %v", err)
@@ -432,6 +450,8 @@ import (
 )
 
 func TestCreateUser_EmitsAudit(t *testing.T) {
+    // NewQuick returns (*Auditor, *Recorder, *MetricsRecorder); the
+    // metrics recorder is unused here.
     auditor, events, _ := audittest.NewQuick(t, "user_create")
     _ = auditor.AuditEvent(NewUserCreateEvent("alice", "success"))
     events.RequireEvent(t, "user_create")
@@ -445,7 +465,7 @@ func TestCreateUser_EmitsAudit(t *testing.T) {
 `go run .` prints one JSON event to stdout (default formatter):
 
 ```json
-{"timestamp":"...","event_type":"user_create","severity":3,"app_name":"my-service","host":"<your-host>","timezone":"UTC","pid":12345,"actor_id":"alice","outcome":"success","target_id":"user-42","event_category":"write"}
+{"timestamp":"2026-01-15T09:00:00.000Z","event_type":"user_create","severity":3,"app_name":"my-service","host":"inventory-01","timezone":"UTC","pid":12345,"actor_id":"alice","outcome":"success","target_id":"user-42","event_category":"write"}
 ```
 
 > 📐 **Field order is deterministic** — framework fields first, then required and optional fields (alphabetical), then extra fields, then `event_category`. See [JSON format → Field Order](docs/json-format.md#field-order).


### PR DESCRIPTION
## Summary

- Closes the final acceptance criterion on #467 (README quickstart must be followable without scrolling to other sections). The library-level work for AI-coding-assistant friendliness is now complete: PRs A-C polished godoc, added five testable Example functions, and shipped `llms.txt` / `llms-full.txt`; this PR D tightens the README's first impression.

## What changed

**README Step 3 → Step 4 transition.** A short bridging paragraph after the `audit-gen` bash command now explains what the generator emits: each event in the taxonomy becomes `NewXxxEvent(required...)` plus `.SetXxx()` setters for optional fields, and reserved standard fields like `target_id`, `source_ip`, `reason` also get setters without taxonomy declaration. Cross-references to `docs/code-generation.md` and the in-README Reserved Standard Fields section close the loop.

**README Step 4 main.go.** Adds the `//go:generate` directive matching `examples/02-code-generation` so re-running codegen after a taxonomy change is `go generate ./...`. The blank import `_ "github.com/axonops/audit/outputs"` gains a one-line annotation listing the five factories it registers. The `outputconfig.New` call gains a one-line comment naming its three argument kinds. The `.SetTargetID` call gains a one-line comment explaining `target_id` is reserved.

**README Step 5 test.** Annotates the discarded third return from `audittest.NewQuick` as the metrics recorder so a stranger doesn't have to guess what was thrown away.

**README Output section.** The sample JSON line is now internally consistent — all literal example values instead of mixing placeholders (`"..."` / `"<your-host>"`) with literals (`pid: 12345`).

**llms-full.txt** regenerated via `make regen-llms` (README is one of its sources after #467 PR C; the `regen-llms-check` guard in `check-static` would otherwise fail CI).

**CHANGELOG.md** entry under `## [Unreleased]` → `### Documentation`.

## Acceptance criterion coverage

- AC #7 (README quickstart self-contained, shows imports): **delivered**.
- AC #9 (audit-gen generated code includes doc comments): **already met** by `cmd/audit-gen/template.go` lines 96, 109-112, 117, 126-127, 133, 139, 142, 149, 152-156, 158, 161, 176, 185-188. No code change needed.

After this PR all 9 acceptance criteria on #467 are met.

## Test plan

- [x] `make check` green locally (full gate: fmt, vet, lint, test-race, build, tidy, security, regen-*-check, etc.)
- [x] `make regen-llms-check` confirms `llms-full.txt` is in sync after the README change.
- [x] Cross-reference anchor `#reserved-standard-fields` verified against GitHub's anchor algorithm by comparing with the existing TOC at line 15 (`#quick-start` / `#key-features` — emoji-prefixed headings).
- [x] Pre-coding consults (user-guide-reviewer + docs-writer) ran on the planned diff before writing.
- [x] Post-coding consults (user-guide-reviewer + docs-writer) verified the as-written diff.
- [ ] CI green on all matrix legs.