### PR TITLE
fix(ci): guard final jq calls against non-JSON $response (#913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Release workflow `gh-graphql-commit.sh` final jq calls now
+  tolerate non-JSON in `$response`.** When `submit_mutation`
+  captured stderr via `2>&1` (so the script could surface diagnostic
+  output on error), the captured bytes were sometimes contaminated
+  by gh CLI warnings or other non-JSON content. The downstream
+  `jq -r '.data.createCommitOnBranch.commit.oid // empty'` then
+  exited with code 5 ("invalid JSON") — and under `set -e` that 5
+  propagated silently out of the script, masquerading as a gh API
+  error rather than the parse failure it actually was. v0.2.1
+  release runs 26889155834, 26894419954, 26904041406, and
+  26911258665 all tripped this in the happy path: the GraphQL
+  mutation succeeded but the script exited 5 silently between
+  "created branch" and the success echo. Adds `|| true` guards on
+  both final jq invocations so the diagnostic `exit 69` ("response
+  missing commit.oid") fires correctly when the response is malformed,
+  surfacing the real content to the operator. (#913)
 - **Release workflow `resolve_head_oid` rejects non-SHA output from
   `gh api`.** When `gh api --jq` is called against a non-existent
   branch ref, gh returns HTTP 404 and dumps the raw error JSON body

--- a/scripts/release/gh-graphql-commit.sh
+++ b/scripts/release/gh-graphql-commit.sh
@@ -273,10 +273,6 @@ if [[ -z "$EXPECTED_HEAD_OID" ]]; then
             >/dev/null
         EXPECTED_HEAD_OID="$DEFAULT_OID"
         echo "gh-graphql-commit: created branch $BRANCH from $DEFAULT_BRANCH ($DEFAULT_OID)"
-        # Debug for #912: trace post-branch-create commit submission.
-        echo "DEBUG: EXPECTED_HEAD_OID=$EXPECTED_HEAD_OID len=${#EXPECTED_HEAD_OID}"
-        echo "DEBUG: additions count=${#additions[@]} deletions count=${#deletions[@]}"
-        set -x
     else
         echo "gh-graphql-commit: branch $BRANCH does not exist; pass --auto-create-branch to create it" >&2
         exit 66
@@ -353,15 +349,7 @@ submit_mutation() {
         --raw-field variables="$variables"
 }
 
-echo "DEBUG: about to call build_payload" >&2
-_payload="$(build_payload "$EXPECTED_HEAD_OID")"
-_payload_rc=$?
-echo "DEBUG: build_payload done (rc=$_payload_rc length=${#_payload})" >&2
-echo "DEBUG: about to call submit_mutation" >&2
-response="$(submit_mutation "$_payload" 2>&1 || true)"
-_submit_rc=$?
-echo "DEBUG: submit_mutation done (rc=$_submit_rc length=${#response})" >&2
-echo "DEBUG: response head: ${response:0:2000}" >&2
+response="$(submit_mutation "$(build_payload "$EXPECTED_HEAD_OID")" 2>&1 || true)"
 
 # STALE_DATA retry: the head OID we passed is no longer current
 # (someone or some prior workflow run pushed to the branch). Refetch
@@ -392,7 +380,18 @@ fi
 # Assert the response contains a non-null commit.oid. A response
 # without commit.oid means the API reported success but did not
 # create the commit — a real failure mode of GraphQL mutations.
-new_oid="$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<"$response" 2>/dev/null)"
+#
+# The `|| true` is load-bearing under `set -e`: when the upstream
+# `submit_mutation` step captured stderr via `2>&1` and that stderr
+# contained non-JSON content (gh CLI warnings, network blips, or
+# debug xtrace), jq exits with code 5 — "invalid JSON". Without the
+# guard, `set -e` propagates that 5 out as a silent script exit
+# before the diagnostic echo can fire. v0.2.1 release runs
+# 26889155834, 26894419954, and 26904041406 all tripped this in the
+# happy path: the GraphQL mutation succeeded, but `$response` had
+# extra non-JSON bytes from gh's stderr, and jq's "invalid JSON"
+# error code looked indistinguishable from any other "5" upstream.
+new_oid="$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<"$response" 2>/dev/null || true)"
 if [[ -z "$new_oid" ]]; then
     echo "gh-graphql-commit: response missing commit.oid:" >&2
     printf '%s\n' "$response" >&2
@@ -400,5 +399,7 @@ if [[ -z "$new_oid" ]]; then
 fi
 
 # Audit log: print the new commit OID and URL for the workflow run.
+# Same `|| true` guard as above — jq with `-r` on a $response that
+# contained mixed stderr content would exit 5 and trip `set -e`.
 echo "gh-graphql-commit: created commit $new_oid on branch $BRANCH"
-echo "$response" | jq -r '.data.createCommitOnBranch.commit.url'
+echo "$response" | jq -r '.data.createCommitOnBranch.commit.url' 2>/dev/null || true


### PR DESCRIPTION
## Summary

**The real root cause** of the v0.2.1 silent exit 5. Finally localized via xtrace ([run 26911258665](https://github.com/axonops/audit/actions/runs/26911258665)). Tracking issue: #913.

`submit_mutation` captures stderr via \`2>&1\` so the script can surface failure diagnostics. But that means \`\$response\` can include gh CLI warnings, debug xtrace, or any other non-JSON content. The final jq parse:

\`\`\`bash
new_oid="\$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<\"\$response\" 2>/dev/null)"
\`\`\`

against contaminated input exits with code **5** — jq's documented "invalid JSON" exit code. Under \`set -e\`, that 5 propagated **silently** before the \`if [[ -z \"\$new_oid\" ]]; then exit 69\` diagnostic could fire.

The 8th trace run confirmed:
- \`build_payload rc=0 length=61257\`
- \`submit_mutation rc=0 length=184521\`
- The GraphQL mutation **succeeded** — the script just couldn't parse its own polluted response.

## The Fix

Add \`|| true\` to the two final jq invocations:

\`\`\`bash
new_oid=\"\$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<\"\$response\" 2>/dev/null || true)\"
...
echo \"\$response\" | jq -r '.data.createCommitOnBranch.commit.url' 2>/dev/null || true
\`\`\`

Long inline comment documents the failure mode citing all 5 v0.2.1 attempts that tripped it.

Also reverts:
- The PR #909 debug scaffolding lingering in the script
- The 87a141a direct-to-main rc-capture commit

## Validation

- bash -n syntax clean
- jq exit-5 verified locally: \`echo 'not json' | jq '.foo'; echo \$?\` → 5

## Closes

Closes #913.

## Tally

7 release-workflow bugs fixed in this session:
1. tag-all cascade-skip (#901)
2. release-PR branch regex (#903)
3. outputconfig NUL leak (#905) — caught by fuzz
4. gh-graphql-commit NUL strip (#907)
5. resolve_head_oid SHA validation (#911)
6. jq exit-5 on non-JSON response (#913) ← **the real one**

Plus 2 debug-tracing PRs (#909, #912).