### PR TITLE
chore: bump Go toolchain to 1.26.4 for GO-2026-5037

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,7 +364,7 @@ jobs:
             echo "::error::Invalid GORELEASE_VER from tool-versions.txt: '$GORELEASE_VER'"
             exit 1
           fi
-          GOTOOLCHAIN=go1.26.3 go install "golang.org/x/exp/cmd/gorelease@$GORELEASE_VER"
+          GOTOOLCHAIN=go1.26.4 go install "golang.org/x/exp/cmd/gorelease@$GORELEASE_VER"
 
       - name: Run make api-check
         id: check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   option internally. Surfaced by api-ergonomics-reviewer in the
   v0.2.0 release gate as the v1.0 BLOCKER 1.
 
+### Security
+
+- Go toolchain bumped to `1.26.4` for new Go stdlib vulnerability
+  GO-2026-5037 ("Inefficient candidate hostname parsing in
+  crypto/x509", fixed in `crypto/x509@go1.26.4`). Updated across
+  every `go.mod` (39 modules + examples), `GO_TOOLCHAIN` in the
+  Makefile, `GOTOOLCHAIN` in `release.yml`, and the
+  `docs/development-workflow.md` toolchain references.
+
 ### Fixed
 
 - **The v0.2.0 Known Issue "`DeliveryReporter` contract gap on

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ WORKSPACE_MODULES := $(MODULES) $(EXAMPLE_MODULES)
 # Windows (Git Bash tolerates forward slashes in Windows absolute
 # paths). (#877)
 GOBIN             := $(subst \,/,$(shell go env GOPATH))/bin
-GO_TOOLCHAIN      := go1.26.3
+GO_TOOLCHAIN      := go1.26.4
 # Windows go install appends .exe to executables; everything else is
 # bare. Used when the recipe must invoke an installed tool by absolute
 # path (cross-platform CI legs run under Git Bash).

--- a/cmd/audit-gen/go.mod
+++ b/cmd/audit-gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/cmd/audit-gen
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/cmd/audit-validate/go.mod
+++ b/cmd/audit-validate/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/cmd/audit-validate
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/cmd/bdd-report/go.mod
+++ b/cmd/bdd-report/go.mod
@@ -1,5 +1,5 @@
 module github.com/axonops/audit/cmd/bdd-report
 
-go 1.26.3
+go 1.26.4
 
 require github.com/yuin/goldmark v1.8.2

--- a/cmd/junit-report/go.mod
+++ b/cmd/junit-report/go.mod
@@ -1,5 +1,5 @@
 module github.com/axonops/audit/cmd/junit-report
 
-go 1.26.3
+go 1.26.4
 
 require github.com/yuin/goldmark v1.8.2

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -47,7 +47,7 @@ repo root (gitignored). Its content is just a list of modules the
 workspace covers:
 
 ```
-go 1.26.3
+go 1.26.4
 
 use (
     .
@@ -95,12 +95,12 @@ use (
 
 ### Prerequisites
 
-- **Go toolchain.** The module files declare `go 1.26.3`. Any Go
+- **Go toolchain.** The module files declare `go 1.26.4`. Any Go
   toolchain that supports `GOTOOLCHAIN` auto-download (Go 1.21 or
-  newer) will fetch 1.26.3 automatically unless `GOTOOLCHAIN=local`
+  newer) will fetch 1.26.4 automatically unless `GOTOOLCHAIN=local`
   is set in your environment. If you need a deterministic local
-  toolchain, install go1.26.3 explicitly:
-  `go install golang.org/dl/go1.26.3@latest && go1.26.3 download`.
+  toolchain, install go1.26.4 explicitly:
+  `go install golang.org/dl/go1.26.4@latest && go1.26.4 download`.
 - **GNU `make`** on PATH. Windows: use WSL or install
   `make` via Chocolatey/Scoop.
 - **`$(go env GOPATH)/bin` on `PATH`** if you want to invoke
@@ -377,9 +377,9 @@ make workspace
 
 ### `go.mod file indicates go 1.x but the current version is 1.26`
 
-**Cause:** Your local Go toolchain is older than `go 1.26.3`.
+**Cause:** Your local Go toolchain is older than `go 1.26.4`.
 
-**Fix:** Either upgrade Go (`go install golang.org/dl/go1.26.3@latest && go1.26.3 download`) or rely on the `GOTOOLCHAIN` auto-download. If you have `GOTOOLCHAIN=local` set in your env, unset it.
+**Fix:** Either upgrade Go (`go install golang.org/dl/go1.26.4@latest && go1.26.4 download`) or rely on the `GOTOOLCHAIN` auto-download. If you have `GOTOOLCHAIN=local` set in your env, unset it.
 
 ### `make test` fails with `unknown revision <version>` on a sub-module path
 

--- a/examples/01-basic/go.mod
+++ b/examples/01-basic/go.mod
@@ -1,5 +1,5 @@
 module github.com/axonops/audit/examples/01-basic
 
-go 1.26.3
+go 1.26.4
 
 require github.com/axonops/audit v0.1.13

--- a/examples/02-code-generation/go.mod
+++ b/examples/02-code-generation/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/02-code-generation
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/03-file-output/go.mod
+++ b/examples/03-file-output/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/03-file-output
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/04-formatters/go.mod
+++ b/examples/04-formatters/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/04-formatters
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/05-standard-fields/go.mod
+++ b/examples/05-standard-fields/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/05-standard-fields
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/06-syslog-output/go.mod
+++ b/examples/06-syslog-output/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/06-syslog-output
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/07-webhook-output/go.mod
+++ b/examples/07-webhook-output/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/07-webhook-output
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/08-loki-output/go.mod
+++ b/examples/08-loki-output/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/08-loki-output
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/09-splunk-output/go.mod
+++ b/examples/09-splunk-output/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/09-splunk-output
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/10-multi-output/go.mod
+++ b/examples/10-multi-output/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/10-multi-output
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/11-event-routing/go.mod
+++ b/examples/11-event-routing/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/11-event-routing
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/12-sensitivity-labels/go.mod
+++ b/examples/12-sensitivity-labels/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/12-sensitivity-labels
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/13-hmac-integrity/go.mod
+++ b/examples/13-hmac-integrity/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/13-hmac-integrity
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/14-tls-policy/go.mod
+++ b/examples/14-tls-policy/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/14-tls-policy
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/15-buffering/go.mod
+++ b/examples/15-buffering/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/15-buffering
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/16-middleware/go.mod
+++ b/examples/16-middleware/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/16-middleware
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/17-health-endpoint/go.mod
+++ b/examples/17-health-endpoint/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/17-health-endpoint
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/18-testing/go.mod
+++ b/examples/18-testing/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/18-testing
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/19-migration/go.mod
+++ b/examples/19-migration/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/19-migration
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/examples/20-prometheus-reference/go.mod
+++ b/examples/20-prometheus-reference/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/20-prometheus-reference
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/axonops/audit => ../..
 

--- a/examples/21-capstone/go.mod
+++ b/examples/21-capstone/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/examples/21-capstone
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/file/go.mod
+++ b/file/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/file
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit/file v0.1.11

--- a/iouring/go.mod
+++ b/iouring/go.mod
@@ -1,3 +1,3 @@
 module github.com/axonops/audit/iouring
 
-go 1.26.3
+go 1.26.4

--- a/loki/go.mod
+++ b/loki/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/loki
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/outputconfig/go.mod
+++ b/outputconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/outputconfig
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/outputs/go.mod
+++ b/outputs/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/outputs
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/secrets/env/go.mod
+++ b/secrets/env/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/secrets/env
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit/secrets v0.1.13

--- a/secrets/file/go.mod
+++ b/secrets/file/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/secrets/file
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit/secrets v0.1.13

--- a/secrets/go.mod
+++ b/secrets/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/secrets
 
-go 1.26.3
+go 1.26.4
 
 require github.com/stretchr/testify v1.11.1
 

--- a/secrets/openbao/go.mod
+++ b/secrets/openbao/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/secrets/openbao
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/secrets/vault/go.mod
+++ b/secrets/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/secrets/vault
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/splunk/go.mod
+++ b/splunk/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/splunk
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/syslog/go.mod
+++ b/syslog/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/syslog
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13

--- a/webhook/go.mod
+++ b/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/axonops/audit/webhook
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/axonops/audit v0.1.13


### PR DESCRIPTION
## Summary

Mechanical Go toolchain bump from 1.26.3 → 1.26.4 to clear the new Go stdlib advisory **GO-2026-5037** ("Inefficient candidate hostname parsing in crypto/x509", fixed in `crypto/x509@go1.26.4`). The vulnerability surfaces through every published module via govulncheck — `Test - Security` matrix on PR CI is failing across every module from 2026-06-03 onward (see PR #898's CI run 26865596376).

This affects `main` itself as much as any in-flight PR; it's a pre-existing stdlib advisory that only manifests when CI re-runs after the upstream disclosure.

## Scope

- 39 `go.mod` files (core + 11 submodules + 21 examples + 4 cmd): `go 1.26.3` → `go 1.26.4`
- `Makefile` line 57: `GO_TOOLCHAIN := go1.26.3` → `go1.26.4`
- `.github/workflows/release.yml` line 367: `GOTOOLCHAIN=go1.26.3` → `go1.26.4`
- `docs/development-workflow.md`: 7 instructional toolchain references
- `go.work` + `go.work.sum`: regenerated by `make workspace`
- `CHANGELOG.md`: new `[Unreleased] ### Security` entry

No code changes. Same playbook as the v0.1.5 1.26.2 → 1.26.3 bump (#832 — GO-2026-4971 + GO-2026-4918).

## Verification

Locally on this branch:
- `make security` (govulncheck) → no vulnerabilities found, every module
- `make lint` → 0 issues, every module
- `make test-core` → all green
- `go.work` regenerated to `go 1.26.4`

## Why no issue reference

This is a "trivial chore" exception per CLAUDE.md commit rules — mechanical security bump with no code changes, matching the precedent set by prior toolchain bumps. The upstream advisory ID (`GO-2026-5037`) is the contextual reference.

## Unblocks

- PR #898 (`feat(tls): encrypted PKCS#8 v2 client private keys`) — its `Test - Security` matrix is currently red on the same advisory.
- Any subsequent PR will need this bump in main before `Test - Security` passes.

## Test plan
- [x] `make security` clean
- [x] `make lint` clean
- [x] `make test-core` green
- [x] `go.work` regenerated
- [ ] Full CI green on this PR