### PR TITLE
fix(ci): validate resolve_head_oid output is a 40-hex SHA (#910)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,12 +454,6 @@ jobs:
           PUBLISH_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
-          # Debug tracing for #908: localise the silent exit 5 that
-          # blocks v0.2.1 release at this step. Both the workflow
-          # shell and gh-graphql-commit.sh produce no output before
-          # exiting 5 — `set -x` plus explicit progress echoes pin
-          # down which command tripped.
-          set -x
           # gh-graphql-commit.sh enforces a release-series branch
           # name (`^release/v[0-9]+\.[0-9]+\.x$`) per security
           # hardening in #841. The series branch is a transient
@@ -494,24 +488,15 @@ jobs:
           # fails the commit.
           git add -A
 
-          echo "DEBUG: about to invoke gh-graphql-commit.sh, BRANCH=$BRANCH"
-          echo "DEBUG: git status BEFORE commit:"
-          git status --short | head -5
-          echo "DEBUG: number of changes: $(git status --porcelain | wc -l)"
-
           # App-signed commit via createCommitOnBranch (#841). The
           # legacy `git commit + git push` required toggling
           # required_signatures off; the GraphQL mutation signs with
           # the App identity server-side and satisfies the branch
           # protection rule directly.
-          # Debug for #908: invoke via bash -x to trace each command
-          # inside the script too. The script's `set +x` line is also
-          # removed temporarily for this debug PR.
-          bash -x scripts/release/gh-graphql-commit.sh \
+          scripts/release/gh-graphql-commit.sh \
             --branch "$BRANCH" \
             --message "release: pin inter-module deps to $PUBLISH_VERSION" \
             --auto-create-branch
-          echo "DEBUG: gh-graphql-commit.sh returned exit code: $?"
 
           # `gh pr create` may emit progress lines before the URL —
           # ask for the PR number directly via --json so we don't have

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Release workflow `resolve_head_oid` rejects non-SHA output from
+  `gh api`.** When `gh api --jq` is called against a non-existent
+  branch ref, gh returns HTTP 404 and dumps the raw error JSON body
+  to stdout — bypassing the `--jq '.object.sha'` filter that should
+  have returned empty. Without validation, the caller's
+  `[[ -z "$OID" ]]` check failed (the error JSON is non-empty), the
+  create-branch fallback was skipped, and the GraphQL `createCommit`
+  mutation received the error JSON as `expectedHeadOid` → silent
+  exit 5 with no diagnostic. The function now validates the captured
+  value against `^[0-9a-f]{40}$` and returns empty otherwise. v0.2.1
+  release runs 26889155834 and 26894419954 both tripped this. The
+  debug-tracing scaffolding from #909 is removed in the same commit.
+  (#910)
 - **Release workflow `gh-graphql-commit.sh` now correctly parses
   multi-file `git status -z` output.** The script captured the
   NUL-delimited porcelain via `$(git status -z ...)`, but bash's

--- a/scripts/release/gh-graphql-commit.sh
+++ b/scripts/release/gh-graphql-commit.sh
@@ -66,9 +66,7 @@
 #      it to stdout for the workflow run-log audit trail.
 
 set -euo pipefail
-# Debug for #908: do NOT disable tracing — invoked via `bash -x`
-# from the workflow step so each command echoes to stderr.
-# set +x  # defence-in-depth: ensure no caller has enabled tracing
+set +x  # defence-in-depth: ensure no caller has enabled tracing
 
 # Cleanup: scrub GH_TOKEN from environment on exit even though the
 # workflow runner will reclaim it. Belts and braces.
@@ -234,10 +232,25 @@ done
 # Resolve expected head OID
 # ----------------------------------------------------------------
 
+# resolve_head_oid prints the 40-char hex SHA at the tip of <branch>
+# on origin, or an empty string if the branch does not exist (404)
+# or any other API failure occurs. The defensive validation matters:
+# on a 404 (branch missing), `gh api --jq` does NOT apply the jq
+# filter — it dumps the raw error JSON body to stdout. Without
+# validation, the caller's `[[ -z "$EXPECTED_HEAD_OID" ]]` check
+# returns false (the error JSON is non-empty), the create-branch
+# fallback is bypassed, and the GraphQL mutation receives the error
+# JSON as expectedHeadOid. v0.2.1 release runs 26889155834 and
+# 26894419954 both tripped this. The 40-hex-char regex guards
+# against any non-SHA-shaped output. (#910)
 resolve_head_oid() {
     local branch="$1"
-    gh api "repos/$OWNER/$REPO/git/ref/heads/$branch" \
-        --jq '.object.sha' 2>/dev/null || true
+    local raw
+    raw=$(gh api "repos/$OWNER/$REPO/git/ref/heads/$branch" \
+        --jq '.object.sha' 2>/dev/null || true)
+    if [[ "$raw" =~ ^[0-9a-f]{40}$ ]]; then
+        printf '%s' "$raw"
+    fi
 }
 
 EXPECTED_HEAD_OID="$(resolve_head_oid "$BRANCH")"


### PR DESCRIPTION
## Summary

Fix #6 (and final, hopefully) in the release-workflow debug session. Tracking issue: #910. Closes #908 (debug placeholder).

xtrace on v0.2.1 release run [26899104133](https://github.com/axonops/audit/actions/runs/26899104133) (with the debug PR #909) pinpointed the silent exit 5 at update-deps-pr:

```
+ EXPECTED_HEAD_OID='{"message":"Not Found","documentation_url":"...","status":"404"}'
+ [[ -z {"message":"Not Found",...} ]]
```

`gh api --jq '.object.sha'` against a non-existent branch returns the raw 404 error JSON body (gh skips --jq on errors), not empty. The caller's `[[ -z "$OID" ]]` check sees non-empty → bypasses the create-branch fallback → GraphQL mutation gets the error JSON as `expectedHeadOid` → 5xx response → gh exits 5 → set -e propagates silently.

## The Fix

Validate the captured value against `^[0-9a-f]{40}$`:

```bash
resolve_head_oid() {
    local branch="$1"
    local raw
    raw=$(gh api "repos/$OWNER/$REPO/git/ref/heads/$branch" \
        --jq '.object.sha' 2>/dev/null || true)
    if [[ "$raw" =~ ^[0-9a-f]{40}$ ]]; then
        printf '%s' "$raw"
    fi
}
```

5-case truth table verified locally — real SHA passes through; error JSON / garbage / empty / non-hex all become empty.

## Also Reverts Debug Scaffolding from #909

- Workflow's `set -x` removed
- DEBUG echo lines removed
- `bash -x` replaced with plain script invocation
- `gh-graphql-commit.sh`'s `set +x` defence-in-depth restored

## Validation

- bash -n syntax clean
- YAML structurally valid
- 5-case truth table all pass

## Test plan
- [x] Local truth-table verification
- [x] bash -n + YAML parse clean
- [ ] CI green
- [ ] v0.2.1 6th attempt: update-deps-pr opens the release PR

## Closes

Closes #910. Closes #908.

## Cumulative debug count

This is bug #6 in the release flow (cumulative this session):
1. tag-all cascade-skip ambiguity (#900/#901)
2. release-PR branch regex mismatch (#902/#903)
3. outputconfig NUL leak (#904/#905)
4. gh-graphql-commit.sh NUL strip (#906/#907)
5. debug tracing PR (#908/#909)
6. resolve_head_oid gh CLI quirk (#910 — this PR)