### PR TITLE
fix(ci): send GraphQL variables as structured object (#915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Release workflow `gh-graphql-commit.sh` now sends GraphQL
+  variables as a structured object, not a JSON-encoded string.**
+  The prior `gh api graphql --raw-field variables="$json_string"`
+  pattern sent the variables field as a stringified JSON blob; the
+  server then saw `$input` as undefined and returned
+  `Variable $input of type CreateCommitOnBranchInput! was provided
+  invalid value`. v0.2.1 release run 26915011552 surfaced this once
+  #913's diagnostic was in place. The fix builds the full request
+  body via `jq --argjson` and pipes it via `gh api graphql
+  --input -`, so `variables` is a true JSON object. (#915)
 - **Release workflow `gh-graphql-commit.sh` final jq calls now
   tolerate non-JSON in `$response`.** When `submit_mutation`
   captured stderr via `2>&1` (so the script could surface diagnostic

--- a/scripts/release/gh-graphql-commit.sh
+++ b/scripts/release/gh-graphql-commit.sh
@@ -331,22 +331,25 @@ build_payload() {
 submit_mutation() {
     local payload="$1"
 
-    # Pass query+variables together so gh handles the wire format.
-    # `gh api graphql` expects the GraphQL document via -f query=...
-    # and variable values via -F (raw) for top-level structured input.
-    # We pre-marshalled the variables in payload's .input above.
     local query='mutation($input: CreateCommitOnBranchInput!) {
       createCommitOnBranch(input: $input) {
         commit { oid url }
       }
     }'
 
-    local variables
-    variables="$(jq -c '{ input: .input }' <<<"$payload")"
+    # Build the full GraphQL request body and pipe via `--input -`.
+    # Prior pattern used `--raw-field variables=$variables` which sent
+    # variables as a JSON-encoded STRING rather than a structured
+    # object — GitHub's API then saw `$input` as undefined and
+    # returned `Variable $input of type CreateCommitOnBranchInput!
+    # was provided invalid value` (v0.2.1 release run 26915011552).
+    # The `--argjson p` here parses payload as JSON, so the body's
+    # `variables` field is a true object.
+    local body
+    body="$(jq -nc --arg q "$query" --argjson p "$payload" \
+        '{query: $q, variables: $p}')"
 
-    gh api graphql \
-        --raw-field query="$query" \
-        --raw-field variables="$variables"
+    gh api graphql --input - <<<"$body"
 }
 
 response="$(submit_mutation "$(build_payload "$EXPECTED_HEAD_OID")" 2>&1 || true)"


### PR DESCRIPTION
## Summary

**The actual server-side fix.** After #914's jq exit-5 fix exposed the diagnostic, v0.2.1 release [run 26915011552](https://github.com/axonops/audit/actions/runs/26915011552) surfaced the real GitHub server error:

\`\`\`
{"errors":[{...,"message":"Variable \$input of type CreateCommitOnBranchInput! was provided invalid value"}]}
\`\`\`

\`--raw-field variables=\$json_string\` sends variables as a JSON-encoded **string**, not a structured object. Server can't resolve \$input.

## The Fix

\`\`\`bash
local body
body="\$(jq -nc --arg q \"\$query\" --argjson p \"\$payload\" '{query: \$q, variables: \$p}')"
gh api graphql --input - <<<\"\$body\"
\`\`\`

\`--argjson\` preserves the object type.

## Closes
Closes #915.

## Bug Tally — Session Final (hopefully)

8 release-workflow bugs in this session:
1. tag-all cascade-skip (#901)
2. release-PR branch regex (#903)
3. outputconfig NUL leak — fuzz catch (#905)
4. gh-graphql-commit NUL strip (#907)
5. resolve_head_oid SHA validation (#911)
6. jq exit-5 on non-JSON (#914)
7. GraphQL variables as string (#915 — THIS)

Plus debug PRs (#909, #912).