### PR TITLE
fix(ci): guard tag-all on event_name to block cascade-skip (#900)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -610,6 +610,17 @@ jobs:
   # The job needs preflight + wait-for-pr-merge with `if: always()`
   # plus result-checks so it runs only when the upstream completed
   # successfully.
+  #
+  # The event-name guards are load-bearing: relying on
+  # `wait-for-pr-merge.result == 'skipped'` to signal the recovery
+  # path is ambiguous, because `skipped` ALSO occurs when an upstream
+  # workflow_dispatch job (ci / fuzz-long / update-deps-pr) failed and
+  # cascade-skipped wait-for-pr-merge. The v0.2.0 release attempt (run
+  # 26802604151) tripped exactly this: cmd/audit-gen CI cancelled →
+  # update-deps-pr skipped → wait-for-pr-merge skipped → tag-all ran
+  # and emitted the cryptic "No merge SHA available" error 5 jobs
+  # downstream of the real failure. Guarding on github.event_name is
+  # the canonical "which path is this?" signal.
   # =====================================================================
   tag-all:
     name: Tag all published modules
@@ -619,7 +630,10 @@ jobs:
     if: |
       always() &&
       needs.preflight.result == 'success' &&
-      (needs.wait-for-pr-merge.result == 'success' || needs.wait-for-pr-merge.result == 'skipped')
+      (
+        (github.event_name == 'workflow_dispatch' && needs.wait-for-pr-merge.result == 'success') ||
+        github.event_name == 'push'
+      )
     permissions:
       contents: read  # App token grants writes
     outputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Release workflow `tag-all` no longer mis-fires when CI
+  cascade-skips `wait-for-pr-merge`.** The gate now uses
+  `github.event_name` to disambiguate the workflow_dispatch happy
+  path from the push:tag recovery path, instead of relying on the
+  ambiguous `wait-for-pr-merge.result == 'skipped'` signal. The
+  v0.2.0 release attempt failed with this bug class (run
+  26802604151): `cmd/audit-gen` CI cancelled → CI Pass failed →
+  `update-deps-pr`/`wait-for-pr-merge` cascade-skipped → `tag-all`
+  ran with no SHA and emitted "No merge SHA available". The
+  `cmd/audit-gen` flake itself is fixed independently (#894 Item 6);
+  this fix prevents the same class of upstream cascade-skip from
+  ever again surfacing as a misleading `tag-all` failure. (#900)
 - **The v0.2.0 Known Issue "`DeliveryReporter` contract gap on
   `file` and `syslog` outputs" is resolved.** Both outputs declared
   `ReportsDelivery() bool { return true }` but never called


### PR DESCRIPTION
## Summary

Fix release-workflow bug discovered in v0.2.0 release attempt ([run 26802604151](https://github.com/axonops/audit/actions/runs/26802604151)). Tracking issue: #900.

The previous `tag-all` gate accepted `wait-for-pr-merge.result == 'skipped'` as a recovery-path signal, but the same status ALSO matches when `wait-for-pr-merge` was cascade-skipped by an upstream `workflow_dispatch` failure. v0.2.0 tripped exactly this: `cmd/audit-gen` CI cancelled → CI Pass failed → `update-deps-pr`/`wait-for-pr-merge` cascade-skipped → `tag-all` ran with no SHA and emitted the cryptic "No merge SHA available" error 5 jobs downstream of the real cause.

## The Fix

Switch from a `result == 'skipped'` heuristic to a `github.event_name` guard:

```yaml
if: |
  always() &&
  needs.preflight.result == 'success' &&
  (
    (github.event_name == 'workflow_dispatch' && needs.wait-for-pr-merge.result == 'success') ||
    github.event_name == 'push'
  )
```

### Truth table

| `github.event_name`  | `wait-for-pr-merge.result` | tag-all | Note                       |
|----------------------|----------------------------|---------|----------------------------|
| workflow_dispatch    | success                    | run     | happy path                 |
| workflow_dispatch    | skipped                    | **block** | cascade-skip (the v0.2.0 bug) |
| workflow_dispatch    | failure                    | block   | PR closed without merging  |
| workflow_dispatch    | cancelled                  | block   | manual cancel              |
| push                 | skipped                    | run     | recovery path              |
| push                 | success                    | run     | defensive                  |

## Validation

- **devops agent review** — PASS verdict. Covered logical correctness, every cell of the truth table above, recovery-path SHA flow, downstream-job gating (`goreleaser`, `mutation-test-attach`, `verify`, `invariants`, `summary`).
- **`python3 -c 'yaml.safe_load(...)'`** — YAML structurally valid.
- **No other gating expression** in `release.yml` uses `result == 'skipped'` (verified with `grep -n "result == 'skipped'" .github/workflows/release.yml` — only the new descriptive comment block matches).
- `cmd/audit-gen` flake fixed independently (#894 Item 6) — this PR blocks the bug class.

## Docs

CHANGELOG `[Unreleased] ### Fixed` records the bug class. No `docs/releasing.md` update needed — operator-visible behaviour is unchanged; the internal mechanism is documented inline in the workflow.

## Closes

Closes #900.

## Test plan
- [x] devops agent PASS
- [x] YAML structurally valid
- [x] `grep result == 'skipped'` returns only the comment block
- [ ] CI green (will follow on push)
- [ ] Real release run on v0.2.1 — final verification on the workflow_dispatch happy path