### PR TITLE
docs: add submodule READMEs with compile-tested Quick Starts (#918)

### DIFF
--- a/audittest/README.md
+++ b/audittest/README.md
@@ -1,0 +1,291 @@
+# audittest — test helpers for code that emits audit events
+
+[![Go Reference][godoc-badge]][godoc]
+
+In-memory test auditor for unit and integration tests of applications
+that use the `audit` library. Captures every emitted event in a
+`Recorder` you can assert against, captures every metrics call in a
+`MetricsRecorder`, and runs synchronously by default so assertions
+do not race the drain goroutine.
+
+> **Module path**: `github.com/axonops/audit/audittest`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [Testing guide][testing-doc] · [godoc examples][godoc]
+
+## Why
+
+You have an HTTP handler, a gRPC service, or a background worker that
+calls `auditor.AuditEvent(...)`. In tests you need to assert:
+
+- The expected event was emitted.
+- The expected fields were set.
+- Nothing was emitted when nothing should have been.
+- Sensitivity-label stripping behaved as configured.
+- Metrics (submitted count, validation errors, output errors) match
+  the expected pattern.
+
+You **could** spin up a real auditor with a file output, run the test,
+read the file, and parse it. That's a lot of moving parts (file I/O,
+goroutine timing, cleanup, JSON parsing) for a unit test.
+
+`audittest` gives you a real `*audit.Auditor` — same validation, same
+taxonomy enforcement, same options — but with an in-memory `Recorder`
+as the output and synchronous delivery as the default. Events are
+parsed back into a structured `RecordedEvent` so you assert on Go
+values, not raw JSON. No goroutine, no files, no `time.Sleep`, no
+Close-before-assert ceremony.
+
+This package is for **library consumers**. It is not for testing the
+audit library itself — that work lives in `internal/testhelper`.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/audittest
+```
+
+## Quick start
+
+```go
+package myservice_test
+
+import (
+    "testing"
+
+    "github.com/axonops/audit"
+    "github.com/axonops/audit/audittest"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var taxonomyYAML = []byte(`
+version: 1
+categories:
+  write:
+    - user_create
+events:
+  user_create:
+    fields:
+      outcome: {required: true}
+      actor_id: {required: true}
+`)
+
+func TestUserCreateEmitsAuditEvent(t *testing.T) {
+    auditor, events, metrics := audittest.New(t, taxonomyYAML)
+
+    // Code under test.
+    svc := NewUserService(auditor)
+    err := svc.CreateUser(ctx, "alice")
+    require.NoError(t, err)
+
+    // Synchronous by default — events are already in the Recorder.
+    require.Equal(t, 1, events.Count())
+
+    evt := events.RequireEvent(t, "user_create")
+    assert.Equal(t, "alice", evt.StringField("actor_id"))
+    assert.Equal(t, "success", evt.StringField("outcome"))
+
+    // And metrics were recorded.
+    assert.Equal(t, 1, metrics.SubmittedCount())
+}
+```
+
+`audittest.New` returns three things:
+
+- `*audit.Auditor` — pass it into your service the same way you would
+  in production.
+- `*audittest.Recorder` — read events out of it after the test runs
+  the code under test.
+- `*audittest.MetricsRecorder` — already wired in via
+  `audit.WithMetrics`; query it for submission counts, output errors,
+  validation errors, etc.
+
+`tb.Cleanup` is registered automatically; the auditor closes when the
+test finishes.
+
+## Even less ceremony: `NewQuick`
+
+When you do not care about taxonomy validation and just want to assert
+that some event types were emitted:
+
+```go
+func TestThing(t *testing.T) {
+    auditor, events, _ := audittest.NewQuick(t, "user_create", "user_delete")
+
+    _ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+        "anything": "goes",
+    }))
+
+    events.RequireEvent(t, "user_create")
+}
+```
+
+`NewQuick` builds a permissive taxonomy on the fly — every listed
+event type accepts any fields, no required fields, no validation
+errors. Use it for tests that exercise emission paths but do not
+care about field shape.
+
+## Assertions
+
+`Recorder` exposes a fluent assertion API:
+
+```go
+// Counts and indexing.
+events.Count()
+events.Events()             // slice snapshot
+events.First()              // (RecordedEvent, ok)
+events.Last()               // (RecordedEvent, ok)
+
+// Lookup.
+events.FindByType("user_create")
+events.FindByField("actor_id", "alice")
+
+// Hard assertions (call tb.Fatal on mismatch).
+events.RequireEvents(t, 3)
+events.RequireEvent(t, "user_create")
+events.RequireEmpty(t)
+
+// Soft assertion (call tb.Error, allow further checks).
+events.AssertContains(t, "user_create", audit.Fields{"actor_id": "alice"})
+```
+
+Individual `RecordedEvent` values have typed accessors that handle
+the JSON round-trip (numbers come back as `float64`):
+
+```go
+evt.StringField("actor_id")  // ""
+evt.IntField("retry_count")  // 0  (handles float64 → int)
+evt.FloatField("amount")     // 0.0
+evt.BoolField("first_login") // false
+evt.Field("anything")        // any
+evt.HasField("k", v)         // reflect.DeepEqual
+evt.UserFields()             // strips framework fields (host, app_name, pid, …)
+```
+
+## Table-driven tests
+
+Reset between sub-tests instead of creating a new auditor each time:
+
+```go
+auditor, events, _ := audittest.New(t, taxonomyYAML)
+
+for _, tc := range []struct {
+    name string
+    in   request
+    want string
+}{
+    {"alice", request{user: "alice"}, "alice"},
+    {"bob",   request{user: "bob"},   "bob"},
+} {
+    t.Run(tc.name, func(t *testing.T) {
+        events.Reset()
+
+        handle(auditor, tc.in)
+
+        evt := events.RequireEvent(t, "user_create")
+        assert.Equal(t, tc.want, evt.StringField("actor_id"))
+    })
+}
+```
+
+## Async tests
+
+The default is synchronous. If you need to exercise the actual async
+pipeline — drain timeout, buffer backpressure, ordering under
+concurrency — opt in with `WithAsync` and use `WaitForN` instead of
+asserting immediately:
+
+```go
+auditor, events, _ := audittest.New(t, taxonomyYAML, audittest.WithAsync())
+
+go emitBurst(auditor) // 100 events from a goroutine
+
+if !events.WaitForN(t, 100, 2*time.Second) {
+    t.Fatalf("timed out waiting for events, got %d", events.Count())
+}
+```
+
+`WaitForN` polls at 10 ms, returns `true` as soon as the target is
+reached, `false` on timeout. Pass a larger timeout for slower CI.
+
+## Sensitivity-label stripping
+
+Verify that a compliance output does **not** see PII-labelled fields:
+
+```go
+var taxonomyYAML = []byte(`
+version: 1
+sensitivity:
+  labels:
+    pii:
+      fields: [email]
+categories: {write: [user_create]}
+events:
+  user_create:
+    fields:
+      actor_id: {required: true}
+      email: {}
+`)
+
+auditor, events, _ := audittest.New(t, taxonomyYAML,
+    audittest.WithExcludeLabels("recorder", "pii"),
+)
+
+_ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+    "actor_id": "alice",
+    "email":    "alice@example.com",
+}))
+
+evt := events.Events()[0]
+assert.Equal(t, "alice", evt.StringField("actor_id"))
+assert.Nil(t, evt.Field("email")) // stripped before delivery
+```
+
+The string `"recorder"` must match the recorder's name — the default
+is `"recorder"` (or whatever you pass to `NewNamedRecorder`).
+
+## Options
+
+| Option | Purpose |
+|---|---|
+| `WithValidationMode(mode)` | Override validation mode (default: `ValidationStrict`) |
+| `WithSync()` / `WithAsync()` | Toggle synchronous (default) / async delivery |
+| `WithDisabled()` | No-op auditor — accepts events but never delivers |
+| `WithExcludeLabels(name, ...)` | Strip taxonomy-labelled fields before delivery to the named output |
+| `WithVerbose()` | Re-enable auditor diagnostic logs (silenced by default) |
+| `WithAuditOption(opt)` | Pass through any `audit.Option` not covered above |
+
+`WithAuditOption` is the escape hatch — use it for `audit.WithAppName`,
+`audit.WithHost`, `audit.WithFormatter`, or anything else that does not
+have a dedicated `audittest.With*` helper.
+
+## TLS test certificates
+
+For tests that exercise the syslog/webhook/Loki/Splunk outputs against
+local TLS endpoints, the package also ships `GenerateTestCerts(tb)` —
+a self-signed CA plus server and client certificates written to
+`tb.TempDir`. ECDSA P-256, one-hour expiry, cleaned up automatically.
+
+```go
+certs := audittest.GenerateTestCerts(t)
+// certs.CAPath, certs.CertPath, certs.KeyPath, certs.ClientCert, certs.ClientKey
+// certs.TLSCfg is a ready-to-use server tls.Config
+```
+
+This exists because Go's `internal/` mechanism is module-scoped — the
+core's `internal/testhelper` is not visible to the `file`, `syslog`,
+`webhook`, etc. sub-modules. `audittest` is the public sibling that
+the sub-modules' test code imports for shared TLS plumbing.
+
+## See also
+
+- **[docs/testing.md][testing-doc]** — the broader testing guide for
+  audit-enabled services
+- **[godoc examples][godoc]** — runnable examples for `New`, `NewQuick`,
+  `WaitForN`, `WithExcludeLabels`
+- **[github.com/axonops/audit][audit-godoc]** — the core library
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/audittest
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/audittest.svg
+[audit-godoc]: https://pkg.go.dev/github.com/axonops/audit
+[testing-doc]: https://github.com/axonops/audit/blob/main/docs/testing.md

--- a/cmd/audit-gen/README.md
+++ b/cmd/audit-gen/README.md
@@ -1,0 +1,241 @@
+# audit-gen — code generator for type-safe audit event builders
+
+[![Go Reference][godoc-badge]][godoc]
+
+A command-line code generator for the
+[`github.com/axonops/audit`][parent] library. Reads a YAML taxonomy
+file and emits one of four artifact types: typed Go event builders
+(default), a JSON Schema validator, a CEF mapping template, or a
+complete Splunk Technology Add-on directory tree.
+
+> **Module path**: `github.com/axonops/audit/cmd/audit-gen`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [docs/code-generation.md][cg-doc] · [examples/02-code-generation/][cg-example]
+
+## Why
+
+Without code generation, emitting an event is a `map[string]any`
+keyed by raw strings:
+
+```go
+auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+    "actor_id": "alice",
+    "outcom":   "success", // typo — caught only at runtime
+}))
+```
+
+A typo in the event name, a missing required field, or a stale
+field name compiles cleanly and fails — silently or at runtime —
+later. For an audit-grade event stream that's not acceptable.
+
+`audit-gen` reads the taxonomy you would have written by hand and
+generates:
+
+- `const` blocks for every event type, category, field name, and
+  sensitivity label
+- Typed builders like `NewUserCreateEvent(actorID, outcome)` whose
+  required fields are constructor parameters — you cannot forget
+  them — and whose optional fields are chainable setters
+- A compile-time map of `event type → required/optional fields`
+
+This converts every "did I name this field correctly?" question
+from a runtime check into a compile-time check.
+
+`audit-gen` only generates code. To gate `outputs.yaml` against the
+same taxonomy at deploy time, use the sibling
+[`audit-validate`](../audit-validate/) tool.
+
+## Install
+
+```bash
+# As a binary (recommended for CI):
+go install github.com/axonops/audit/cmd/audit-gen@latest
+
+# Or via go run (one-shot, no install):
+go run github.com/axonops/audit/cmd/audit-gen@latest -input taxonomy.yaml \
+    -output audit_generated.go -package mypackage
+```
+
+Pre-built binaries for `linux/{amd64,arm64}`, `darwin/{amd64,arm64}`,
+and `windows/amd64` are attached to every release tag at
+<https://github.com/axonops/audit/releases>.
+
+An OCI image is published to GitHub Container Registry on every
+release (multi-arch manifest: amd64 + arm64):
+
+```bash
+docker run --rm -v "$PWD:/src" ghcr.io/axonops/audit-gen:latest \
+    -input /src/taxonomy.yaml \
+    -output /src/audit_generated.go \
+    -package mypackage
+```
+
+Requires Go 1.26+ when installing from source.
+
+## Usage
+
+```bash
+audit-gen -input <taxonomy.yaml> -output <path|-> -package <name> [flags]
+```
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `-input` | _(required)_ | Path to the taxonomy YAML file. |
+| `-output` | _(required)_ | Output path, or `-` for stdout. For `-format=splunk-ta`, must be a directory. |
+| `-package` | _(required for `-format=go`)_ | Go package name for the generated source file. |
+| `-format` | `go` | Output format: `go`, `json-schema`, `cef-template`, `splunk-ta`. |
+| `-header` | auto | File header. Default is a `DO NOT EDIT` banner with the input filename. |
+| `-types` | `true` | Emit event-type constants. |
+| `-fields` | `true` | Emit field-name constants. |
+| `-categories` | `true` | Emit category constants. |
+| `-labels` | `true` | Emit sensitivity-label constants. |
+| `-builders` | `true` | Emit typed event builder structs. |
+| `-standard-setters` | `all` | Reserved-field setter emission: `all` (every builder gets every reserved setter) or `explicit` (only taxonomy-declared reserved fields). |
+| `-vendor-product` | `AxonOps:Audit` | CIM `vendor_product` for the `splunk-ta` format. |
+| `-splunk-ta-name` | `TA-axonops-audit` | Splunk app id for the `splunk-ta` format (must match the output directory basename for AppInspect). |
+| `-splunk-ta-version` | `0.1.0` | Version stamped into `app.conf` for the `splunk-ta` format. |
+| `-version` | — | Print version and exit. |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success. |
+| `1` | Invalid arguments or missing required flags. |
+| `2` | YAML parse error or taxonomy validation failure. |
+| `3` | Output file write error. |
+
+## Quick start
+
+Given `taxonomy.yaml`:
+
+```yaml
+version: 1
+categories:
+  write:
+    severity: 3
+    events: [user_create]
+events:
+  user_create:
+    description: "A new user account was created"
+    fields:
+      outcome:  { required: true }
+      actor_id: { required: true }
+```
+
+Generate:
+
+```bash
+audit-gen -input taxonomy.yaml \
+    -output audit_generated.go \
+    -package mypackage
+```
+
+The generated `audit_generated.go` contains:
+
+```go
+// (abbreviated — see examples/02-code-generation/audit_generated.go
+// for the full canonical layout)
+const (
+    // EventUserCreate — A new user account was created
+    EventUserCreate = "user_create"
+
+    FieldActorID = "actor_id"
+    FieldOutcome = "outcome"
+    // ... plus every reserved standard field
+)
+```
+
+…and a typed builder you call like this:
+
+```go
+import "context"
+
+ev := NewUserCreateEvent("alice", "success") // required fields = ctor params
+ev.SetRequestID("req-42")                    // optional reserved-field setter
+ev.Audit(ctx, auditor)
+```
+
+Forgetting `actor_id` is now a compile error. Misspelling the
+event name is a compile error. Sending an `outcome` field that
+isn't in the taxonomy fails when the loader parses the YAML.
+
+The complete worked example is at
+[`examples/02-code-generation/`][cg-example].
+
+### `go generate` integration
+
+Add a single directive to a Go file in the target package and
+commit the generated source:
+
+```go
+//go:generate go run github.com/axonops/audit/cmd/audit-gen \
+//     -input taxonomy.yaml \
+//     -output audit_generated.go \
+//     -package mypackage
+package mypackage
+```
+
+Then:
+
+```bash
+go generate ./...
+```
+
+## CI integration
+
+Verify the generated file is in sync with the taxonomy on every PR:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: actions/setup-go@v6
+  with:
+    go-version: '1.26'
+
+- name: Regenerate
+  run: go generate ./...
+
+- name: Fail on drift
+  run: git diff --exit-code -- audit_generated.go
+```
+
+Or pin a specific binary version into a job:
+
+```yaml
+- name: Install audit-gen
+  run: go install github.com/axonops/audit/cmd/audit-gen@v0.2.0
+
+- name: Regenerate
+  run: audit-gen -input taxonomy.yaml -output audit_generated.go -package mypackage
+
+- run: git diff --exit-code -- audit_generated.go
+```
+
+Maintainers triggering proxy.golang.org indexing after a release tag:
+
+```bash
+make publish-trigger VERSION=v0.2.0
+```
+
+This walks the published modules — including
+`github.com/axonops/audit/cmd/audit-gen` — and forces a proxy
+fetch so `go install …@v0.2.0` resolves immediately.
+
+## See also
+
+- [Code generation guide][cg-doc] — full reference, including
+  `-standard-setters=explicit`, schema/CEF artifact formats, and
+  the Splunk TA layout
+- [Taxonomy YAML reference][tax-doc] — the schema audit-gen reads
+- [Worked example][cg-example] — `examples/02-code-generation/`
+- Related tools: [`audit-validate`](../audit-validate/),
+  [`bdd-report`](../bdd-report/),
+  [`junit-report`](../junit-report/)
+- [Source](https://github.com/axonops/audit/tree/main/cmd/audit-gen)
+
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/cmd/audit-gen.svg
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/cmd/audit-gen
+[parent]: https://github.com/axonops/audit
+[cg-doc]: https://github.com/axonops/audit/blob/main/docs/code-generation.md
+[cg-example]: https://github.com/axonops/audit/tree/main/examples/02-code-generation
+[tax-doc]: https://github.com/axonops/audit/blob/main/docs/taxonomy-validation.md

--- a/cmd/audit-validate/README.md
+++ b/cmd/audit-validate/README.md
@@ -1,0 +1,213 @@
+# audit-validate — pre-deploy validator for outputs.yaml
+
+[![Go Reference][godoc-badge]][godoc]
+
+A command-line validator for the
+[`github.com/axonops/audit`][parent] library. Reads a taxonomy YAML
+and an `outputs.yaml` and reports parse errors, schema violations,
+and semantic mismatches (route references unknown event types,
+unknown output kind, unresolved `ref+` secrets, etc.) — the same
+checks the library runs at startup, but as a CI gate before the
+config reaches production.
+
+> **Module path**: `github.com/axonops/audit/cmd/audit-validate`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [docs/validation.md][val-doc] · [docs/taxonomy-validation.md][tax-doc]
+
+## Why
+
+An invalid `outputs.yaml` only fails when the application starts
+up — typically in production, after the deployment pipeline has
+already run. By then the audit library refuses to start and the
+service it lives in either crashes or runs without audit logging,
+both bad outcomes for a compliance-sensitive system.
+
+`audit-validate` runs the same loader as the library
+([`outputconfig.Load`][load]) against the same taxonomy your
+binary embeds. If it exits zero, the runtime will accept the
+config. If it exits non-zero, it tells you which class of error
+fired and where, before any deployment happens.
+
+It's deliberately a separate binary from
+[`audit-gen`](../audit-gen/): different audience (developers vs
+operators), different lifecycle (build time vs deploy time), so
+neither pulls in the other's machinery.
+
+The default release binary is **offline-only** — it has no secret
+providers compiled in and rejects `ref+SCHEME://...` references in
+the outputs YAML as semantic errors. Validate against a live Vault
+or OpenBao by building a custom validator that blank-imports the
+relevant `github.com/axonops/audit/secrets/...` sub-modules.
+
+## Install
+
+```bash
+# As a binary (recommended for CI):
+go install github.com/axonops/audit/cmd/audit-validate@latest
+
+# Or via go run (one-shot, no install):
+go run github.com/axonops/audit/cmd/audit-validate@latest \
+    -taxonomy taxonomy.yaml -outputs outputs.yaml
+```
+
+Pre-built binaries for `linux/{amd64,arm64}`, `darwin/{amd64,arm64}`,
+and `windows/amd64` are attached to every release tag at
+<https://github.com/axonops/audit/releases>.
+
+Requires Go 1.26+ when installing from source.
+
+## Usage
+
+```bash
+audit-validate -taxonomy <file|-> -outputs <file|-> [flags]
+```
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `-taxonomy` | _(required)_ | Path to the taxonomy YAML, or `-` for stdin. |
+| `-outputs` | _(required)_ | Path to the outputs YAML, or `-` for stdin. |
+| `-format` | `text` | Output format: `text` (human-readable) or `json` (machine-readable). |
+| `-quiet` | `false` | Suppress all output; rely on the exit code only. |
+| `-resolve-secrets` | `false` | Reserved. The default release binary rejects this flag because it has no secret providers compiled in. |
+| `-version` | — | Print version and exit. |
+
+Only one of `-taxonomy` / `-outputs` may be `-` at a time (stdin
+can only be read once).
+
+### Exit codes
+
+| Code | Class | Meaning |
+|------|-------|---------|
+| `0` | valid | Configuration passes parse, schema, and semantic checks. |
+| `1` | parse | File missing or YAML failed to parse. |
+| `2` | schema | Required field missing, wrong type, unknown field, usage error, stdin double-use, or `-resolve-secrets` on an offline binary. |
+| `3` | semantic | Route references an unknown event type or category, unknown output type, or an unresolved `ref+` secret string. |
+
+The three classes are distinct on purpose: a parse error means
+"the file is broken" (typically a hand-edit mistake); a schema
+error means "the file is well-formed YAML but doesn't match the
+expected structure"; a semantic error means "the file is valid
+YAML matching the structure but contradicts the taxonomy".
+
+## Quick start
+
+Given a `taxonomy.yaml` defining `user_create` and `user_delete`
+events grouped under a `write` category, and the following
+`outputs.yaml`:
+
+```yaml
+version: 1
+app_name: example
+host: localhost
+outputs:
+  stdout:
+    type: stdout
+  audit-file:
+    type: file
+    file:
+      path: /var/log/audit.jsonl
+    route:
+      include_categories:
+        write: {}
+```
+
+Run:
+
+```bash
+$ audit-validate -taxonomy taxonomy.yaml -outputs outputs.yaml
+audit-validate: configuration is valid
+$ echo $?
+0
+```
+
+Now introduce a typo — route the `wirte` category instead of `write`:
+
+```bash
+$ audit-validate -taxonomy taxonomy.yaml -outputs outputs.yaml
+audit-validate: semantic error: output "audit-file": route references unknown taxonomy entries: category "wirte" not found
+$ echo $?
+3
+```
+
+Machine-readable form for downstream tooling:
+
+```bash
+$ audit-validate -format json -taxonomy taxonomy.yaml -outputs outputs.yaml
+{
+  "errors": [
+    {
+      "code": "semantic",
+      "message": "route 0 references unknown taxonomy entries: category \"wirte\" not found"
+    }
+  ],
+  "valid": false
+}
+```
+
+### stdin
+
+For Kubernetes templating pipelines that don't write the rendered
+YAML to disk:
+
+```bash
+helm template ./chart | yq '.data."outputs.yaml"' \
+    | audit-validate -taxonomy ./taxonomy.yaml -outputs -
+```
+
+## CI integration
+
+Gate every PR that touches `taxonomy.yaml` or `outputs.yaml`:
+
+```yaml
+# .github/workflows/ci.yml
+name: validate audit config
+on:
+  pull_request:
+    paths:
+      - 'taxonomy.yaml'
+      - 'config/outputs/**.yaml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Install audit-validate
+        run: go install github.com/axonops/audit/cmd/audit-validate@v0.2.0
+
+      - name: Validate every env
+        run: |
+          for f in config/outputs/*.yaml; do
+            echo "::group::$f"
+            audit-validate -taxonomy taxonomy.yaml -outputs "$f"
+            echo "::endgroup::"
+          done
+```
+
+Exit code 3 (semantic) typically indicates the taxonomy and
+outputs drifted apart — for example, an event type was renamed in
+`taxonomy.yaml` but the route in `outputs.yaml` still references
+the old name. Wire both files to the same review path.
+
+## See also
+
+- [Validation guide][val-doc] — full workflow, including
+  custom-built validators with secret providers blank-imported
+- [Taxonomy YAML reference][tax-doc] — the schema validated against
+- [Output configuration reference][out-doc] — what goes in `outputs.yaml`
+- Related tools: [`audit-gen`](../audit-gen/),
+  [`bdd-report`](../bdd-report/),
+  [`junit-report`](../junit-report/)
+- [Source](https://github.com/axonops/audit/tree/main/cmd/audit-validate)
+
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/cmd/audit-validate.svg
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/cmd/audit-validate
+[parent]: https://github.com/axonops/audit
+[val-doc]: https://github.com/axonops/audit/blob/main/docs/validation.md
+[tax-doc]: https://github.com/axonops/audit/blob/main/docs/taxonomy-validation.md
+[out-doc]: https://github.com/axonops/audit/blob/main/docs/output-configuration.md
+[load]: https://pkg.go.dev/github.com/axonops/audit/outputconfig#Load

--- a/cmd/bdd-report/README.md
+++ b/cmd/bdd-report/README.md
@@ -1,0 +1,152 @@
+# bdd-report — cucumber JSON to HTML/Markdown renderer
+
+[![Go Reference][godoc-badge]][godoc]
+
+An internal CI tool for the [`github.com/axonops/audit`][parent]
+repository. Reads a cucumber JSON report (as emitted by
+[godog][godog]'s `cucumber:<file>` formatter) and writes a
+standalone HTML or GitHub-flavoured Markdown report to stdout.
+
+> **Module path**: `github.com/axonops/audit/cmd/bdd-report`
+> **Status**: pre-release (v0.x) · internal CI use
+> **Sibling tool**: [`junit-report`](../junit-report/) (same renderer, JUnit XML input)
+
+## Why
+
+godog produces a structured cucumber JSON report. Humans don't
+read JSON. CI reviewers want to see at a glance which scenarios
+passed, which failed, which steps inside each scenario failed,
+and what the failure message was — preferably without leaving the
+GitHub Actions tab.
+
+`bdd-report` is a small dedicated renderer for that one job. The
+HTML output is single-file, embedded CSS, no JavaScript, no
+external assets — drop it into a workflow artefact and reviewers
+can open it locally. The Markdown output targets
+[GitHub-flavoured Markdown][gfm]: inline
+`<details>`/`<summary>` collapsible blocks render natively on
+`github.com` and inside the Actions step summary panel.
+
+It is mostly used inside this repository's CI; nothing prevents
+external use, but it has no public Go API (it's `package main`)
+and no stability commitment beyond what this repo needs.
+
+## Install
+
+```bash
+# Pinned binary (rare — typically used via `go run` from the repo):
+go install github.com/axonops/audit/cmd/bdd-report@latest
+
+# Or via go run:
+go run github.com/axonops/audit/cmd/bdd-report@latest [flags]
+```
+
+Requires Go 1.26+. No runtime dependencies.
+
+## Usage
+
+```bash
+bdd-report -suite <name> -input <cucumber.json> [-format html|markdown] [-only-failures]
+```
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `-suite` | _(required)_ | Suite name shown in the report header (e.g. `core`, `webhook`). |
+| `-input` | stdin | Path to the cucumber JSON file. Omit (or pass `-`) to read from stdin. |
+| `-format` | `html` | Output format: `html` or `markdown` (alias `md`). |
+| `-only-failures` | `false` | Markdown only: emit only failed scenarios. Suitable for the `$GITHUB_STEP_SUMMARY` 1 MiB cap. |
+| `-version` | — | Print version and exit. |
+
+Output is always written to stdout. Redirect to a file:
+
+```bash
+bdd-report -suite core -input report.json -format html > report.html
+```
+
+Non-zero exit when the input is missing, empty, or malformed.
+
+## Quick start
+
+Run a BDD suite with godog's cucumber formatter and convert the
+report:
+
+```bash
+go test -tags integration -v \
+    ./tests/bdd -run TestFeatures -godog.format=cucumber:/tmp/r.json
+
+bdd-report -suite core -input /tmp/r.json -format html > report.html
+bdd-report -suite core -input /tmp/r.json -format markdown > report.md
+```
+
+Open `report.html` in a browser. The page is single-file with
+embedded CSS — no JavaScript, no network requests. Each feature
+collapses to a header that shows pass/fail counts; failed
+scenarios auto-expand and show the failed step's error body.
+
+The Markdown form renders directly when pasted into a GitHub
+issue or PR comment:
+
+```markdown
+# BDD report — core
+
+**42 scenarios** · **41 passed** · **1 failed**
+
+<details open>
+<summary><strong>Feature: HTTP middleware</strong> — 5✓ · 1✗</summary>
+...
+</details>
+```
+
+## CI integration
+
+This repo wires `bdd-report` into every BDD matrix leg via the
+shared composite action at
+[`.github/actions/upload-test-report`][upload-action]. The
+caller-side step looks like this:
+
+```yaml
+- name: Run BDD tests
+  env:
+    BDD_REPORT_FILE: ${{ runner.temp }}/bdd-report-${{ matrix.suite }}.json
+  run: make ${{ matrix.target }}
+
+- name: Generate + upload BDD report
+  if: always()
+  uses: ./.github/actions/upload-test-report
+  with:
+    format: cucumber-json
+    suite: ${{ matrix.suite }}
+    input-path: ${{ runner.temp }}/bdd-report-${{ matrix.suite }}.json
+    artifact-prefix: bdd-report
+```
+
+The composite action invokes `bdd-report` twice — once for the
+full HTML/Markdown artefacts, once with `-only-failures` for the
+step summary panel — and uploads both as workflow artefacts named
+`bdd-report-<suite>` (HTML) and `bdd-report-<suite>-md`
+(Markdown).
+
+### Truncation under the step-summary cap
+
+`$GITHUB_STEP_SUMMARY` has a hard 1 MiB limit. In `-only-failures`
+mode, `bdd-report` tracks the running output size and emits a
+truncation footer once the budget is exceeded — pointing
+reviewers at the full Markdown artefact for the rest. A single
+feature whose serialised form alone exceeds the cap will
+overshoot once; GitHub silently truncates the tail in that case
+and reviewers download the artefact for the full report.
+
+## See also
+
+- Sibling: [`junit-report`](../junit-report/) — same renderer,
+  JUnit XML input
+- Composite CI action: [`.github/actions/upload-test-report`][upload-action]
+- Cucumber JSON schema: <https://github.com/cucumber/cucumber-json-schema>
+- [Source](https://github.com/axonops/audit/tree/main/cmd/bdd-report)
+
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/cmd/bdd-report.svg
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/cmd/bdd-report
+[parent]: https://github.com/axonops/audit
+[godog]: https://github.com/cucumber/godog
+[gfm]: https://github.github.com/gfm/
+[upload-action]: https://github.com/axonops/audit/blob/main/.github/actions/upload-test-report/action.yml

--- a/cmd/junit-report/README.md
+++ b/cmd/junit-report/README.md
@@ -1,0 +1,158 @@
+# junit-report — JUnit XML to HTML/Markdown renderer
+
+[![Go Reference][godoc-badge]][godoc]
+
+An internal CI tool for the [`github.com/axonops/audit`][parent]
+repository. Reads a JUnit XML report (as emitted by
+[`gotestsum --junitfile`][gotestsum]) and writes a standalone HTML
+or GitHub-flavoured Markdown report to stdout. Sibling to
+[`bdd-report`](../bdd-report/) — same renderer, JUnit XML input
+instead of cucumber JSON.
+
+> **Module path**: `github.com/axonops/audit/cmd/junit-report`
+> **Status**: pre-release (v0.x) · internal CI use
+> **Sibling tool**: [`bdd-report`](../bdd-report/) (same renderer, cucumber JSON input)
+
+## Why
+
+`go test -json` and `gotestsum --junitfile` produce machine-
+readable output. Humans still want to see, at a glance, which
+package failed, which test failed inside it, and what the failure
+or panic body looked like — without manually grepping the JUnit
+XML or scrolling through raw test logs.
+
+`junit-report` is a small dedicated renderer for that one job.
+The HTML output is single-file, embedded CSS, no JavaScript, no
+external assets. The Markdown output targets
+[GitHub-flavoured Markdown][gfm]: inline `<details>`/`<summary>`
+blocks render natively on `github.com` and inside the Actions
+step summary panel.
+
+It distinguishes JUnit's two failure flavours: `<failure>`
+(assertion mismatch) and `<error>` (panic or test-setup failure).
+Both surface separately in the report so reviewers can spot
+panics without trawling through assertion fails.
+
+It is mostly used inside this repository's CI; nothing prevents
+external use, but it has no public Go API (it's `package main`)
+and no stability commitment beyond what this repo needs.
+
+## Install
+
+```bash
+# Pinned binary (rare — typically used via `go run` from the repo):
+go install github.com/axonops/audit/cmd/junit-report@latest
+
+# Or via go run:
+go run github.com/axonops/audit/cmd/junit-report@latest [flags]
+```
+
+Requires Go 1.26+. No runtime dependencies.
+
+## Usage
+
+```bash
+junit-report -suite <name> -input <junit.xml> [-format html|markdown] [-only-failures]
+```
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `-suite` | _(required)_ | Suite or module name shown in the report header (e.g. `core`, `webhook`). |
+| `-input` | stdin | Path to the JUnit XML file. Omit (or pass `-`) to read from stdin. |
+| `-format` | `html` | Output format: `html` or `markdown` (alias `md`). |
+| `-only-failures` | `false` | Markdown only: emit only failed and errored tests. Suitable for the `$GITHUB_STEP_SUMMARY` 1 MiB cap. |
+| `-version` | — | Print version and exit. |
+
+Output is always written to stdout. Redirect to a file:
+
+```bash
+junit-report -suite core -input report.xml -format html > report.html
+```
+
+Non-zero exit when the input is missing, empty, or malformed.
+Both `<testsuites>`-rooted (gotestsum, modern Surefire) and bare
+`<testsuite>`-rooted (older runners) JUnit documents are accepted.
+
+## Quick start
+
+Run a Go test suite through gotestsum to capture JUnit XML, then
+render:
+
+```bash
+gotestsum \
+    --junitfile=/tmp/r.xml \
+    --format=pkgname \
+    -- -race ./...
+
+junit-report -suite core -input /tmp/r.xml -format html > report.html
+junit-report -suite core -input /tmp/r.xml -format markdown > report.md
+```
+
+Open `report.html` in a browser. Each test suite (Go package)
+collapses to a header with per-suite pass/fail/error/skip counts.
+Failed and errored tests auto-expand, showing the JUnit
+`<failure>` / `<error>` body or the captured `<system-err>` (the
+panic stack trace lands there when gotestsum can't extract a
+structured failure record).
+
+## CI integration
+
+This repo wires `junit-report` into the unit-test job for every
+module via the shared composite action at
+[`.github/actions/upload-test-report`][upload-action]. The
+caller-side step looks like this:
+
+```yaml
+- name: Run module tests
+  run: make test-${{ matrix.flag }}
+  # The shared go_test_with_junit Makefile helper writes
+  # ./<module>/<module>-junit.xml as a side-effect.
+
+- name: Generate + upload test report
+  if: always()
+  uses: ./.github/actions/upload-test-report
+  with:
+    format: junit-xml
+    suite: ${{ matrix.flag }}
+    input-path: ${{ matrix.module }}/${{ matrix.flag }}-junit.xml
+    artifact-prefix: test-report
+```
+
+The composite action invokes `junit-report` twice — once for the
+full HTML/Markdown artefacts, once with `-only-failures` for the
+step summary panel — and uploads both as workflow artefacts named
+`test-report-<suite>` (HTML) and `test-report-<suite>-md`
+(Markdown).
+
+### Truncation under the step-summary cap
+
+`$GITHUB_STEP_SUMMARY` has a hard 1 MiB limit. In `-only-failures`
+mode, `junit-report` tracks the running output size and emits a
+truncation footer once the budget is exceeded — pointing
+reviewers at the full Markdown artefact for the rest. A single
+suite whose serialised form alone exceeds the cap will overshoot
+once; GitHub silently truncates the tail in that case and
+reviewers download the artefact for the full report.
+
+## Parity with bdd-report
+
+The escape helpers, Markdown writer, and step-summary truncation
+logic in `render.go` / `writer.go` are byte-identical between
+`junit-report` and `bdd-report`. `make check-report-parity`
+enforces this in CI so a fix to one renderer applies to both.
+
+## See also
+
+- Sibling: [`bdd-report`](../bdd-report/) — same renderer,
+  cucumber JSON input
+- Composite CI action: [`.github/actions/upload-test-report`][upload-action]
+- [gotestsum][gotestsum] — the Go test runner that produces the
+  JUnit XML this tool consumes
+- [Source](https://github.com/axonops/audit/tree/main/cmd/junit-report)
+
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/cmd/junit-report.svg
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/cmd/junit-report
+[parent]: https://github.com/axonops/audit
+[gotestsum]: https://github.com/gotestyourself/gotestsum
+[gfm]: https://github.github.com/gfm/
+[upload-action]: https://github.com/axonops/audit/blob/main/.github/actions/upload-test-report/action.yml

--- a/file/README.md
+++ b/file/README.md
@@ -1,0 +1,201 @@
+# file — local audit-log file output with rotation
+
+[![Go Reference][godoc-badge]][godoc]
+
+Writes serialised audit events to a local file with size-based
+rotation, count- and age-based backup retention, and optional
+gzip compression of rotated files. Implements the
+[`audit.Output`][audit-output] interface.
+
+> **Module path**: `github.com/axonops/audit/file`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [file-output.md][docs] · [examples/03-file-output][example]
+
+## Why
+
+A local file is the simplest durable destination for an audit trail.
+Standard Unix tools (`grep`, `jq`, `tail -f`) work on it directly,
+rotated backups can be shipped to S3 or tape for compliance retention,
+and there are no network dependencies — no SIEM outage can drop events
+on the floor. Pair with HMAC integrity (configured at the output level
+in `outputs.yaml`) for tamper-evident logs that satisfy SOX, HIPAA,
+and PCI DSS file-based audit-trail requirements.
+
+Use file output when you want a complete unfiltered audit trail on
+local disk, and ship the file (or its rotated backups) into a SIEM
+separately. Use webhook, syslog, Loki, or Splunk directly when you
+want the event stream pushed into a remote system without an
+intermediate file.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/file
+```
+
+Requires Go 1.26+. See the [main README](../README.md) for transitive
+dependencies.
+
+## Quick start
+
+The blank import registers the `file` output factory; the YAML
+loader does the rest. Most consumers use the YAML path — see
+[YAML configuration](#yaml-configuration) below.
+
+For programmatic construction:
+
+```go
+import (
+    "github.com/axonops/audit"
+    "github.com/axonops/audit/file"
+)
+
+out, err := file.New(&file.Config{
+    Path:       "/var/log/audit/events.log",
+    MaxSizeMB:  100,
+    MaxBackups: 5,
+    MaxAgeDays: 30,
+})
+if err != nil {
+    return err
+}
+
+tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
+if err != nil {
+    return err
+}
+auditor, err := audit.New(
+    audit.WithTaxonomy(tax),
+    audit.WithAppName("my-service"),
+    audit.WithHost("host-01"),
+    audit.WithOutputs(out),
+)
+if err != nil {
+    return err
+}
+defer func() { _ = auditor.Close() }()
+```
+
+`Output.Write` is non-blocking: events are copied and enqueued onto an
+internal buffered channel; a background `writeLoop` drains them and
+batches each iteration into a single vectored write. Drops are
+surfaced via `OutputMetrics.RecordDrop`. The parent directory of
+`Path` MUST exist before `New` is called; the file itself is created
+if missing.
+
+## YAML configuration
+
+```yaml
+version: 1
+app_name: "my-service"
+host: "${HOSTNAME}"
+
+outputs:
+  audit_log:
+    type: file
+    file:
+      path: "/var/log/audit/events.log"
+      max_size_mb: 100
+      max_backups: 5
+      max_age_days: 30
+      group_readable: false      # default — file mode 0o600
+      compress: true             # default — gzip rotated backups
+      fsync_each_batch: false    # default — page-cache durability
+      buffer_size: 10000         # default — events dropped when full
+```
+
+A blank import registers the `file` output type with the YAML loader:
+
+```go
+import _ "github.com/axonops/audit/file"
+```
+
+The convenience [`outputs`][outputs] package blank-imports every
+built-in backend in one line.
+
+## Configuration reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `path` | string | *(required)* | Filesystem path. Relative paths resolved to absolute at construction. Parent directory MUST exist. Symlinks in the parent path are rejected as a path-traversal defence. |
+| `max_size_mb` | int | `100` | Rotate when the active file exceeds this many MiB. Max `10240` (10 GiB). |
+| `max_backups` | int | `5` | Number of rotated backup files retained. Max `100`. Zero falls back to the default — there is no "keep all" mode. |
+| `max_age_days` | int | `30` | Backups older than this are deleted. Max `365`. Zero falls back to the default — there is no "ignore age" mode. |
+| `group_readable` | bool | `false` | When `false` the file is mode `0o600` (owner only). When `true` it is `0o640` (owner + group read) — required when a SIEM forwarder (Filebeat, Promtail, Fluentd) runs as a separate user in the file's group. World-readable and group-writable modes are not supported. |
+| `compress` | bool | `true` | Gzip-compress rotated backup files asynchronously. JSON audit events typically compress 80–90 %. |
+| `buffer_size` | int | `10000` | Internal async channel capacity. When full, new events are dropped and `OutputMetrics.RecordDrop` is called. Max `100000`. |
+| `fsync_each_batch` | bool | `false` | When `true`, each batched `writev(2)` is followed by `fsync(2)` so the bytes are on stable storage before the writeLoop iteration returns. Trades 0.1–50 ms per batch (depending on storage) for per-batch durability. See [Durability contract][docs-durability] for the throughput model. |
+
+## Durability
+
+By default, batches land on the OS page cache when `writev(2)`
+returns. A power loss between then and the kernel's next writeback
+(typically 5–30 s on a default ext4 mount) can lose the most recent
+batch — roughly 130 KiB at typical event sizes. For most audit
+workloads this is comfortably inside compliance SLAs.
+
+Set `fsync_each_batch: true` to eliminate this window at the cost of
+per-batch fsync latency. The sustained event rate becomes
+approximately `batch_size / (writev_latency + fsync_latency)`; on a
+SATA SSD at 3 ms fsync per 256-event batch, that is about
+85 k events/s. Higher producer rates surface as `RecordDrop` calls
+from the internal channel.
+
+`fsync_each_batch` does NOT fsync the parent directory on file
+creation or rotation — for directory-level durability, mount the
+audit-log directory with `dirsync`. See the [reference doc][docs] for
+the full durability model.
+
+## Rotation
+
+Rotation fires when the active file exceeds `max_size_mb`. The file
+descriptor is closed, the file is renamed with a timestamp suffix
+(`events.log-2026-04-05T12-00-00.000`), and a new file is opened at
+the original path. If `compress: true`, the rotated backup is gzipped
+asynchronously. Backups are pruned by count (`max_backups`) and age
+(`max_age_days`) after every rotation.
+
+**Do not run the audit library's rotator alongside `logrotate(8)` on
+the same file** — both tools rename out from under each other and you
+get unpredictable backup chains. See [logrotate coexistence][docs-logrotate]
+for the production guidance.
+
+## Optional `RotationRecorder`
+
+Per-output metrics (wired via `WithOutputMetrics` or the YAML factory)
+MAY also implement `file.RotationRecorder`:
+
+```go
+type RotationRecorder interface {
+    RecordRotation(path string)
+}
+```
+
+If present, `RecordRotation` is called after each successful
+rotation. Discovery is by structural typing — no explicit registration.
+Precedent: `net/http.Flusher` on `http.ResponseWriter`.
+
+## See also
+
+- [Full output reference][docs] — config validation, file-permission
+  enforcement, fsync error semantics, logrotate coexistence
+- [Worked example][example] — `outputs.yaml` + `main.go` driving the
+  file output end-to-end with rotation
+- [Async delivery model](../docs/async-delivery.md) — two-level
+  buffering, drop semantics, graceful shutdown
+- [HMAC integrity](../docs/hmac-integrity.md) — tamper-evident audit
+  trails configured per-output
+- Related outputs:
+  [`syslog`](../syslog/) (push to a SIEM via RFC 5424),
+  [`webhook`](../webhook/) (push to an HTTPS endpoint),
+  [`loki`](../loki/) (push to Grafana Loki),
+  [`splunk`](../splunk/) (push to Splunk HEC)
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/file
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/file.svg
+[audit-output]: https://pkg.go.dev/github.com/axonops/audit#Output
+[docs]: ../docs/file-output.md
+[docs-durability]: ../docs/file-output.md#durability-contract
+[docs-logrotate]: ../docs/file-output.md#coexistence-with-logrotate
+[example]: ../examples/03-file-output/
+[outputs]: ../outputs/

--- a/loki/README.md
+++ b/loki/README.md
@@ -1,0 +1,217 @@
+# loki — Grafana Loki output (LogQL push API)
+
+[![Go Reference][godoc-badge]][godoc]
+
+Pushes audit events to a Grafana Loki instance via the HTTP push API
+(`POST /loki/api/v1/push`) with configurable stream labels, gzip
+compression, multi-tenant support, and TLS. Implements the
+[`audit.Output`][audit-output] interface.
+
+> **Module path**: `github.com/axonops/audit/loki`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [loki-output.md][docs] · [examples/08-loki-output][example]
+
+## Why
+
+Loki is the de-facto open-source log store for Grafana-native
+observability stacks. Pushing audit events to Loki gives you LogQL —
+`{event_type="auth_failure"} | json | actor_id="alice"` — alongside
+your application logs and metrics, in one query language, in one UI.
+You also get Grafana alerting on audit patterns without an additional
+SIEM, multi-tenant isolation via `X-Scope-OrgID`, and Loki's stream
+label model for cheap categorical filtering before LogQL parses the
+JSON body.
+
+Use Loki when you already run Grafana for metrics and logs and want
+audit events in the same surface. Use [`splunk`](../splunk/) for
+direct Splunk HEC delivery, [`syslog`](../syslog/) when the
+destination speaks RFC 5424, or [`webhook`](../webhook/) for generic
+HTTP sinks.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/loki
+```
+
+Requires Go 1.26+. See the [main README](../README.md) for transitive
+dependencies.
+
+## Quick start
+
+```go
+import (
+    "github.com/axonops/audit"
+    "github.com/axonops/audit/loki"
+)
+
+out, err := loki.New(&loki.Config{
+    URL:      "https://loki.example.com/loki/api/v1/push",
+    TenantID: "acme-corp",
+    Labels: loki.LabelConfig{
+        Static: map[string]string{
+            "job":         "audit",
+            "environment": "production",
+        },
+    },
+    Gzip: true,
+})
+if err != nil {
+    return err
+}
+
+tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
+if err != nil {
+    return err
+}
+auditor, err := audit.New(
+    audit.WithTaxonomy(tax),
+    audit.WithAppName("my-service"),
+    audit.WithHost("host-01"),
+    audit.WithOutputs(out),
+)
+if err != nil {
+    return err
+}
+defer func() { _ = auditor.Close() }()
+```
+
+Loki is JSON-only — the formatter for a Loki output cannot be changed
+to CEF or any other format, because LogQL relies on `| json` to parse
+the line body. Custom user-defined fields stay in the JSON body and
+remain queryable via `| json | field="value"`; the label set is
+deliberately scoped to a small, low-cardinality default to stay
+within Loki's recommended per-tenant stream ceiling.
+
+## YAML configuration
+
+```yaml
+version: 1
+app_name: "my-service"
+host: "${HOSTNAME}"
+
+outputs:
+  loki_audit:
+    type: loki
+    loki:
+      url: "https://loki.example.com/loki/api/v1/push"
+      tenant_id: "${LOKI_TENANT}"     # X-Scope-OrgID for multi-tenant Loki
+      batch_size: 100                 # default — events per push
+      max_batch_bytes: 1048576        # 1 MiB — flush at this payload size
+      max_event_bytes: 1048576        # 1 MiB — reject oversized events
+      flush_interval: "5s"            # default
+      timeout: "10s"                  # default
+      max_retries: 3                  # default — retry on 429/5xx
+      gzip: true                      # YAML default true; Go zero-value false
+      buffer_size: 10000              # default — events dropped when full
+      labels:
+        static:
+          job: "audit"
+          environment: "production"
+        dynamic:
+          pid: false                  # exclude PID (high cardinality)
+      # basic_auth:
+      #   username: "loki-writer"
+      #   password: "${LOKI_PASSWORD}"
+      # bearer_token: "${LOKI_TOKEN}"
+      tls:
+        ca:   "/etc/audit/ca.pem"
+        # cert: "/etc/audit/client-cert.pem"   # mTLS
+        # key:  "/etc/audit/client-key.pem"
+        # key_password: "${TLS_KEY_PASSWORD}"
+        # allow_tls12: false                    # default — TLS 1.3 only
+```
+
+A blank import registers the `loki` output type with the YAML loader:
+
+```go
+import _ "github.com/axonops/audit/loki"
+```
+
+## Configuration reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | *(required)* | Full push endpoint including path, e.g. `https://loki:3100/loki/api/v1/push`. HTTPS required unless `allow_insecure_http: true`. URLs with embedded credentials are rejected — use `basic_auth`. |
+| `tenant_id` | string | — | `X-Scope-OrgID` header for multi-tenant Loki. |
+| `basic_auth.username` | string | — | HTTP basic auth username. Required when `basic_auth` is set. Mutually exclusive with `bearer_token`. |
+| `basic_auth.password` | string | — | HTTP basic auth password. Use a secret reference in production. |
+| `bearer_token` | string | — | Sets `Authorization: Bearer <token>`. Mutually exclusive with `basic_auth`. |
+| `headers` | map[string]string | — | Additional HTTP headers. The library reserves `Authorization`, `X-Scope-OrgID`, `Content-Type`, `Content-Encoding`, and `Host` — use the dedicated config fields for those. CRLF in either name or value is rejected. |
+| `labels.static` | map[string]string | — | Constant labels applied to every event. Keys must match `[a-zA-Z_][a-zA-Z0-9_]*` (Loki requirement). Values must be non-empty and free of control characters. |
+| `labels.dynamic.app_name` | bool | included | Drop the per-event `app_name` label when `false`. |
+| `labels.dynamic.host` | bool | included | Drop the per-event `host` label when `false`. Significant cardinality in fleet deployments — consider excluding. |
+| `labels.dynamic.timezone` | bool | included | Drop the `timezone` label when `false`. Cardinality typically 1. |
+| `labels.dynamic.pid` | bool | included | Drop the `pid` label when `false`. **Strongly recommended in production** — every process restart creates a new label value. |
+| `labels.dynamic.event_type` | bool | included | Drop the `event_type` label when `false`. |
+| `labels.dynamic.event_category` | bool | included | Drop the `event_category` label when `false`. |
+| `labels.dynamic.severity` | bool | included | Drop the `severity` label when `false`. |
+| `tls.ca` | string | — | Path to a PEM CA bundle. Falls back to the system root pool when empty. |
+| `tls.cert` | string | — | mTLS client certificate. Set with `tls.key`. |
+| `tls.key` | string | — | mTLS client private key. Supports PKCS#8 v2 encrypted keys via `tls.key_password`. |
+| `tls.key_password` | string | — | Password for encrypted `tls.key`. |
+| `tls.allow_tls12` | bool | `false` | TLS 1.3 only when `false`. |
+| `batch_size` | int | `100` | Events per push request. Range `1`–`10000`. |
+| `max_batch_bytes` | int | `1048576` (1 MiB) | Maximum uncompressed payload per push. Range `1024`–`10485760` (1 KiB–10 MiB). |
+| `max_event_bytes` | int | `1048576` (1 MiB) | Per-event cap. Events exceeding this are rejected with `audit.ErrEventTooLarge`. Range `1024`–`10485760`. |
+| `flush_interval` | duration | `5s` | Maximum time between pushes. Range `100ms`–`5m`. |
+| `timeout` | duration | `10s` | HTTP request timeout. Range `1s`–`5m`. The transport-level `ResponseHeaderTimeout` is derived as `max(timeout/2, 1s)`. |
+| `max_retries` | int | `3` | Retry attempts for 429/5xx. Range `1`–`20`. |
+| `buffer_size` | int | `10000` | Internal async channel capacity. Events dropped when full. Range `100`–`1000000`. |
+| `gzip` | bool | YAML `true` / Go `false` | Gzip-compress push requests (the only encoding Loki accepts). Programmatic constructors must set this explicitly — the Go zero value is `false`. |
+| `allow_insecure_http` | bool | `false` | Permit `http://`. MUST NOT be `true` in production. |
+| `allow_private_ranges` | bool | `false` | Permit RFC 1918 / loopback. Intended for testing. |
+| `verify_on_startup` | bool | `true` | When `true`, `New` performs a TCP dial and TLS handshake before returning. |
+| `startup_verification_timeout` | duration | `5s` | Probe budget. Ignored when `verify_on_startup: false`. |
+
+## Stream labels and cardinality
+
+Each unique combination of label values is a separate Loki stream.
+Loki's recommended ceiling is around 100 k active streams per tenant —
+once you blow past that, ingestion latency degrades sharply and the
+tenant can be rate-limited. The dynamic label set is chosen to stay
+inside that ceiling for typical multi-host, multi-app deployments:
+
+| Label             | Cardinality driver                            | Default | Recommendation                                  |
+|-------------------|-----------------------------------------------|---------|-------------------------------------------------|
+| `app_name`        | distinct applications per tenant              | on      | usually low (<20) — safe to keep                |
+| `host`            | distinct hosts                                | on      | fleet deployments: consider excluding           |
+| `timezone`        | distinct timezones                            | on      | typically 1 — safe to keep                      |
+| `pid`             | every process restart creates a new value     | on      | **exclude in production**                       |
+| `event_type`      | size of the taxonomy                          | on      | usually 10–200 — safe to keep                   |
+| `event_category`  | distinct categories                           | on      | typically 5–20 — safe to keep                   |
+| `severity`        | at most 11 (0–10)                             | on      | always safe to keep                             |
+
+User-defined fields are NEVER labels — they stay in the JSON body and
+are queryable through `| json | field_name="value"`.
+
+## Delivery model
+
+Events batch in memory and push when any of these thresholds is
+reached: `batch_size` events queued, accumulated payload reaches
+`max_batch_bytes`, or `flush_interval` elapses. `Close` flushes
+remaining events. Retries fire on 429 (honouring `Retry-After`) and
+5xx with exponential backoff.
+
+Delivery is **at-least-once** — duplicate delivery is possible if the
+server accepts the payload but the acknowledgement is lost.
+
+## See also
+
+- [Full output reference][docs] — push API details, label cardinality,
+  multi-tenancy, gzip
+- [Worked example][example] — `outputs.yaml` + `main.go` that pushes
+  to a local Loki container
+- [TLS policy](../docs/output-configuration.md#tls) — TLS 1.3-only
+  defaults, TLS 1.2 fallback
+- Related outputs:
+  [`splunk`](../splunk/) (Splunk HEC),
+  [`syslog`](../syslog/) (RFC 5424),
+  [`webhook`](../webhook/) (generic HTTPS),
+  [`file`](../file/) (local file with rotation)
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/loki
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/loki.svg
+[audit-output]: https://pkg.go.dev/github.com/axonops/audit#Output
+[docs]: ../docs/loki-output.md
+[example]: ../examples/08-loki-output/

--- a/outputconfig/README.md
+++ b/outputconfig/README.md
@@ -1,0 +1,332 @@
+# outputconfig — YAML loader for audit outputs
+
+[![Go Reference][godoc-badge]][godoc]
+
+Loads an `outputs.yaml` file at process start, validates it, constructs
+every configured output via the registry, and returns a ready-to-use
+[`*audit.Auditor`][audit-godoc] (or the underlying [`audit.Option`][option-godoc]
+slice) for you to wire into the rest of your application.
+
+> **Module path**: `github.com/axonops/audit/outputconfig`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [Full reference][output-configuration-doc] · [Code-generation example][example-02]
+
+## Why
+
+You have two ways to configure audit outputs:
+
+1. **In Go.** Call `audit.New(audit.WithOutputs(out1, out2), ...)` and
+   wire per-output routes via `audit.WithNamedOutput(out, audit.WithRoute(r))`.
+   The compiler checks everything, but every output change is a
+   recompile + redeploy.
+2. **In YAML.** Write an `outputs.yaml` file describing what goes where,
+   read it at startup, hand it to this package. Operators reconfigure
+   outputs at deploy time — change the SIEM endpoint, add a per-output
+   route, rotate an HMAC salt — **without recompiling Go.**
+
+`outputconfig` is option 2. It is the configuration loader; it is not
+itself an output. It does not register output types either — those come
+from blank-importing the output modules (see below). It just turns YAML
+into [`audit.Option`][option-godoc] values.
+
+This separation matters because audit logging is a compliance function:
+the destinations, routing, and integrity settings frequently need to
+change without a code change going through review.
+
+### What `outputconfig` does NOT do
+
+- It does **not** register output types. The YAML key `type: file`
+  resolves to a constructor that the `file` module's `init()` put
+  into the registry. If you do not blank-import `github.com/axonops/audit/file`
+  (or the umbrella `github.com/axonops/audit/outputs` package),
+  `Load()` fails with "unknown output type: file" — no output is ever
+  silently dropped.
+- It does **not** define a taxonomy. You still write your taxonomy
+  separately (typically `taxonomy.yaml`, embedded via `go:embed`),
+  parse it with `audit.ParseTaxonomyYAML`, and pass it in.
+- It does **not** own the auditor lifecycle. `defer auditor.Close()`
+  is still your responsibility.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/outputconfig
+```
+
+## Quick start
+
+The 80% case is one call: `outputconfig.New`. Parse the taxonomy, load
+the outputs YAML, create the auditor.
+
+```go
+package main
+
+import (
+    "context"
+    _ "embed"
+    "log"
+
+    "github.com/axonops/audit"
+    "github.com/axonops/audit/outputconfig"
+    _ "github.com/axonops/audit/outputs" // registers stdout, file, syslog, webhook, loki, splunk
+)
+
+//go:embed taxonomy.yaml
+var taxonomyYAML []byte
+
+func main() {
+    // outputconfig.New(ctx, taxonomyYAML []byte, outputsConfigPath string, opts ...audit.Option)
+    auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml")
+    if err != nil {
+        log.Fatalf("audit setup: %v", err)
+    }
+    defer func() { _ = auditor.Close() }()
+
+    _ = auditor.AuditEvent(audit.NewEvent("user_create", audit.Fields{
+        "actor_id": "alice",
+        "outcome":  "success",
+    }))
+}
+```
+
+The blank import `_ "github.com/axonops/audit/outputs"` is the line
+that registers `file`, `syslog`, `webhook`, `loki`, `splunk`, and
+`stdout` output types with the registry. Without it, only output
+types whose modules you imported directly are recognised.
+
+A minimal `outputs.yaml` to go with the above:
+
+```yaml
+version: 1
+app_name: my-service
+host: ${HOSTNAME:-localhost}
+
+outputs:
+  console:
+    type: stdout
+  audit_log:
+    type: file
+    file:
+      path: /var/log/my-service/audit.log
+      max_size_mb: 100
+```
+
+## The registry pattern
+
+Output types live in their own Go modules so that adopters only pull
+in what they use. Each output module registers itself in `init()`:
+
+```go
+// inside github.com/axonops/audit/file/init.go (illustrative)
+func init() {
+    audit.MustRegisterOutputFactory("file", fileFactory)
+}
+```
+
+`outputconfig.Load` walks your YAML, looks up the factory for each
+`type:` string, and calls it. If the factory isn't there, you get a
+hard error at startup.
+
+The canonical pattern is:
+
+```go
+import (
+    "github.com/axonops/audit/outputconfig"
+    _ "github.com/axonops/audit/outputs" // pulls in ALL built-in outputs
+)
+```
+
+For smaller binaries, blank-import only what you use:
+
+```go
+import (
+    "github.com/axonops/audit/outputconfig"
+    _ "github.com/axonops/audit/file"    // type: file
+    _ "github.com/axonops/audit/webhook" // type: webhook
+)
+```
+
+Custom output types you wrote yourself? Either give them an `init()`
+that calls `audit.MustRegisterOutputFactory`, or pass
+`outputconfig.WithFactory(name, factory)` to `NewWithLoad`.
+
+## Inspecting before constructing
+
+When you want to inspect the parsed outputs before wiring them into
+an auditor — for example, to log "starting with N outputs" or to add
+extra `audit.Option` values conditionally — call `Load` directly
+instead of the `New` facade:
+
+```go
+loaded, err := outputconfig.Load(ctx, yamlBytes, taxonomy)
+if err != nil {
+    return fmt.Errorf("audit config: %w", err)
+}
+
+for _, info := range loaded.OutputMetadata() {
+    log.Printf("output %s (type=%s)", info.Name, info.Type)
+}
+
+opts := append([]audit.Option{audit.WithTaxonomy(taxonomy)}, loaded.Options()...)
+opts = append(opts, audit.WithMetrics(myPromMetrics))
+
+auditor, err := audit.New(opts...)
+if err != nil {
+    _ = loaded.Close() // hand back the outputs Load constructed
+    return err
+}
+```
+
+`Loaded.Options()` is the slice the facade hands to `audit.New`. It
+already contains `WithAppName`, `WithHost`, queue size, validation
+mode, and one `WithNamedOutput` per configured output. You add
+`WithTaxonomy` (because you typically already have it for other
+reasons) plus anything else your application needs.
+
+## LoadOption
+
+`Load` and `NewWithLoad` accept `LoadOption` values for advanced
+plumbing:
+
+| Option | Purpose |
+|---|---|
+| `WithSecretProvider(p)` | Register a secrets backend for `ref+vault://…` URIs in the YAML |
+| `WithSecretTimeout(d)` | Override the secret-resolution timeout (default 10s) |
+| `WithCoreMetrics(m)` | Use a single shared `audit.Metrics` for the auditor (Prometheus, etc.) |
+| `WithOutputMetrics(f)` | Per-output metrics factory — gets a fresh `Metrics` for each output, tagged with its name |
+| `WithFactory(name, f)` | Register a custom output type without an `init()` blank import |
+| `WithDiagnosticLogger(l)` | Send loader lifecycle messages to your `*slog.Logger` |
+
+## YAML schema (overview)
+
+The full reference, with every field, type, default, and validation
+rule, lives in [docs/output-configuration.md][output-configuration-doc].
+The top-level shape is:
+
+```yaml
+version: 1                         # required, must be 1
+app_name: my-service               # required, non-empty, max 255 bytes
+host: ${HOSTNAME:-localhost}       # required, env vars allowed
+timezone: UTC                      # optional, overrides auto-detected zone
+
+auditor:                           # optional core auditor settings
+  enabled: true                    # default: true
+  queue_size: 10000                # default: 10_000, max 1_000_000
+  shutdown_timeout: 5s             # default: 5s, max 60s
+  validation_mode: strict          # strict (default) | warn | permissive
+  omit_empty: false                # default: false
+
+standard_fields:                   # optional defaults for reserved fields
+  env: production
+  region: eu-west-1
+
+secrets:                           # optional secret-provider declarations
+  providers:
+    vault:
+      type: vault
+      address: https://vault.internal:8200
+  timeout: 10s
+
+outputs:                           # required, at least one enabled
+  audit_log:                       # output name (1..64 bytes, [a-z0-9_-])
+    type: file                     # registered output type
+    enabled: true                  # optional, default true
+    file:                          # output-specific config block
+      path: /var/log/audit.log
+      max_size_mb: 100
+    formatter:                     # optional per-output formatter override
+      type: cef
+      vendor: MyCompany
+      product: MyApp
+    route:                         # optional per-output event filter
+      include_categories:
+        security: {}
+    exclude_labels: [pii]          # optional sensitivity label strip
+    hmac:                          # optional per-output HMAC integrity
+      enabled: true
+      salt:
+        version: v1
+        value: ${HMAC_SALT}
+      algorithm: HMAC-SHA-256
+```
+
+TLS, where applicable, is configured **per-output** (under each
+output's nested block — e.g. `syslog.tls`, `webhook.tls`,
+`loki.tls`, `splunk.tls`) and **per-secret-provider** (under
+`secrets.providers.<name>.tls`). Schema is consistent across all of
+them:
+
+```yaml
+tls:
+  ca: /etc/ssl/ca.pem
+  cert: /etc/ssl/client.pem
+  key: /etc/ssl/client.key
+  key_password: ${TLS_KEY_PW}
+  allow_tls12: false
+```
+
+There is no top-level `tls:` key. See the per-output documentation
+for which fields are accepted under each output type.
+
+## Environment variables and secrets
+
+String values support `${VAR}` and `${VAR:-default}` substitution.
+Expansion happens **after** YAML parsing so an env var value cannot
+inject YAML structure.
+
+For secrets that must not live in env vars or the YAML at all
+(database passwords, HMAC salts, API tokens), use the `ref+` URI form
+resolved by a registered secrets provider — see
+[docs/secrets.md][secrets-doc] for the supported schemes
+(`ref+vault://`, `ref+openbao://`, …) and provider configuration.
+
+## Configuration reference
+
+The full field-level reference — every config key, its type, default,
+valid range, and boundary behaviour — is in
+**[docs/output-configuration.md][output-configuration-doc]**. This
+README does not duplicate the field tables.
+
+Per-output reference docs:
+
+- [docs/stdout-output.md][stdout-doc]
+- [docs/file-output.md][file-doc]
+- [docs/syslog-output.md][syslog-doc]
+- [docs/webhook-output.md][webhook-doc]
+- [docs/loki-output.md][loki-doc]
+- [docs/splunk-output.md][splunk-doc]
+
+## See also
+
+- **[Full output-configuration reference][output-configuration-doc]** — the field-level spec
+- **[examples/02-code-generation][example-02]** — the canonical
+  `outputconfig.New` + `go:embed` taxonomy + generated builders pattern
+- **[examples/10-multi-output][example-10]** — fan-out to multiple
+  outputs from a single YAML
+- **[examples/11-event-routing][example-11]** — per-output `route:`
+  filters in YAML
+- **[examples/15-buffering][example-15]** — queue size, drain timeout,
+  drop behaviour
+- **[github.com/axonops/audit/outputs][outputs-godoc]** — the umbrella
+  blank-import package
+- **[github.com/axonops/audit/secrets][secrets-godoc]** — secret
+  provider plumbing for `ref+` URIs
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/outputconfig
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/outputconfig.svg
+[audit-godoc]: https://pkg.go.dev/github.com/axonops/audit#Auditor
+[option-godoc]: https://pkg.go.dev/github.com/axonops/audit#Option
+[outputs-godoc]: https://pkg.go.dev/github.com/axonops/audit/outputs
+[secrets-godoc]: https://pkg.go.dev/github.com/axonops/audit/secrets
+[output-configuration-doc]: https://github.com/axonops/audit/blob/main/docs/output-configuration.md
+[stdout-doc]: https://github.com/axonops/audit/blob/main/docs/stdout-output.md
+[file-doc]: https://github.com/axonops/audit/blob/main/docs/file-output.md
+[syslog-doc]: https://github.com/axonops/audit/blob/main/docs/syslog-output.md
+[webhook-doc]: https://github.com/axonops/audit/blob/main/docs/webhook-output.md
+[loki-doc]: https://github.com/axonops/audit/blob/main/docs/loki-output.md
+[splunk-doc]: https://github.com/axonops/audit/blob/main/docs/splunk-output.md
+[secrets-doc]: https://github.com/axonops/audit/blob/main/docs/secrets.md
+[example-02]: https://github.com/axonops/audit/tree/main/examples/02-code-generation
+[example-10]: https://github.com/axonops/audit/tree/main/examples/10-multi-output
+[example-11]: https://github.com/axonops/audit/tree/main/examples/11-event-routing
+[example-15]: https://github.com/axonops/audit/tree/main/examples/15-buffering

--- a/outputs/README.md
+++ b/outputs/README.md
@@ -1,0 +1,141 @@
+# outputs — one blank import registers every built-in output
+
+[![Go Reference][godoc-badge]][godoc]
+
+Convenience umbrella that blank-imports `file`, `syslog`, `webhook`,
+`loki`, and `splunk`, and registers the built-in `stdout` factory.
+Use it when you want every output type available in a single line.
+
+> **Module path**: `github.com/axonops/audit/outputs`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [Outputs overview][outputs-doc] · [Writing custom outputs][custom-outputs-doc]
+
+## Why
+
+Output types live in their own Go modules (`audit/file`, `audit/syslog`,
+`audit/webhook`, `audit/loki`, `audit/splunk`) so adopters only pay for
+the dependencies they actually use. Each module's `init()` registers
+its factory with the core registry, so a blank import is enough — you
+do not call the constructor by hand.
+
+Once you go past two or three output types, the import block becomes
+boilerplate:
+
+```go
+import (
+    _ "github.com/axonops/audit/file"
+    _ "github.com/axonops/audit/syslog"
+    _ "github.com/axonops/audit/webhook"
+    _ "github.com/axonops/audit/loki"
+    _ "github.com/axonops/audit/splunk"
+)
+```
+
+This package is the one-liner replacement. It blank-imports the five
+sub-modules above and registers the built-in `stdout` factory in its
+own `init()`, so any of the YAML `type:` strings just work.
+
+```go
+import _ "github.com/axonops/audit/outputs"
+```
+
+This is the same pattern as the standard library's `image/all`:
+import for the side effect, get every codec registered.
+
+## When NOT to use it
+
+Production deployments that ship binaries to constrained environments
+should blank-import only the output types they actually use. Pulling in
+this package transitively brings in every output module's dependencies
+— HTTP clients, syslog libraries, compression codecs — even if the
+deployment only ever writes to a local file.
+
+```go
+// Smaller binary, file-only:
+import (
+    "github.com/axonops/audit/outputconfig"
+    _ "github.com/axonops/audit/file"
+)
+```
+
+Use the umbrella for development, examples, demos, the capstone, and
+internal services where binary size is not a concern. Reach for the
+individual imports when it matters.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/outputs
+```
+
+## Quick start
+
+```go
+package main
+
+import (
+    "context"
+    _ "embed"
+    "log"
+
+    "github.com/axonops/audit/outputconfig"
+    _ "github.com/axonops/audit/outputs" // registers all built-in output types
+)
+
+//go:embed taxonomy.yaml
+var taxonomyYAML []byte
+
+func main() {
+    auditor, err := outputconfig.New(context.Background(), taxonomyYAML, "outputs.yaml")
+    if err != nil {
+        log.Fatalf("audit setup: %v", err)
+    }
+    defer func() { _ = auditor.Close() }()
+
+    // ... use the auditor ...
+}
+```
+
+The package exposes **no identifiers** — there is nothing to call. The
+import is the API. The `_ "..."` syntax is required; an unblank import
+would fail to compile because nothing in `outputs.outputs` is
+referenced.
+
+## What it registers
+
+| YAML `type:` | Registered by | Lives in |
+|---|---|---|
+| `stdout` | `outputs.init()` | core `audit` package (factory) |
+| `file` | `audit/file.init()` | `github.com/axonops/audit/file` |
+| `syslog` | `audit/syslog.init()` | `github.com/axonops/audit/syslog` |
+| `webhook` | `audit/webhook.init()` | `github.com/axonops/audit/webhook` |
+| `loki` | `audit/loki.init()` | `github.com/axonops/audit/loki` |
+| `splunk` | `audit/splunk.init()` | `github.com/axonops/audit/splunk` |
+
+Double-registration is safe — `audit.RegisterOutputFactory` overwrites
+the previous entry silently. So you can blank-import this package
+alongside a custom factory registration:
+
+```go
+import (
+    _ "github.com/axonops/audit/outputs" // built-ins
+    _ "your.org/audit-kafka"             // your custom 'kafka' type
+)
+```
+
+## See also
+
+- **[docs/outputs.md][outputs-doc]** — overview of every built-in output type
+- **[docs/writing-custom-outputs.md][custom-outputs-doc]** — implement
+  your own output type and register a factory
+- **[github.com/axonops/audit/outputconfig][outputconfig-godoc]** — the
+  YAML loader that consumes the factories this package registers
+- **[examples/02-code-generation][example-02]** — the canonical
+  blank-import + `outputconfig.New` pattern
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/outputs
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/outputs.svg
+[outputconfig-godoc]: https://pkg.go.dev/github.com/axonops/audit/outputconfig
+[outputs-doc]: https://github.com/axonops/audit/blob/main/docs/outputs.md
+[custom-outputs-doc]: https://github.com/axonops/audit/blob/main/docs/writing-custom-outputs.md
+[example-02]: https://github.com/axonops/audit/tree/main/examples/02-code-generation

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,219 @@
+# secrets — secret-reference interfaces and `ref+` URI parser
+
+[![Go Reference][godoc-badge]][godoc]
+
+The core types for resolving `ref+SCHEME://PATH#KEY` URIs in audit
+output configuration. Defines the `Provider` and `BatchProvider`
+interfaces, the `Ref` struct and parser, and the sentinel error set.
+No backends — concrete providers ship as separate sub-modules.
+
+> **Module path**: `github.com/axonops/audit/secrets`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [Secrets reference](../docs/secrets.md) · [Writing custom providers](../docs/writing-custom-secret-providers.md)
+
+## Why
+
+Credentials in YAML files are a recurring incident: they leak via
+backups, source control, container images, and config-dump endpoints.
+The `ref+` URI convention (borrowed from [vals]) lets a YAML value
+declare its source without containing the value:
+
+```yaml
+hmac:
+  salt:
+    value: "ref+openbao://secret/data/audit/hmac#salt"
+```
+
+`outputconfig.Load` parses the YAML, resolves each `ref+` URI through
+the registered provider for its scheme, and substitutes the plaintext
+into the typed config tree before constructing outputs. Resolution
+runs at load time — once — so the hot path is unaffected.
+
+This package defines the protocol; it ships no provider code. That
+keeps the core module dependency-free (stdlib-only). Vault, OpenBao,
+file, and env providers each live in their own sub-module so consumers
+pay only for the backends they use.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/secrets
+```
+
+Requires Go 1.26+. Stdlib-only.
+
+## Quick start
+
+Most consumers never import this package directly — `outputconfig.Load`
+handles parse + resolve. Import a provider instead:
+
+```go
+import (
+    "github.com/axonops/audit/outputconfig"
+    "github.com/axonops/audit/secrets/openbao"
+)
+
+provider, err := openbao.New(&openbao.Config{
+    Address: os.Getenv("BAO_ADDR"),
+    Token:   os.Getenv("BAO_TOKEN"),
+})
+if err != nil {
+    return err
+}
+defer provider.Close()
+
+result, err := outputconfig.Load(ctx, yamlData, taxonomy,
+    outputconfig.WithSecretProvider(provider),
+)
+```
+
+Or skip programmatic setup entirely and declare providers in
+`outputs.yaml` — `outputconfig.Load` constructs and closes them:
+
+```yaml
+secrets:
+  timeout: "15s"
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+```
+
+Direct use of this package is for implementing a custom provider, or
+for parsing/validating refs in tooling. See
+[Writing custom providers](../docs/writing-custom-secret-providers.md).
+
+## URI grammar
+
+```
+ref+SCHEME://PATH#KEY
+```
+
+| Component | Rules |
+|-----------|-------|
+| `ref+`    | Literal lowercase prefix. |
+| `SCHEME`  | Lowercase alphanumeric + hyphens. First char a letter. |
+| `://`     | Required separator. |
+| `PATH`    | Scheme-dependent. Vault/OpenBao: no leading/trailing `/`, no `..`, no `.`, no empty segments, no percent-encoding. `file://`: must start with `/`. `env://`: POSIX variable name. |
+| `#KEY`    | Required for vault/openbao/file-with-JSON. Forbidden for `env://`. |
+
+Full grammar table in [docs/secrets.md §URI Syntax](../docs/secrets.md#uri-syntax).
+
+`ParseRef` returns `(zero, nil)` for inputs that do not start with
+`ref+` — they are treated as literal YAML values. It returns
+`(zero, ErrMalformedRef)` for inputs that start with `ref+` but
+violate any rule. Error messages never echo the input substring
+(the input may contain attacker-influenced bytes); see the
+redaction notes on `Ref.String` and `redactRef` in the godoc.
+
+## The `Provider` interface
+
+```go
+type Provider interface {
+    Scheme() string
+    Resolve(ctx context.Context, ref Ref) (string, error)
+    Close() error
+}
+```
+
+The optional `BatchProvider` extension enables path-level caching —
+implementing it lets the resolver fetch all keys at one path in a
+single API call, useful for KV v2 stores:
+
+```go
+type BatchProvider interface {
+    Provider
+    ResolvePath(ctx context.Context, path string) (map[string]string, error)
+}
+```
+
+The resolver calls `Provider` methods from a single goroutine during
+`outputconfig.Load`. Providers carry credentials and MUST redact them
+in their `fmt.Stringer` output. Construction MUST NOT perform network
+I/O — defer connection to the first `Resolve` call. See the godoc on
+each method for the full contract.
+
+## How providers are registered
+
+There is no package-level registry and no blank-import side effects.
+Providers reach the resolver by one of two routes:
+
+1. **Programmatic.** Construct the provider and pass it to
+   `outputconfig.Load` via `outputconfig.WithSecretProvider`. The
+   caller owns the provider's lifecycle (including `defer
+   provider.Close()`).
+2. **YAML.** Declare the provider in the `secrets:` block of
+   `outputs.yaml`. `outputconfig.Load` constructs it, uses it,
+   and closes it before returning. Today this route supports
+   `openbao` and `vault`; `file` and `env` providers are stateless
+   and have no YAML config to declare — programmatic setup is the
+   one-liner `file.New()` / `env.New()`.
+
+Duplicate registration (same scheme via both routes) is a config
+error: `Load` returns an error wrapping `ErrOutputConfigInvalid`.
+
+## Built-in providers
+
+| Scheme    | Module                                                       | Backend                                  |
+|-----------|--------------------------------------------------------------|------------------------------------------|
+| `env`     | [`secrets/env`](./env/)         | Process environment variables            |
+| `file`    | [`secrets/file`](./file/)       | Filesystem (K8s mounted secrets, Docker secrets) |
+| `openbao` | [`secrets/openbao`](./openbao/) | [OpenBao] KV v2                          |
+| `vault`   | [`secrets/vault`](./vault/)     | [HashiCorp Vault] KV v2                  |
+
+Each provider lives in its own Go sub-module — import only the ones
+you need. To add a backend the library does not ship (AWS Secrets
+Manager, GCP Secret Manager, Azure Key Vault, an internal API), see
+[Writing custom providers](../docs/writing-custom-secret-providers.md).
+
+## Sentinel errors
+
+All provider errors wrap one of these — use `errors.Is`:
+
+| Sentinel                   | Meaning                                                       |
+|----------------------------|---------------------------------------------------------------|
+| `ErrMalformedRef`          | Structural error in a `ref+` URI (parse-time).                |
+| `ErrProviderNotRegistered` | No provider registered for the URI's scheme.                  |
+| `ErrSecretNotFound`        | Path or key does not exist at the backend.                    |
+| `ErrSecretResolveFailed`   | Transient or permanent network / auth failure.                |
+| `ErrUnresolvedRef`         | Safety-net: a `ref+` URI survived resolution (typo, missing provider). |
+
+`ErrSecretResolveFailed` is the only sentinel where retry may help
+(token rotation, restored connectivity); the others are permanent
+until config is corrected.
+
+## Security model (summary)
+
+The full model is in [docs/secrets.md §Security Model](../docs/secrets.md#security-model);
+the headline guarantees the interfaces enforce:
+
+- **Path redaction.** `Ref.String`, `Ref.GoString`, and `Ref.Format`
+  return `ref+SCHEME://[REDACTED]#KEY`. The path reveals
+  infrastructure topology (mount points, secret engine names) and
+  MUST NOT appear in logs.
+- **No substring echo in errors.** `ParseRef` errors describe the
+  failure category, never the input substring (the input may be
+  attacker-influenced).
+- **Single-pass resolution.** Resolved values are not re-scanned.
+  A secret value containing `ref+...` is treated as a literal,
+  preventing confused-deputy redirection.
+- **Stdlib-only.** This package has no third-party dependencies.
+
+## See also
+
+- [Secrets reference](../docs/secrets.md) — full URI grammar, resolution
+  pipeline, caching, timeout, rotation, anti-patterns.
+- [Writing custom secret providers](../docs/writing-custom-secret-providers.md) —
+  worked AWS Secrets Manager example + security checklist.
+- [Output configuration YAML](../docs/output-configuration.md) — the
+  `secrets:` block reference (timeout, provider fields).
+- Built-in providers:
+  - [`secrets/env`](./env/) — environment variables (dev / K8s env injection)
+  - [`secrets/file`](./file/) — filesystem (K8s mounted secrets)
+  - [`secrets/openbao`](./openbao/) — OpenBao KV v2
+  - [`secrets/vault`](./vault/) — HashiCorp Vault KV v2
+
+[vals]: https://github.com/helmfile/vals
+[OpenBao]: https://openbao.org/
+[HashiCorp Vault]: https://www.vaultproject.io/
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/secrets
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/secrets.svg

--- a/secrets/env/README.md
+++ b/secrets/env/README.md
@@ -1,0 +1,129 @@
+# secrets/env — environment-variable secret provider
+
+[![Go Reference][godoc-badge]][godoc]
+
+Resolves `ref+env://VAR_NAME` references in audit YAML configuration
+to the value of the named process environment variable. Stateless,
+zero-config, safe for concurrent use.
+
+> **Module path**: `github.com/axonops/audit/secrets/env`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [Secrets reference](../../docs/secrets.md) · [Capstone example](../../examples/21-capstone/)
+
+## Why
+
+For deployments where credentials are already injected into the
+process environment — Kubernetes `env.valueFrom.secretKeyRef`, ECS
+task definitions, Nomad templates, Helm `secretRef` — there is no
+benefit in routing through Vault or the filesystem just to read the
+same value back. `ref+env://` lets a single YAML file work across
+environments without conditional logic: the operator controls which
+env vars are populated.
+
+Use this provider for:
+
+- **Development.** Quick iteration with `EXPORT WEBHOOK_TOKEN=...`.
+- **CI.** Job-scoped credentials via GitHub Actions / GitLab CI
+  variables.
+- **Kubernetes with env-injected secrets.** When the platform already
+  projects a Secret into the container's environment.
+
+For Kubernetes deployments using **mounted Secret volumes** (the
+more common pattern), prefer [`secrets/file`](../file/) — it survives
+rotation via the `..data` atomic-symlink swap without a pod restart.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/secrets/env
+```
+
+Requires Go 1.26+. Stdlib-only.
+
+## Quick start
+
+YAML — reference env vars in any string field:
+
+```yaml
+outputs:
+  alerts:
+    type: webhook
+    webhook:
+      url: "ref+env://WEBHOOK_URL"
+      headers:
+        Authorization: "ref+env://WEBHOOK_AUTH_HEADER"
+```
+
+Go — register the provider before calling `outputconfig.Load`:
+
+```go
+import (
+    "github.com/axonops/audit/outputconfig"
+    "github.com/axonops/audit/secrets/env"
+)
+
+provider := env.New()
+defer provider.Close() // no-op; here for symmetry
+
+result, err := outputconfig.Load(ctx, yamlData, taxonomy,
+    outputconfig.WithSecretProvider(provider),
+)
+```
+
+The provider has no configuration. The zero value (`env.Provider{}`)
+is also usable.
+
+## Configuration reference
+
+No configuration. `New()` takes no arguments.
+
+`Resolve` is called with a `Ref` parsed from `ref+env://VAR_NAME`:
+
+| URI component | Constraint                                              |
+|---------------|---------------------------------------------------------|
+| `VAR_NAME`    | POSIX env var name: `[A-Z_][A-Z0-9_]*`. Validated by the provider. |
+| `#fragment`   | Not supported. Refs containing `#` are rejected at parse time. |
+
+The variable name is **never echoed** in error messages — knowing
+which env var your config consults is itself information a log
+scraper should not gain. Distinguish failure modes via `errors.Is`
+against the sentinels listed below; the provider's slog category
+surfaces the failure class for local debugging.
+
+| Sentinel                  | When                                                     |
+|---------------------------|----------------------------------------------------------|
+| `secrets.ErrMalformedRef` | Var name fails POSIX validation, or ref carries a `#fragment`. |
+| `secrets.ErrSecretResolveFailed` | Var is unset, **or set to an empty string**. Empty audit secrets are never legitimate; set-to-empty is treated identically to unset. |
+
+## When NOT to use it
+
+**Do not use `env://` in production for high-value credentials.**
+Environment variables are visible to any process running as the
+same UID via `/proc/PID/environ` (Linux), `procfs`-equivalent
+interfaces on other Unixes, and process-listing tools. They also
+appear in core dumps and heap profiles. A compromised sidecar, a
+debugging tool left in production, or a logging agent that scrapes
+process metadata can extract them.
+
+For production:
+
+- **Mounted secrets** (K8s `volumeMounts`, Docker secrets) →
+  [`secrets/file`](../file/). Survives rotation; smaller blast
+  radius (only processes that read the file path see the value).
+- **Centralised secret store** with audit logging and ACLs →
+  [`secrets/vault`](../vault/) or [`secrets/openbao`](../openbao/).
+
+## See also
+
+- [Secrets reference](../../docs/secrets.md) — `ref+` URI grammar,
+  resolution pipeline, security model.
+- [Writing custom secret providers](../../docs/writing-custom-secret-providers.md) —
+  if `env`, `file`, `vault`, and `openbao` all miss your platform.
+- Sibling providers:
+  - [`secrets/file`](../file/) — filesystem (K8s mounted secrets, the
+    rotation-safe alternative to `env`)
+  - [`secrets/openbao`](../openbao/) — OpenBao KV v2 (production)
+  - [`secrets/vault`](../vault/) — HashiCorp Vault KV v2 (production)
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/secrets/env
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/secrets/env.svg

--- a/secrets/file/README.md
+++ b/secrets/file/README.md
@@ -1,0 +1,159 @@
+# secrets/file — filesystem secret provider
+
+[![Go Reference][godoc-badge]][godoc]
+
+Resolves `ref+file:///absolute/path` references in audit YAML
+configuration to file contents on the local filesystem. Designed for
+Kubernetes mounted Secret volumes, Docker secrets, and systemd
+`LoadCredential=`. Stateless, zero-config, safe for concurrent use.
+
+> **Module path**: `github.com/axonops/audit/secrets/file`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [Secrets reference](../../docs/secrets.md) · [Capstone example](../../examples/21-capstone/)
+
+## Why
+
+Kubernetes Secret volumes, Docker secrets, and systemd
+`LoadCredential=` all converge on the same pattern: the platform
+mounts secret material at a path on the container/process filesystem,
+typically under `/var/run/secrets/...` or `/run/credentials/...`.
+This is the dominant production pattern for Kubernetes workloads.
+
+The `file` provider reads those files at `outputconfig.Load` time
+and substitutes the contents into the YAML config tree. A single
+`outputs.yaml` works across environments because the operator
+controls what is mounted where.
+
+Compared to [`secrets/env`](../env/):
+
+- **Survives rotation.** Kubernetes Secret volumes use an atomic
+  `..data` symlink swap on rotation; subsequent reads see the new
+  value without a pod restart.
+- **Smaller blast radius.** Only processes that read the path see
+  the value; not visible via `/proc/PID/environ`.
+- **Larger values.** Bearer tokens, multi-line PEM bundles, JSON
+  blobs (the provider supports a JSON-key fragment for multi-field
+  files).
+
+Use [`secrets/openbao`](../openbao/) or [`secrets/vault`](../vault/)
+when you need centralised audit logging on every secret read,
+dynamic secrets, or fine-grained ACLs beyond filesystem permissions.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/secrets/file
+```
+
+Requires Go 1.26+. Stdlib-only.
+
+## Quick start
+
+YAML — reference absolute file paths. The fragment is optional:
+
+```yaml
+outputs:
+  alerts:
+    type: webhook
+    webhook:
+      url: "https://siem.example.com/ingest"
+      # Whole-file mode: trailing newline is trimmed.
+      bearer_token: "ref+file:///var/run/secrets/myapp/token"
+
+  secure_log:
+    type: file
+    file:
+      path: "/var/log/audit/secure.log"
+    hmac:
+      enabled: true
+      salt:
+        version: "2026-Q1"
+        # JSON file with dotted-fragment path into a nested object.
+        value: "ref+file:///etc/secrets/audit.json#hmac.salt"
+      algorithm: HMAC-SHA-256
+```
+
+Go — register before calling `outputconfig.Load`:
+
+```go
+import (
+    "github.com/axonops/audit/outputconfig"
+    "github.com/axonops/audit/secrets/file"
+)
+
+provider := file.New()
+defer provider.Close() // no-op; here for symmetry
+
+result, err := outputconfig.Load(ctx, yamlData, taxonomy,
+    outputconfig.WithSecretProvider(provider),
+)
+```
+
+The provider has no configuration. The zero value (`file.Provider{}`)
+is also usable. A variadic `Option` parameter is reserved for future
+settings; no options exist today.
+
+## Resolution modes
+
+| Ref form                                | Behaviour |
+|-----------------------------------------|-----------|
+| `ref+file:///path/to/file`              | Returns the entire file contents. A single trailing `\n` is trimmed. |
+| `ref+file:///path/to/file.json#a.b.c`   | Parses the file as JSON and traverses the dotted path. Only string leaves are returned; numeric / boolean / object terminals return `ErrSecretResolveFailed`. |
+
+Symlinks are followed (required for the Kubernetes `..data` atomic
+swap pattern).
+
+## Configuration reference
+
+No struct fields. `New(opts ...Option)` accepts a variadic option
+list for forward compatibility; no options are defined today.
+
+| Constraint                | Value                                                      |
+|---------------------------|------------------------------------------------------------|
+| Path must be absolute     | `filepath.IsAbs` (must start with `/` on Unix).            |
+| Path validation           | No `..` segments, no NUL byte, no percent-encoding.        |
+| Max file size             | 1 MiB. Files larger return `ErrSecretResolveFailed`.       |
+| JSON key separator        | `.` (dotted path into nested objects).                     |
+| Empty key segment in path | Rejected: `ErrMalformedRef`.                               |
+
+The file path is **never echoed** in error messages — knowing the
+secret path leaks deployment topology. Distinguish failure modes via
+`errors.Is` against the sentinels below.
+
+| Sentinel                          | When                                                     |
+|-----------------------------------|----------------------------------------------------------|
+| `secrets.ErrMalformedRef`         | Non-absolute path, traversal segment, NUL byte, percent-encoding, empty JSON key segment. |
+| `secrets.ErrSecretResolveFailed`  | File not found, permission denied, exceeds 1 MiB, invalid JSON when `#fragment` is set, JSON key not found, terminal value not a string. |
+
+## When NOT to use it
+
+**Do not use `file://` to read arbitrary host paths in production.**
+The provider trusts the operator-supplied YAML — the path is the
+trust boundary. A malicious or compromised YAML source could read
+`/etc/shadow` or any file the process can open. In multi-tenant
+deployments where YAML is supplied by anything other than the
+operator (a config API, a templated render), use
+[`secrets/openbao`](../openbao/) or [`secrets/vault`](../vault/)
+instead — they constrain reads to a backend ACL, not a filesystem
+permission set.
+
+**Do not use `file://` for files larger than 1 MiB.** The provider
+caps reads at 1 MiB to bound memory if a misconfigured ref points at
+`/dev/zero` or a runaway log file. Large secret bundles must be split.
+
+## See also
+
+- [Secrets reference](../../docs/secrets.md) — `ref+` URI grammar,
+  resolution pipeline, caching (note: `file` provider re-reads on
+  every `Load` invocation, which is the correct semantics for K8s
+  atomic-swap rotation).
+- [Writing custom secret providers](../../docs/writing-custom-secret-providers.md) —
+  worked AWS Secrets Manager example.
+- Sibling providers:
+  - [`secrets/env`](../env/) — environment variables (smaller values,
+    no rotation survival)
+  - [`secrets/openbao`](../openbao/) — OpenBao KV v2 (centralised, audited)
+  - [`secrets/vault`](../vault/) — HashiCorp Vault KV v2 (centralised, audited)
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/secrets/file
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/secrets/file.svg

--- a/secrets/openbao/README.md
+++ b/secrets/openbao/README.md
@@ -1,0 +1,265 @@
+# secrets/openbao — OpenBao KV v2 secret provider
+
+[![Go Reference][godoc-badge]][godoc]
+
+Resolves `ref+openbao://PATH#KEY` references in audit YAML
+configuration against an [OpenBao] KV v2 secret engine. SSRF-safe by
+default (private ranges, loopback, cloud-metadata endpoints blocked),
+HTTPS-only by default, with path-level caching via
+`secrets.BatchProvider`.
+
+> **Module path**: `github.com/axonops/audit/secrets/openbao`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [Secrets reference](../../docs/secrets.md) · [Capstone example](../../examples/21-capstone/)
+
+## Why
+
+OpenBao is the production-grade option in the audit library's secret
+provider matrix. Compared to filesystem and env-var providers it adds:
+
+- **Centralised audit log.** Every token use is recorded by the
+  server — you see who read which secret and when, independent of
+  the application's logs.
+- **Out-of-process rotation.** Rotate the underlying secret in
+  OpenBao; restart consumers to pick up the new value. No file
+  redeploy, no env var change.
+- **Fine-grained ACLs.** Policies scope read access by path; the
+  audit service's token sees only what its policy permits.
+- **Dynamic secrets.** When backed by dynamic-secret engines (PKI,
+  database, AWS), secrets are minted per request with a TTL.
+
+The `openbao` and [`vault`](../vault/) providers are nearly
+identical — OpenBao is an open-source fork that maintains KV v2 API
+compatibility. Choose `openbao` for OpenBao deployments; choose
+[`vault`](../vault/) for HashiCorp Vault.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/secrets/openbao
+```
+
+Requires Go 1.26+. Depends on the core `audit` package for `TLSPolicy`,
+`SSRFDialControl`, and `LoadX509KeyPairWithPassword`.
+
+## Quick start
+
+### YAML-driven (recommended)
+
+Declare the provider in `outputs.yaml` — `outputconfig.Load`
+constructs, uses, and closes it for you:
+
+```yaml
+secrets:
+  timeout: "15s"
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+
+outputs:
+  secure_log:
+    type: file
+    file:
+      path: "/var/log/audit/secure.log"
+    hmac:
+      enabled: true
+      salt:
+        version: "2026-Q1"
+        value: "ref+openbao://secret/data/audit/hmac#salt"
+      algorithm: HMAC-SHA-256
+```
+
+```go
+result, err := outputconfig.Load(ctx, yamlData, taxonomy)
+```
+
+### Programmatic
+
+```go
+import (
+    "github.com/axonops/audit/outputconfig"
+    "github.com/axonops/audit/secrets/openbao"
+)
+
+provider, err := openbao.New(&openbao.Config{
+    Address: os.Getenv("BAO_ADDR"),
+    Token:   os.Getenv("BAO_TOKEN"),
+})
+if err != nil {
+    return fmt.Errorf("openbao: %w", err)
+}
+defer provider.Close()
+
+result, err := outputconfig.Load(ctx, yamlData, taxonomy,
+    outputconfig.WithSecretProvider(provider),
+)
+```
+
+`New` validates the address and constructs the HTTP client but does
+not perform network I/O — the first `Resolve` call initiates the
+connection.
+
+## KV v2 path convention
+
+Both providers expect the **API path**, not the CLI logical path.
+This is the single most common misconfiguration: the CLI command
+
+```
+bao kv get secret/audit/hmac
+```
+
+maps to the API path `secret/data/audit/hmac`. Ref URIs MUST include
+the `/data/` segment:
+
+```
+ref+openbao://secret/data/audit/hmac#salt
+```
+
+Using `secret/audit/hmac` returns a 404 (`ErrSecretNotFound`).
+
+## Configuration reference
+
+### Go struct (`openbao.Config`)
+
+| Field                | Required | Default          | Description |
+|----------------------|----------|------------------|-------------|
+| `Address`            | Yes      | —                | Server URL. MUST use `https://` unless `AllowInsecureHTTP` is set. Trailing `/` is stripped. Embedded credentials (`user:pass@`) are rejected. |
+| `Token`              | Yes      | —                | Authentication token sent as `X-Vault-Token`. Stored as `[]byte` and zeroed on `Close()` (best-effort; see [memory retention](#memory-retention)). |
+| `Namespace`          | No       | `""`             | OpenBao namespace prefix; sent as `X-Vault-Namespace` header on every request. |
+| `TLSCA`              | No       | system roots     | Path to a CA certificate PEM file for verifying the server certificate. |
+| `TLSCert`            | No       | —                | Path to a client certificate for mTLS. MUST be set together with `TLSKey`. |
+| `TLSKey`             | No       | —                | Path to the client private key for mTLS. MUST be set together with `TLSCert`. |
+| `TLSKeyPassword`     | No       | `nil`            | Password for a PKCS#8 v2 `ENCRYPTED PRIVATE KEY` PEM in `TLSKey`. See [encrypted keys](#encrypted-client-keys) (#896). |
+| `TLSPolicy`          | No       | TLS 1.3 only     | `*audit.TLSPolicy`. Controls minimum TLS version and cipher selection. |
+| `AllowInsecureHTTP`  | No       | `false`          | Permit `http://` URLs. **MUST NOT be `true` in production** — plaintext HTTP exposes the auth token to any in-network observer. |
+| `AllowPrivateRanges` | No       | `false`          | Permit connections to RFC 1918 private addresses, IPv6 ULA, and loopback. Cloud metadata endpoints (`169.254.169.254`) remain blocked regardless. Required for local development. |
+
+### YAML
+
+The YAML schema mirrors the Go struct with `snake_case` field names.
+TLS settings live in a nested `tls:` block — not as flat keys.
+
+```yaml
+secrets:
+  timeout: "15s"        # optional; default 10s, min 1s, max 120s
+  openbao:
+    address: "${BAO_ADDR}"
+    token: "${BAO_TOKEN}"
+    namespace: "engineering"           # optional
+    allow_insecure_http: false         # default; never true in production
+    allow_private_ranges: false        # default; true for local dev
+    tls:
+      ca: /etc/ssl/openbao-ca.pem      # optional
+      cert: /etc/ssl/audit-client.pem  # optional, with key
+      key: /etc/ssl/audit-client.key   # optional, with cert
+      key_password: "${TLS_KEY_PW}"    # optional; for PKCS#8 v2 encrypted keys
+      allow_tls12: false               # default; true to accept TLS 1.2
+      allow_weak_ciphers: false        # default; true permits CBC suites on TLS 1.2
+```
+
+Only `${ENV}` substitution applies inside `secrets:` — `ref+` URIs
+are NOT resolved here (they would be circular: providers must exist
+before secrets can be resolved). Tokens MUST come from environment
+variables.
+
+See [Per-Output TLS](../../docs/output-configuration.md#per-output-tls)
+for the full TLS block reference. Note that for HTTP-based providers,
+`allow_insecure_http` and `allow_private_ranges` live at the
+**top level** of the provider block, not inside `tls:` (they govern
+the URL scheme and the SSRF dial control, not the TLS handshake).
+
+### Encrypted client keys
+
+When `tls.key` is a PKCS#8 v2 `ENCRYPTED PRIVATE KEY` PEM block
+(PBKDF2 or scrypt + AES-CBC), supply the password via
+`tls.key_password`. Legacy PKCS#1 `DEK-Info` encrypted keys are
+refused with `audit.ErrLegacyEncryptedPEMKey` — rewrap with:
+
+```bash
+openssl pkcs8 -topk8 -v2 aes256 -in legacy.key -out modern.key
+```
+
+Full details and validation matrix in
+[Encrypted private keys](../../docs/output-configuration.md#encrypted-private-keys-tlskey_password)
+(#896).
+
+## Authentication
+
+Pass the OpenBao token in `Config.Token` (Go) or `secrets.openbao.token`
+(YAML). The token MUST have `read` capability on every secret path
+referenced from the YAML. A minimal policy:
+
+```hcl
+path "secret/data/audit/*" {
+  capabilities = ["read"]
+}
+```
+
+There is no built-in token renewal — the provider stores the token for
+its lifetime. If the token expires during a `Load`, you get
+`ErrSecretResolveFailed` wrapping a 403. For long-lived processes,
+prefer short-TTL tokens (AppRole, Kubernetes auth) and rotate by
+restarting the process. See
+[Authentication](../../docs/secrets.md#authentication) for AppRole and
+Kubernetes auth recipes.
+
+## Memory retention
+
+Tokens are stored as `[]byte` and zeroed on `Close()`. This is
+best-effort:
+
+- Setting the `X-Vault-Token` HTTP header converts the bytes to an
+  immutable Go string. `Close()` zeros the underlying slice; the
+  header-map string copy persists until GC.
+- The provider drops header-map references after each request as
+  defence-in-depth (#479), narrowing the retention window.
+- `Provider.String`, `GoString`, and `Format` always return
+  `openbao{host: HOST, token: [REDACTED]}` — the token never appears
+  in any `fmt` verb (`%v`, `%+v`, `%#v`).
+
+Resolved secret values flow into output config structs and persist
+for the auditor's lifetime; memory dumps will contain them. Rotation
+is the primary mitigation. Full model in
+[SECURITY.md §Secrets and Memory Retention](../../SECURITY.md#secrets-and-memory-retention).
+
+## When NOT to use it
+
+- **No OpenBao cluster yet.** For local development, see
+  [`secrets/file`](../file/) (mounted secret files) or
+  [`secrets/env`](../env/) (environment variables). Both ship with
+  zero infrastructure.
+- **HashiCorp Vault deployment.** Use [`secrets/vault`](../vault/)
+  instead — the API surface is identical but the scheme is `vault`
+  and there is a separate Go module.
+- **`allow_insecure_http: true` in production.** The auth token is
+  sent on every request; plaintext HTTP exposes it to any in-network
+  observer. Acceptable only for local Docker Compose where the
+  provider runs on the internal Docker network.
+- **`allow_private_ranges: true` in untrusted networks.** Disables
+  SSRF protection against RFC 1918 ranges and IPv6 ULA. Acceptable
+  only when the operator owns both endpoints (in-cluster Vault/OpenBao
+  with NetworkPolicy isolation). Cloud-metadata endpoints remain
+  blocked regardless.
+
+See [Production Checklist — Dangerous Opt-In Flags](../../docs/secrets.md#production-checklist--dangerous-opt-in-flags).
+
+## See also
+
+- [Secrets reference](../../docs/secrets.md) — `ref+` URI grammar,
+  caching, timeout, secret rotation, security model.
+- [Writing custom secret providers](../../docs/writing-custom-secret-providers.md) —
+  for backends not in the built-in set.
+- [Per-output TLS](../../docs/output-configuration.md#per-output-tls) —
+  the shared TLS block schema used by HTTP-based providers and outputs.
+- [Encrypted private keys](../../docs/output-configuration.md#encrypted-private-keys-tlskey_password) —
+  `TLSKeyPassword` / `tls.key_password` reference (#896).
+- [Capstone example](../../examples/21-capstone/) — end-to-end CRUD
+  service with OpenBao-backed HMAC salts and route-specific secrets.
+- Sibling providers:
+  - [`secrets/vault`](../vault/) — HashiCorp Vault KV v2 (identical API)
+  - [`secrets/file`](../file/) — filesystem (dev, K8s mounted secrets)
+  - [`secrets/env`](../env/) — environment variables (dev, CI)
+
+[OpenBao]: https://openbao.org/
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/secrets/openbao
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/secrets/openbao.svg

--- a/secrets/vault/README.md
+++ b/secrets/vault/README.md
@@ -1,0 +1,290 @@
+# secrets/vault — HashiCorp Vault KV v2 secret provider
+
+[![Go Reference][godoc-badge]][godoc]
+
+Resolves `ref+vault://PATH#KEY` references in audit YAML
+configuration against a [HashiCorp Vault] KV v2 secret engine.
+SSRF-safe by default (private ranges, loopback, cloud-metadata
+endpoints blocked), HTTPS-only by default, with path-level caching
+via `secrets.BatchProvider`.
+
+> **Module path**: `github.com/axonops/audit/secrets/vault`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [Secrets reference](../../docs/secrets.md) · [Capstone example](../../examples/21-capstone/)
+
+## Why
+
+HashiCorp Vault is the production-grade option in the audit library's
+secret provider matrix. Compared to filesystem and env-var providers
+it adds:
+
+- **Centralised audit log.** Every token use is recorded by the
+  server — you see who read which secret and when, independent of
+  the application's logs.
+- **Out-of-process rotation.** Rotate the underlying secret in Vault;
+  restart consumers to pick up the new value. No file redeploy, no
+  env var change.
+- **Fine-grained ACLs.** Policies scope read access by path; the
+  audit service's token sees only what its policy permits.
+- **Dynamic secrets.** When backed by dynamic-secret engines (PKI,
+  database, AWS), secrets are minted per request with a TTL.
+- **Vault Enterprise namespaces.** Multi-tenant isolation via the
+  `Namespace` field.
+
+The `vault` and [`openbao`](../openbao/) providers are nearly
+identical — OpenBao is an open-source fork that maintains KV v2 API
+compatibility. Choose `vault` for HashiCorp Vault deployments; choose
+[`openbao`](../openbao/) for OpenBao.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/secrets/vault
+```
+
+Requires Go 1.26+. Depends on the core `audit` package for `TLSPolicy`,
+`SSRFDialControl`, and `LoadX509KeyPairWithPassword`.
+
+## Quick start
+
+### YAML-driven (recommended)
+
+Declare the provider in `outputs.yaml` — `outputconfig.Load`
+constructs, uses, and closes it for you:
+
+```yaml
+secrets:
+  timeout: "15s"
+  vault:
+    address: "${VAULT_ADDR}"
+    token: "${VAULT_TOKEN}"
+    namespace: "engineering"          # optional, Vault Enterprise
+
+outputs:
+  alerts:
+    type: webhook
+    webhook:
+      url: "https://siem.example.com/audit"
+      headers:
+        Authorization: "ref+vault://secret/data/siem/creds#authorization_header"
+```
+
+```go
+result, err := outputconfig.Load(ctx, yamlData, taxonomy)
+```
+
+### Programmatic
+
+```go
+import (
+    "github.com/axonops/audit/outputconfig"
+    "github.com/axonops/audit/secrets/vault"
+)
+
+provider, err := vault.New(&vault.Config{
+    Address: os.Getenv("VAULT_ADDR"),
+    Token:   os.Getenv("VAULT_TOKEN"),
+})
+if err != nil {
+    return fmt.Errorf("vault: %w", err)
+}
+defer provider.Close()
+
+result, err := outputconfig.Load(ctx, yamlData, taxonomy,
+    outputconfig.WithSecretProvider(provider),
+)
+```
+
+`New` validates the address and constructs the HTTP client but does
+not perform network I/O — the first `Resolve` call initiates the
+connection.
+
+## KV v2 path convention
+
+The provider expects the **API path**, not the CLI logical path.
+This is the single most common misconfiguration: the CLI command
+
+```
+vault kv get secret/siem/creds
+```
+
+maps to the API path `secret/data/siem/creds`. Ref URIs MUST include
+the `/data/` segment:
+
+```
+ref+vault://secret/data/siem/creds#authorization_header
+```
+
+Using `secret/siem/creds` returns a 404 (`ErrSecretNotFound`).
+
+## Configuration reference
+
+### Go struct (`vault.Config`)
+
+| Field                | Required | Default          | Description |
+|----------------------|----------|------------------|-------------|
+| `Address`            | Yes      | —                | Server URL. MUST use `https://` unless `AllowInsecureHTTP` is set. Trailing `/` is stripped. Embedded credentials (`user:pass@`) are rejected. |
+| `Token`              | Yes      | —                | Authentication token sent as `X-Vault-Token`. Stored as `[]byte` and zeroed on `Close()` (best-effort; see [memory retention](#memory-retention)). |
+| `Namespace`          | No       | `""`             | Vault Enterprise namespace prefix; sent as `X-Vault-Namespace` header on every request. |
+| `TLSCA`              | No       | system roots     | Path to a CA certificate PEM file for verifying the server certificate. |
+| `TLSCert`            | No       | —                | Path to a client certificate for mTLS. MUST be set together with `TLSKey`. |
+| `TLSKey`             | No       | —                | Path to the client private key for mTLS. MUST be set together with `TLSCert`. |
+| `TLSKeyPassword`     | No       | `nil`            | Password for a PKCS#8 v2 `ENCRYPTED PRIVATE KEY` PEM in `TLSKey`. See [encrypted keys](#encrypted-client-keys) (#896). |
+| `TLSPolicy`          | No       | TLS 1.3 only     | `*audit.TLSPolicy`. Controls minimum TLS version and cipher selection. |
+| `AllowInsecureHTTP`  | No       | `false`          | Permit `http://` URLs. **MUST NOT be `true` in production** — plaintext HTTP exposes the auth token to any in-network observer. |
+| `AllowPrivateRanges` | No       | `false`          | Permit connections to RFC 1918 private addresses, IPv6 ULA, and loopback. Cloud metadata endpoints (`169.254.169.254`) remain blocked regardless. Required for local development. |
+
+### YAML
+
+The YAML schema mirrors the Go struct with `snake_case` field names.
+TLS settings live in a nested `tls:` block — not as flat keys.
+
+```yaml
+secrets:
+  timeout: "15s"        # optional; default 10s, min 1s, max 120s
+  vault:
+    address: "${VAULT_ADDR}"
+    token: "${VAULT_TOKEN}"
+    namespace: "engineering"           # optional, Vault Enterprise
+    allow_insecure_http: false         # default; never true in production
+    allow_private_ranges: false        # default; true for local dev
+    tls:
+      ca: /etc/ssl/vault-ca.pem        # optional
+      cert: /etc/ssl/audit-client.pem  # optional, with key
+      key: /etc/ssl/audit-client.key   # optional, with cert
+      key_password: "${TLS_KEY_PW}"    # optional; for PKCS#8 v2 encrypted keys
+      allow_tls12: false               # default; true to accept TLS 1.2
+      allow_weak_ciphers: false        # default; true permits CBC suites on TLS 1.2
+```
+
+Only `${ENV}` substitution applies inside `secrets:` — `ref+` URIs
+are NOT resolved here (they would be circular: providers must exist
+before secrets can be resolved). Tokens MUST come from environment
+variables.
+
+See [Per-Output TLS](../../docs/output-configuration.md#per-output-tls)
+for the full TLS block reference. Note that for HTTP-based providers,
+`allow_insecure_http` and `allow_private_ranges` live at the
+**top level** of the provider block, not inside `tls:` (they govern
+the URL scheme and the SSRF dial control, not the TLS handshake).
+
+### Encrypted client keys
+
+When `tls.key` is a PKCS#8 v2 `ENCRYPTED PRIVATE KEY` PEM block
+(PBKDF2 or scrypt + AES-CBC), supply the password via
+`tls.key_password`. Legacy PKCS#1 `DEK-Info` encrypted keys are
+refused with `audit.ErrLegacyEncryptedPEMKey` — rewrap with:
+
+```bash
+openssl pkcs8 -topk8 -v2 aes256 -in legacy.key -out modern.key
+```
+
+Full details and validation matrix in
+[Encrypted private keys](../../docs/output-configuration.md#encrypted-private-keys-tlskey_password)
+(#896).
+
+## Authentication
+
+Pass the Vault token in `Config.Token` (Go) or `secrets.vault.token`
+(YAML). The token MUST have `read` capability on every secret path
+referenced from the YAML. A minimal policy:
+
+```hcl
+path "secret/data/audit/*" {
+  capabilities = ["read"]
+}
+```
+
+There is no built-in token renewal — the provider stores the token for
+its lifetime. If the token expires during a `Load`, you get
+`ErrSecretResolveFailed` wrapping a 403. For long-lived processes,
+prefer short-TTL tokens via:
+
+- **AppRole** — role_id + secret_id login produces a short-lived
+  client token.
+- **Kubernetes auth** — exchanges the service account JWT for a
+  Vault token, rotated by the platform.
+- **Workload identity** — AWS IAM, GCP, Azure auth methods.
+
+Login recipes in [Authentication](../../docs/secrets.md#authentication).
+
+## Vault Enterprise namespaces
+
+Set `Namespace` (Go) or `namespace` (YAML) to address a Vault Enterprise
+namespace. The value is sent as `X-Vault-Namespace` on every request:
+
+```yaml
+secrets:
+  vault:
+    address: "${VAULT_ADDR}"
+    token: "${VAULT_TOKEN}"
+    namespace: "tenant-acme/audit"
+```
+
+Open-source Vault and OpenBao ignore this header; setting it is
+harmless on those deployments. For multi-namespace consumers,
+register two providers (programmatically) with distinct
+`Config.Namespace` values — or, in YAML, the `secrets:` block
+supports one provider per scheme, so a process needing two namespaces
+must use the programmatic path.
+
+## Memory retention
+
+Tokens are stored as `[]byte` and zeroed on `Close()`. This is
+best-effort:
+
+- Setting the `X-Vault-Token` HTTP header converts the bytes to an
+  immutable Go string. `Close()` zeros the underlying slice; the
+  header-map string copy persists until GC.
+- The provider drops header-map references after each request as
+  defence-in-depth (#479), narrowing the retention window.
+- `Provider.String`, `GoString`, and `Format` always return
+  `vault{host: HOST, token: [REDACTED]}` — the token never appears
+  in any `fmt` verb (`%v`, `%+v`, `%#v`).
+
+Resolved secret values flow into output config structs and persist
+for the auditor's lifetime; memory dumps will contain them. Rotation
+is the primary mitigation. Full model in
+[SECURITY.md §Secrets and Memory Retention](../../SECURITY.md#secrets-and-memory-retention).
+
+## When NOT to use it
+
+- **No Vault cluster yet.** For local development, see
+  [`secrets/file`](../file/) (mounted secret files) or
+  [`secrets/env`](../env/) (environment variables). Both ship with
+  zero infrastructure.
+- **OpenBao deployment.** Use [`secrets/openbao`](../openbao/) — the
+  API surface is identical but the scheme is `openbao` and there is
+  a separate Go module.
+- **`allow_insecure_http: true` in production.** The auth token is
+  sent on every request; plaintext HTTP exposes it to any in-network
+  observer. Acceptable only for local Docker Compose where the
+  provider runs on the internal Docker network.
+- **`allow_private_ranges: true` in untrusted networks.** Disables
+  SSRF protection against RFC 1918 ranges and IPv6 ULA. Acceptable
+  only when the operator owns both endpoints (in-cluster Vault with
+  NetworkPolicy isolation). Cloud-metadata endpoints remain blocked
+  regardless.
+
+See [Production Checklist — Dangerous Opt-In Flags](../../docs/secrets.md#production-checklist--dangerous-opt-in-flags).
+
+## See also
+
+- [Secrets reference](../../docs/secrets.md) — `ref+` URI grammar,
+  caching, timeout, secret rotation, security model.
+- [Writing custom secret providers](../../docs/writing-custom-secret-providers.md) —
+  for backends not in the built-in set.
+- [Per-output TLS](../../docs/output-configuration.md#per-output-tls) —
+  the shared TLS block schema used by HTTP-based providers and outputs.
+- [Encrypted private keys](../../docs/output-configuration.md#encrypted-private-keys-tlskey_password) —
+  `TLSKeyPassword` / `tls.key_password` reference (#896).
+- [Capstone example](../../examples/21-capstone/) — end-to-end CRUD
+  service demonstrating secret-backed HMAC salts and route credentials.
+- Sibling providers:
+  - [`secrets/openbao`](../openbao/) — OpenBao KV v2 (identical API)
+  - [`secrets/file`](../file/) — filesystem (dev, K8s mounted secrets)
+  - [`secrets/env`](../env/) — environment variables (dev, CI)
+
+[HashiCorp Vault]: https://www.vaultproject.io/
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/secrets/vault
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/secrets/vault.svg

--- a/splunk/README.md
+++ b/splunk/README.md
@@ -1,0 +1,246 @@
+# splunk — Splunk HTTP Event Collector (HEC) output
+
+[![Go Reference][godoc-badge]][godoc]
+
+Posts audit events to a Splunk indexer (Splunk Enterprise or Splunk
+Cloud) via the HTTP Event Collector with gzip compression, full HEC
+error-code handling, exponential backoff, and optional indexer
+acknowledgement for at-least-once delivery. Implements the
+[`audit.Output`][audit-output] interface.
+
+> **Module path**: `github.com/axonops/audit/splunk`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [splunk-output.md][docs] · [examples/09-splunk-output][example]
+
+## Why
+
+Splunk is the dominant enterprise SIEM and security data platform. The
+HTTP Event Collector is its purpose-built ingestion path — token-auth,
+indexed-field extraction at the HEC layer, CIM (Common Information
+Model) compatibility for cross-source correlation, and indexer
+acknowledgement for compliance-grade durability. You could push events
+to Splunk via syslog or a generic webhook, but the HEC `/event`
+envelope (`sourcetype`, `index`, `host`, `fields`) and `/services/collector/ack`
+are first-class and unavailable through the other paths.
+
+Use the splunk output when Splunk is your destination, when you need
+CIM-compliant event shape for the security data model, or when you
+need indexer acknowledgement (`AckMode: required`) for at-least-once
+delivery. Use [`webhook`](../webhook/) when the destination is any
+other HTTPS endpoint, [`syslog`](../syslog/) for SIEMs (including
+Splunk via a syslog forwarder) that prefer RFC 5424, or
+[`loki`](../loki/) for Grafana-native log storage.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/splunk
+```
+
+Requires Go 1.26+. See the [main README](../README.md) for transitive
+dependencies.
+
+## Quick start
+
+```go
+import (
+    "os"
+
+    "github.com/axonops/audit"
+    "github.com/axonops/audit/splunk"
+)
+
+out, err := splunk.New(&splunk.Config{
+    URL:        "https://splunk.example.com:8088",
+    Token:      os.Getenv("SPLUNK_HEC_TOKEN"),
+    Sourcetype: "axonops:audit",
+    Index:      "audit",
+})
+if err != nil {
+    return err
+}
+
+tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
+if err != nil {
+    return err
+}
+auditor, err := audit.New(
+    audit.WithTaxonomy(tax),
+    audit.WithAppName("my-service"),
+    audit.WithHost("host-01"),
+    audit.WithOutputs(out),
+)
+if err != nil {
+    return err
+}
+defer func() { _ = auditor.Close() }()
+```
+
+HEC tokens authenticate via the `Authorization: Splunk <token>`
+header — note the literal `Splunk` scheme (not `Bearer`). The library
+rejects tokens that start with `Splunk ` or `Bearer ` (foot-gun: the
+consumer pasted in the scheme prefix) and tokens containing CR/LF/NUL.
+
+For Splunk Cloud, use the stack shortcut URL — the library expands it
+to the canonical HEC endpoint:
+
+```go
+out, err := splunk.New(&splunk.Config{
+    URL:   "splunkcloud://acme-prod",
+    // Expands to https://http-inputs-acme-prod.splunkcloud.com:443
+    Token: os.Getenv("SPLUNK_HEC_TOKEN"),
+})
+```
+
+## YAML configuration
+
+```yaml
+version: 1
+app_name: "my-service"
+host: "${HOSTNAME}"
+
+outputs:
+  splunk_audit:
+    type: splunk
+    splunk:
+      url: "https://splunk.example.com:8088"
+      token: "${SPLUNK_HEC_TOKEN}"
+      sourcetype: "axonops:audit"
+      source: "audit"
+      index: "audit"
+      endpoint: "event"           # default — JSON envelope per event
+      # endpoint: "raw"           # newline-delimited bodies; metadata in query string
+
+      batch_size: 500             # default — events per HTTP POST
+      max_batch_bytes: 819200     # default — 800 KiB (1 MB HEC cap with margin)
+      max_event_bytes: 1048576    # 1 MiB — reject oversized events
+      flush_interval: "2s"        # default
+      timeout: "10s"              # default
+      max_retries: 10             # default — HEC 5xx with exponential backoff
+      gzip: true                  # default — strongly recommended (6-12× ratio)
+      buffer_size: 10000          # default
+
+      # Optional: indexer acknowledgement (compliance-grade durability)
+      ack_mode: "off"             # "off" (default), "best_effort", or "required"
+      # ack_poll_interval: "10s"
+      # ack_resend_window: "5m"
+
+      # Optional: copy named JSON fields into the HEC envelope's
+      # `fields` object for index-time extraction.
+      indexed_fields:
+        - actor_id
+        - resource_id
+
+    formatter:
+      type: cim_change            # CIM-compliant event shape
+      vendor_product: "AxonOps:Audit"
+```
+
+A blank import registers the `splunk` output type with the YAML
+loader:
+
+```go
+import _ "github.com/axonops/audit/splunk"
+```
+
+## Configuration reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | *(required)* | HEC endpoint. Two forms: `https://<host>:<port>` (Splunk Enterprise / self-managed) or `splunkcloud://<stack>` (expands to the canonical Splunk Cloud URL). HTTPS required unless `allow_insecure_http: true`. |
+| `token` | string | *(required)* | HEC token. Plain opaque string — do NOT prefix with `Splunk ` or `Bearer `. CR/LF/NUL is rejected. |
+| `endpoint` | string | `"event"` | `"event"` for `/services/collector/event` (JSON envelope per event, supports `indexed_fields`); `"raw"` for `/services/collector/raw` (newline-delimited bodies, metadata in query string, no envelope). |
+| `sourcetype` | string | `"audit:event"` | HEC `sourcetype`. |
+| `source` | string | `"audit"` | HEC `source`. |
+| `index` | string | — | HEC `index`. Empty = the HEC token's default index. |
+| `host` | string | `os.Hostname()` | HEC `host`. |
+| `indexed_fields` | []string | — | Field names copied from the event JSON into the HEC envelope's `fields` object for index-time extraction. String values only. Ignored on `endpoint: raw`. |
+| `batch_size` | int | `500` | Maximum events per HTTP POST. Range `1`–`10000`. |
+| `max_batch_bytes` | int | `819200` (800 KiB) | Payload-byte threshold. Sized to leave 200 KiB headroom under HEC's 1 MB stock `max_content_length` so over-cap drops never reach the server (HTTP 413). Range `1024`–`1048576` (1 KiB–1 MiB; Splunk Cloud hard cap). |
+| `max_event_bytes` | int | `1048576` (1 MiB) | Per-event cap. Events exceeding this are rejected with `audit.ErrEventTooLarge`. Range `1024`–`10485760`. |
+| `flush_interval` | duration | `2s` | Maximum time between pushes. Range `100ms`–`5m`. |
+| `timeout` | duration | `10s` | HTTP request timeout. Range `1s`–`5m`. |
+| `max_retries` | int | `10` | Retry attempts for HEC 5xx with exponential backoff (`retry_base_delay` to `retry_max_delay`, ±`retry_jitter`). Range `0`–`100`. |
+| `retry_base_delay` | duration | `500ms` | Exponential backoff base. |
+| `retry_max_delay` | duration | `30s` | Exponential backoff ceiling. |
+| `retry_jitter` | float | `0.2` | ±20 % jitter applied to backoff. |
+| `gzip` | bool | `true` | Compress push payloads. Audit-shaped JSON typically compresses 6–12×; CPU cost is dominated by network savings. |
+| `buffer_size` | int | `10000` | Internal async channel capacity. Events dropped when full. Range `100`–`1000000`. |
+| `user_agent` | string | `"audit-splunk/<version>"` | User-Agent header. Must match `[A-Za-z0-9._/ -]+`. |
+| `headers` | map[string]string | — | Additional headers. Reserved: `Authorization`, `X-Splunk-Request-Channel`, `Content-Type`, `Content-Encoding`, `User-Agent`. CR/LF/NUL is rejected. |
+| `ack_mode` | string | `"off"` | Indexer acknowledgement: `"off"`, `"best_effort"`, or `"required"`. See [Indexer acknowledgement](#indexer-acknowledgement) below. |
+| `ack_poll_interval` | duration | `10s` | Polling interval for `/services/collector/ack`. Ignored when `ack_mode: off`. |
+| `ack_resend_window` | duration | `5m` | Maximum time to wait for a positive ack before resending. Ignored when `ack_mode: off`. |
+| `tls.ca` | string | — | PEM CA bundle for server verification. |
+| `tls.cert` | string | — | mTLS client certificate (Splunk Enterprise 10.0+ only — Splunk Cloud HEC does not support mTLS). |
+| `tls.key` | string | — | mTLS client private key. Supports PKCS#8 v2 encrypted keys via `tls.key_password`. |
+| `tls.key_password` | string | — | Password for encrypted `tls.key`. |
+| `tls.allow_tls12` | bool | `false` | TLS 1.3 only when `false`. |
+| `allow_insecure_http` | bool | `false` | Permit `http://`. MUST NOT be `true` in production. |
+| `allow_private_ranges` | bool | `false` | Permit RFC 1918 / loopback. Cloud-metadata IPs remain blocked. |
+| `verify_on_startup` | bool | `true` | TCP dial + TLS handshake + HEC `/health` probe at `New`. |
+| `startup_verification_timeout` | duration | `5s` | Probe budget. |
+
+## Splunk Cloud
+
+`splunkcloud://<stack>` expands to
+`https://http-inputs-<stack>.splunkcloud.com:443`. The stack name must
+match `^[a-z0-9][a-z0-9-]{0,62}$` (AWS stack-naming rules — defends
+against host smuggling like `acme.evil.com`). The shortcut form rejects
+any path, port, query, fragment, or opaque component; use the full
+`https://` form for non-standard cases.
+
+Splunk Cloud HEC does NOT support mTLS — configuring `tls.cert`,
+`tls.key`, or `tls.ca` with a `splunkcloud://` URL is rejected at
+config validation. For mTLS, target a self-managed HTTPS proxy that
+terminates the client certificate and forwards to Splunk Cloud.
+
+## Indexer acknowledgement
+
+HEC indexer acknowledgement is the durability gap between "HEC
+accepted" (HTTP 200) and "the indexer replicated the event at the
+cluster's replication factor". Three modes:
+
+| Mode          | Channel header | Polling | Buffer gating          | Use when                                |
+|---------------|----------------|---------|------------------------|-----------------------------------------|
+| `off`         | none           | no      | n/a                    | Standard observability — HTTP 200 is the only durability signal. Lowest overhead. |
+| `best_effort` | yes            | yes     | NOT gated              | You want delivery telemetry (`ack_*` metrics) without producer back-pressure. |
+| `required`    | yes            | yes     | gated until positive   | Compliance-grade at-least-once delivery. Events stay in the in-flight buffer until ack returns positive; on `ack_resend_window` timeout the events re-send. |
+
+The HEC token MUST have ACK enabled in Splunk for `best_effort` /
+`required`. With `ack_mode: required`, when the in-flight buffer
+reaches `buffer_size` new batches drop with reason
+`ack_buffer_full` rather than stalling — `Write` remains
+non-blocking by contract.
+
+## CIM Change formatter
+
+Pair the splunk output with `formatter.type: cim_change` (and
+`vendor_product:`) to emit events in Splunk's CIM Change data-model
+shape, with the reference Splunk Technology Add-on (`deploy/splunk-ta-axonops-audit/`)
+auto-extracting every CIM Change field and tagging events
+`tag=change`. The formatter is wired at the auditor level —
+`splunk.Output` itself is formatter-agnostic.
+
+## See also
+
+- [Full output reference][docs] — HEC error codes, retry semantics,
+  ACK protocol, CIM Change formatter
+- [Worked example][example] — `outputs.yaml` + `main.go` pushing to a
+  local Splunk container with the CIM Change formatter
+- [Splunk TA reference][docs-ta] — the bundled add-on for index-time
+  extraction
+- [TLS policy](../docs/output-configuration.md#tls) — TLS 1.3-only
+  defaults, TLS 1.2 fallback
+- Related outputs:
+  [`webhook`](../webhook/) (generic HTTPS — for non-Splunk SIEMs),
+  [`syslog`](../syslog/) (RFC 5424 — for Splunk via syslog forwarder),
+  [`loki`](../loki/) (Grafana Loki),
+  [`file`](../file/) (local file with rotation)
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/splunk
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/splunk.svg
+[audit-output]: https://pkg.go.dev/github.com/axonops/audit#Output
+[docs]: ../docs/splunk-output.md
+[docs-ta]: ../docs/splunk-ta.md
+[example]: ../examples/09-splunk-output/

--- a/syslog/README.md
+++ b/syslog/README.md
@@ -1,0 +1,217 @@
+# syslog — RFC 5424 syslog output (TCP, UDP, TLS, mTLS)
+
+[![Go Reference][godoc-badge]][godoc]
+
+Sends audit events to a syslog receiver as
+[RFC 5424][rfc5424] structured messages over TCP, UDP, or TCP+TLS
+(including mTLS). Implements the [`audit.Output`][audit-output]
+interface. Built on the AxonOps fork of `gravwell/srslog`.
+
+> **Module path**: `github.com/axonops/audit/syslog`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [syslog-output.md][docs] · [examples/06-syslog-output][example]
+
+## Why
+
+Syslog is the lingua franca of SIEM ingestion. Splunk, ArcSight,
+QRadar, Elastic, Graylog, LogRhythm, and every cloud-vendor security
+service accept it natively, and most production environments already
+run an rsyslog or syslog-ng collector that can fan events out to
+multiple downstream consumers without you deploying anything new.
+PCI DSS, SOC 2, and HIPAA commonly require centralised audit
+collection via syslog.
+
+Use syslog when your SIEM speaks it (every SIEM does), when
+infrastructure constraints rule out HTTP, or when you want the
+collector — not the application — to own delivery reliability and
+fan-out. Use [webhook](../webhook/) when the destination speaks HTTPS
+but not syslog (modern SaaS SIEMs); use [`splunk`](../splunk/) for
+direct Splunk HEC delivery without an intermediate forwarder.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/syslog
+```
+
+Requires Go 1.26+. See the [main README](../README.md) for transitive
+dependencies.
+
+## Quick start
+
+```go
+import (
+    "github.com/axonops/audit"
+    "github.com/axonops/audit/syslog"
+)
+
+out, err := syslog.New(&syslog.Config{
+    Network: "tcp",
+    Address: "syslog.internal:514",
+    AppName: "myapp",
+})
+if err != nil {
+    return err
+}
+
+tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
+if err != nil {
+    return err
+}
+auditor, err := audit.New(
+    audit.WithTaxonomy(tax),
+    audit.WithAppName("my-service"),
+    audit.WithHost("host-01"),
+    audit.WithOutputs(out),
+)
+if err != nil {
+    return err
+}
+defer func() { _ = auditor.Close() }()
+```
+
+By default the receiver MUST be reachable at startup — `New` dials the
+syslog server (and completes the TLS handshake on `tcp+tls`) before
+returning, so misconfigured destinations fail fast. Disable the probe
+via the `Config.DisableStartupVerification` Go field (or `verify_on_startup: false`
+in YAML — note the inversion: the YAML key is the positive form) for
+sidecar deployments where the collector may not be ready when the
+application boots; in that mode the writeLoop reconnects transparently
+as the first events arrive.
+
+## YAML configuration
+
+Plain TCP (the simplest production setup, when the syslog collector is
+on the same host or trusted network):
+
+```yaml
+version: 1
+app_name: "my-service"
+host: "${HOSTNAME}"
+
+outputs:
+  siem:
+    type: syslog
+    syslog:
+      network: "tcp"               # "tcp" (default), "udp", or "tcp+tls"
+      address: "syslog.internal:514"
+      app_name: "myapp"            # RFC 5424 APP-NAME
+      facility: "local0"           # default
+      max_retries: 10              # default — reconnect attempts
+      batch_size: 100              # default — events per flush
+      flush_interval: "5s"         # default
+```
+
+TCP+TLS with mTLS (production-grade SIEM ingest):
+
+```yaml
+outputs:
+  siem:
+    type: syslog
+    syslog:
+      network: "tcp+tls"
+      address: "syslog.example.com:6514"
+      app_name: "myapp"
+      facility: "local0"
+      tls:
+        ca:   "/etc/audit/ca.pem"
+        cert: "/etc/audit/client-cert.pem"
+        key:  "/etc/audit/client-key.pem"
+        # key_password: "${TLS_KEY_PASSWORD}"   # PKCS#8 v2 encrypted keys
+        # allow_tls12: false                     # default — TLS 1.3 only
+    formatter:
+      type: cef                    # CEF is the SIEM-native format
+      vendor: "MyCompany"
+      product: "MyApp"
+      version: "1.0"
+```
+
+A blank import registers the `syslog` output type with the YAML
+loader:
+
+```go
+import _ "github.com/axonops/audit/syslog"
+```
+
+## Configuration reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `address` | string | *(required)* | Receiver `host:port`. |
+| `network` | string | `"tcp"` | `"tcp"`, `"udp"`, or `"tcp+tls"`. UDP may silently truncate messages over the network MTU (~2 KiB) — use TCP or TCP+TLS for reliable delivery of large audit events. |
+| `app_name` | string | `"audit"` | RFC 5424 APP-NAME field. Cascades from the top-level auditor `app_name` when omitted. |
+| `facility` | string | `"local0"` | Syslog facility. One of: `kern`, `user`, `mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `authpriv`, `ftp`, `local0`–`local7`. Unknown values are rejected. |
+| `hostname` | string | `os.Hostname()` | RFC 5424 HOSTNAME field. Must be printable ASCII (bytes 33–126), max 255 bytes. |
+| `tls.ca` | string | — | Path to a PEM CA bundle used to verify the server certificate on `tcp+tls`. |
+| `tls.cert` | string | — | Path to the client certificate for mTLS. Must be set together with `tls.key`. |
+| `tls.key` | string | — | Path to the client private key for mTLS. PKCS#8 v2 encrypted keys are supported via `tls.key_password`. PKCS#1 DEK-Info legacy keys are refused. |
+| `tls.key_password` | string | — | Password for an encrypted `tls.key`. Use a secret reference (`ref+openbao://…`, env var) in production. |
+| `tls.allow_tls12` | bool | `false` | When `false`, only TLS 1.3 is accepted. Set `true` to permit TLS 1.2 fallback. |
+| `tls_handshake_timeout` | duration | `10s` | TCP dial + TLS handshake budget per connection attempt (`tcp+tls` only). Range `100ms`–`60s`. |
+| `max_retries` | int | `10` | Consecutive reconnect attempts before giving up. Max `20`. |
+| `buffer_size` | int | `10000` | Internal async channel capacity. Events dropped when full; `OutputMetrics.RecordDrop` is called. Max `100000`. |
+| `batch_size` | int | `100` | Events accumulated before flushing. Set `1` to flush every event immediately. Max `10000`. |
+| `flush_interval` | duration | `5s` | Maximum time between flushes regardless of batch fill. Range `1ms`–`1h`. |
+| `max_batch_bytes` | int | `1048576` (1 MiB) | Payload-byte threshold that flushes the batch independently of `batch_size`. A single event over this size is flushed alone; it is never dropped. Range `1024`–`10485760` (1 KiB–10 MiB). |
+| `max_event_bytes` | int | `1048576` (1 MiB) | Per-event size cap. Events exceeding this are rejected with `audit.ErrEventTooLarge`. Defends against consumer-controlled memory pressure. Range `1024`–`10485760` (1 KiB–10 MiB). |
+| `verify_on_startup` | bool | `true` | When `true`, `New` performs a TCP dial — and on `tcp+tls` a TLS handshake — before returning. Set `false` for sidecar startup ordering. |
+| `startup_verification_timeout` | duration | `5s` | Budget for the construction-time connectivity probe. Ignored when `verify_on_startup: false`. |
+
+## Reconnection
+
+TCP and TLS connections re-establish automatically on write failure
+with exponential backoff (100 ms base, capped at 30 s), up to
+`max_retries` attempts. UDP is connectionless — there is no reconnect,
+but oversized datagrams may be silently dropped by the network.
+
+A per-output metrics implementation MAY also implement
+`syslog.ReconnectRecorder`:
+
+```go
+type ReconnectRecorder interface {
+    RecordReconnect(success bool, attempt int)
+}
+```
+
+If present, `RecordReconnect` is called on every reconnect attempt.
+Discovery is by structural typing — no explicit registration.
+
+## Severity mapping
+
+Audit severity (0–10) maps to syslog severity as follows:
+
+| Audit | Syslog                | Notes                                  |
+|------:|-----------------------|----------------------------------------|
+| 10    | `LOG_CRIT` (2)        | Critical security events               |
+| 8–9   | `LOG_ERR` (3)         | High-severity events                   |
+| 6–7   | `LOG_WARNING` (4)     | Medium-severity events                 |
+| 4–5   | `LOG_NOTICE` (5)      | Normal operational events              |
+| 1–3   | `LOG_INFO` (6)        | Low-severity informational events      |
+| 0     | `LOG_DEBUG` (7)       | Debug / trace                          |
+
+`LOG_EMERG` (0) and `LOG_ALERT` (1) are intentionally never emitted —
+they trigger console broadcasts and pager alerts on many syslog
+receivers, which an audit library has no business doing.
+
+## See also
+
+- [Full output reference][docs] — RFC 5424 message structure, TLS
+  configuration, facility selection, CEF pairing, troubleshooting
+- [Worked example][example] — `outputs.yaml` + `main.go` with an
+  embedded TCP receiver so the example runs without external services
+- [CEF format reference](../docs/cef-format.md) — the SIEM-native
+  formatter typically paired with syslog
+- [TLS policy](../docs/output-configuration.md#tls) — TLS 1.3-only
+  defaults, TLS 1.2 fallback, weak-cipher policy
+- Related outputs:
+  [`file`](../file/) (local file with rotation),
+  [`webhook`](../webhook/) (HTTPS push for SaaS SIEMs),
+  [`splunk`](../splunk/) (direct Splunk HEC),
+  [`loki`](../loki/) (Grafana Loki for LogQL)
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/syslog
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/syslog.svg
+[audit-output]: https://pkg.go.dev/github.com/axonops/audit#Output
+[docs]: ../docs/syslog-output.md
+[example]: ../examples/06-syslog-output/
+[rfc5424]: https://datatracker.ietf.org/doc/html/rfc5424

--- a/tests/readme_snippets/readme_snippets_test.go
+++ b/tests/readme_snippets/readme_snippets_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package readme_snippets contains compile-only tests that lift the
+// Quick Start examples out of each submodule README and run them
+// against the current public API. The Quick Starts in v0.2.0 carried
+// signatures that did not compile against `audit.New` because no
+// such guard existed; this test prevents the same drift in v0.2.x+.
+//
+// Each `compileXxxQuickStart` function mirrors the README code block.
+// Keep the snippets here byte-for-byte aligned with the README — when
+// the README changes, this file changes in the same commit.
+package readme_snippets_test
+
+import (
+	"testing"
+
+	"github.com/axonops/audit"
+	"github.com/axonops/audit/file"
+	"github.com/axonops/audit/loki"
+	"github.com/axonops/audit/splunk"
+	"github.com/axonops/audit/syslog"
+	"github.com/axonops/audit/webhook"
+)
+
+// devTaxonomyYAML is the minimal taxonomy used to satisfy the
+// `audit.ParseTaxonomyYAML(taxonomyYAML)` call shown in every Quick
+// Start. Real consumers embed their taxonomy via `go:embed`; the
+// snippet does not show that bit.
+const devTaxonomyYAML = `
+version: 1
+categories:
+  write: [user_create]
+events:
+  user_create:
+    fields:
+      actor_id: {required: true}
+      outcome: {required: true}
+`
+
+// TestFileQuickStart mirrors file/README.md Quick Start.
+func TestFileQuickStart(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	out, err := file.New(&file.Config{
+		Path:       dir + "/events.log",
+		MaxSizeMB:  100,
+		MaxBackups: 5,
+		MaxAgeDays: 30,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tax, err := audit.ParseTaxonomyYAML([]byte(devTaxonomyYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditor, err := audit.New(
+		audit.WithTaxonomy(tax),
+		audit.WithAppName("my-service"),
+		audit.WithHost("host-01"),
+		audit.WithOutputs(out),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = auditor.Close() }()
+
+	// Emit one event so the auditor lifecycle (init + queue + close)
+	// is exercised — mirrors what a real Quick Start consumer would do
+	// after the snippet ends.
+	_ = auditor.AuditEvent(audit.MustNewEventKV("user_create",
+		"actor_id", "alice",
+		"outcome", "success",
+	))
+}
+
+// TestSyslogQuickStart mirrors syslog/README.md Quick Start.
+func TestSyslogQuickStart(t *testing.T) {
+	t.Parallel()
+	out, err := syslog.New(&syslog.Config{
+		Network: "udp",
+		Address: "127.0.0.1:0",
+	})
+	if err != nil {
+		t.Skipf("syslog dial unavailable in this environment: %v", err)
+	}
+
+	tax, err := audit.ParseTaxonomyYAML([]byte(devTaxonomyYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditor, err := audit.New(
+		audit.WithTaxonomy(tax),
+		audit.WithAppName("my-service"),
+		audit.WithHost("host-01"),
+		audit.WithOutputs(out),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = auditor.Close() }()
+
+	// Emit one event so the auditor lifecycle (init + queue + close)
+	// is exercised — mirrors what a real Quick Start consumer would do
+	// after the snippet ends.
+	_ = auditor.AuditEvent(audit.MustNewEventKV("user_create",
+		"actor_id", "alice",
+		"outcome", "success",
+	))
+}
+
+// TestWebhookQuickStart mirrors webhook/README.md Quick Start.
+func TestWebhookQuickStart(t *testing.T) {
+	t.Parallel()
+	out, err := webhook.New(&webhook.Config{
+		URL:                        "http://127.0.0.1:0/audit",
+		DisableStartupVerification: true,
+		AllowInsecureHTTP:          true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tax, err := audit.ParseTaxonomyYAML([]byte(devTaxonomyYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditor, err := audit.New(
+		audit.WithTaxonomy(tax),
+		audit.WithAppName("my-service"),
+		audit.WithHost("host-01"),
+		audit.WithOutputs(out),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = auditor.Close() }()
+
+	// Emit one event so the auditor lifecycle (init + queue + close)
+	// is exercised — mirrors what a real Quick Start consumer would do
+	// after the snippet ends.
+	_ = auditor.AuditEvent(audit.MustNewEventKV("user_create",
+		"actor_id", "alice",
+		"outcome", "success",
+	))
+}
+
+// TestLokiQuickStart mirrors loki/README.md Quick Start.
+func TestLokiQuickStart(t *testing.T) {
+	t.Parallel()
+	out, err := loki.New(&loki.Config{
+		URL:                        "http://127.0.0.1:0/loki/api/v1/push",
+		DisableStartupVerification: true,
+		AllowInsecureHTTP:          true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tax, err := audit.ParseTaxonomyYAML([]byte(devTaxonomyYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditor, err := audit.New(
+		audit.WithTaxonomy(tax),
+		audit.WithAppName("my-service"),
+		audit.WithHost("host-01"),
+		audit.WithOutputs(out),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = auditor.Close() }()
+
+	// Emit one event so the auditor lifecycle (init + queue + close)
+	// is exercised — mirrors what a real Quick Start consumer would do
+	// after the snippet ends.
+	_ = auditor.AuditEvent(audit.MustNewEventKV("user_create",
+		"actor_id", "alice",
+		"outcome", "success",
+	))
+}
+
+// TestSplunkQuickStart mirrors splunk/README.md Quick Start.
+func TestSplunkQuickStart(t *testing.T) {
+	t.Parallel()
+	out, err := splunk.New(&splunk.Config{
+		URL:                        "http://127.0.0.1:0",
+		Token:                      "dev-token",
+		DisableStartupVerification: true,
+		AllowInsecureHTTP:          true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tax, err := audit.ParseTaxonomyYAML([]byte(devTaxonomyYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditor, err := audit.New(
+		audit.WithTaxonomy(tax),
+		audit.WithAppName("my-service"),
+		audit.WithHost("host-01"),
+		audit.WithOutputs(out),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = auditor.Close() }()
+
+	// Emit one event so the auditor lifecycle (init + queue + close)
+	// is exercised — mirrors what a real Quick Start consumer would do
+	// after the snippet ends.
+	_ = auditor.AuditEvent(audit.MustNewEventKV("user_create",
+		"actor_id", "alice",
+		"outcome", "success",
+	))
+}

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -1,0 +1,207 @@
+# webhook — batched HTTPS webhook output
+
+[![Go Reference][godoc-badge]][godoc]
+
+Posts batched audit events to an HTTPS endpoint as NDJSON (or whatever
+content-type the configured formatter declares), with exponential
+backoff retry on 5xx/429, SSRF protection, mTLS support, and graceful
+shutdown. Implements the [`audit.Output`][audit-output] interface.
+
+> **Module path**: `github.com/axonops/audit/webhook`
+> **Status**: pre-release (v0.x)
+> **Documentation**: [webhook-output.md][docs] · [examples/07-webhook-output][example]
+
+## Why
+
+A generic HTTPS webhook is the path of least resistance for SIEMs and
+log platforms that don't speak syslog: Datadog, New Relic,
+SumoLogic-by-HTTP, Elastic via an HTTP ingest pipeline, custom
+PagerDuty / Slack alerting, or any internal HTTP intake service. You
+get TLS, authentication via custom headers (Bearer, API key, HMAC
+signature), and HTTP's well-defined retry semantics (429 with
+`Retry-After`, 5xx with backoff) without writing a transport layer.
+
+Use webhook when the destination is HTTP-only, when you need
+fine-grained header control (per-tenant `X-Tenant-ID`, signed
+`X-Hub-Signature`), or as the lowest-common-denominator integration
+for SaaS endpoints. Use [`syslog`](../syslog/) for SIEMs that speak
+RFC 5424 (lower overhead, no JSON envelope), [`loki`](../loki/) for
+LogQL-native querying, or [`splunk`](../splunk/) for direct Splunk
+HEC delivery.
+
+## Install
+
+```bash
+go get github.com/axonops/audit/webhook
+```
+
+Requires Go 1.26+. See the [main README](../README.md) for transitive
+dependencies.
+
+## Quick start
+
+```go
+import (
+    "os"
+
+    "github.com/axonops/audit"
+    "github.com/axonops/audit/webhook"
+)
+
+out, err := webhook.New(&webhook.Config{
+    URL:     "https://ingest.example.com/audit",
+    Headers: map[string]string{
+        "Authorization": "Bearer " + os.Getenv("WEBHOOK_TOKEN"),
+    },
+})
+if err != nil {
+    return err
+}
+
+tax, err := audit.ParseTaxonomyYAML(taxonomyYAML)
+if err != nil {
+    return err
+}
+auditor, err := audit.New(
+    audit.WithTaxonomy(tax),
+    audit.WithAppName("my-service"),
+    audit.WithHost("host-01"),
+    audit.WithOutputs(out),
+)
+if err != nil {
+    return err
+}
+defer func() { _ = auditor.Close() }()
+```
+
+HTTPS is mandatory by default; `Config.AllowInsecureHTTP` (or
+`allow_insecure_http: true` in YAML) exists only for local development.
+The endpoint MUST be reachable at construction time (TCP dial + TLS
+handshake under a 5 s budget) unless `Config.DisableStartupVerification`
+is set (or `verify_on_startup: false` in YAML — note the inversion:
+the YAML key is the positive form) for sidecar startup ordering.
+
+## YAML configuration
+
+```yaml
+version: 1
+app_name: "my-service"
+host: "${HOSTNAME}"
+
+outputs:
+  alerts:
+    type: webhook
+    webhook:
+      url: "https://ingest.example.com/audit"
+      headers:
+        Authorization: "Bearer ${WEBHOOK_TOKEN}"
+        X-Tenant-ID: "acme-corp"
+      batch_size: 100              # default — events per HTTP POST
+      flush_interval: "5s"         # default
+      timeout: "10s"               # default — full request/response budget
+      max_retries: 3               # default — 5xx/429 retry attempts
+      buffer_size: 10000           # default — events dropped when full
+      max_batch_bytes: 1048576     # 1 MiB — flush when payload reaches this
+      max_event_bytes: 1048576     # 1 MiB — reject oversized events
+      tls:
+        ca:   "/etc/audit/ca.pem"
+        cert: "/etc/audit/client-cert.pem"   # for mTLS
+        key:  "/etc/audit/client-key.pem"    # for mTLS
+        # key_password: "${TLS_KEY_PASSWORD}"  # PKCS#8 v2 encrypted key
+        # allow_tls12: false                   # default — TLS 1.3 only
+```
+
+A blank import registers the `webhook` output type with the YAML
+loader:
+
+```go
+import _ "github.com/axonops/audit/webhook"
+```
+
+## Configuration reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | *(required)* | HTTPS endpoint (or `http://` if `allow_insecure_http: true`). URLs with embedded credentials (`user:pass@`) are rejected — use `headers` for auth. |
+| `headers` | map[string]string | — | Custom HTTP headers added to every request. Header values whose names contain `auth`, `key`, `secret`, `token`, `cookie`, `password`, `credential`, `signature`, `hmac`, or `session` are redacted in debug output. CRLF in either name or value is rejected. |
+| `tls.ca` | string | — | Path to a PEM CA bundle for server verification. Falls back to the system root pool when empty. |
+| `tls.cert` | string | — | Path to the client certificate for mTLS. Must be set with `tls.key`. |
+| `tls.key` | string | — | Path to the client private key for mTLS. Supports PKCS#8 v2 encrypted keys via `tls.key_password`. PKCS#1 DEK-Info legacy keys are refused. |
+| `tls.key_password` | string | — | Password for an encrypted `tls.key`. Use a secret reference (`ref+openbao://…`, env var) in production. |
+| `tls.allow_tls12` | bool | `false` | When `false`, only TLS 1.3. Set `true` for TLS 1.2 fallback. |
+| `batch_size` | int | `100` | Maximum events per HTTP POST. Max `10000`. |
+| `max_batch_bytes` | int | `1048576` (1 MiB) | Payload-byte flush threshold (sum of event lengths). A single event exceeding this is sent in its own request; it is never dropped. Range `1024`–`10485760` (1 KiB–10 MiB). |
+| `max_event_bytes` | int | `1048576` (1 MiB) | Per-event size cap at `Write` entry. Events exceeding this are rejected with `audit.ErrEventTooLarge`. Defends against consumer-controlled memory pressure. Range `1024`–`10485760`. |
+| `flush_interval` | duration | `5s` | Maximum time between flushes. The timer resets after every flush (size- or timer-triggered). |
+| `timeout` | duration | `10s` | Full request/response timeout. The transport-level `ResponseHeaderTimeout` is derived as `max(timeout/2, 1s)` so a small `timeout` cannot wedge a per-stage budget below what a real TLS handshake needs. |
+| `max_retries` | int | `3` | Total delivery attempts for 5xx and 429 responses. `Retry-After` is honoured for 429. Max `20`. |
+| `buffer_size` | int | `10000` | Internal async channel capacity. Events dropped when full; `OutputMetrics.RecordDrop` is called. Max `1000000`. |
+| `allow_insecure_http` | bool | `false` | Permit `http://` URLs. MUST NOT be `true` in production — plaintext HTTP exposes Authorization headers to network observers. |
+| `allow_private_ranges` | bool | `false` | Disable SSRF protection for RFC 1918 private and loopback ranges. Cloud-metadata IPs (169.254.169.254 etc.) remain blocked regardless. |
+| `verify_on_startup` | bool | `true` | When `true`, `New` performs a TCP dial and — for `https://` — a TLS handshake before returning. Set `false` for sidecars. |
+| `startup_verification_timeout` | duration | `5s` | Probe budget. Ignored when `verify_on_startup: false`. |
+
+## Authentication
+
+The webhook output does not bake in any specific authentication
+scheme — set the appropriate header:
+
+```yaml
+headers:
+  Authorization: "Bearer ${API_TOKEN}"      # OAuth2 / generic bearer
+  # Authorization: "Splunk ${HEC_TOKEN}"    # Splunk HEC literal scheme
+  # X-API-Key: "${API_KEY}"                 # API-key services
+  # X-Hub-Signature-256: …                  # add via a custom middleware
+```
+
+For HMAC request signing (`X-Hub-Signature-256` etc.) the signature
+depends on the request body, which means it can't be set as a static
+header — implement a custom output or proxy in front of the webhook.
+
+## Delivery model
+
+Events are buffered in memory and batched as a single HTTP POST when
+any of these thresholds is reached:
+
+- `batch_size` events are queued
+- accumulated payload reaches `max_batch_bytes`
+- `flush_interval` elapses since the last flush
+- `Close` is called
+
+Failed batches retry with exponential backoff on 5xx and 429
+responses. 4xx other than 429 are non-retryable — the batch is
+dropped and `RecordError` is recorded.
+
+Delivery semantics are **at-least-once**: a batch may be delivered
+more than once if the server accepts the payload but the
+acknowledgement is lost. Consumers requiring exactly-once should
+deduplicate on the event's content hash or a consumer-defined idempotency key.
+
+## SSRF protection
+
+By default the webhook output refuses to connect to RFC 1918 private
+ranges, loopback, link-local, multicast, and cloud-metadata IPs
+(169.254.169.254 etc.). `AllowPrivateRanges: true` opts back in for
+private addresses but cloud-metadata IPs remain blocked unconditionally.
+
+## See also
+
+- [Full output reference][docs] — batching architecture, NDJSON
+  payload structure, HMAC integrity, SSRF policy, retry semantics
+- [Worked example][example] — `outputs.yaml` + `main.go` with an
+  embedded HTTP receiver so the example runs without external services
+- [TLS policy](../docs/output-configuration.md#tls) — TLS 1.3-only
+  defaults, TLS 1.2 fallback, weak-cipher policy
+- [HMAC integrity](../docs/hmac-integrity.md) — tamper-evident audit
+  trails configured per-output
+- Related outputs:
+  [`syslog`](../syslog/) (RFC 5424 — when the destination speaks syslog),
+  [`splunk`](../splunk/) (Splunk HEC — purpose-built for Splunk),
+  [`loki`](../loki/) (Grafana Loki — purpose-built for LogQL),
+  [`file`](../file/) (local file with rotation)
+
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/webhook
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/webhook.svg
+[audit-output]: https://pkg.go.dev/github.com/axonops/audit#Output
+[docs]: ../docs/webhook-output.md
+[example]: ../examples/07-webhook-output/


### PR DESCRIPTION
## Summary

PR-1 of the v0.2.2 plan (umbrella #918). Adds README.md to every published submodule (17 files) plus a compile-only test that lifts each output Quick Start out of the README and runs it against the current API. The test is the cascade-prevention guard — v0.2.0 shipped Quick Starts with a fictitious `audit.New(ctx, taxonomyYAML, ...)` signature because no such guard existed.

## Modules covered

- **Outputs**: file, syslog, webhook, loki, splunk
- **Config / aggregator / test helper**: outputconfig, outputs, audittest
- **Secrets**: secrets, secrets/env, secrets/file, secrets/openbao, secrets/vault
- **CLI tools**: cmd/audit-gen, cmd/audit-validate, cmd/bdd-report, cmd/junit-report

`iouring/README.md` already exists and was the style template.

## Audit findings applied

**code-reviewer audit (round 1)**:
- 4 BLOCKER: `audit.New` signature in 5 output Quick Starts; cmd/audit-validate YAML schema (array → map); outputconfig `WithOutput` (singular) → `WithOutputs`+`WithNamedOutput`+`WithRoute`
- 14 MAJOR: Go-vs-YAML field-name disambiguation (DisableStartupVerification/verify_on_startup etc.)

**user-guide-reviewer audit (round 2)**:
- 1 BLOCKER: cmd/audit-validate route.include_categories (list → map per outputconfig/route.go:42)
- 4 MAJOR: webhook+splunk missing `os` import; outputconfig.New signature documented inline; splunk splunkcloud:// fragment wrapped in complete Config block; cmd/audit-gen generated-code marked "abbreviated" with pointer to canonical example

## Cascade-prevention test

`tests/readme_snippets/readme_snippets_test.go` — 5 t.Parallel subtests. Each:
1. Constructs the output via the snippet's exact Config literal
2. Builds the auditor with the README's exact `audit.New()` call
3. Emits a sample event
4. Closes cleanly

Future drift in either the public API OR the README breaks the test in CI.

## Verification

- `go test ./tests/readme_snippets/...` — 5/5 PASS
- `golangci-lint run tests/readme_snippets` — 0 issues
- `go vet ./...` — clean

## No standalone issue

Per maintainer direction in #918: PR-1 (README fixes) is not a separately-tracked issue. The umbrella #918 covers it.

## Test plan
- [x] Compile test 5/5 PASS
- [x] go vet clean
- [x] golangci-lint clean on new test file
- [ ] CI green