### PR TITLE
debug(ci): add tracing to localize update-deps-pr exit 5 (#908)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,6 +454,12 @@ jobs:
           PUBLISH_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
+          # Debug tracing for #908: localise the silent exit 5 that
+          # blocks v0.2.1 release at this step. Both the workflow
+          # shell and gh-graphql-commit.sh produce no output before
+          # exiting 5 — `set -x` plus explicit progress echoes pin
+          # down which command tripped.
+          set -x
           # gh-graphql-commit.sh enforces a release-series branch
           # name (`^release/v[0-9]+\.[0-9]+\.x$`) per security
           # hardening in #841. The series branch is a transient
@@ -488,15 +494,24 @@ jobs:
           # fails the commit.
           git add -A
 
+          echo "DEBUG: about to invoke gh-graphql-commit.sh, BRANCH=$BRANCH"
+          echo "DEBUG: git status BEFORE commit:"
+          git status --short | head -5
+          echo "DEBUG: number of changes: $(git status --porcelain | wc -l)"
+
           # App-signed commit via createCommitOnBranch (#841). The
           # legacy `git commit + git push` required toggling
           # required_signatures off; the GraphQL mutation signs with
           # the App identity server-side and satisfies the branch
           # protection rule directly.
-          scripts/release/gh-graphql-commit.sh \
+          # Debug for #908: invoke via bash -x to trace each command
+          # inside the script too. The script's `set +x` line is also
+          # removed temporarily for this debug PR.
+          bash -x scripts/release/gh-graphql-commit.sh \
             --branch "$BRANCH" \
             --message "release: pin inter-module deps to $PUBLISH_VERSION" \
             --auto-create-branch
+          echo "DEBUG: gh-graphql-commit.sh returned exit code: $?"
 
           # `gh pr create` may emit progress lines before the URL —
           # ask for the PR number directly via --json so we don't have

--- a/scripts/release/gh-graphql-commit.sh
+++ b/scripts/release/gh-graphql-commit.sh
@@ -66,7 +66,9 @@
 #      it to stdout for the workflow run-log audit trail.
 
 set -euo pipefail
-set +x  # defence-in-depth: ensure no caller has enabled tracing
+# Debug for #908: do NOT disable tracing — invoked via `bash -x`
+# from the workflow step so each command echoes to stderr.
+# set +x  # defence-in-depth: ensure no caller has enabled tracing
 
 # Cleanup: scrub GH_TOKEN from environment on exit even though the
 # workflow runner will reclaim it. Belts and braces.


### PR DESCRIPTION
## Summary

Debug PR — adds tracing to localize the silent exit 5 in update-deps-pr after #906/#907 fix.

v0.2.1 release 4th attempt ([run 26894419954](https://github.com/axonops/audit/actions/runs/26894419954)) fails at update-deps-pr with exit code 5, ~1.3s execution, ZERO output. Branch \`release/v0.2.x\` is NOT created on origin → gh-graphql-commit.sh fails before branch-create.

## Changes

- `.github/workflows/release.yml` Open release PR step: `set -x` enabled, explicit DEBUG echoes around `gh-graphql-commit.sh` invocation, invoked via `bash -x`.
- `scripts/release/gh-graphql-commit.sh:70` `set +x` commented out for debug duration.

## After This Lands

Re-trigger v0.2.1 release (5th attempt). The trace will pin down WHICH command in the workflow shell or gh-graphql-commit.sh exits 5. Follow-up PR will remove tracing and apply the real fix.

## Test plan
- [x] bash -n syntax clean
- [ ] CI green
- [ ] v0.2.1 5th attempt produces trace output

## Closes
Closes #908 (after follow-up fix lands).