### PR TITLE
fix(ci): use release-series branch in update-deps-pr (#902)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,7 +454,15 @@ jobs:
           PUBLISH_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
-          BRANCH="release/$PUBLISH_VERSION"
+          # gh-graphql-commit.sh enforces a release-series branch
+          # name (`^release/v[0-9]+\.[0-9]+\.x$`) per security
+          # hardening in #841. The series branch is a transient
+          # working branch — recreated on every release run, so
+          # collapsing patch versions onto a single series name is
+          # the intended design. Derive it by replacing the final
+          # `.PATCH` (plus any `-PRE` suffix) with `.x`.
+          SERIES=$(echo "$PUBLISH_VERSION" | sed -E 's/\.[0-9]+(-.*)?$/.x/')
+          BRANCH="release/$SERIES"
 
           # Recreate the branch idempotently. A previous failed run
           # may have left both a branch AND an orphaned open PR on it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Release-PR branch name now uses the release-series convention
+  (`release/vX.Y.x`)** to match the `gh-graphql-commit.sh` regex
+  added in #841. The previous `release/vX.Y.Z`-style name violated
+  the script's allowlist and blocked v0.2.1 release at
+  `update-deps-pr` ("`--branch must match
+  ^release/v[0-9]+\.[0-9]+\.x$`"). v0.2.0 did not expose this — CI
+  failed upstream before `update-deps-pr` ran. (#902)
 - **Release workflow `tag-all` no longer mis-fires when CI
   cascade-skips `wait-for-pr-merge`.** The gate now uses
   `github.event_name` to disambiguate the workflow_dispatch happy


### PR DESCRIPTION
## Summary

Fix release-workflow bug discovered during v0.2.1 release attempt ([run 26879587288](https://github.com/axonops/audit/actions/runs/26879587288) — failed at \`update-deps-pr\`). Tracking issue: #902.

`update-deps-pr` constructed \`BRANCH=\"release/\$PUBLISH_VERSION\"\` (e.g. \`release/v0.2.1\`), but \`scripts/release/gh-graphql-commit.sh\` (added in #841 as security hardening) enforces \`^release/v[0-9]+\.[0-9]+\.x\$\` — a release-SERIES branch name. v0.2.0 didn't surface this because CI cascade-skipped \`update-deps-pr\`; v0.2.1 reached it and tripped the regex.

## The Fix

Derive the series branch via sed:

\`\`\`bash
SERIES=\$(echo \"\$PUBLISH_VERSION\" | sed -E 's/\\.[0-9]+(-.*)?\$/.x/')
BRANCH=\"release/\$SERIES\"
\`\`\`

The series branch is a **transient working branch** — the existing workflow logic deletes and recreates it on every release run, so collapsing patch versions onto a single series name is the design intent (matches how \`gh-graphql-commit.sh\` was written).

### Truth table (verified locally)

| \`PUBLISH_VERSION\` | \`BRANCH\`            |
|---------------------|-----------------------|
| \`v0.2.1\`          | \`release/v0.2.x\`    |
| \`v0.2.2\`          | \`release/v0.2.x\`    |
| \`v1.0.0\`          | \`release/v1.0.x\`    |
| \`v10.20.30\`       | \`release/v10.20.x\`  |
| \`v0.2.1-pre.1\`    | \`release/v0.2.x\`    |
| \`v1.0.0-rc.2\`     | \`release/v1.0.x\`    |

All six match \`^release/v[0-9]+\.[0-9]+\.x\$\`.

## Validation

- **Local sed truth-table check** — all 6 cases pass the regex.
- **YAML parse** — \`python3 -c 'yaml.safe_load(...)'\` clean.
- **devops agent review** — to follow on this PR.

## Why this wasn't caught before

- #841 introduced \`gh-graphql-commit.sh\` with the strict regex but didn't update the workflow's branch-name construction.
- v0.1.x releases used the legacy flow (pre-#841) which didn't call this script.
- v0.2.0 release attempt cascade-skipped \`update-deps-pr\` due to a separate cmd/audit-gen CI flake (fixed in #897 Item 6), so the regex was never exercised.
- v0.2.1 release attempt cleared all upstream gates → reached \`update-deps-pr\` → hit the regex.

## Closes

Closes #902.

## Test plan
- [x] Sed truth-table verification (6 cases)
- [x] YAML structural validity
- [ ] devops agent PASS
- [ ] CI green on this PR
- [ ] v0.2.1 re-trigger after merge: \`update-deps-pr\` reaches \`gh-graphql-commit.sh\` cleanly