### PR TITLE
feat: Splunk ACK + CIM formatter + splunkcloud:// (PR 2 — #55)

### DIFF
--- a/format_cim.go
+++ b/format_cim.go
@@ -1,0 +1,339 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CIMChangeFormatter serialises audit events shaped for the Splunk
+// Common Information Model "Change" data model (CIM 6.1). Wire format
+// is newline-delimited JSON (NDJSON); ContentType is
+// "application/x-ndjson".
+//
+// Field mapping (audit ↔ CIM Change):
+//
+//	timestamp        → _time (epoch seconds, ms precision)
+//	event_type       → action
+//	event_category   → change_type
+//	actor / actor.id → user / user_id
+//	actor.name       → user_name
+//	target / target.id → object / object_id
+//	target.type / target_type → object_category
+//	target.path / target_path → object_path
+//	target.attrs / target_attrs → object_attrs (JSON-stringified)
+//	outcome          → status (collapsed) + outcome (preserved)
+//	source_ip        → src
+//	severity         → severity_id (numeric extension; not CIM-canonical)
+//	app_name         → vendor_product (default; overridable)
+//	host             → dvc + host
+//
+// Outcome → status collapse. The CIM Change `status` field is a
+// binary enum (success | failure). Audit outcomes other than
+// "success" — including "failure", "denied", "error", "pending",
+// "unknown" — collapse to "failure" for `status`. The formatter
+// ALSO preserves the original `outcome` field verbatim so the
+// granular value is recoverable downstream — Splunk searches can
+// pivot on `status` for CIM compliance AND on `outcome` for
+// fine-grained reporting.
+//
+// Unmapped fields. Any field not in the mapping table above passes
+// through to the JSON output with its original key, alphabetically
+// ordered after the CIM fields. Snake_case is preserved.
+//
+// VendorProduct. Defaults to the application name set via
+// [FrameworkFieldSetter.SetFrameworkFields]. Override per-output via
+// [CIMChangeFormatter.VendorProduct] to set the Splunk `vendor_product`
+// identifier explicitly (e.g., "AxonOps:Audit").
+//
+// # Concurrency
+//
+// Safe for concurrent use by multiple goroutines, per the
+// [Formatter] contract.
+//
+// # Future CIM data models
+//
+// This formatter targets the Change data model only. Authentication,
+// Network Traffic, etc. are scheduled to ship as separate formatter
+// types (e.g. CIMAuthenticationFormatter / `type: cim_authentication`).
+type CIMChangeFormatter struct {
+	// VendorProduct sets the CIM `vendor_product` field. When empty,
+	// falls back to the appName set via SetFrameworkFields.
+	VendorProduct string
+
+	// Framework fields set once via SetFrameworkFields.
+	appName  string
+	host     string
+	timezone string
+	pid      int
+}
+
+// ContentType implements [Formatter.ContentType].
+func (f *CIMChangeFormatter) ContentType() string { return "application/x-ndjson" }
+
+// SetFrameworkFields implements [FrameworkFieldSetter].
+func (f *CIMChangeFormatter) SetFrameworkFields(appName, host, timezone string, pid int) {
+	f.appName = appName
+	f.host = host
+	f.timezone = timezone
+	f.pid = pid
+}
+
+// auditFieldsRemappedToCIM are the source-side field names handled by
+// the explicit CIM mapping. They are excluded from the pass-through
+// loop to prevent duplicate emission of (e.g.) both event_category
+// and change_type. `outcome` is deliberately NOT in this set — the
+// formatter preserves it alongside the collapsed `status` so the
+// binary collapse remains recoverable.
+var auditFieldsRemappedToCIM = map[string]struct{}{
+	"timestamp":      {},
+	"event_type":     {},
+	"event_category": {},
+	"actor":          {},
+	"actor_id":       {},
+	"target":         {},
+	"target_id":      {},
+	"target_type":    {},
+	"target_path":    {},
+	"target_attrs":   {},
+	"source_ip":      {},
+	"severity":       {}, // emitted as `severity_id` instead
+}
+
+// Format implements [Formatter.Format].
+func (f *CIMChangeFormatter) Format(ts time.Time, eventType string, fields Fields, def *EventDef, opts *FormatOptions) ([]byte, error) { //nolint:gocyclo,cyclop // long-but-flat orchestrator; per-field mapping is in helpers
+	out := make(map[string]any, len(fields)+8)
+
+	// _time: epoch seconds with ms precision (CIM canonical form).
+	out["_time"] = float64(ts.UnixMilli()) / 1000.0
+
+	// action: closed-set CIM verb; we forward eventType verbatim and
+	// rely on the consumer's TA mapping rules to normalise to the
+	// CIM enum (PR 3 ships the TA generator with FIELDALIAS rules).
+	out["action"] = eventType
+
+	// change_type: from event_category if present.
+	if v, ok := fields["event_category"]; ok && !opts.IsExcluded("event_category") {
+		out["change_type"] = v
+	}
+
+	mapActor(out, fields, opts)
+	if err := mapTarget(out, fields, opts); err != nil {
+		return nil, fmt.Errorf("audit: cim_change format: %w", err)
+	}
+
+	// status: outcome collapsed to binary success/failure. The
+	// original outcome is preserved by the pass-through loop below
+	// because `outcome` is deliberately NOT in
+	// auditFieldsRemappedToCIM — so consumers can recover the
+	// granular value from `outcome` when `status` is "failure".
+	if v, ok := fields["outcome"]; ok && !opts.IsExcluded("outcome") {
+		out["status"] = collapseOutcomeToCIMStatus(v)
+	}
+
+	// src: from source_ip.
+	if v, ok := fields["source_ip"]; ok && !opts.IsExcluded("source_ip") {
+		out["src"] = v
+	}
+
+	// severity_id: numeric severity from def. Named with the `_id`
+	// suffix per CIM convention for numeric tag-friendly enums; this
+	// avoids collision with consumer-supplied string `severity` fields
+	// and signals "this is a non-canonical extension to CIM Change".
+	// Skipped if the consumer excluded `severity` via FormatOptions.
+	if def != nil && !opts.IsExcluded("severity") {
+		out["severity_id"] = int64(def.ResolvedSeverity())
+	}
+
+	// vendor_product: explicit override or fallback to appName.
+	if vp := f.resolvedVendorProduct(); vp != "" {
+		out["vendor_product"] = vp
+	}
+
+	// dvc + host: from framework host.
+	if f.host != "" {
+		out["dvc"] = f.host
+		out["host"] = f.host
+	}
+
+	mapPassThrough(out, fields, opts)
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("audit: cim_change format: %w", err)
+	}
+	// Append the NDJSON terminator in-place — reuses b's capacity
+	// when there is headroom, avoiding a second allocation.
+	return append(b, '\n'), nil
+}
+
+// mapActor flattens the `actor` and `actor_id` audit fields onto the
+// CIM user / user_id / user_name keys. Accepts both `map[string]any`
+// and `map[string]string` for the nested form. Precedence: a flat
+// `actor_id` overrides any `actor.id` extracted from the nested
+// form.
+func mapActor(out map[string]any, fields Fields, opts *FormatOptions) { //nolint:gocognit,gocyclo,cyclop // per-type switch is the simplest correct form
+	if v, ok := fields["actor"]; ok && !opts.IsExcluded("actor") {
+		out["user"] = v
+		switch m := v.(type) {
+		case map[string]any:
+			if id, ok := m["id"]; ok {
+				out["user_id"] = id
+			}
+			if name, ok := m["name"]; ok {
+				out["user_name"] = name
+			}
+		case map[string]string:
+			if id, ok := m["id"]; ok {
+				out["user_id"] = id
+			}
+			if name, ok := m["name"]; ok {
+				out["user_name"] = name
+			}
+		}
+	}
+	if v, ok := fields["actor_id"]; ok && !opts.IsExcluded("actor_id") {
+		out["user_id"] = v
+	}
+}
+
+// mapTarget flattens the `target` audit field plus the optional
+// `target_id` / `target_type` / `target_path` / `target_attrs` flat
+// variants onto the CIM object / object_id / object_category /
+// object_path / object_attrs keys.
+func mapTarget(out map[string]any, fields Fields, opts *FormatOptions) error { //nolint:gocognit,gocyclo,cyclop // per-type switch + flat-overrides; refactoring further obscures the mapping
+	if v, ok := fields["target"]; ok && !opts.IsExcluded("target") {
+		out["object"] = v
+		switch m := v.(type) {
+		case map[string]any:
+			if err := extractTargetSubfields(out, m); err != nil {
+				return err
+			}
+		case map[string]string:
+			extractTargetSubfieldsFromStringMap(out, m)
+		}
+	}
+	// Flat overrides — these win over any subfield value extracted
+	// from the nested map above (operator-supplied flat field is
+	// the explicit choice).
+	if v, ok := fields["target_id"]; ok && !opts.IsExcluded("target_id") {
+		out["object_id"] = v
+	}
+	if v, ok := fields["target_type"]; ok && !opts.IsExcluded("target_type") {
+		out["object_category"] = v
+	}
+	if v, ok := fields["target_path"]; ok && !opts.IsExcluded("target_path") {
+		out["object_path"] = v
+	}
+	if v, ok := fields["target_attrs"]; ok && !opts.IsExcluded("target_attrs") {
+		attrsJSON, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("target_attrs marshal: %w", err)
+		}
+		out["object_attrs"] = string(attrsJSON)
+	}
+	return nil
+}
+
+func extractTargetSubfields(out, m map[string]any) error {
+	if id, ok := m["id"]; ok {
+		out["object_id"] = id
+	}
+	if typ, ok := m["type"]; ok {
+		out["object_category"] = typ
+	}
+	if path, ok := m["path"]; ok {
+		out["object_path"] = path
+	}
+	if attrs, ok := m["attrs"]; ok {
+		attrsJSON, err := json.Marshal(attrs)
+		if err != nil {
+			return fmt.Errorf("target.attrs marshal: %w", err)
+		}
+		out["object_attrs"] = string(attrsJSON)
+	}
+	return nil
+}
+
+func extractTargetSubfieldsFromStringMap(out map[string]any, m map[string]string) {
+	if id, ok := m["id"]; ok {
+		out["object_id"] = id
+	}
+	if typ, ok := m["type"]; ok {
+		out["object_category"] = typ
+	}
+	if path, ok := m["path"]; ok {
+		out["object_path"] = path
+	}
+	// attrs in a string map is just a string — emit verbatim.
+	if attrs, ok := m["attrs"]; ok {
+		out["object_attrs"] = attrs
+	}
+}
+
+// mapPassThrough copies every field NOT in auditFieldsRemappedToCIM
+// to the output map. Output ordering is determined by json.Marshal
+// (sorted) — sort the keys here for forward-compat with custom
+// marshallers and so future code that iterates the output sees a
+// stable order.
+func mapPassThrough(out map[string]any, fields Fields, opts *FormatOptions) {
+	extraKeys := make([]string, 0, len(fields))
+	for k := range fields {
+		if _, mapped := auditFieldsRemappedToCIM[k]; mapped {
+			continue
+		}
+		if opts.IsExcluded(k) {
+			continue
+		}
+		extraKeys = append(extraKeys, k)
+	}
+	sort.Strings(extraKeys)
+	for _, k := range extraKeys {
+		out[k] = fields[k]
+	}
+}
+
+// resolvedVendorProduct returns the override if set, otherwise the
+// framework AppName.
+func (f *CIMChangeFormatter) resolvedVendorProduct() string {
+	if f.VendorProduct != "" {
+		return f.VendorProduct
+	}
+	return f.appName
+}
+
+// collapseOutcomeToCIMStatus implements the binary outcome → status
+// collapse documented on [CIMChangeFormatter]. Returns "success" for
+// the success outcome (case-insensitive), "failure" otherwise.
+func collapseOutcomeToCIMStatus(v any) string {
+	s, ok := v.(string)
+	if !ok {
+		return "failure"
+	}
+	if strings.EqualFold(s, "success") {
+		return "success"
+	}
+	return "failure"
+}
+
+// Compile-time interface assertions.
+var (
+	_ Formatter            = (*CIMChangeFormatter)(nil)
+	_ FrameworkFieldSetter = (*CIMChangeFormatter)(nil)
+)

--- a/format_cim_test.go
+++ b/format_cim_test.go
@@ -1,0 +1,446 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit"
+)
+
+// cimDef is the EventDef used across CIM formatter tests. The CIM
+// formatter is largely def-agnostic — it remaps field names by key,
+// not by required/optional categorisation.
+var cimDef = &audit.EventDef{
+	Required: []string{"actor_id", "outcome"},
+	Optional: []string{"event_category"},
+}
+
+func decodeCIM(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	require.NotEmpty(t, data)
+	require.Equal(t, byte('\n'), data[len(data)-1], "output must terminate with newline")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data[:len(data)-1], &m),
+		"output must be valid JSON: %s", string(data))
+	return m
+}
+
+// TestCIM_FrameworkFieldsMappedToCIMNames verifies the full mapping
+// table (audit → CIM Change) for the most common event shape.
+func TestCIM_FrameworkFieldsMappedToCIMNames(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	f.SetFrameworkFields("AxonOps:Audit", "host-01", "UTC", 12345)
+	data, err := f.Format(testTime, "user_create", audit.Fields{
+		"event_category": "account",
+		"actor": map[string]any{
+			"id":   "alice",
+			"name": "Alice Cooper",
+		},
+		"target": map[string]any{
+			"id":   "bob",
+			"type": "user",
+			"path": "/users/bob",
+			"attrs": map[string]any{
+				"role": "admin",
+			},
+		},
+		"outcome":   "success",
+		"source_ip": "10.0.0.5",
+	}, cimDef, nil)
+	require.NoError(t, err)
+
+	m := decodeCIM(t, data)
+
+	// _time is epoch seconds with ms precision.
+	assert.InDelta(t, float64(testTime.UnixMilli())/1000.0, m["_time"], 0.001)
+
+	// action ↔ event_type.
+	assert.Equal(t, "user_create", m["action"])
+
+	// change_type ↔ event_category.
+	assert.Equal(t, "account", m["change_type"])
+
+	// user / user_id / user_name from actor.
+	assert.Equal(t, "alice", m["user_id"])
+	assert.Equal(t, "Alice Cooper", m["user_name"])
+	assert.NotNil(t, m["user"], "user must be present (nested actor)")
+
+	// object / object_id / object_category / object_path / object_attrs.
+	assert.Equal(t, "bob", m["object_id"])
+	assert.Equal(t, "user", m["object_category"])
+	assert.Equal(t, "/users/bob", m["object_path"])
+	// object_attrs is JSON-stringified — decode + compare.
+	attrStr, ok := m["object_attrs"].(string)
+	require.True(t, ok, "object_attrs must be JSON-stringified")
+	var attrs map[string]any
+	require.NoError(t, json.Unmarshal([]byte(attrStr), &attrs))
+	assert.Equal(t, "admin", attrs["role"])
+
+	// status from outcome.
+	assert.Equal(t, "success", m["status"])
+
+	// src from source_ip.
+	assert.Equal(t, "10.0.0.5", m["src"])
+
+	// vendor_product from appName fallback.
+	assert.Equal(t, "AxonOps:Audit", m["vendor_product"])
+
+	// dvc + host from framework host.
+	assert.Equal(t, "host-01", m["dvc"])
+	assert.Equal(t, "host-01", m["host"])
+}
+
+// TestCIM_OutcomeSuccessMapsToStatusSuccess pins the success-path of
+// the binary status collapse.
+func TestCIM_OutcomeSuccessMapsToStatusSuccess(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{"outcome": "success"}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	assert.Equal(t, "success", m["status"])
+}
+
+// TestCIM_OutcomeFailureMapsToStatusFailure covers the lossy collapse:
+// every non-success outcome value collapses to "failure". The
+// formatter's godoc lists "failure", "denied", "error", "pending",
+// "unknown" — table-driven here, including case variants and
+// non-string types. Also anchors that the ORIGINAL outcome value is
+// PRESERVED via the pass-through (the collapse is lossy on `status`
+// but `outcome` is recoverable downstream).
+func TestCIM_OutcomeFailureMapsToStatusFailure(t *testing.T) {
+	tests := []struct {
+		outcome any
+		name    string
+	}{
+		{"failure", "failure"},
+		{"denied", "denied"},
+		{"error", "error"},
+		{"pending", "pending"},
+		{"unknown", "unknown"},
+		{"", "empty string"},
+		{"FAILURE", "uppercase FAILURE"},
+		{0, "int 0"},
+		{nil, "nil"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &audit.CIMChangeFormatter{}
+			data, err := f.Format(testTime, "x", audit.Fields{"outcome": tc.outcome}, cimDef, nil)
+			require.NoError(t, err)
+			m := decodeCIM(t, data)
+			assert.Equal(t, "failure", m["status"],
+				"non-success outcome %v must collapse to failure", tc.outcome)
+			// The original outcome value MUST be preserved alongside
+			// the collapsed status so consumers can recover the
+			// granular value.
+			if tc.outcome != nil {
+				assert.Contains(t, m, "outcome",
+					"original outcome %v must be preserved alongside status", tc.outcome)
+			}
+		})
+	}
+}
+
+// TestCIM_OutcomeIsPreservedAlongsideStatus pins the recoverability
+// of the lossy collapse: every event with an outcome emits BOTH
+// the collapsed `status` AND the original `outcome` so consumers
+// can disambiguate downstream.
+func TestCIM_OutcomeIsPreservedAlongsideStatus(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{"outcome": "denied"}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	assert.Equal(t, "failure", m["status"], "binary CIM status")
+	assert.Equal(t, "denied", m["outcome"], "original outcome preserved")
+}
+
+// TestCIM_OutcomeCaseInsensitiveSuccess — "Success" / "SUCCESS"
+// match success. The collapse uses strings.EqualFold.
+func TestCIM_OutcomeCaseInsensitiveSuccess(t *testing.T) {
+	for _, s := range []string{"Success", "SUCCESS", "sUcCeSs"} {
+		t.Run(s, func(t *testing.T) {
+			f := &audit.CIMChangeFormatter{}
+			data, err := f.Format(testTime, "x", audit.Fields{"outcome": s}, cimDef, nil)
+			require.NoError(t, err)
+			m := decodeCIM(t, data)
+			assert.Equal(t, "success", m["status"],
+				"case-insensitive success match must hold for %q", s)
+		})
+	}
+}
+
+// TestCIM_PreservesUnmappedCustomFields verifies that fields not in
+// the CIM mapping table pass through to the output verbatim AND
+// that MAPPED fields are NOT duplicated in their original form
+// (anti-tautology: a mutant impl that emits everything via the
+// pass-through would fail this test).
+func TestCIM_PreservesUnmappedCustomFields(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{
+		"actor_id":       "alice",        // mapped → user_id
+		"event_category": "account",      // mapped → change_type
+		"source_ip":      "10.0.0.1",     // mapped → src
+		"custom_field":   "custom_value", // unmapped
+		"trace_id":       "abc-123",      // unmapped
+		"approval_step":  3,              // unmapped
+	}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	// Unmapped fields pass through verbatim.
+	assert.Equal(t, "custom_value", m["custom_field"])
+	assert.Equal(t, "abc-123", m["trace_id"])
+	assert.Contains(t, []any{3.0, int64(3), float64(3)}, m["approval_step"])
+	// Mapped fields are NOT duplicated under their original audit
+	// key — they appear only under the CIM-canonical key.
+	_, hasEventCategory := m["event_category"]
+	assert.False(t, hasEventCategory,
+		"event_category must be remapped to change_type, not duplicated")
+	_, hasSourceIP := m["source_ip"]
+	assert.False(t, hasSourceIP,
+		"source_ip must be remapped to src, not duplicated")
+	_, hasActorID := m["actor_id"]
+	assert.False(t, hasActorID,
+		"actor_id must be remapped to user_id, not duplicated")
+	// And the CIM-canonical names are present.
+	assert.Equal(t, "account", m["change_type"])
+	assert.Equal(t, "10.0.0.1", m["src"])
+	assert.Equal(t, "alice", m["user_id"])
+}
+
+// TestCIM_TargetIDFlatMappedToObjectID anchors the flat `target_id`
+// mapping (separate from the nested `target.id` extraction).
+func TestCIM_TargetIDFlatMappedToObjectID(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{"target_id": "topic-7"}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	assert.Equal(t, "topic-7", m["object_id"])
+	// And the original audit key is NOT duplicated.
+	_, has := m["target_id"]
+	assert.False(t, has, "target_id must be remapped to object_id")
+}
+
+// TestCIM_TargetFlatVariantsMapToObjectFields covers target_type,
+// target_path, target_attrs (the flat variants that some audit
+// schemas use instead of the nested `target.type` etc.).
+func TestCIM_TargetFlatVariantsMapToObjectFields(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{
+		"target_type":  "user",
+		"target_path":  "/users/bob",
+		"target_attrs": map[string]any{"role": "admin"},
+	}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	assert.Equal(t, "user", m["object_category"])
+	assert.Equal(t, "/users/bob", m["object_path"])
+	// target_attrs is JSON-stringified.
+	require.Contains(t, m, "object_attrs")
+	attrStr, ok := m["object_attrs"].(string)
+	require.True(t, ok)
+	var attrs map[string]any
+	require.NoError(t, json.Unmarshal([]byte(attrStr), &attrs))
+	assert.Equal(t, "admin", attrs["role"])
+}
+
+// TestCIM_ActorAsStringMap verifies the formatter handles a
+// `map[string]string` actor (some taxonomy-generated code uses
+// concrete-typed maps rather than `map[string]any`).
+func TestCIM_ActorAsStringMap(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{
+		"actor": map[string]string{"id": "alice", "name": "Alice"},
+	}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	assert.Equal(t, "alice", m["user_id"],
+		"actor as map[string]string must still populate user_id")
+	assert.Equal(t, "Alice", m["user_name"])
+}
+
+// TestCIM_FlatTargetIDOverridesNested anchors the precedence rule:
+// when both nested `target.id` AND flat `target_id` are present,
+// the flat value wins (explicit > derived).
+func TestCIM_FlatTargetIDOverridesNested(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{
+		"target":    map[string]any{"id": "nested-id"},
+		"target_id": "flat-id",
+	}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	assert.Equal(t, "flat-id", m["object_id"],
+		"flat target_id must override nested target.id")
+}
+
+// TestCIM_SeverityEmittedAsSeverityID verifies the CIM-flavoured
+// `severity_id` name (avoids collision with consumer-supplied string
+// `severity` fields).
+func TestCIM_SeverityEmittedAsSeverityID(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	// severity_id is present and is a number (JSON decodes to float64).
+	_, has := m["severity_id"]
+	assert.True(t, has, "severity_id must be emitted from def.ResolvedSeverity()")
+	// The legacy `severity` key MUST NOT be emitted under the CIM name.
+	_, hasLegacy := m["severity"]
+	assert.False(t, hasLegacy, "legacy `severity` name must not be emitted (use severity_id)")
+}
+
+// TestCIM_NilEventDef — the def parameter is documented as never nil
+// when called by the library, but defensive testing: nil def must
+// not panic and severity_id must be omitted.
+func TestCIM_NilEventDef(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{"actor_id": "alice"}, nil, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	_, has := m["severity_id"]
+	assert.False(t, has, "severity_id must be omitted when def is nil")
+	// Rest of the mapping still works.
+	assert.Equal(t, "alice", m["user_id"])
+}
+
+// TestCIM_FormatOptions_ExcludeMappedField verifies that
+// opts.IsExcluded() is honoured for MAPPED fields, not just for
+// pass-through fields. A consumer who excludes `outcome` from a
+// per-output route must not see `status` either (the formatter
+// derives status from outcome).
+func TestCIM_FormatOptions_ExcludeMappedField(t *testing.T) {
+	// Construct FormatOptions with a "pii" label that excludes the
+	// outcome and severity fields.
+	opts := &audit.FormatOptions{
+		ExcludedLabels: map[string]struct{}{"pii": {}},
+		FieldLabels: map[string]map[string]struct{}{
+			"outcome":  {"pii": {}},
+			"severity": {"pii": {}},
+		},
+	}
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{
+		"outcome":  "success",
+		"actor_id": "alice",
+	}, cimDef, opts)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	// status MUST NOT be emitted when outcome is excluded.
+	_, hasStatus := m["status"]
+	assert.False(t, hasStatus, "status must be omitted when outcome is excluded")
+	// outcome itself MUST NOT be emitted (excluded by label).
+	_, hasOutcome := m["outcome"]
+	assert.False(t, hasOutcome, "outcome must be omitted when excluded")
+	// severity_id MUST NOT be emitted when severity is excluded.
+	_, hasSev := m["severity_id"]
+	assert.False(t, hasSev, "severity_id must be omitted when severity is excluded")
+	// Non-excluded mapped fields still appear.
+	assert.Equal(t, "alice", m["user_id"])
+}
+
+// TestCIM_NestedActorObjectPreserved verifies that the full nested
+// actor / target objects survive in the output alongside the
+// flattened CIM user_id / object_id top-level fields.
+func TestCIM_NestedActorObjectPreserved(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{
+		"actor": map[string]any{
+			"id":   "alice",
+			"name": "Alice Cooper",
+			"role": "admin",
+		},
+		"target": map[string]any{
+			"id":   "topic-1",
+			"type": "topic",
+		},
+	}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+
+	// Flattened CIM top-level fields.
+	assert.Equal(t, "alice", m["user_id"])
+	assert.Equal(t, "topic-1", m["object_id"])
+
+	// Nested objects survive — including custom fields like "role".
+	actor, ok := m["user"].(map[string]any)
+	require.True(t, ok, "user must be a nested object; got %T", m["user"])
+	assert.Equal(t, "admin", actor["role"],
+		"nested actor object must preserve all original fields")
+
+	target, ok := m["object"].(map[string]any)
+	require.True(t, ok, "object must be a nested object; got %T", m["object"])
+	assert.Equal(t, "topic", target["type"])
+}
+
+// TestCIM_VendorProductFromConfig — explicit VendorProduct option
+// overrides the framework appName.
+func TestCIM_VendorProductFromConfig(t *testing.T) {
+	f := &audit.CIMChangeFormatter{VendorProduct: "Acme:CustomTag"}
+	f.SetFrameworkFields("default-app-name", "h", "UTC", 0)
+	data, err := f.Format(testTime, "x", audit.Fields{}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	assert.Equal(t, "Acme:CustomTag", m["vendor_product"],
+		"VendorProduct option must override SetFrameworkFields appName")
+}
+
+// TestCIM_VendorProductFromFrameworkContext — when VendorProduct is
+// empty, fall back to the appName supplied via SetFrameworkFields.
+func TestCIM_VendorProductFromFrameworkContext(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	f.SetFrameworkFields("AxonOps:Audit", "h", "UTC", 0)
+	data, err := f.Format(testTime, "x", audit.Fields{}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	assert.Equal(t, "AxonOps:Audit", m["vendor_product"])
+}
+
+// TestCIM_VendorProductOmittedWhenBothEmpty — when neither override
+// nor appName is set, vendor_product is omitted (zero-value).
+func TestCIM_VendorProductOmittedWhenBothEmpty(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{}, cimDef, nil)
+	require.NoError(t, err)
+	m := decodeCIM(t, data)
+	_, ok := m["vendor_product"]
+	assert.False(t, ok, "vendor_product must be omitted when both override and appName are empty")
+}
+
+// TestCIM_ContentType pins the wire format.
+func TestCIM_ContentType(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	assert.Equal(t, "application/x-ndjson", f.ContentType())
+}
+
+// TestCIM_NewlineDelimited verifies that the output is exactly one
+// JSON object terminated by exactly one newline — the NDJSON
+// contract Splunk's HEC /raw and webhook consumers depend on.
+func TestCIM_NewlineDelimited(t *testing.T) {
+	f := &audit.CIMChangeFormatter{}
+	data, err := f.Format(testTime, "x", audit.Fields{"outcome": "success"}, cimDef, nil)
+	require.NoError(t, err)
+	// Exactly one newline.
+	assert.Equal(t, 1, strings.Count(string(data), "\n"))
+	// No embedded \n inside the JSON object.
+	body := string(data[:len(data)-1])
+	assert.NotContains(t, body, "\n",
+		"NDJSON body must not contain embedded newlines")
+}

--- a/outputconfig/formatter.go
+++ b/outputconfig/formatter.go
@@ -26,12 +26,13 @@ import (
 // CEF SeverityFunc, DescriptionFunc, and FieldMapping are NOT
 // configurable via YAML — they require Go code.
 type yamlFormatterConfig struct { //nolint:govet // fieldalignment: readability preferred
-	Type      string `yaml:"type"`
-	Timestamp string `yaml:"timestamp"`
-	OmitEmpty bool   `yaml:"omit_empty"`
-	Vendor    string `yaml:"vendor"`
-	Product   string `yaml:"product"`
-	Version   string `yaml:"version"`
+	Type          string `yaml:"type"`
+	Timestamp     string `yaml:"timestamp"`
+	OmitEmpty     bool   `yaml:"omit_empty"`
+	Vendor        string `yaml:"vendor"`
+	Product       string `yaml:"product"`
+	Version       string `yaml:"version"`
+	VendorProduct string `yaml:"vendor_product"`
 }
 
 // extractFormatterType returns the formatter type string from a raw
@@ -82,8 +83,10 @@ func buildFormatter(raw any) (audit.Formatter, error) {
 		return buildJSONFormatter(&cfg)
 	case "cef":
 		return buildCEFFormatter(&cfg)
+	case "cim_change":
+		return buildCIMChangeFormatter(&cfg)
 	default:
-		return nil, fmt.Errorf("formatter: unknown type %q (valid: json, cef)", cfg.Type)
+		return nil, fmt.Errorf("formatter: unknown type %q (valid: json, cef, cim_change)", cfg.Type)
 	}
 }
 
@@ -91,6 +94,10 @@ func buildJSONFormatter(cfg *yamlFormatterConfig) (*audit.JSONFormatter, error) 
 	// Reject CEF-specific fields on a JSON formatter.
 	if cfg.Vendor != "" || cfg.Product != "" || cfg.Version != "" {
 		return nil, fmt.Errorf("formatter: json does not support vendor/product/version options")
+	}
+	// Reject CIM-specific fields on a JSON formatter.
+	if cfg.VendorProduct != "" {
+		return nil, fmt.Errorf("formatter: json does not support vendor_product option (use cim_change for that)")
 	}
 
 	ts := audit.TimestampFormat(cfg.Timestamp)
@@ -114,6 +121,10 @@ func buildCEFFormatter(cfg *yamlFormatterConfig) (*audit.CEFFormatter, error) {
 	if cfg.Timestamp != "" {
 		return nil, fmt.Errorf("formatter: cef does not support timestamp option (got %q)", cfg.Timestamp)
 	}
+	// Reject CIM-specific fields on a CEF formatter.
+	if cfg.VendorProduct != "" {
+		return nil, fmt.Errorf("formatter: cef does not support vendor_product option (use vendor and product separately)")
+	}
 
 	return &audit.CEFFormatter{
 		Vendor:    cfg.Vendor,
@@ -123,5 +134,26 @@ func buildCEFFormatter(cfg *yamlFormatterConfig) (*audit.CEFFormatter, error) {
 		// SeverityFunc, DescriptionFunc, and FieldMapping are NOT
 		// configurable via YAML. Consumers who need these should
 		// construct the CEFFormatter programmatically.
+	}, nil
+}
+
+// buildCIMChangeFormatter constructs a [audit.CIMChangeFormatter]
+// from YAML. The CIM Change formatter targets the Splunk CIM 6.1
+// Change data model. Wire format is NDJSON (`application/x-ndjson`).
+// Only the `vendor_product` option is honoured; `timestamp` is
+// rejected because CIM canonicalises `_time` to epoch milliseconds
+// and an alternate timestamp format would silently mis-index.
+func buildCIMChangeFormatter(cfg *yamlFormatterConfig) (*audit.CIMChangeFormatter, error) {
+	if cfg.Timestamp != "" {
+		return nil, fmt.Errorf("formatter: cim_change does not support timestamp option (CIM uses epoch milliseconds in _time)")
+	}
+	if cfg.Vendor != "" || cfg.Product != "" || cfg.Version != "" {
+		return nil, fmt.Errorf("formatter: cim_change does not support vendor/product/version (use vendor_product instead)")
+	}
+	if cfg.OmitEmpty {
+		return nil, fmt.Errorf("formatter: cim_change does not support omit_empty (CIM mapping is explicit)")
+	}
+	return &audit.CIMChangeFormatter{
+		VendorProduct: cfg.VendorProduct,
 	}, nil
 }

--- a/outputconfig/formatter_test.go
+++ b/outputconfig/formatter_test.go
@@ -162,6 +162,93 @@ func TestBuildFormatter_UnknownType_Error(t *testing.T) {
 	// text-only: buildFormatter helper, see TestBuildFormatter_JSON_InvalidTimestamp_Error.
 	assert.Contains(t, err.Error(), "unknown type")
 	assert.Contains(t, err.Error(), "protobuf")
+	// Error message must enumerate every valid type so operators
+	// reading the error can self-correct without grepping docs.
+	for _, valid := range []string{"json", "cef", "cim_change"} {
+		assert.Contains(t, err.Error(), valid,
+			"unknown-type error should enumerate %q as a valid alternative", valid)
+	}
+}
+
+// TestCIM_RegisteredInOutputconfigFormatter verifies that
+// `type: cim_change` constructs a [audit.CIMChangeFormatter] via the
+// public buildFormatter path.
+func TestCIM_RegisteredInOutputconfigFormatter(t *testing.T) {
+	v := parseFormatterValue(t, "type: cim_change\nvendor_product: AxonOps:Audit\n")
+	f, err := outputconfig.BuildFormatterForTest(v)
+	require.NoError(t, err)
+	cim, ok := f.(*audit.CIMChangeFormatter)
+	require.True(t, ok, "expected *audit.CIMChangeFormatter, got %T", f)
+	assert.Equal(t, "AxonOps:Audit", cim.VendorProduct)
+}
+
+// TestBuildFormatter_CIMChange_VendorProduct — vendor_product is the
+// only formatter-specific option honoured by the YAML factory.
+func TestBuildFormatter_CIMChange_VendorProduct(t *testing.T) {
+	v := parseFormatterValue(t, "type: cim_change\nvendor_product: \"My:App\"\n")
+	f, err := outputconfig.BuildFormatterForTest(v)
+	require.NoError(t, err)
+	cim, ok := f.(*audit.CIMChangeFormatter)
+	require.True(t, ok)
+	assert.Equal(t, "My:App", cim.VendorProduct)
+}
+
+// TestBuildFormatter_CIMChange_NoOptions — the default vendor_product
+// (empty) means the formatter will fall back to the FrameworkContext
+// appName at runtime. Empty config is valid.
+func TestBuildFormatter_CIMChange_NoOptions(t *testing.T) {
+	v := parseFormatterValue(t, "type: cim_change\n")
+	f, err := outputconfig.BuildFormatterForTest(v)
+	require.NoError(t, err)
+	cim, ok := f.(*audit.CIMChangeFormatter)
+	require.True(t, ok)
+	assert.Empty(t, cim.VendorProduct)
+}
+
+// TestBuildFormatter_CIMChange_TimestampRejected — CIM canonicalises
+// _time to epoch milliseconds; accepting an alternate timestamp
+// option would silently mis-index events at Splunk.
+func TestBuildFormatter_CIMChange_TimestampRejected(t *testing.T) {
+	v := parseFormatterValue(t, "type: cim_change\ntimestamp: rfc3339nano\n")
+	_, err := outputconfig.BuildFormatterForTest(v)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cim_change does not support timestamp")
+}
+
+// TestBuildFormatter_CIMChange_CEFFieldsRejected — vendor/product/
+// version are CEF-only; CIM uses the combined `vendor_product`.
+func TestBuildFormatter_CIMChange_CEFFieldsRejected(t *testing.T) {
+	v := parseFormatterValue(t, "type: cim_change\nvendor: foo\n")
+	_, err := outputconfig.BuildFormatterForTest(v)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cim_change does not support vendor/product/version")
+}
+
+// TestBuildFormatter_CIMChange_OmitEmptyRejected — CIM mapping is
+// explicit; omit_empty is meaningless because the formatter only
+// emits fields it has values for.
+func TestBuildFormatter_CIMChange_OmitEmptyRejected(t *testing.T) {
+	v := parseFormatterValue(t, "type: cim_change\nomit_empty: true\n")
+	_, err := outputconfig.BuildFormatterForTest(v)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cim_change does not support omit_empty")
+}
+
+// TestBuildFormatter_JSON_VendorProductRejected — vendor_product is
+// CIM-only; setting it on JSON is a misconfiguration.
+func TestBuildFormatter_JSON_VendorProductRejected(t *testing.T) {
+	v := parseFormatterValue(t, "type: json\nvendor_product: foo\n")
+	_, err := outputconfig.BuildFormatterForTest(v)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "json does not support vendor_product")
+}
+
+// TestBuildFormatter_CEF_VendorProductRejected — same on CEF.
+func TestBuildFormatter_CEF_VendorProductRejected(t *testing.T) {
+	v := parseFormatterValue(t, "type: cef\nvendor_product: foo\n")
+	_, err := outputconfig.BuildFormatterForTest(v)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cef does not support vendor_product")
 }
 
 func TestBuildFormatter_InvalidStructure_Error(t *testing.T) {
@@ -184,6 +271,7 @@ func TestExtractFormatterType(t *testing.T) {
 		{"scalar json", "json", "json"},
 		{"mapping with type", "type: cef", "cef"},
 		{"mapping with type json", "type: json\ntimestamp: unix_ms", "json"},
+		{"mapping with type cim_change", "type: cim_change\nvendor_product: x", "cim_change"},
 		{"mapping without type", "timestamp: unix_ms", ""},
 		{"empty scalar", `""`, ""},
 	}

--- a/outputconfig/tests/bdd/features/output_config.feature
+++ b/outputconfig/tests/bdd/features/output_config.feature
@@ -322,6 +322,60 @@ Feature: YAML Output Configuration
     Then the config load should succeed
     And the loki output formatter should be JSON
 
+  # --- CIM Change formatter (#55 PR 2) ---
+
+  Scenario: outputs may select the cim_change formatter
+    Given a test taxonomy
+    And the following output configuration YAML:
+      """
+      version: 1
+      app_name: AxonOps:Audit
+      host: test
+      outputs:
+        stdout_cim:
+          type: stdout
+          formatter:
+            type: cim_change
+            vendor_product: "AxonOps:Audit"
+      """
+    When I try to create an auditor from the YAML config
+    Then the config load should succeed
+
+  Scenario: cim_change rejects timestamp option
+    Given a test taxonomy
+    And the following output configuration YAML:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        stdout_cim:
+          type: stdout
+          formatter:
+            type: cim_change
+            timestamp: rfc3339nano
+      """
+    When I try to create an auditor from the YAML config
+    Then the config load should fail with an error containing "cim_change does not support timestamp"
+
+  Scenario: cim_change rejects CEF-style vendor/product/version
+    Given a test taxonomy
+    And the following output configuration YAML:
+      """
+      version: 1
+      app_name: test
+      host: test
+      outputs:
+        stdout_cim:
+          type: stdout
+          formatter:
+            type: cim_change
+            vendor: foo
+            product: bar
+      """
+    When I try to create an auditor from the YAML config
+    Then the config load should fail with an error containing "cim_change does not support vendor/product/version"
+
   Scenario: default_formatter key rejected with error
     Given a test taxonomy
     And the following output configuration YAML:

--- a/splunk/ack.go
+++ b/splunk/ack.go
@@ -1,0 +1,499 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunk
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// randReader is the entropy source for [newChannelGUID]. Production
+// uses crypto/rand.Reader; tests inject a failing reader to exercise
+// the ErrCryptoRandFailed code path.
+var randReader io.Reader = rand.Reader //nolint:revive,gochecknoglobals // package-level swap point for test entropy injection
+
+// channelGUID is a 128-bit identifier in UUID v4 textual form
+// (8-4-4-4-12 hex with version 4 and variant 10). One per [Output]
+// instance.
+type channelGUID string
+
+// newChannelGUID returns a crypto/rand-sourced UUID v4. On any
+// failure of the entropy source it returns ErrCryptoRandFailed —
+// callers MUST propagate (never substitute a zero or pseudo-random
+// GUID; a deterministic channel value would let an attacker observe
+// or replay ack states).
+func newChannelGUID(r io.Reader) (channelGUID, error) {
+	var b [16]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrCryptoRandFailed, err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return channelGUID(fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])), nil
+}
+
+// AckMetricsRecorder is an optional extension implemented by
+// [audit.OutputMetrics] instances that care about ACK telemetry.
+// The library detects support via a runtime type assertion (same
+// pattern as [file.RotationRecorder]). Implementations that do not
+// implement this interface silently skip the ACK metric calls.
+type AckMetricsRecorder interface {
+	// RecordAckPending reports the current count of batches awaiting
+	// acknowledgement. Called once per poll tick.
+	RecordAckPending(gauge int)
+	// RecordAckConfirmed records that `count` batches received a
+	// positive ack in the last poll. Called once per poll tick when
+	// count > 0.
+	RecordAckConfirmed(count int)
+	// RecordAckTimedOut records that `count` batches exceeded the
+	// configured AckResendWindow. Called once per poll tick when
+	// count > 0. Only fires for AckModeRequired.
+	RecordAckTimedOut(count int)
+	// RecordAckBufferFullDrop records that `count` events were
+	// dropped because the in-flight buffer was full (AckModeRequired
+	// only). Called from the batchLoop side, not from the poller.
+	RecordAckBufferFullDrop(count int)
+}
+
+// AckSnapshot is a point-in-time view of the tracker's counters.
+// Returned by [Output.AckMetricsSnapshot] for consumers who prefer
+// pull-based reads over the push-based [AckMetricsRecorder] path.
+type AckSnapshot struct {
+	// Pending is len(inFlight) — batches with ackIDs we haven't yet
+	// confirmed or timed out.
+	Pending int
+	// Confirmed is the cumulative count of batches with a positive ack.
+	Confirmed int64
+	// TimedOut is the cumulative count of batches whose AckResendWindow
+	// elapsed without a positive ack (AckModeRequired only).
+	TimedOut int64
+	// BufferFullDrops is the cumulative count of events dropped because
+	// the in-flight buffer was full (AckModeRequired only).
+	BufferFullDrops int64
+}
+
+// flushBufs bundles the per-flush scratch buffers so the batchLoop
+// and the resend path (poller goroutine, AckModeRequired) each own a
+// separate set — `flushBatchAux` is called from both goroutines, and
+// these buffers are not concurrent-safe.
+type flushBufs struct {
+	envelope  bytes.Buffer
+	raw       bytes.Buffer
+	compress  bytes.Buffer
+	gz        *gzip.Writer // initialised once at construction
+	retryHint time.Duration
+}
+
+// newFlushBufs constructs a flushBufs with its gzip writer pre-allocated.
+func newFlushBufs() *flushBufs {
+	b := &flushBufs{}
+	b.gz = gzip.NewWriter(&b.compress)
+	return b
+}
+
+// inFlightBatch holds one outstanding batch whose ackID is being
+// polled. Owned exclusively by ackTracker; never escapes the package.
+type inFlightBatch struct {
+	ackID   int64
+	entries []splunkEntry // retained for resend in AckModeRequired
+	sentAt  time.Time
+	resends int
+}
+
+// ackTracker is the per-output ACK state machine. One instance per
+// [Output] when AckMode != AckModeOff (nil otherwise). The tracker
+// runs exactly one goroutine — [ackTracker.pollLoop] — which polls
+// /services/collector/ack at the configured AckPollInterval and
+// applies confirmations / resends in a single tick.
+//
+// # Concurrency invariants
+//
+//   - `channel` and `pollURL` are immutable after newAckTracker;
+//     safe lock-free read.
+//   - `inFlight` is guarded by `mu`. Mutated by tracker.register
+//     (batchLoop goroutine), tracker.applyConfirmations and
+//     tracker.checkResendWindow (pollLoop goroutine), and
+//     tracker.flushOnClose (Close caller).
+//   - `confirmed` / `timedOut` / `bufferFullDrops` are atomic.Int64;
+//     updated outside mu, read lock-free by [Output.AckMetricsSnapshot].
+//   - `closed` is guarded by mu; transitions false→true once.
+//   - `ctx` / `cancel` / `done` set in newAckTracker; cancel is
+//     idempotent.
+type ackTracker struct { //nolint:govet // fieldalignment: readability preferred (grouped by concern)
+	cfg     *Config
+	out     *Output
+	channel channelGUID
+	pollURL string
+
+	// In-flight state.
+	mu       sync.Mutex
+	inFlight map[int64]*inFlightBatch
+	closed   bool
+
+	// Resend buffers — owned exclusively by pollLoop. Decoupled from
+	// the batchLoop's flush buffers so resends don't race against
+	// in-flight flushes.
+	resendBufs *flushBufs
+
+	// Lock-free counters.
+	confirmed       atomic.Int64
+	timedOut        atomic.Int64
+	bufferFullDrops atomic.Int64
+
+	// Rate-limited warns.
+	warnPollFailure *dropLimiter
+
+	// Goroutine lifecycle.
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// newAckTracker constructs and returns a tracker for the given
+// Output. Does NOT start the poll goroutine — caller is responsible
+// for `go tr.pollLoop(ctx)` after the feature-detection probe has
+// succeeded.
+func newAckTracker(ctx context.Context, out *Output, channel channelGUID) (*ackTracker, error) {
+	pollURL, err := joinAckURL(out.cfg.URL, string(channel))
+	if err != nil {
+		return nil, fmt.Errorf("audit/splunk: build ack URL: %w", err)
+	}
+	tCtx, cancel := context.WithCancel(ctx)
+	return &ackTracker{
+		cfg:             out.cfg,
+		out:             out,
+		channel:         channel,
+		pollURL:         pollURL,
+		inFlight:        make(map[int64]*inFlightBatch, out.cfg.BufferSize/out.cfg.BatchSize+1),
+		resendBufs:      newFlushBufs(),
+		warnPollFailure: newDropLimiter(dropWarnInterval),
+		ctx:             tCtx,
+		cancel:          cancel,
+		done:            make(chan struct{}),
+	}, nil
+}
+
+// register adds a freshly-sent batch to the in-flight set. Called by
+// the batchLoop goroutine after a successful doPost that returned an
+// ackID. The `entries` slice is retained for resend in
+// AckModeRequired; AckModeBestEffort callers pass `nil` to save
+// memory because resends are never attempted in best-effort mode.
+func (t *ackTracker) register(ackID int64, entries []splunkEntry) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return
+	}
+	t.inFlight[ackID] = &inFlightBatch{
+		ackID:   ackID,
+		entries: entries,
+		sentAt:  time.Now(),
+	}
+}
+
+// inFlightCount returns the current in-flight buffer occupancy.
+// Called by the batchLoop side before a flush in AckModeRequired to
+// enforce the BufferSize cap (AC 59).
+func (t *ackTracker) inFlightCount() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.inFlight)
+}
+
+// recordBufferFullDrop is the batchLoop-side hook for AC 59. Called
+// when an oversize batch would push in-flight past BufferSize.
+func (t *ackTracker) recordBufferFullDrop(count int) {
+	if t == nil {
+		return
+	}
+	t.bufferFullDrops.Add(int64(count))
+	if rec, ok := t.out.outputMetrics.(AckMetricsRecorder); ok {
+		rec.RecordAckBufferFullDrop(count)
+	}
+}
+
+// pollLoop is the tracker's sole goroutine. Ticks at AckPollInterval
+// and on each tick: (1) snapshots outstanding ackIDs, (2) polls
+// /services/collector/ack, (3) applies confirmations, (4) checks the
+// resend window (AckModeRequired only). Exits when t.ctx is
+// cancelled (via [ackTracker.stop]).
+//
+// The `ctx` parameter is unused — pollLoop selects on t.ctx so
+// tracker.stop() reliably cancels regardless of the caller's ctx.
+// Kept for symmetry with batchLoop and to allow future per-tick
+// context derivation.
+func (t *ackTracker) pollLoop(_ context.Context) {
+	defer close(t.done)
+	ticker := time.NewTicker(t.cfg.AckPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-t.ctx.Done():
+			return
+		case <-ticker.C:
+			t.tick(t.ctx)
+		}
+	}
+}
+
+// tick is the per-iteration body of pollLoop, extracted for testability.
+func (t *ackTracker) tick(ctx context.Context) {
+	ids := t.snapshotIDs()
+	if len(ids) == 0 {
+		t.publishPending()
+		return
+	}
+	confirmed, err := t.pollAcks(ctx, ids)
+	if err != nil {
+		if t.warnPollFailure.allow() {
+			t.out.logger.Warn("audit/splunk: ack poll failed",
+				"output", t.out.name, "error", t.out.redact(err))
+		}
+		// Don't apply confirmations; let the resend-window logic
+		// handle it on the next tick.
+	} else {
+		t.applyConfirmations(confirmed)
+	}
+	if t.cfg.AckMode == AckModeRequired {
+		t.checkResendWindow(ctx)
+	}
+	t.publishPending()
+}
+
+// snapshotIDs returns the current in-flight ackID list. Safe to call
+// from any goroutine.
+func (t *ackTracker) snapshotIDs() []int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.inFlight) == 0 {
+		return nil
+	}
+	ids := make([]int64, 0, len(t.inFlight))
+	for id := range t.inFlight {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// applyConfirmations removes confirmed ackIDs from the in-flight map
+// and increments the confirmed counter. Drops the retained entries
+// slice for confirmed batches so resend storage is bounded.
+func (t *ackTracker) applyConfirmations(confirmed map[int64]bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var n int64
+	for id, ok := range confirmed {
+		if !ok {
+			continue
+		}
+		if _, present := t.inFlight[id]; present {
+			delete(t.inFlight, id)
+			n++
+		}
+	}
+	if n > 0 {
+		t.confirmed.Add(n)
+		if rec, ok := t.out.outputMetrics.(AckMetricsRecorder); ok {
+			rec.RecordAckConfirmed(int(n))
+		}
+	}
+}
+
+// checkResendWindow scans in-flight batches whose sentAt is older
+// than AckResendWindow. Each such batch is removed from in-flight,
+// counted as timed out, and re-enqueued via flushBatchAux on the
+// tracker's own resendBufs (decoupled from the batchLoop). Only
+// called for AckModeRequired.
+func (t *ackTracker) checkResendWindow(ctx context.Context) {
+	now := time.Now()
+	var toResend []*inFlightBatch
+	t.mu.Lock()
+	for id, batch := range t.inFlight {
+		if now.Sub(batch.sentAt) > t.cfg.AckResendWindow {
+			toResend = append(toResend, batch)
+			delete(t.inFlight, id)
+		}
+	}
+	t.mu.Unlock()
+	if len(toResend) == 0 {
+		return
+	}
+	t.timedOut.Add(int64(len(toResend)))
+	if rec, ok := t.out.outputMetrics.(AckMetricsRecorder); ok {
+		rec.RecordAckTimedOut(len(toResend))
+	}
+	for _, batch := range toResend {
+		t.out.logger.Warn("audit/splunk: ack resend window elapsed — resending",
+			"output", t.out.name,
+			"batch_size", len(batch.entries),
+			"prior_resends", batch.resends)
+		if len(batch.entries) == 0 {
+			continue
+		}
+		t.out.flushBatchAux(ctx, batch.entries, t.resendBufs)
+	}
+}
+
+// publishPending fires the pending-count gauge to the
+// AckMetricsRecorder if the metrics sink implements it.
+func (t *ackTracker) publishPending() {
+	if rec, ok := t.out.outputMetrics.(AckMetricsRecorder); ok {
+		t.mu.Lock()
+		n := len(t.inFlight)
+		t.mu.Unlock()
+		rec.RecordAckPending(n)
+	}
+}
+
+// pollAcks issues `POST /services/collector/ack?channel=<GUID>` with
+// body `{"acks":[id,...]}` and parses the response
+// `{"acks":{"<id>":true|false,...}}`. Returns a map keyed by ackID
+// with the confirmation status. Response body is bounded by
+// `io.LimitReader(maxResponseDrainAck)` (1 MiB; documented at
+// http.go).
+func (t *ackTracker) pollAcks(ctx context.Context, ids []int64) (map[int64]bool, error) {
+	body, err := json.Marshal(struct {
+		Acks []int64 `json:"acks"`
+	}{Acks: ids})
+	if err != nil {
+		return nil, fmt.Errorf("encode ack body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.pollURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build ack request: %w", err)
+	}
+	t.out.applyRequestHeaders(req, false)
+	resp, err := t.out.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ack request: %w", err)
+	}
+	defer drainAndClose(resp, maxResponseDrainAck)
+
+	if !checkResponseSize(resp, maxResponseDrainAck) {
+		// Force connection close — peer lied about Content-Length.
+		resp.Close = true
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("ack response Content-Length %d exceeds %d", resp.ContentLength, int64(maxResponseDrainAck))
+	}
+
+	respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseDrainAck))
+
+	if resp.StatusCode != http.StatusOK {
+		// Detect ack-disabled via HEC code 14. classify() returns
+		// actionAckDisabled for this combo; we parse the code here
+		// to give a precise error for the operator log.
+		hecCode, _ := parseHECCode(respBytes)
+		if hecCode == 14 {
+			return nil, fmt.Errorf("%w: HEC returned code 14 from /ack", ErrAckDisabled)
+		}
+		return nil, fmt.Errorf("ack HTTP %d (hec=%d)", resp.StatusCode, hecCode)
+	}
+
+	var parsed struct {
+		Acks map[string]bool `json:"acks"`
+	}
+	if err := json.Unmarshal(respBytes, &parsed); err != nil {
+		return nil, fmt.Errorf("decode ack response: %w", err)
+	}
+	out := make(map[int64]bool, len(parsed.Acks))
+	for k, v := range parsed.Acks {
+		var id int64
+		if _, err := fmt.Sscanf(k, "%d", &id); err == nil {
+			out[id] = v
+		}
+	}
+	return out, nil
+}
+
+// flushOnClose observes the in-flight set draining naturally via
+// the still-running pollLoop. Called from [Output.Close] BEFORE
+// tracker.stop() cancels the loop. Best-effort: if the budget
+// elapses with in-flight remaining, those batches are abandoned
+// (resend on next process start is not the library's job —
+// operators integrate with a journaling layer for strong durability).
+//
+// flushOnClose MUST NOT call tick() directly — the pollLoop owns the
+// resendBufs and any concurrent flushBatchAux invocation from this
+// goroutine would race against an in-flight tick.
+func (t *ackTracker) flushOnClose(_ context.Context) {
+	if t == nil {
+		return
+	}
+	budget := 2 * t.cfg.Timeout
+	deadline := time.Now().Add(budget)
+	pollEvery := t.cfg.AckPollInterval
+	for time.Now().Before(deadline) {
+		t.mu.Lock()
+		n := len(t.inFlight)
+		t.mu.Unlock()
+		if n == 0 {
+			return
+		}
+		time.Sleep(pollEvery)
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.inFlight) > 0 {
+		t.out.logger.Warn("audit/splunk: Close timed out with batches still in-flight",
+			"output", t.out.name, "remaining", len(t.inFlight))
+	}
+}
+
+// stop cancels the poll goroutine and waits for it to exit. Called
+// after flushOnClose from [Output.Close].
+func (t *ackTracker) stop() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.closed = true
+	t.mu.Unlock()
+	t.cancel()
+	<-t.done
+}
+
+// snapshot returns a point-in-time view of the tracker's counters.
+// Lock-free per the concurrency annotations above; the only locked
+// read is `len(inFlight)`.
+func (t *ackTracker) snapshot() AckSnapshot {
+	if t == nil {
+		return AckSnapshot{}
+	}
+	t.mu.Lock()
+	n := len(t.inFlight)
+	t.mu.Unlock()
+	return AckSnapshot{
+		Pending:         n,
+		Confirmed:       t.confirmed.Load(),
+		TimedOut:        t.timedOut.Load(),
+		BufferFullDrops: t.bufferFullDrops.Load(),
+	}
+}

--- a/splunk/ack_probe.go
+++ b/splunk/ack_probe.go
@@ -1,0 +1,73 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ackFeatureProbe sends a single synthetic event to /event with the
+// channel header (via the just-wired tracker). Returns nil when HEC
+// responds with a non-nil ackID. Returns ErrAckDisabled (wrapped)
+// when HEC responds with code 14 ("ACK is disabled"); returns any
+// underlying error otherwise.
+//
+// The synthetic event is a `{"event":"audit-splunk channel probe",
+// "_ack_probe":1}` envelope. It is intentionally a real event so an
+// operator browsing the Splunk index can see one row per process
+// start — the marker field `_ack_probe:1` filters them out of normal
+// dashboards.
+//
+// Called from New() AFTER the /health probe has succeeded and AFTER
+// the tracker has been wired (so applyRequestHeaders attaches the
+// channel header).
+func (o *Output) ackFeatureProbe(ctx context.Context) error {
+	if o.tracker == nil {
+		return errors.New("audit/splunk: ackFeatureProbe called with nil tracker (internal error)")
+	}
+
+	probeEvent := []byte(`{"event_type":"_ack_probe","timestamp":"` + time.Now().UTC().Format(time.RFC3339Nano) + `","_ack_probe":1}`)
+
+	// Wrap into the /event envelope (the probe always uses /event,
+	// even when the consumer configured /raw — the /raw endpoint
+	// doesn't support ACK feature detection because the response
+	// envelope is different).
+	o.batchBufs.envelope.Reset()
+	if _, err := wrapEvent(&o.batchBufs.envelope, o.cfg, probeEvent, time.Now()); err != nil {
+		return fmt.Errorf("audit/splunk: ack probe wrap: %w", err)
+	}
+	payload := o.batchBufs.envelope.Bytes()
+
+	action, status, hecCode, ackID, postErr := o.doPost(ctx, payload, false, o.batchBufs)
+	o.batchBufs.retryHint = 0
+	if action == actionAckDisabled || hecCode == 14 {
+		return fmt.Errorf("%w (HTTP %d, HEC code %d)", ErrAckDisabled, status, hecCode)
+	}
+	if postErr != nil {
+		return fmt.Errorf("audit/splunk: ack probe: %w", postErr)
+	}
+	if ackID == nil {
+		// HEC responded with 200 but no ackID — token must have ACK
+		// silently disabled on the channel.
+		return fmt.Errorf("%w (HEC returned no ackId)", ErrAckDisabled)
+	}
+	// Register the probe so the poll loop confirms it; the synthetic
+	// event is treated like any other in-flight batch.
+	o.tracker.register(*ackID, nil)
+	return nil
+}

--- a/splunk/ack_test.go
+++ b/splunk/ack_test.go
@@ -1,0 +1,619 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/iotest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/axonops/audit"
+)
+
+// ackTestStub is a HEC stub that records every request and supports
+// configurable /event ackID emission and /ack polling responses.
+type ackTestStub struct {
+	mu          sync.Mutex
+	eventReqs   atomic.Int64
+	ackReqs     atomic.Int64
+	channelHdrs []string // recorded X-Splunk-Request-Channel values per event request
+	bodies      [][]byte // recorded /event bodies
+	ackIDs      atomic.Int64
+
+	// ackResponses maps ackID → bool to return on /ack polls. Default
+	// (key absent): false. Tests pre-populate to simulate confirmations.
+	ackResponses map[int64]bool
+
+	// /event response controls.
+	eventReturnsCode14 atomic.Bool // simulate ACK disabled
+
+	srv *httptest.Server
+}
+
+func newAckTestStub() *ackTestStub {
+	s := &ackTestStub{ackResponses: make(map[int64]bool)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/collector/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"text":"HEC is healthy","code":17}`))
+	})
+	mux.HandleFunc("/services/collector/event", func(w http.ResponseWriter, r *http.Request) {
+		s.eventReqs.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		s.mu.Lock()
+		s.channelHdrs = append(s.channelHdrs, r.Header.Get("X-Splunk-Request-Channel"))
+		s.bodies = append(s.bodies, body)
+		s.mu.Unlock()
+		if s.eventReturnsCode14.Load() {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"text":"ACK is disabled","code":14}`))
+			return
+		}
+		ackID := s.ackIDs.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"text":"Success","code":0,"ackId":` + strconv.FormatInt(ackID, 10) + `}`))
+	})
+	mux.HandleFunc("/services/collector/ack", func(w http.ResponseWriter, r *http.Request) {
+		s.ackReqs.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		// Parse acks from the request to figure out which IDs to
+		// answer. Simple — return true for IDs in s.ackResponses
+		// with value true, false otherwise.
+		var req struct {
+			Acks []int64 `json:"acks"`
+		}
+		_ = json.Unmarshal(body, &req)
+		s.mu.Lock()
+		ackMap := make(map[string]bool, len(req.Acks))
+		for _, id := range req.Acks {
+			ackMap[strconv.FormatInt(id, 10)] = s.ackResponses[id]
+		}
+		s.mu.Unlock()
+		out, _ := jsonMarshalAck(ackMap)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(out)
+	})
+	s.srv = httptest.NewServer(mux)
+	return s
+}
+
+func (s *ackTestStub) URL() string            { return s.srv.URL }
+func (s *ackTestStub) Close()                 { s.srv.Close() }
+func (s *ackTestStub) eventRequests() int64   { return s.eventReqs.Load() }
+func (s *ackTestStub) ackPollRequests() int64 { return s.ackReqs.Load() }
+func (s *ackTestStub) confirmAck(id int64)    { s.mu.Lock(); s.ackResponses[id] = true; s.mu.Unlock() }
+func (s *ackTestStub) confirmAllOutstanding(t *ackTracker) {
+	for _, id := range t.snapshotIDs() {
+		s.confirmAck(id)
+	}
+}
+func (s *ackTestStub) lastChannelHeader() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.channelHdrs) == 0 {
+		return ""
+	}
+	return s.channelHdrs[len(s.channelHdrs)-1]
+}
+
+// jsonMarshalAck encodes the /ack response envelope.
+func jsonMarshalAck(m map[string]bool) ([]byte, error) {
+	return json.Marshal(struct {
+		Acks map[string]bool `json:"acks"`
+	}{Acks: m})
+}
+
+// ackTestConfig returns a Config that targets the stub and uses
+// short timing values for fast tests.
+func ackTestConfig(url string, mode AckMode) *Config {
+	gz := false
+	return &Config{
+		URL:                        url,
+		Token:                      "tkn",
+		AllowInsecureHTTP:          true,
+		AllowPrivateRanges:         true,
+		DisableStartupVerification: false,
+		StartupVerificationTimeout: 2 * time.Second,
+		AckMode:                    mode,
+		AckPollInterval:            50 * time.Millisecond,
+		AckResendWindow:            200 * time.Millisecond,
+		BufferSize:                 100,
+		BatchSize:                  1,
+		MaxBatchBytes:              MinMaxBatchBytes,
+		MaxEventBytes:              MinMaxEventBytes,
+		FlushInterval:              100 * time.Millisecond,
+		Gzip:                       &gz,
+		Timeout:                    1 * time.Second,
+		UserAgent:                  "audit-splunk/test",
+		MaxRetries:                 0,
+		RetryBaseDelay:             5 * time.Millisecond,
+		RetryMaxDelay:              10 * time.Millisecond,
+		RetryJitter:                0.0,
+	}
+}
+
+// --- Named tests (per issue #55 PR 2 specification) ---
+
+// TestAck_OffMode_NoChannelHeader — AckModeOff (default) must NOT
+// emit the X-Splunk-Request-Channel header.
+func TestAck_OffMode_NoChannelHeader(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeOff)
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)))
+	require.NoError(t, out.Close())
+
+	assert.GreaterOrEqual(t, stub.eventRequests(), int64(1))
+	assert.Empty(t, stub.lastChannelHeader(),
+		"AckModeOff must not send X-Splunk-Request-Channel")
+}
+
+// TestAck_BestEffort_ChannelHeaderSent — best-effort emits a UUID v4
+// channel header on every /event request.
+func TestAck_BestEffort_ChannelHeaderSent(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeBestEffort)
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)))
+	require.NoError(t, out.Close())
+
+	ch := stub.lastChannelHeader()
+	uuidV4 := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	assert.True(t, uuidV4.MatchString(ch),
+		"channel header %q must be a UUID v4", ch)
+}
+
+// TestAck_BestEffort_AckPollsAtInterval — the tracker polls /ack at
+// the configured interval; at least one poll fires after a write.
+func TestAck_BestEffort_AckPollsAtInterval(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeBestEffort)
+	cfg.AckPollInterval = 50 * time.Millisecond
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	defer func() { _ = out.Close() }()
+
+	require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)))
+	require.Eventually(t, func() bool {
+		return stub.ackPollRequests() >= 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"ack poll endpoint must be hit at least once")
+}
+
+// TestAck_BestEffort_BufferNotGated — best-effort does NOT gate the
+// buffer on ack confirmations. Writes proceed even when no ack ever
+// returns true.
+func TestAck_BestEffort_BufferNotGated(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeBestEffort)
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	defer func() { _ = out.Close() }()
+
+	// 50 rapid writes — none of which will be confirmed.
+	for i := 0; i < 50; i++ {
+		require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)),
+			"Write must remain non-blocking under un-confirmed ACK")
+	}
+}
+
+// TestAck_Required_BufferGatedUntilAckPositive — required mode keeps
+// events in-flight until /ack confirms. Drains when /ack returns true.
+func TestAck_Required_BufferGatedUntilAckPositive(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeRequired)
+	cfg.AckPollInterval = 50 * time.Millisecond
+	// Generous resend window so the test isn't racing the resend
+	// timer — we only care about the confirmation drain path.
+	cfg.AckResendWindow = 30 * time.Second
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	defer func() { _ = out.Close() }()
+
+	require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)))
+
+	// Wait for BOTH the probe and the actual write to reach the
+	// server (probe lands during New(); write follows).
+	require.Eventually(t, func() bool {
+		return stub.eventRequests() >= 2 && out.tracker.inFlightCount() >= 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"probe + event must both register as in-flight before confirmation")
+
+	// Confirm all outstanding acks.
+	stub.confirmAllOutstanding(out.tracker)
+
+	// Within a few poll ticks, in-flight should drain.
+	require.Eventually(t, func() bool {
+		return out.tracker.inFlightCount() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"in-flight buffer must drain after positive ack")
+	assert.GreaterOrEqual(t, out.tracker.snapshot().Confirmed, int64(2))
+}
+
+// TestAck_Required_ResendWindowTimeout_Resends — when /ack returns
+// false past the AckResendWindow, the tracker re-sends the batch.
+func TestAck_Required_ResendWindowTimeout_Resends(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeRequired)
+	cfg.AckPollInterval = 50 * time.Millisecond
+	cfg.AckResendWindow = 200 * time.Millisecond
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	defer func() { _ = out.Close() }()
+
+	require.NoError(t, out.Write([]byte(`{"event_type":"resend-me"}`)))
+
+	// The first /event reaches the stub. Then /ack returns false
+	// indefinitely. After AckResendWindow elapses, the tracker
+	// re-sends the same envelope — count event requests reaching
+	// ≥ 2 (probe + first event + resend).
+	require.Eventually(t, func() bool {
+		return out.tracker.snapshot().TimedOut >= 1
+	}, 3*time.Second, 50*time.Millisecond,
+		"resend window must trigger at least one timeout")
+}
+
+// TestAck_Required_BufferFull_DropsNewEventsWithMetric — when the
+// in-flight buffer fills, new events trigger a drop with metric
+// reason=ack_buffer_full. AC 59: producer (Write) remains non-blocking.
+func TestAck_Required_BufferFull_DropsNewEventsWithMetric(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	rec := &ackMetricsRecorder{}
+	cfg := ackTestConfig(stub.URL(), AckModeRequired)
+	cfg.BufferSize = MinBufferSize
+	cfg.BatchSize = 1
+	cfg.FlushInterval = 100 * time.Millisecond
+	out, err := New(cfg, nil, WithOutputMetrics(rec))
+	require.NoError(t, err)
+	defer func() { _ = out.Close() }()
+
+	// Saturate beyond the BufferSize. /ack never confirms, so
+	// in-flight grows until the cap; subsequent batches drop with
+	// ack_buffer_full.
+	for i := 0; i < 2*MinBufferSize; i++ {
+		_ = out.Write([]byte(`{"event_type":"x"}`))
+	}
+	require.Eventually(t, func() bool {
+		return rec.bufferFullDrops.Load() >= 1
+	}, 3*time.Second, 50*time.Millisecond,
+		"buffer-full drops must record on AckMetricsRecorder")
+}
+
+// TestAck_GUIDIsCryptoRand_NotZero — generated GUIDs are UUID v4
+// strings, non-zero, and pairwise distinct over a sample.
+func TestAck_GUIDIsCryptoRand_NotZero(t *testing.T) {
+	uuidV4 := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	const n = 1000
+	seen := make(map[channelGUID]struct{}, n)
+	for i := 0; i < n; i++ {
+		g, err := newChannelGUID(randReader)
+		require.NoError(t, err)
+		assert.True(t, uuidV4.MatchString(string(g)),
+			"GUID %q must match UUID v4 pattern", g)
+		assert.NotEqual(t, channelGUID("00000000-0000-4000-8000-000000000000"), g,
+			"GUID must not be zero")
+		_, dup := seen[g]
+		assert.False(t, dup, "GUID %q must be unique across %d samples", g, n)
+		seen[g] = struct{}{}
+	}
+}
+
+// TestAck_CryptoRandFailure_NewReturnsError — when the entropy
+// source fails, New() returns ErrCryptoRandFailed. No goroutine is
+// started (goleak verifies clean termination).
+func TestAck_CryptoRandFailure_NewReturnsError(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	saved := randReader
+	defer func() { randReader = saved }()
+	randReader = iotest.ErrReader(io.ErrUnexpectedEOF)
+
+	cfg := ackTestConfig(stub.URL(), AckModeBestEffort)
+	_, err := New(cfg, nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCryptoRandFailed),
+		"New() must wrap ErrCryptoRandFailed when crypto/rand fails: got %v", err)
+}
+
+// TestAck_FeatureDetectAtStartup_HECDisabledAckFails — when HEC
+// returns code 14 on the feature-detection probe, New() returns
+// ErrAckDisabled.
+func TestAck_FeatureDetectAtStartup_HECDisabledAckFails(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	stub.eventReturnsCode14.Store(true)
+
+	cfg := ackTestConfig(stub.URL(), AckModeBestEffort)
+	_, err := New(cfg, nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAckDisabled),
+		"New() must wrap ErrAckDisabled when HEC code 14 is returned on probe: got %v", err)
+}
+
+// TestAck_StateMachine_NoGoroutineLeak — explicit goleak verifier
+// for the full lifecycle (New + write + Close).
+func TestAck_StateMachine_NoGoroutineLeak(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeRequired)
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)))
+	require.NoError(t, out.Close())
+}
+
+// TestAck_PollEndpointFormat — the /ack request has the documented
+// URL path, channel query, Authorization header, and body shape.
+func TestAck_PollEndpointFormat(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	var captured struct {
+		mu     sync.Mutex
+		path   string
+		query  string
+		auth   string
+		body   []byte
+		method string
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/collector/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"text":"HEC is healthy","code":17}`))
+	})
+	var ackID atomic.Int64
+	mux.HandleFunc("/services/collector/event", func(w http.ResponseWriter, _ *http.Request) {
+		id := ackID.Add(1)
+		_, _ = w.Write([]byte(`{"text":"Success","code":0,"ackId":` + strconv.FormatInt(id, 10) + `}`))
+	})
+	mux.HandleFunc("/services/collector/ack", func(w http.ResponseWriter, r *http.Request) {
+		captured.mu.Lock()
+		captured.path = r.URL.Path
+		captured.query = r.URL.RawQuery
+		captured.auth = r.Header.Get("Authorization")
+		captured.body, _ = io.ReadAll(r.Body)
+		captured.method = r.Method
+		captured.mu.Unlock()
+		_, _ = w.Write([]byte(`{"acks":{}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := ackTestConfig(srv.URL, AckModeBestEffort)
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)))
+	require.Eventually(t, func() bool {
+		captured.mu.Lock()
+		defer captured.mu.Unlock()
+		return captured.path != ""
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, out.Close())
+
+	captured.mu.Lock()
+	defer captured.mu.Unlock()
+	assert.Equal(t, "POST", captured.method)
+	assert.Equal(t, "/services/collector/ack", captured.path)
+	assert.Contains(t, captured.query, "channel=")
+	assert.True(t, strings.HasPrefix(captured.auth, "Splunk "),
+		"Authorization must be Splunk-scheme: %q", captured.auth)
+	assert.Contains(t, string(captured.body), `"acks"`)
+}
+
+// TestAck_PoolResponseBody_LimitReaderApplied — a hostile /ack
+// response with a Content-Length above the 1 MiB cap is rejected.
+func TestAck_PoolResponseBody_LimitReaderApplied(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/collector/health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"text":"HEC is healthy","code":17}`))
+	})
+	mux.HandleFunc("/services/collector/event", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"text":"Success","code":0,"ackId":1}`))
+	})
+	mux.HandleFunc("/services/collector/ack", func(w http.ResponseWriter, _ *http.Request) {
+		// Advertise 2 MiB; cap is 1 MiB.
+		w.Header().Set("Content-Length", "2097152")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"acks":{}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := ackTestConfig(srv.URL, AckModeBestEffort)
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)))
+	// Wait for one poll tick. The tracker should NOT have applied
+	// any confirmations because the response was rejected.
+	time.Sleep(150 * time.Millisecond)
+	require.NoError(t, out.Close())
+	assert.Equal(t, int64(0), out.tracker.snapshot().Confirmed,
+		"oversized /ack response must be rejected, not parsed")
+}
+
+// TestOutput_Close_FlushesAckRequiredQueue — Close drains the
+// in-flight buffer up to the configured budget when /ack confirms
+// during shutdown.
+func TestOutput_Close_FlushesAckRequiredQueue(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeRequired)
+	cfg.AckResendWindow = 30 * time.Second // avoid resend races
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, out.Write([]byte(`{"event_type":"x"}`)))
+	// Wait until BOTH the probe (registered during New()) and the
+	// actual write are in-flight.
+	require.Eventually(t, func() bool {
+		return stub.eventRequests() >= 2 && out.tracker.inFlightCount() >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+	// Confirm all outstanding before Close.
+	stub.confirmAllOutstanding(out.tracker)
+	require.NoError(t, out.Close())
+
+	assert.Equal(t, 0, out.tracker.snapshot().Pending,
+		"Close must drain the in-flight buffer when /ack confirms")
+	assert.GreaterOrEqual(t, out.tracker.snapshot().Confirmed, int64(2))
+}
+
+// TestAckTracker_RegisterAfterClosed_NoOp covers the closed-state
+// branch in tracker.register — once closed, new registrations are
+// silently dropped (no panic, no leak).
+func TestAckTracker_RegisterAfterClosed_NoOp(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	cfg := ackTestConfig(stub.URL(), AckModeBestEffort)
+	out, err := New(cfg, nil)
+	require.NoError(t, err)
+	tr := out.tracker
+	require.NoError(t, out.Close())
+
+	// After Close, register is a no-op. Snapshot the in-flight count
+	// before and after — the closed-state branch in tracker.register
+	// must not modify the map.
+	before := tr.inFlightCount()
+	tr.register(999, nil)
+	assert.Equal(t, before, tr.inFlightCount(),
+		"register after Close must be a silent no-op (no map growth)")
+}
+
+// TestAckTracker_NilReceiverSafe — every public-ish tracker method
+// must tolerate a nil receiver (AckModeOff Output paths call them).
+func TestAckTracker_NilReceiverSafe(t *testing.T) {
+	var t0 *ackTracker
+	assert.NotPanics(t, func() {
+		t0.register(1, nil)
+		_ = t0.inFlightCount()
+		t0.recordBufferFullDrop(1)
+		t0.flushOnClose(context.Background())
+		t0.stop()
+		_ = t0.snapshot()
+	})
+}
+
+// TestOutput_AckMetricsSnapshot_PullsCounters covers the public
+// snapshot accessor — empty when ACK is disabled, populated when
+// ACK is on.
+func TestOutput_AckMetricsSnapshot_PullsCounters(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"))
+	stub := newAckTestStub()
+	defer stub.Close()
+
+	// AckModeOff: snapshot is zero-valued.
+	cfgOff := ackTestConfig(stub.URL(), AckModeOff)
+	outOff, err := New(cfgOff, nil)
+	require.NoError(t, err)
+	snap := outOff.AckMetricsSnapshot()
+	assert.Equal(t, AckSnapshot{}, snap, "AckModeOff snapshot must be zero-valued")
+	require.NoError(t, outOff.Close())
+
+	// AckModeBestEffort: snapshot reflects the running tracker.
+	cfgOn := ackTestConfig(stub.URL(), AckModeBestEffort)
+	cfgOn.AckResendWindow = 30 * time.Second
+	outOn, err := New(cfgOn, nil)
+	require.NoError(t, err)
+	require.NoError(t, outOn.Write([]byte(`{"event_type":"x"}`)))
+	require.Eventually(t, func() bool {
+		return outOn.AckMetricsSnapshot().Pending >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+	stub.confirmAllOutstanding(outOn.tracker)
+	require.Eventually(t, func() bool {
+		return outOn.AckMetricsSnapshot().Confirmed >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, outOn.Close())
+}
+
+// TestAckGUID_Property_AllUUIDv4 — every generated GUID matches the
+// strict UUID v4 regex. Sample is wider than TestAck_GUIDIsCryptoRand_NotZero
+// to catch low-probability bit-pattern bugs.
+func TestAckGUID_Property_AllUUIDv4(t *testing.T) {
+	uuidV4 := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	for i := 0; i < 10000; i++ {
+		g, err := newChannelGUID(randReader)
+		require.NoError(t, err)
+		require.True(t, uuidV4.MatchString(string(g)),
+			"iteration %d: GUID %q failed UUID v4 regex", i, g)
+	}
+}
+
+// ackMetricsRecorder is a test OutputMetrics that ALSO implements
+// the AckMetricsRecorder interface. Used in
+// TestAck_Required_BufferFull_DropsNewEventsWithMetric and others.
+type ackMetricsRecorder struct {
+	audit.NoOpOutputMetrics
+	pending         atomic.Int64
+	confirmed       atomic.Int64
+	timedOut        atomic.Int64
+	bufferFullDrops atomic.Int64
+}
+
+func (r *ackMetricsRecorder) RecordAckPending(gauge int) { r.pending.Store(int64(gauge)) }
+func (r *ackMetricsRecorder) RecordAckConfirmed(count int) {
+	r.confirmed.Add(int64(count))
+}
+func (r *ackMetricsRecorder) RecordAckTimedOut(count int) {
+	r.timedOut.Add(int64(count))
+}
+func (r *ackMetricsRecorder) RecordAckBufferFullDrop(count int) {
+	r.bufferFullDrops.Add(int64(count))
+}

--- a/splunk/config.go
+++ b/splunk/config.go
@@ -202,9 +202,17 @@ type Config struct { //nolint:govet // fieldalignment: readability preferred (gr
 	// ============ Required ============
 
 	// URL is the HEC endpoint. Two accepted forms:
-	//   "https://splunk.example.com:8088"           - Splunk Enterprise
-	//   "splunkcloud://acme-prod"                   - Splunk Cloud stack
-	//                                                  shortcut (PR 2 — rejected in PR 1)
+	//   "https://splunk.example.com:8088"           - Splunk Enterprise / self-managed
+	//   "splunkcloud://acme-prod"                   - Splunk Cloud stack shortcut
+	//
+	// The `splunkcloud://<stack>` form is expanded at config validation
+	// to `https://http-inputs-<stack>.splunkcloud.com:443`. The stack
+	// name MUST match `^[a-z0-9][a-z0-9-]{0,62}$`. The shortcut form
+	// rejects any non-empty path, port, query, fragment, or opaque
+	// component (use the full `https://` form for non-standard cases),
+	// and rejects [Config.TLSCert] / [Config.TLSKey] (Splunk Cloud HEC
+	// does not support mTLS — use a self-managed HTTPS proxy with
+	// mTLS termination if mTLS is required).
 	URL string
 
 	// Token is the HEC token (opaque string). Required. Validated to
@@ -368,7 +376,7 @@ var validCloudStack = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
 // defaults to unset fields, and returns the first violation as a
 // wrapped [ErrConfigInvalid]. Idempotent. Mutates the receiver to
 // apply defaults.
-func (c *Config) Validate() error { //nolint:cyclop,gocyclo,funlen // long-but-flat validation; clarity > decomposition
+func (c *Config) Validate() error { //nolint:cyclop,gocyclo,funlen,gocognit // long-but-flat validation; clarity > decomposition
 	if c == nil {
 		return fmt.Errorf("%w: nil config", ErrConfigInvalid)
 	}
@@ -387,10 +395,29 @@ func (c *Config) Validate() error { //nolint:cyclop,gocyclo,funlen // long-but-f
 	}
 	switch u.Scheme {
 	case "splunkcloud":
-		// PR 1 rejects this scheme with a clear "PR 2" pointer.
-		// PR 2 validates the host against validCloudStack and
-		// expands to the Splunk Cloud HEC URL form.
-		return fmt.Errorf("%w: splunkcloud:// URL scheme is implemented in PR 2; use the full https://http-inputs-<stack>.splunkcloud.com URL in PR 1", ErrPR1NotImplemented)
+		// Expand to canonical Splunk Cloud HEC URL. The stack name
+		// lives in the host component (URL form
+		// `splunkcloud://<stack>`). Reject any non-empty path / port
+		// / query / fragment / opaque (e.g., `splunkcloud:foo` with
+		// no double-slash sets u.Opaque) — they make no sense for
+		// the shortcut form and a typo is more likely than intent.
+		if u.Opaque != "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" || u.Port() != "" {
+			return fmt.Errorf("%w: splunkcloud:// URL must be the bare form splunkcloud://<stack> with no path, port, query, or fragment", ErrConfigInvalid)
+		}
+		if err := ValidateCloudStack(u.Host); err != nil {
+			return err
+		}
+		// Splunk Cloud HEC presents a public-CA-signed cert and does
+		// NOT support custom TLS material (mTLS client cert/key or
+		// custom CA bundle). Reject the ambiguous config rather than
+		// silently dropping the operator's settings — somebody who
+		// configured TLS material expects it to be used.
+		if c.TLSCert != "" || c.TLSKey != "" || c.TLSCA != "" {
+			return fmt.Errorf("%w: splunkcloud:// does not support custom TLS material (TLSCert/TLSKey/TLSCA); target https:// to a self-managed proxy with mTLS termination if required", ErrConfigInvalid)
+		}
+		// Rewrite to the canonical form. Idempotent: a re-Validate()
+		// observes https:// and takes the https branch directly.
+		c.URL = "https://http-inputs-" + u.Host + ".splunkcloud.com:443"
 	case "https":
 		// ok
 	case "http":

--- a/splunk/config.go
+++ b/splunk/config.go
@@ -457,9 +457,6 @@ func (c *Config) Validate() error { //nolint:cyclop,gocyclo,funlen,gocognit // l
 	if c.AckMode < AckModeOff || c.AckMode > AckModeRequired {
 		return fmt.Errorf("%w: AckMode value %d out of range (must be AckModeOff, AckModeBestEffort, or AckModeRequired)", ErrConfigInvalid, c.AckMode)
 	}
-	if c.AckMode != AckModeOff {
-		return fmt.Errorf("%w: AckMode=%s ships in PR 2; use AckModeOff in PR 1", ErrPR1NotImplemented, c.AckMode)
-	}
 
 	// --- Numeric bounds ---
 	if c.BatchSize < MinBatchSize || c.BatchSize > MaxBatchSize {

--- a/splunk/config_test.go
+++ b/splunk/config_test.go
@@ -194,13 +194,6 @@ func TestValidate_BoundsTable(t *testing.T) { //nolint:funlen // table-driven by
 			wantErr: splunk.ErrConfigInvalid,
 		},
 		{
-			name: "AckModeBestEffort rejected in PR 1",
-			mutate: func(c *splunk.Config) {
-				c.AckMode = splunk.AckModeBestEffort
-			},
-			wantErr: splunk.ErrPR1NotImplemented,
-		},
-		{
 			name: "AckMode out of range",
 			mutate: func(c *splunk.Config) {
 				c.AckMode = splunk.AckMode(99)

--- a/splunk/config_test.go
+++ b/splunk/config_test.go
@@ -194,13 +194,6 @@ func TestValidate_BoundsTable(t *testing.T) { //nolint:funlen // table-driven by
 			wantErr: splunk.ErrConfigInvalid,
 		},
 		{
-			name: "splunkcloud:// scheme rejected in PR 1",
-			mutate: func(c *splunk.Config) {
-				c.URL = "splunkcloud://acme-prod"
-			},
-			wantErr: splunk.ErrPR1NotImplemented,
-		},
-		{
 			name: "AckModeBestEffort rejected in PR 1",
 			mutate: func(c *splunk.Config) {
 				c.AckMode = splunk.AckModeBestEffort
@@ -291,4 +284,116 @@ func TestValidateCloudStack(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConfig_SplunkCloud_ExpandsCorrectly verifies that a
+// `splunkcloud://<stack>` URL is rewritten in-place by Validate() to
+// the canonical Splunk Cloud HEC URL form.
+func TestConfig_SplunkCloud_ExpandsCorrectly(t *testing.T) {
+	cfg := validCfgForValidate()
+	cfg.URL = "splunkcloud://acme-prod"
+	require.NoError(t, cfg.Validate())
+	assert.Equal(t, "https://http-inputs-acme-prod.splunkcloud.com:443", cfg.URL,
+		"Validate() must rewrite the URL to the canonical Splunk Cloud HEC form")
+}
+
+// TestConfig_SplunkCloud_Idempotent verifies that calling Validate()
+// twice on the same config is safe: the second call observes the
+// already-rewritten https:// URL and takes the https branch.
+func TestConfig_SplunkCloud_Idempotent(t *testing.T) {
+	cfg := validCfgForValidate()
+	cfg.URL = "splunkcloud://acme-prod"
+	require.NoError(t, cfg.Validate())
+	rewritten := cfg.URL
+	require.NoError(t, cfg.Validate(), "second Validate() must succeed")
+	assert.Equal(t, rewritten, cfg.URL,
+		"second Validate() must not mutate the URL again")
+}
+
+// TestConfig_SplunkCloud_RejectsInvalidStackName drives the
+// rejection list from the issue body's AC 17. Each entry must fail
+// Validate() with ErrConfigInvalid.
+func TestConfig_SplunkCloud_RejectsInvalidStackName(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"dot in stack", "splunkcloud://acme-prod.evil.com"},
+		{"at sign in stack", "splunkcloud://acme@evil.com"},
+		{"path appended", "splunkcloud://acme/path"},
+		{"port appended", "splunkcloud://acme:1234"},
+		{"space in stack", "splunkcloud://acme prod"},
+		{"cyrillic homograph", "splunkcloud://аcme-prod"}, // leading Cyrillic 'а'
+		{"empty stack", "splunkcloud://"},
+		{"64-char stack", "splunkcloud://" + strings.Repeat("a", 64)},
+		{"query appended", "splunkcloud://acme?foo=bar"},
+		{"fragment appended", "splunkcloud://acme#frag"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validCfgForValidate()
+			cfg.URL = tc.url
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.ErrorIs(t, err, splunk.ErrConfigInvalid)
+		})
+	}
+}
+
+// TestConfig_SplunkCloud_RejectionPrecedence pins which rejection
+// fires first when a URL has BOTH a structural fault (path/port/
+// query/fragment) AND a bad stack name. Structural errors fire
+// first — they're more actionable for the operator. Code-reviewer
+// follow-up: anchor the precedence so a future refactor that swaps
+// the order is caught by this test, not by an angry user.
+func TestConfig_SplunkCloud_RejectionPrecedence(t *testing.T) {
+	t.Run("structural error fires before stack-name error", func(t *testing.T) {
+		cfg := validCfgForValidate()
+		cfg.URL = "splunkcloud://has.dot/and-path" // both bad
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "must be the bare form",
+			"structural rejection message should fire before stack-name rejection")
+	})
+	t.Run("stack-name error fires for content-only fault", func(t *testing.T) {
+		cfg := validCfgForValidate()
+		cfg.URL = "splunkcloud://HAS_UPPERCASE"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "splunkcloud stack name",
+			"content rejection should mention stack name")
+	})
+}
+
+// TestConfig_SplunkCloud_WithCustomTLSMaterial_Rejected verifies
+// that `splunkcloud://` rejects ANY custom TLS material — TLSCert,
+// TLSKey, or TLSCA. Splunk Cloud presents a public-CA-signed cert;
+// silently dropping the operator's TLS settings would be a security
+// surprise.
+func TestConfig_SplunkCloud_WithCustomTLSMaterial_Rejected(t *testing.T) {
+	t.Run("TLSCert set", func(t *testing.T) {
+		cfg := validCfgForValidate()
+		cfg.URL = "splunkcloud://acme-prod"
+		cfg.TLSCert = "/path/to/client.crt"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, splunk.ErrConfigInvalid)
+		assert.Contains(t, err.Error(), "does not support custom TLS material")
+	})
+	t.Run("TLSKey set", func(t *testing.T) {
+		cfg := validCfgForValidate()
+		cfg.URL = "splunkcloud://acme-prod"
+		cfg.TLSKey = "/path/to/client.key"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, splunk.ErrConfigInvalid)
+	})
+	t.Run("TLSCA set", func(t *testing.T) {
+		cfg := validCfgForValidate()
+		cfg.URL = "splunkcloud://acme-prod"
+		cfg.TLSCA = "/path/to/ca.crt"
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, splunk.ErrConfigInvalid)
+	})
 }

--- a/splunk/envelope.go
+++ b/splunk/envelope.go
@@ -235,3 +235,19 @@ func joinHealthURL(base string) (string, error) {
 	u.RawQuery = ""
 	return u.String(), nil
 }
+
+// joinAckURL returns the configured base URL with the /services/
+// collector/ack path appended and `channel=<GUID>` set as the query.
+// The channel GUID must be a valid UUID v4 textual form (validated
+// by the caller via newChannelGUID).
+func joinAckURL(base, channel string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/services/collector/ack"
+	q := u.Query()
+	q.Set("channel", channel)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/splunk/errors.go
+++ b/splunk/errors.go
@@ -225,4 +225,18 @@ var (
 	// scheme; `AckMode != AckModeOff`). Carries a remediation hint
 	// in the wrapped message.
 	ErrPR1NotImplemented = errors.New("audit/splunk: feature not implemented in PR 1 (ships in PR 2)")
+
+	// ErrAckDisabled is returned from [New] when the configured
+	// [AckMode] is not [AckModeOff] but the HEC token / channel has
+	// indexer acknowledgement disabled. The library refuses to
+	// proceed because the operator's chosen durability guarantee
+	// (best-effort or required) cannot be honoured.
+	ErrAckDisabled = errors.New("audit/splunk: HEC indexer acknowledgement is disabled on this token/channel")
+
+	// ErrCryptoRandFailed is returned from [New] when `crypto/rand`
+	// fails to produce the 128-bit channel GUID. The library NEVER
+	// falls back to a zero or pseudo-random GUID — a unique channel
+	// is load-bearing for ACK correctness, and a deterministic value
+	// would let an attacker observe / replay ack states.
+	ErrCryptoRandFailed = errors.New("audit/splunk: crypto/rand failed during channel GUID generation")
 )

--- a/splunk/http.go
+++ b/splunk/http.go
@@ -127,77 +127,60 @@ func drainAndClose(resp *http.Response, drainCap int64) {
 var errRedirectBlocked = errors.New("audit/splunk: redirects are not followed")
 
 // doPost sends a single HTTP POST to the configured HEC URL. Returns
-// (action, statusCode, hecCode, error). On success the action is
-// [actionSuccess]; the response body has already been drained and
-// closed before return.
-func (o *Output) doPost(ctx context.Context, body []byte, compressed bool) (hecAction, int, int, error) {
+// (action, statusCode, hecCode, ackID, error). On success the action
+// is [actionSuccess]; the response body has already been drained and
+// closed before return. ackID is non-nil iff the response contained
+// an `ackId` field (only when AckMode != AckModeOff and HEC has ACK
+// enabled on the channel).
+//
+// The `bufs` argument is the caller's flushBufs — `bufs.retryHint`
+// is populated on actionRetry so the caller's retry loop can honour
+// the server's Retry-After.
+func (o *Output) doPost(ctx context.Context, body []byte, compressed bool, bufs *flushBufs) (hecAction, int, int, *int64, error) { //nolint:gocyclo,cyclop // long-but-flat HTTP wrapper; control flow follows classify() and resp.Header
 	u := o.endpointURL
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
 	if err != nil {
-		return actionDrop, 0, 0, fmt.Errorf("audit/splunk: request: %w", err)
+		return actionDrop, 0, 0, nil, fmt.Errorf("audit/splunk: request: %w", err)
 	}
 	o.applyRequestHeaders(req, compressed)
 
 	resp, err := o.client.Do(req)
 	if err != nil {
 		if errors.Is(err, errRedirectBlocked) {
-			return actionDrop, 0, 0, fmt.Errorf("audit/splunk: redirect blocked: %w", err)
+			return actionDrop, 0, 0, nil, fmt.Errorf("audit/splunk: redirect blocked: %w", err)
 		}
 		if ctx.Err() != nil {
-			return actionRetry, 0, 0, fmt.Errorf("audit/splunk: cancelled: %w", ctx.Err())
+			return actionRetry, 0, 0, nil, fmt.Errorf("audit/splunk: cancelled: %w", ctx.Err())
 		}
-		// TLS handshake errors and cert validation failures are NOT
-		// retryable — retrying against a misconfigured cert chain
-		// will just exhaust the retry budget without progress (AC
-		// 54). The errors.As probe finds a wrapped *tls.RecordHeaderError
-		// or x509 verification failure.
 		if isTLSError(err) {
-			return actionDrop, 0, 0, fmt.Errorf("audit/splunk: TLS error (non-retryable): %w", err)
+			return actionDrop, 0, 0, nil, fmt.Errorf("audit/splunk: TLS error (non-retryable): %w", err)
 		}
-		return actionRetry, 0, 0, fmt.Errorf("audit/splunk: request failed: %w", err)
+		return actionRetry, 0, 0, nil, fmt.Errorf("audit/splunk: request failed: %w", err)
 	}
 
-	// AC 70 — Content-Length fast-fail. Reject before allocating any
-	// buffer when the server advertises a body larger than the cap.
-	// Force `resp.Close = true` so the underlying TCP connection is
-	// NOT returned to the idle pool — we don't trust this peer for
-	// keep-alive after they lied about Content-Length
-	// (security-reviewer HIGH-2).
 	if !checkResponseSize(resp, maxResponseDrainEventOrRaw) {
-		// resp.Close documents intent on the Response object; the
-		// load-bearing mechanism that prevents pool reuse is closing
-		// Body without draining — net/http's persistConn detects the
-		// unread bytes and refuses to return the connection to the
-		// idle pool (security-reviewer HIGH-2 / M1).
 		resp.Close = true
 		_ = resp.Body.Close()
-		return actionDrop, resp.StatusCode, 0, fmt.Errorf(
+		return actionDrop, resp.StatusCode, 0, nil, fmt.Errorf(
 			"audit/splunk: response Content-Length %d exceeds cap %d (non-retryable)",
 			resp.ContentLength, int64(maxResponseDrainEventOrRaw))
 	}
 
-	// resp.Trailer (populated only after the body is fully consumed)
-	// is deliberately not inspected — the drainAndClose path below
-	// uses io.LimitReader + io.Discard which never populates trailers
-	// into anywhere observable, so there's nothing to strip
-	// (security-reviewer MEDIUM-2).
 	defer drainAndClose(resp, maxResponseDrainEventOrRaw)
 
-	// Read the response into a bounded buffer so we can parse the
-	// HEC code envelope. Caps at 64 KiB.
 	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseDrainEventOrRaw))
-	hecCode, _ := parseHECCode(bodyBytes)
+	hecCode, ackID := parseHECResponse(bodyBytes)
 
 	act := classify(resp.StatusCode, hecCode)
 	if act == actionSuccess {
-		return act, resp.StatusCode, hecCode, nil
+		return act, resp.StatusCode, hecCode, ackID, nil
 	}
 	if act == actionCapacityWarn {
-		return act, resp.StatusCode, hecCode, nil
+		return act, resp.StatusCode, hecCode, ackID, nil
 	}
 	if act == actionRetry {
-		o.retryHint = parseRetryAfter(resp.Header.Get("Retry-After"))
-		return act, resp.StatusCode, hecCode, &hecError{
+		bufs.retryHint = parseRetryAfter(resp.Header.Get("Retry-After"))
+		return act, resp.StatusCode, hecCode, nil, &hecError{
 			HTTPStatus: resp.StatusCode,
 			Code:       hecCode,
 			Action:     act,
@@ -205,12 +188,26 @@ func (o *Output) doPost(ctx context.Context, body []byte, compressed bool) (hecA
 		}
 	}
 	// actionStop / actionDrop / actionAckDisabled — non-retryable.
-	return act, resp.StatusCode, hecCode, &hecError{
+	return act, resp.StatusCode, hecCode, nil, &hecError{
 		HTTPStatus: resp.StatusCode,
 		Code:       hecCode,
 		Action:     act,
 		Text:       sanitizeText(string(bodyBytes)),
 	}
+}
+
+// parseHECResponse decodes a HEC response body and returns its
+// (code, ackID) fields. Both default to zero/nil on parse failure.
+// Bounded by the caller's io.LimitReader.
+func parseHECResponse(body []byte) (int, *int64) {
+	if len(body) == 0 {
+		return 0, nil
+	}
+	var resp hecResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, nil
+	}
+	return resp.Code, resp.AckID
 }
 
 // applyRequestHeaders sets all HTTP headers on the request. Consumer
@@ -228,6 +225,11 @@ func (o *Output) applyRequestHeaders(req *http.Request, compressed bool) {
 	}
 	// Auth — must never be overridable by consumer headers.
 	req.Header.Set("Authorization", "Splunk "+o.cfg.Token)
+	// X-Splunk-Request-Channel — required when ACK is enabled on
+	// the token. Tracker is nil when AckMode == AckModeOff.
+	if o.tracker != nil {
+		req.Header.Set("X-Splunk-Request-Channel", string(o.tracker.channel))
+	}
 }
 
 // parseHECCode decodes a HEC response body and returns its `code`

--- a/splunk/register_test.go
+++ b/splunk/register_test.go
@@ -298,22 +298,51 @@ verify_on_startup: false
 		"explicit zero batch_size must be rejected as out-of-range, not silently defaulted")
 }
 
-// TestFactory_AckModeNotOffRejectedInPR1 — ack_mode != off is the
-// PR-2 feature; PR 1 rejects with ErrPR1NotImplemented at config
-// validation. This is the codepath that demonstrates the
-// PR-staging contract via YAML.
-func TestFactory_AckModeNotOffRejectedInPR1(t *testing.T) {
+// TestFactory_AckModeAcceptsRequired — ack_mode: required is now
+// supported in PR 2. Construction succeeds when the stub HEC
+// responds with an ackID on the feature-detection probe.
+func TestFactory_AckModeAcceptsRequired(t *testing.T) {
 	t.Parallel()
+	stub := newRegisterStubWithAck(t)
 	rawYAML := []byte(`
-url: https://splunk.example.com:8088
+url: ` + stub.URL + `
 token: tkn
+allow_insecure_http: true
+allow_private_ranges: true
 ack_mode: required
+ack_poll_interval: 100ms
+ack_resend_window: 10s
 verify_on_startup: false
 `)
 	factory := audit.LookupOutputFactory("splunk")
-	_, err := factory("ack_required", rawYAML, audit.FrameworkContext{})
-	require.Error(t, err)
-	assert.ErrorIs(t, err, splunk.ErrPR1NotImplemented)
+	out, err := factory("ack_required", rawYAML, audit.FrameworkContext{})
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+}
+
+// newRegisterStubWithAck returns a stub that responds to /event with
+// an ackId field (so the feature-detection probe succeeds for
+// AckMode != Off tests).
+func newRegisterStubWithAck(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/services/collector/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"text":"HEC is healthy","code":17}`))
+		case "/services/collector/event":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"text":"Success","code":0,"ackId":42}`))
+		case "/services/collector/ack":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"acks":{"42":true}}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"text":"Success","code":0}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 // newRegisterStub returns a minimal HEC stub (HTTPS via

--- a/splunk/splunk.go
+++ b/splunk/splunk.go
@@ -15,8 +15,6 @@
 package splunk
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -103,12 +101,13 @@ type Output struct { //nolint:govet // fieldalignment: readability preferred
 	closed        atomic.Bool
 	stopped       atomic.Bool // permanent STOP state (token disabled etc.)
 
-	// Flush-path state — owned exclusively by the batch goroutine.
-	envelopeBuf bytes.Buffer
-	rawBuf      bytes.Buffer
-	compressBuf bytes.Buffer
-	gzWriter    *gzip.Writer
-	retryHint   time.Duration
+	// Flush-path state owned exclusively by the batch goroutine.
+	// Bundled in batchBufs so the resend path (ackTracker poller)
+	// can call flushBatchAux with its own per-goroutine flushBufs.
+	batchBufs *flushBufs
+
+	// ackTracker is non-nil iff AckMode != AckModeOff.
+	tracker *ackTracker
 
 	// Drop limiters and metrics.
 	dropsOversized     *dropLimiter
@@ -129,7 +128,7 @@ type Output struct { //nolint:govet // fieldalignment: readability preferred
 // `metrics` may be nil — the output records via a no-op
 // [audit.NoOpOutputMetrics] when omitted. Use [WithOutputMetrics] to
 // pass a real [audit.OutputMetrics] sink.
-func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
+func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) { //nolint:gocognit // construction orchestrator; ACK + probe + tracker each is its own block
 	if cfg == nil {
 		return nil, fmt.Errorf("%w: nil config", ErrConfigInvalid)
 	}
@@ -211,7 +210,7 @@ func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 		fallbackTimestamps: newDropLimiter(dropWarnInterval),
 		maxEventBytes:      cfg.MaxEventBytes,
 	}
-	out.gzWriter = gzip.NewWriter(&out.compressBuf)
+	out.batchBufs = newFlushBufs()
 
 	// Startup verification: probe /health before launching the batch
 	// goroutine. Errors abort construction (no goroutine leak — the
@@ -224,6 +223,37 @@ func New(cfg *Config, metrics audit.Metrics, opts ...Option) (*Output, error) {
 			cancel()
 			return nil, err
 		}
+	}
+
+	// ACK feature detection + tracker construction. When AckMode !=
+	// AckModeOff: generate a channel GUID via crypto/rand (fatal on
+	// failure), send a synthetic feature-probe event with the
+	// channel header (fatal if HEC reports code 14 / ack disabled),
+	// then construct and start the tracker.
+	if cfg.AckMode != AckModeOff {
+		channel, err := newChannelGUID(randReader)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		tr, err := newAckTracker(ctx, out, channel)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		// Wire the tracker BEFORE the probe so applyRequestHeaders
+		// adds the X-Splunk-Request-Channel on the probe request.
+		out.tracker = tr
+		if !cfg.DisableStartupVerification {
+			probeCtx, probeCancel := context.WithTimeout(ctx, cfg.StartupVerificationTimeout)
+			err := out.ackFeatureProbe(probeCtx)
+			probeCancel()
+			if err != nil {
+				cancel()
+				return nil, err
+			}
+		}
+		go tr.pollLoop(ctx)
 	}
 
 	go out.batchLoop(ctx)
@@ -277,8 +307,23 @@ func (o *Output) Close() error {
 		o.cancel()
 		<-o.done
 	}
+	// After the batch goroutine has drained, give the ack tracker a
+	// budget to confirm any remaining in-flight batches. Best-effort:
+	// after the budget elapses, any remaining in-flight batches are
+	// abandoned (the resend goroutine is then cancelled). The ack
+	// poller goroutine MUST exit before we return.
+	if o.tracker != nil {
+		o.tracker.flushOnClose(context.Background())
+		o.tracker.stop()
+	}
 	o.cancel()
 	return nil
+}
+
+// AckMetricsSnapshot returns the current ACK counters. Zero value
+// if ACK is disabled. Lock-free; safe to call from any goroutine.
+func (o *Output) AckMetricsSnapshot() AckSnapshot {
+	return o.tracker.snapshot()
 }
 
 // LastDeliveryAge implements [audit.DeliveryReporter].
@@ -403,13 +448,38 @@ func (o *Output) batchLoop(ctx context.Context) { //nolint:gocognit,gocyclo,cycl
 	}
 }
 
-// flushBatch serialises and sends a batch of events. Drives the
-// retry loop with backoff and Retry-After. The function is called
-// only by [batchLoop]; the flush-path buffers are not concurrent-
-// safe.
-func (o *Output) flushBatch(ctx context.Context, batch []splunkEntry) { //nolint:gocyclo,cyclop,gocognit // long-but-flat; control flow follows the action returned by classify()
+// flushBatch is the batchLoop's entry point — uses the Output's
+// owned [Output.batchBufs] for serialisation/compression and the
+// retry-state buffer. Thin wrapper around flushBatchAux.
+func (o *Output) flushBatch(ctx context.Context, batch []splunkEntry) {
+	o.flushBatchAux(ctx, batch, o.batchBufs)
+}
+
+// flushBatchAux serialises and sends a batch of events. Drives the
+// retry loop with backoff and Retry-After. May be called from the
+// batchLoop goroutine (with o.batchBufs) or from the ackTracker
+// poller goroutine for resends (with tracker.resendBufs); the
+// flushBufs argument decouples the two flush paths so they don't
+// share mutable state.
+func (o *Output) flushBatchAux(ctx context.Context, batch []splunkEntry, bufs *flushBufs) { //nolint:gocyclo,cyclop,gocognit,funlen // long-but-flat; control flow follows the action returned by classify()
 	if len(batch) == 0 {
 		return
+	}
+
+	// AC 59 — when AckModeRequired, enforce the in-flight buffer cap
+	// here (NOT on Write, so the producer remains non-blocking). A
+	// batch that would push in-flight past BufferSize is dropped.
+	if o.tracker != nil && o.cfg.AckMode == AckModeRequired {
+		if o.tracker.inFlightCount()+len(batch) > o.cfg.BufferSize {
+			o.logger.Warn("audit/splunk: ack-required in-flight buffer full — dropping batch",
+				"output", o.name, "batch_size", len(batch),
+				"in_flight", o.tracker.inFlightCount(),
+				"buffer_size", o.cfg.BufferSize,
+				"reason", "ack_buffer_full")
+			o.tracker.recordBufferFullDrop(len(batch))
+			o.recordDrop(len(batch))
+			return
+		}
 	}
 
 	// Build the payload.
@@ -418,17 +488,17 @@ func (o *Output) flushBatch(ctx context.Context, batch []splunkEntry) { //nolint
 		compressed bool
 	)
 	if o.cfg.Endpoint == EndpointRaw {
-		o.rawBuf.Reset()
+		bufs.raw.Reset()
 		for _, e := range batch {
-			rawEventLine(&o.rawBuf, e.data)
+			rawEventLine(&bufs.raw, e.data)
 		}
-		payload = o.rawBuf.Bytes()
+		payload = bufs.raw.Bytes()
 	} else {
-		o.envelopeBuf.Reset()
+		bufs.envelope.Reset()
 		now := time.Now()
 		var nFallback int
 		for _, e := range batch {
-			fellBack, err := wrapEvent(&o.envelopeBuf, o.cfg, e.data, now)
+			fellBack, err := wrapEvent(&bufs.envelope, o.cfg, e.data, now)
 			if err != nil {
 				o.logger.Warn("audit/splunk: envelope wrap failed — dropping event",
 					"output", o.name, "error", err)
@@ -439,15 +509,11 @@ func (o *Output) flushBatch(ctx context.Context, batch []splunkEntry) { //nolint
 				nFallback++
 			}
 		}
-		// AC 23 — surface extractTime fallbacks via a rate-limited warn
-		// so a sustained stream of mis-typed timestamps is visible to
-		// operators without spamming the log. The marker omits the event
-		// payload (PII risk); count + batch_size is the actionable signal.
 		if nFallback > 0 && o.fallbackTimestamps.allow() {
 			o.logger.Warn("audit/splunk: timestamp extraction failed — using ingest time",
 				"output", o.name, "count_in_batch", nFallback, "batch_size", len(batch))
 		}
-		payload = o.envelopeBuf.Bytes()
+		payload = bufs.envelope.Bytes()
 	}
 	if len(payload) == 0 {
 		return
@@ -467,60 +533,67 @@ func (o *Output) flushBatch(ctx context.Context, batch []splunkEntry) { //nolint
 	}
 
 	if o.cfg.Gzip != nil && *o.cfg.Gzip {
-		o.compressBuf.Reset()
-		o.gzWriter.Reset(&o.compressBuf)
-		if _, err := o.gzWriter.Write(payload); err != nil {
+		bufs.compress.Reset()
+		bufs.gz.Reset(&bufs.compress)
+		if _, err := bufs.gz.Write(payload); err != nil {
 			o.logger.Warn("audit/splunk: gzip write failed — dropping batch",
 				"output", o.name, "error", err)
 			o.outputMetrics.RecordDrop()
 			return
 		}
-		if err := o.gzWriter.Close(); err != nil {
+		if err := bufs.gz.Close(); err != nil {
 			o.logger.Warn("audit/splunk: gzip close failed — dropping batch",
 				"output", o.name, "error", err)
 			o.outputMetrics.RecordDrop()
 			return
 		}
-		payload = o.compressBuf.Bytes()
+		payload = bufs.compress.Bytes()
 		compressed = true
 	}
 
-	// Retry loop. Every exit path must zero `retryHint` so a previous
-	// batch's Retry-After does not leak across batches (code-reviewer B2).
+	// Retry loop. Every exit path must zero retryHint so a previous
+	// batch's Retry-After does not leak across batches.
 	start := time.Now()
 	maxRetries := o.cfg.MaxRetries
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		action, _, hecCode, err := o.doPost(ctx, payload, compressed)
+		action, _, hecCode, ackID, err := o.doPost(ctx, payload, compressed, bufs)
 
 		switch action {
 		case actionSuccess, actionCapacityWarn:
-			o.retryHint = 0
+			bufs.retryHint = 0
 			o.recordSuccess(len(batch), time.Since(start))
 			if action == actionCapacityWarn {
 				o.logger.Warn("audit/splunk: HEC at capacity (code 24/25)",
 					"output", o.name, "hec_code", hecCode)
+			}
+			// Register the batch with the tracker if ACK is enabled.
+			// For AckModeBestEffort we pass nil entries (resends never
+			// fire); for AckModeRequired we retain the entries for
+			// resend.
+			if o.tracker != nil && ackID != nil {
+				var retain []splunkEntry
+				if o.cfg.AckMode == AckModeRequired {
+					retain = batch
+				}
+				o.tracker.register(*ackID, retain)
 			}
 			return
 		case actionRetry:
 			if attempt == maxRetries {
 				o.logger.Warn("audit/splunk: retries exhausted — dropping batch",
 					"output", o.name, "batch_size", len(batch), "error", o.redact(err))
-				o.retryHint = 0
+				bufs.retryHint = 0
 				o.recordDrop(len(batch))
 				return
 			}
-			delay := o.retryHint
+			delay := bufs.retryHint
 			if delay <= 0 {
 				delay = splunkBackoff(attempt)
 			}
-			// Cap server-supplied Retry-After at the configured
-			// RetryMaxDelay (AC 53) — even if HEC says "wait 5
-			// minutes", we never wait more than the operator-
-			// configured maximum between attempts.
 			if delay > o.cfg.RetryMaxDelay {
 				delay = o.cfg.RetryMaxDelay
 			}
-			o.retryHint = 0
+			bufs.retryHint = 0
 			select {
 			case <-ctx.Done():
 				return
@@ -530,21 +603,21 @@ func (o *Output) flushBatch(ctx context.Context, batch []splunkEntry) { //nolint
 		case actionStop:
 			o.logger.Error("audit/splunk: HEC permanent failure — stopping output",
 				"output", o.name, "hec_code", hecCode, "error", o.redact(err))
-			o.retryHint = 0
+			bufs.retryHint = 0
 			o.stopped.Store(true)
 			o.recordDrop(len(batch))
 			return
 		case actionAckDisabled:
-			// PR 1 never sets AckMode != Off, so this path is unreachable.
-			o.logger.Error("audit/splunk: HEC reports ack disabled but client sent channel header (ack support ships in PR 2)",
+			o.logger.Error("audit/splunk: HEC reports ack disabled but client sent channel header",
 				"output", o.name)
-			o.retryHint = 0
+			bufs.retryHint = 0
 			o.recordDrop(len(batch))
+			o.stopped.Store(true)
 			return
 		default: // actionDrop
 			o.logger.Warn("audit/splunk: HEC rejected batch — dropping",
 				"output", o.name, "hec_code", hecCode, "error", o.redact(err))
-			o.retryHint = 0
+			bufs.retryHint = 0
 			o.recordDrop(len(batch))
 			return
 		}

--- a/splunk/splunk_test.go
+++ b/splunk/splunk_test.go
@@ -249,12 +249,22 @@ func TestNew_HTTPRejected(t *testing.T) {
 	assert.ErrorIs(t, err, splunk.ErrConfigInvalid)
 }
 
-func TestNew_SplunkCloudScheme_RejectedInPR1(t *testing.T) {
+// TestNew_SplunkCloudScheme_ExpandsAndConstructs verifies that
+// `splunkcloud://<stack>` is expanded to the canonical HTTPS URL
+// during construction. The stub server is unreachable (no real
+// Splunk Cloud DNS in tests), so we DisableStartupVerification and
+// assert the URL rewrite + successful construction.
+func TestNew_SplunkCloudScheme_ExpandsAndConstructs(t *testing.T) {
 	cfg := validCfg("splunkcloud://acme-prod")
 	cfg.DisableStartupVerification = true
-	_, err := splunk.New(cfg, nil)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, splunk.ErrPR1NotImplemented)
+	out, err := splunk.New(cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+	// The URL must be rewritten to the canonical form (visible via
+	// the stored config — sanity check via Name() which derives from
+	// the URL host).
+	assert.Contains(t, out.Name(), "http-inputs-acme-prod.splunkcloud.com",
+		"Name() must reflect the expanded splunkcloud URL host")
 }
 
 func TestNew_AckModeRequired_RejectedInPR1(t *testing.T) {

--- a/splunk/splunk_test.go
+++ b/splunk/splunk_test.go
@@ -267,14 +267,6 @@ func TestNew_SplunkCloudScheme_ExpandsAndConstructs(t *testing.T) {
 		"Name() must reflect the expanded splunkcloud URL host")
 }
 
-func TestNew_AckModeRequired_RejectedInPR1(t *testing.T) {
-	cfg := validCfg("https://x.test")
-	cfg.AckMode = splunk.AckModeRequired
-	cfg.DisableStartupVerification = true
-	_, err := splunk.New(cfg, nil)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, splunk.ErrPR1NotImplemented)
-}
 
 func TestNew_HealthCheckFails(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tests/bdd/features/splunk_output.feature
+++ b/tests/bdd/features/splunk_output.feature
@@ -155,3 +155,34 @@ Feature: Splunk HEC Output
   Scenario: splunkcloud:// with mTLS is rejected
     When I construct a splunk output with URL "splunkcloud://acme-prod" and TLSCert "/p.crt"
     Then construction should fail with ErrConfigInvalid
+
+  # --- HEC Indexer Acknowledgement (#55 PR 2) ---
+
+  Scenario: AckMode=off does not send X-Splunk-Request-Channel
+    Given an auditor with splunk output and AckMode "off"
+    When I audit a uniquely marked splunk "user_create" event
+    Then the splunk receiver should have received exactly 1 envelope within 10 seconds
+    And no request header "X-Splunk-Request-Channel" should be present
+
+  Scenario: AckMode=best_effort sends X-Splunk-Request-Channel and polls /ack
+    Given an auditor with splunk output and AckMode "best_effort"
+    When I audit a uniquely marked splunk "user_create" event
+    Then the splunk receiver should have received exactly 1 envelope within 10 seconds
+    And the request header "X-Splunk-Request-Channel" should match a UUID v4
+    And the /ack endpoint should be polled at least once within 5 seconds
+
+  Scenario: AckMode=required blocks buffer progress until ack positive
+    Given an auditor with splunk output and AckMode "required"
+    When I audit a uniquely marked splunk "user_create" event
+    And the splunk receiver confirms all outstanding ackIDs
+    Then the in-flight count should drain to 0 within 5 seconds
+
+  Scenario: AckMode=required resends events when AckResendWindow elapses
+    Given an auditor with splunk output and AckMode "required" and short resend window
+    When I audit a uniquely marked splunk "user_create" event
+    Then the splunk receiver should record at least 1 timeout within 10 seconds
+
+  Scenario: AckMode=required with full buffer drops new events with metric
+    Given an auditor with splunk output and AckMode "required" and 100 unconfirmed batches
+    When I audit 500 more events
+    Then the buffer-full drop metric should be at least 1 within 10 seconds

--- a/tests/bdd/features/splunk_output.feature
+++ b/tests/bdd/features/splunk_output.feature
@@ -128,8 +128,30 @@ Feature: Splunk HEC Output
     Then the splunk receiver should have received exactly 1 request within 10 seconds
     And the request body should stream-decode to exactly 5 JSON objects
 
-  # --- Splunk-Cloud-stack rejection (PR 1 only — PR 2 enables it) ---
+  # --- Splunk Cloud URL expansion ---
 
-  Scenario: splunkcloud:// URL scheme rejected in PR 1
+  Scenario: splunkcloud://acme-prod expands to the canonical HEC URL
     When I construct a splunk output with URL "splunkcloud://acme-prod"
-    Then construction should fail with ErrPR1NotImplemented
+    Then construction should succeed
+    And the output's URL should equal "https://http-inputs-acme-prod.splunkcloud.com:443"
+
+  Scenario Outline: splunkcloud:// rejects invalid stack name <input>
+    When I construct a splunk output with URL "<input>"
+    Then construction should fail with ErrConfigInvalid
+
+    Examples:
+      | input                              |
+      | splunkcloud://acme-prod.evil.com   |
+      | splunkcloud://acme@evil.com        |
+      | splunkcloud://acme/path            |
+      | splunkcloud://acme:1234            |
+      | splunkcloud://acme prod            |
+      | splunkcloud://                     |
+      | splunkcloud://acme?q=1             |
+      | splunkcloud://acme#frag            |
+      | splunkcloud://HAS_UPPERCASE        |
+      | splunkcloud://-leading-hyphen      |
+
+  Scenario: splunkcloud:// with mTLS is rejected
+    When I construct a splunk output with URL "splunkcloud://acme-prod" and TLSCert "/p.crt"
+    Then construction should fail with ErrConfigInvalid

--- a/tests/bdd/steps/splunk_steps.go
+++ b/tests/bdd/steps/splunk_steps.go
@@ -368,6 +368,16 @@ func registerSplunkSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 
 	ctx.Step(`^I construct a splunk output with URL "([^"]*)"$`, func(url string) error {
 		cfg := &splunk.Config{URL: url, Token: "t", AllowInsecureHTTP: true, DisableStartupVerification: true}
+		out, err := splunk.New(cfg, nil)
+		state.constructionErr = err
+		if err == nil {
+			state.output = out
+		}
+		return nil
+	})
+
+	ctx.Step(`^I construct a splunk output with URL "([^"]*)" and TLSCert "([^"]*)"$`, func(url, tlsCert string) error {
+		cfg := &splunk.Config{URL: url, Token: "t", AllowInsecureHTTP: true, DisableStartupVerification: true, TLSCert: tlsCert}
 		_, err := splunk.New(cfg, nil)
 		state.constructionErr = err
 		return nil
@@ -539,6 +549,39 @@ func registerSplunkSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 	ctx.Step(`^construction should fail with ErrPR1NotImplemented$`, func() error {
 		if !errors.Is(state.constructionErr, splunk.ErrPR1NotImplemented) {
 			return fmt.Errorf("construction error = %v; want ErrPR1NotImplemented", state.constructionErr)
+		}
+		return nil
+	})
+
+	ctx.Step(`^construction should succeed$`, func() error {
+		if state.constructionErr != nil {
+			return fmt.Errorf("construction failed: %v", state.constructionErr)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the output's URL should equal "([^"]*)"$`, func(want string) error {
+		// Output does not expose URL directly. Assert via Name(),
+		// which is "splunk:<host>" computed from the (rewritten) URL.
+		// For URL https://http-inputs-acme-prod.splunkcloud.com:443
+		// the Name is "splunk:http-inputs-acme-prod.splunkcloud.com:443".
+		if state.output == nil {
+			return fmt.Errorf("output is nil — construction did not succeed")
+		}
+		// Strip scheme, take host:port from `want`.
+		const prefix = "https://"
+		if !strings.HasPrefix(want, prefix) {
+			return fmt.Errorf("test fixture URL must start with https:// — got %q", want)
+		}
+		hostPort := strings.TrimPrefix(want, prefix)
+		// Trailing path components, if any, are dropped — the test
+		// fixtures only assert host:port equality.
+		if i := strings.Index(hostPort, "/"); i >= 0 {
+			hostPort = hostPort[:i]
+		}
+		wantName := "splunk:" + hostPort
+		if state.output.Name() != wantName {
+			return fmt.Errorf("Name() = %q; want %q (derived from URL %q)", state.output.Name(), wantName, want)
 		}
 		return nil
 	})

--- a/tests/bdd/steps/splunk_steps.go
+++ b/tests/bdd/steps/splunk_steps.go
@@ -19,6 +19,8 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"regexp"
+	"strconv"
 	"errors"
 	"fmt"
 	"io"
@@ -45,6 +47,7 @@ type splunkStubRequest struct {
 	contentEnc  string
 	userAgent   string
 	contentType string
+	channel     string // X-Splunk-Request-Channel (ACK)
 	body        []byte
 	receivedAt  time.Time
 }
@@ -61,6 +64,13 @@ type splunkStub struct {
 	respBody   []byte
 	failFirstN int32
 	failCount  atomic.Int32
+
+	// ACK support (#55 PR 2).
+	ackEnabled         atomic.Bool
+	ackIDCounter       atomic.Int64
+	ackPollHits        atomic.Int64
+	ackConfirmAll      atomic.Bool // when true, /ack returns true for every queried ID
+	ackResponsesByID   map[int64]bool
 }
 
 // newSplunkStub returns a stub server that responds with HTTP 200 +
@@ -69,8 +79,9 @@ type splunkStub struct {
 // HEC error codes.
 func newSplunkStub() *splunkStub {
 	s := &splunkStub{
-		respStatus: http.StatusOK,
-		respBody:   []byte(`{"text":"Success","code":0}`),
+		respStatus:       http.StatusOK,
+		respBody:         []byte(`{"text":"Success","code":0}`),
+		ackResponsesByID: make(map[int64]bool),
 	}
 	s.server = httptest.NewServer(http.HandlerFunc(s.handle))
 	return s
@@ -96,6 +107,7 @@ func (s *splunkStub) handle(w http.ResponseWriter, r *http.Request) {
 		contentEnc:  r.Header.Get("Content-Encoding"),
 		userAgent:   r.Header.Get("User-Agent"),
 		contentType: r.Header.Get("Content-Type"),
+		channel:     r.Header.Get("X-Splunk-Request-Channel"),
 		body:        finalBody,
 		receivedAt:  time.Now(),
 	})
@@ -109,6 +121,33 @@ func (s *splunkStub) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// /ack endpoint — only relevant when ACK is enabled. Returns
+	// `{"acks":{"<id>":true|false}}` per the IDs in the request.
+	if r.URL.Path == "/services/collector/ack" {
+		s.ackPollHits.Add(1)
+		var req struct {
+			Acks []int64 `json:"acks"`
+		}
+		_ = json.Unmarshal(finalBody, &req)
+		s.mu.Lock()
+		ackMap := make(map[string]bool, len(req.Acks))
+		all := s.ackConfirmAll.Load()
+		for _, id := range req.Acks {
+			if all {
+				ackMap[strconv.FormatInt(id, 10)] = true
+			} else {
+				ackMap[strconv.FormatInt(id, 10)] = s.ackResponsesByID[id]
+			}
+		}
+		s.mu.Unlock()
+		out, _ := json.Marshal(struct {
+			Acks map[string]bool `json:"acks"`
+		}{Acks: ackMap})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(out)
+		return
+	}
+
 	// Inject `failFirstN` failures before serving the configured
 	// response (retry scenarios).
 	if n := atomic.LoadInt32(&s.failFirstN); n > 0 {
@@ -117,6 +156,14 @@ func (s *splunkStub) handle(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(`{"text":"Server is busy","code":9}`))
 			return
 		}
+	}
+
+	// ACK-aware /event response: emit `ackId` when ACK is enabled.
+	if s.ackEnabled.Load() && r.URL.Path == "/services/collector/event" {
+		id := s.ackIDCounter.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"text":"Success","code":0,"ackId":` + strconv.FormatInt(id, 10) + `}`))
+		return
 	}
 
 	s.mu.Lock()
@@ -598,6 +645,151 @@ func registerSplunkSteps(ctx *godog.ScenarioContext, tc *AuditTestContext) {
 		}
 		return nil
 	})
+
+	// --- HEC Indexer Acknowledgement scenarios (#55 PR 2) ---
+
+	ctx.Step(`^an auditor with splunk output and AckMode "([^"]*)"$`, func(mode string) error {
+		state.stub.ackEnabled.Store(mode != "off")
+		return splunkConstruct(state, func(c *splunk.Config) {
+			c.AckMode = parseAckMode(mode)
+			c.AckPollInterval = 50 * time.Millisecond
+			c.AckResendWindow = 30 * time.Second
+		})
+	})
+
+	ctx.Step(`^an auditor with splunk output and AckMode "([^"]*)" and short resend window$`, func(mode string) error {
+		state.stub.ackEnabled.Store(true)
+		return splunkConstruct(state, func(c *splunk.Config) {
+			c.AckMode = parseAckMode(mode)
+			c.AckPollInterval = 50 * time.Millisecond
+			c.AckResendWindow = 200 * time.Millisecond
+		})
+	})
+
+	ctx.Step(`^an auditor with splunk output and AckMode "([^"]*)" and 100 unconfirmed batches$`, func(mode string) error {
+		state.stub.ackEnabled.Store(true)
+		// /ack returns false for everything — buffer fills up.
+		return splunkConstruct(state, func(c *splunk.Config) {
+			c.AckMode = parseAckMode(mode)
+			c.AckPollInterval = 50 * time.Millisecond
+			c.AckResendWindow = 30 * time.Second
+			c.BufferSize = splunk.MinBufferSize
+			c.BatchSize = 1
+		})
+	})
+
+	ctx.Step(`^no request header "([^"]*)" should be present$`, func(name string) error {
+		req, ok := state.stub.lastEventRequest()
+		if !ok {
+			return fmt.Errorf("no event request recorded")
+		}
+		if v := requestHeader(req, name); v != "" {
+			return fmt.Errorf("request header %q unexpectedly present: %q", name, v)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the request header "([^"]*)" should match a UUID v4$`, func(name string) error {
+		req, ok := state.stub.lastEventRequest()
+		if !ok {
+			return fmt.Errorf("no event request recorded")
+		}
+		v := requestHeader(req, name)
+		uuidV4 := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+		if !uuidV4.MatchString(v) {
+			return fmt.Errorf("request header %q = %q; not a UUID v4", name, v)
+		}
+		return nil
+	})
+
+	ctx.Step(`^the /ack endpoint should be polled at least once within (\d+) seconds$`, func(secs int) error {
+		deadline := time.Now().Add(time.Duration(secs) * time.Second)
+		for time.Now().Before(deadline) {
+			if state.stub.ackPollHits.Load() >= 1 {
+				return nil
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return fmt.Errorf("/ack was not polled within %ds", secs)
+	})
+
+	ctx.Step(`^the splunk receiver confirms all outstanding ackIDs$`, func() error {
+		state.stub.ackConfirmAll.Store(true)
+		return nil
+	})
+
+	ctx.Step(`^the in-flight count should drain to 0 within (\d+) seconds$`, func(secs int) error {
+		deadline := time.Now().Add(time.Duration(secs) * time.Second)
+		for time.Now().Before(deadline) {
+			if state.output.AckMetricsSnapshot().Pending == 0 {
+				return nil
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return fmt.Errorf("in-flight did not drain within %ds (pending=%d)",
+			secs, state.output.AckMetricsSnapshot().Pending)
+	})
+
+	ctx.Step(`^the splunk receiver should record at least 1 timeout within (\d+) seconds$`, func(secs int) error {
+		deadline := time.Now().Add(time.Duration(secs) * time.Second)
+		for time.Now().Before(deadline) {
+			if state.output.AckMetricsSnapshot().TimedOut >= 1 {
+				return nil
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		return fmt.Errorf("no timeouts recorded within %ds", secs)
+	})
+
+	ctx.Step(`^the buffer-full drop metric should be at least 1 within (\d+) seconds$`, func(secs int) error {
+		deadline := time.Now().Add(time.Duration(secs) * time.Second)
+		for time.Now().Before(deadline) {
+			if state.output.AckMetricsSnapshot().BufferFullDrops >= 1 {
+				return nil
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return fmt.Errorf("no buffer-full drops recorded within %ds", secs)
+	})
+
+	ctx.Step(`^I audit (\d+) more events$`, func(n int) error {
+		for i := 0; i < n; i++ {
+			_ = state.output.Write([]byte(`{"event_type":"x"}`))
+		}
+		return nil
+	})
+}
+
+// parseAckMode maps the BDD string form to the typed enum.
+func parseAckMode(s string) splunk.AckMode {
+	switch s {
+	case "off":
+		return splunk.AckModeOff
+	case "best_effort":
+		return splunk.AckModeBestEffort
+	case "required":
+		return splunk.AckModeRequired
+	default:
+		return splunk.AckModeOff
+	}
+}
+
+// requestHeader returns the value of the named header from a
+// recorded request, matching the existing splunkStubRequest fields.
+func requestHeader(req splunkStubRequest, name string) string {
+	switch name {
+	case "X-Splunk-Request-Channel":
+		return req.channel
+	case "Authorization":
+		return req.auth
+	case "Content-Encoding":
+		return req.contentEnc
+	case "Content-Type":
+		return req.contentType
+	case "User-Agent":
+		return req.userAgent
+	}
+	return ""
 }
 
 // splunkConstruct builds a splunk output pointed at the scenario's


### PR DESCRIPTION
## Summary

PR 2 of three for issue #55 (Splunk HEC). Lifts the three PR-1 stubs and adds the CIM Change formatter:

1. **`splunkcloud://` URL expansion** (commit `2a35366`) — validates stack against `^[a-z0-9][a-z0-9-]{0,62}$`; rejects path/port/query/fragment/opaque and any TLSCert/TLSKey/TLSCA (Splunk Cloud doesn't support mTLS); rewrites to `https://http-inputs-<stack>.splunkcloud.com:443`.
2. **CIM Change formatter** (commit `4141a24`) — new `format_cim.go` in core, registered as YAML `type: cim_change`. Maps audit fields → Splunk CIM 6.1 Change data model. Outcome → status binary collapse with preservation. `severity_id` (CIM extension). Handles both `map[string]any` and `map[string]string` for actor/target. Naming chosen via api-ergonomics-reviewer (NOT `cim_json` — future CIM data models ship as separate formatter types).
3. **HEC ACK state machine** (commit `028dad4`) — `splunk/ack.go` + `ack_probe.go`. AckModeBestEffort / AckModeRequired. crypto/rand UUID v4 channel GUID. Feature-detect probe rejects on HEC code 14. Single new goroutine (`tracker.pollLoop`). AC 59 buffer gating on batchLoop side (producer non-blocking). `AckMetricsRecorder` typed-extension interface mirrors `file.RotationRecorder`.

## Quality gates

- Coverage on `splunk/*.go`: **90.3%** (≥90% target)
- `go test -race -count=1 ./splunk/...` pass (30s)
- `make test-bdd-splunk`: **33 scenarios, 33 passed** under godog Strict
- `make lint-splunk`: clean on changed files
- `goleak.VerifyTestMain` package-wide
- issue-closer (report-only): **READY TO MERGE** for PR 2 scope (10/10 ACs pass)

## Tests added

- **Unit**: `format_cim_test.go` (16), `outputconfig/formatter_test.go` (8 new), `splunk/ack_test.go` (17 + property test), `splunk/config_test.go` (5 splunkcloud tests)
- **BDD**: 20 new scenarios in `tests/bdd/features/splunk_output.feature` (12 splunkcloud + 5 ACK + 3 CIM in outputconfig/tests/bdd/)

## Design deviations from issue body

- `cim_json` → `cim_change` per api-ergonomics-reviewer (CIM is a data model, not a wire format). Documented in commit `4141a24`. Future CIM Authentication ships as separate type.

## Out of scope (PR 3)

- `cmd/audit-gen --splunk-ta` generator
- `deploy/splunk-ta-axonops-audit/` reference TA
- AppInspect CI verification
- User-facing docs (`docs/splunk-output.md`, `docs/splunk-ta.md`)

## Test plan

- [ ] `go test -race ./splunk/...` green on main after merge
- [ ] Splunk submodule tag triggers fresh CI on main (tidy-check will pass post-tag)
- [ ] Smoke-test a YAML with `type: splunk`, `ack_mode: best_effort`, `formatter: { type: cim_change }`
- [ ] Verify Splunk Cloud expansion: `splunkcloud://acme-prod` constructs without TLS errors