### PR TITLE
fix(outputconfig): sanitize control bytes from factory errors (#904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`outputconfig.Load` sanitises control bytes (NUL / C0 / C1 / DEL)
+  out of factory error messages** before they enter the
+  `outputconfig` error chain. goccy/go-yaml embeds offending source
+  bytes verbatim in its parse-error diagnostics; the prior code let
+  those bytes flow into the wrapped error string, producing
+  `unknown field "\x00"` and similar log-injection vectors. Caught
+  by `FuzzOutputConfigLoad` on the v0.2.1 release-gate 300s fuzz run
+  (3 seeds: `8acc4c4aa19b65a1`, `9959b3c68d859e06`,
+  `9987a348b3deda66`). The new `sanitizedError` wrapper preserves
+  `errors.Is` / `errors.As` via `Unwrap` so sentinels in the
+  factory error remain reachable. (#904)
 - **Release-PR branch name now uses the release-series convention
   (`release/vX.Y.x`)** to match the `gh-graphql-commit.sh` regex
   added in #841. The previous `release/vX.Y.Z`-style name violated

--- a/outputconfig/output.go
+++ b/outputconfig/output.go
@@ -310,13 +310,66 @@ func invokeFactory(name string, f *outputFields, globalAppName, globalHost, glob
 	}
 	output, err := factory(name, rawConfig, fctx)
 	if err != nil {
-		return nil, fmt.Errorf("output %q: %w", name, err)
+		// Sanitize control bytes (NUL / C0 / C1 / DEL) from the
+		// factory's error message before wrapping. goccy/go-yaml
+		// embeds the offending source bytes verbatim in its parse
+		// errors — caught by FuzzOutputConfigLoad on a NUL-containing
+		// inner field name like "\x00:" under `outputs.A.file:`.
+		// Leaking raw NULs into the error chain breaks log
+		// aggregators and is the same class of log-injection defence
+		// the type-name check at lines 269-277 enforces. The wrapper
+		// preserves errors.Is/As via Unwrap so sentinels in the
+		// factory error chain still resolve.
+		return nil, fmt.Errorf("output %q: %w", name, sanitizeErrorText(err))
 	}
 	if output == nil {
 		return nil, fmt.Errorf("output %q: factory for type %q returned nil output without an error — this is a factory bug",
 			name, f.typeName)
 	}
 	return output, nil
+}
+
+// sanitizedError wraps an error so its Error() string is the
+// control-byte-escaped form of the inner error's message, while
+// Unwrap returns the inner error so errors.Is / errors.As continue
+// to traverse the sentinel chain.
+type sanitizedError struct {
+	inner error
+	msg   string
+}
+
+func (e *sanitizedError) Error() string { return e.msg }
+func (e *sanitizedError) Unwrap() error { return e.inner }
+
+// sanitizeErrorText returns err untouched when its Error() contains
+// no control bytes, otherwise returns a wrapper whose Error() replaces
+// each control byte (0x00–0x1F or 0x7F) with its Go-escaped
+// representation. Used at the outputconfig→factory boundary to
+// guarantee no factory's YAML / TOML / JSON parser error can flow
+// raw control bytes from operator-supplied input into the
+// outputconfig error chain (#902 follow-up; FuzzOutputConfigLoad).
+func sanitizeErrorText(err error) error {
+	if err == nil {
+		return nil
+	}
+	s := err.Error()
+	if !strings.ContainsFunc(s, isControlRune) {
+		return err
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isControlRune(r) {
+			fmt.Fprintf(&b, `\x%02x`, r)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return &sanitizedError{inner: err, msg: b.String()}
+}
+
+func isControlRune(r rune) bool {
+	return r < 0x20 || r == 0x7F
 }
 
 // isValidImportPathSegment reports whether s is plausibly a Go

--- a/outputconfig/sanitize_error_test.go
+++ b/outputconfig/sanitize_error_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputconfig_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/outputconfig"
+)
+
+// TestLoad_FactoryErrorWithControlBytes_Sanitized regression-locks
+// the v0.2.1 fix that strips control bytes (NUL / C0 / C1 / DEL) from
+// factory error messages before they enter the outputconfig error
+// chain. goccy/go-yaml's parse errors embed offending source bytes
+// verbatim in the "X: bad" diagnostic context — caught by
+// [FuzzOutputConfigLoad] seed `8acc4c4aa19b65a1`. This test pins the
+// contract from the black-box API so a future refactor of the
+// sanitization helper cannot silently regress it.
+//
+// Additionally asserts the [errors.Is] chain is preserved through the
+// sanitizing wrapper — the sanitizedError type implements Unwrap so
+// sentinels embedded in the factory error are still reachable by
+// callers.
+func TestLoad_FactoryErrorWithControlBytes_Sanitized(t *testing.T) {
+	tax, err := audit.ParseTaxonomyYAML([]byte(`
+version: 1
+categories:
+  write: [user_create]
+events:
+  user_create:
+    fields:
+      actor_id: {required: true}
+      outcome: {required: true}
+`))
+	require.NoError(t, err)
+
+	// Input is the minimised crasher from FuzzOutputConfigLoad. The
+	// `\x00:` inside `outputs.A.file:` makes the file factory's YAML
+	// parser produce an error containing a raw NUL.
+	data := []byte("version: 1\napp_name: 0\nhost: 0\noutputs:\n A:\n    type: file\n    file:\n     \x00:")
+
+	_, err = outputconfig.Load(context.Background(), data, tax)
+	require.Error(t, err, "expected a parse error")
+
+	msg := err.Error()
+	assert.Falsef(t, strings.ContainsRune(msg, 0),
+		"error message must not contain raw NUL; got: %q", msg)
+	for i, r := range msg {
+		if r < 0x20 || r == 0x7F {
+			// Standard whitespace (newline, tab, CR) is acceptable —
+			// many YAML parse errors include a trailing newline in
+			// the carat-pointing context line. Reject everything
+			// else.
+			if r == '\n' || r == '\t' || r == '\r' {
+				continue
+			}
+			t.Errorf("control byte %#x at index %d in error message: %q", r, i, msg)
+		}
+	}
+
+	// Sanitization preserves the errors.Is chain — the wrapped
+	// factory error still satisfies audit.ErrConfigInvalid (the
+	// outputconfig.Load entry point wraps with ErrOutputConfigInvalid
+	// which has ErrConfigInvalid as its inner). This proves Unwrap
+	// is implemented on the sanitizing wrapper.
+	assert.ErrorIsf(t, err, audit.ErrConfigInvalid,
+		"errors.Is must reach audit.ErrConfigInvalid through the sanitizing wrapper; got: %v", err)
+}

--- a/outputconfig/testdata/fuzz/FuzzOutputConfigLoad/8acc4c4aa19b65a1
+++ b/outputconfig/testdata/fuzz/FuzzOutputConfigLoad/8acc4c4aa19b65a1
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("version: 1\napp_name: 0\nhost: 0\noutputs:\n A:\n    type: file\n    file:\n     \x00:")


### PR DESCRIPTION
## Summary

Fix a log-injection vector discovered by `FuzzOutputConfigLoad` on the v0.2.1 release-gate fuzz ([run 26883417355](https://github.com/axonops/audit/actions/runs/26883417355)). Tracking issue: #904.

When an inner factory's YAML parser (goccy/go-yaml) encounters a control byte (NUL / C0 / C1 / DEL) in a field name, the raw bytes flow into the parse-error context line and from there into the outputconfig-wrapped error string. Operators piping audit-library errors into log aggregators / SIEMs would see broken records and could be log-injected by anyone able to influence a YAML field name.

## The Fix

`outputconfig.invokeFactory` now sanitises the factory error before wrapping:

```go
output, err := factory(name, rawConfig, fctx)
if err != nil {
    return nil, fmt.Errorf("output %q: %w", name, sanitizeErrorText(err))
}
```

Where `sanitizeErrorText` returns the original error untouched when no control bytes are present (fast path), else wraps with `sanitizedError` whose `Error()` replaces each control byte with `\xNN`. The wrapper implements `Unwrap()` so `errors.Is` / `errors.As` still traverse to sentinels embedded in the factory chain (e.g. `audit.ErrConfigInvalid`).

## Test Plan

- [x] Reproduce all 3 fuzz seeds locally — pre-fix: ALL FAIL; post-fix: ALL PASS
- [x] 60s fuzz round clean (9M+ exec, no new crashers)
- [x] `make test-outputconfig` green (including new `TestLoad_FactoryErrorWithControlBytes_Sanitized`)
- [x] `golangci-lint run` clean
- [x] `errors.Is(err, audit.ErrConfigInvalid)` preserved through wrapper (asserted in new test)
- [ ] CI green
- [ ] Re-trigger v0.2.1 release after merge

## Why this wasn't caught before

- The 300s `fuzz-long` job runs only on the release workflow, not on per-PR CI (per-PR fuzz is too expensive to run for 5 min per target).
- v0.2.0 cascade-skipped `fuzz-long` due to the cmd/audit-gen CI failure.
- v0.2.1 first attempt cascade-skipped due to the workflow gating bugs (#900/#901, #902/#903).
- v0.2.1 second attempt reached `fuzz-long` cleanly → found the bug.

## Files Changed

- `outputconfig/output.go` — new `sanitizedError` type + `sanitizeErrorText` helper + comment; wrap site updated
- `outputconfig/sanitize_error_test.go` — new black-box regression test
- `outputconfig/testdata/fuzz/FuzzOutputConfigLoad/8acc4c4aa19b65a1` — saved fuzz seed
- `CHANGELOG.md` — `[Unreleased] ### Fixed` entry

## Closes

Closes #904.