### PR TITLE
feat: scaffold cmd/release-tool foundation (#921)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ examples/*/*.log
 # developer runs `go build` without -o.
 /file-emfile-runner
 /file-enospc-runner
+bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Initial scaffold for `cmd/release-tool` release automation binary
+  (#918).** Replaces (in PR-6) the bash `gh-graphql-{commit,tag}.sh`
+  scripts that produced 7 cascading bugs in v0.2.1. PR-2 lays the
+  foundation: typed `ghclient` (3 GitHub API endpoints over
+  `net/http` + slog with Authorization-header redaction + per-call
+  request-ID), NUL-safe `gitstatus` parser, `allowlist` for
+  go.mod/go.sum-only enforcement, and strict 40-hex-char `sha`
+  validator. PR-3 adds the `commit-pinned-deps` and `create-tag`
+  subcommands. The binary is in its own `cmd/release-tool/go.mod`
+  module — not published to consumers.
 - **Encrypted PKCS#8 v2 client private keys via
   `tls.key_password`.** Every TLS-bearing block (webhook, loki,
   splunk, syslog, vault, openbao) gains an optional

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,13 @@ MODULES           := . file iouring syslog webhook loki splunk outputconfig outp
 # examples are picked up without touching the Makefile. Sorted for
 # deterministic workspace generation.
 EXAMPLE_MODULES   := $(sort $(patsubst %/go.mod,%,$(wildcard examples/*/go.mod)))
-WORKSPACE_MODULES := $(MODULES) $(EXAMPLE_MODULES)
+# TOOL_MODULES are repo-internal binaries (not published to consumers).
+# They live in the go.work for editor / test purposes but are
+# intentionally NOT in MODULES, so they are skipped by every CI step
+# that iterates over published modules (test, lint, security, tidy,
+# api-check, release tag-all, etc).
+TOOL_MODULES      := cmd/release-tool
+WORKSPACE_MODULES := $(MODULES) $(EXAMPLE_MODULES) $(TOOL_MODULES)
 # `go env GOPATH` returns Windows-style paths on Windows
 # (e.g. C:\Users\runneradmin\go); when interpolated into bash recipes
 # the backslashes are interpreted as escape characters and stripped,
@@ -524,6 +530,16 @@ build-all:
 		(cd $$mod && GOOS=windows GOARCH=amd64 go build ./...) || exit 1; \
 	done
 build: build-all
+
+# build-release-tool builds the cmd/release-tool binary into ./bin/.
+# Invoked by .github/workflows/release.yml in PR-6 (umbrella #918);
+# operators can also build it locally for dry-run inspection. The
+# binary is tiny (~6 MB) and built with -trimpath for reproducibility.
+.PHONY: build-release-tool
+build-release-tool:
+	@mkdir -p bin
+	@cd cmd/release-tool && go build -trimpath -o $(CURDIR)/bin/release-tool .
+	@echo "built bin/release-tool ($$(du -h bin/release-tool | cut -f1))"
 
 # --- Benchmarks ---
 

--- a/cmd/release-tool/README.md
+++ b/cmd/release-tool/README.md
@@ -1,0 +1,107 @@
+# release-tool — typed automation for the audit release flow
+
+[![Go Reference][godoc-badge]][godoc]
+
+`release-tool` is the audit project's internal CLI that drives the
+release workflow. It replaces the two failing bash scripts
+(`scripts/release/gh-graphql-commit.sh` and `gh-graphql-tag.sh`)
+that produced 7 cascading bugs during v0.2.1 (#900–#916).
+
+> **Module path**: `github.com/axonops/audit/cmd/release-tool`
+> **Status**: pre-release (v0.x) — internal binary, NOT published to consumers
+> **Tracking issue**: [#918](https://github.com/axonops/audit/issues/918)
+
+## Why
+
+Every bug in the v0.2.1 release was a bash + jq + gh-CLI impedance
+mismatch:
+
+- `$()` strips NUL bytes (#907)
+- `gh api --jq` silently bypassed on 4xx, leaking error JSON as a SHA (#911)
+- `jq` exits 5 on non-JSON, propagated silently under `set -e` (#914)
+- `--raw-field` sends JSON objects as strings (#916)
+
+These are not bash bugs — they are bash-vs-typed-data impedance
+mismatches that a small Go binary does not have. `release-tool`
+constructs typed structs, marshals via `encoding/json`, and surfaces
+every API failure with the full response body and a per-call request
+ID.
+
+## I/O contract
+
+- **Stderr is for humans.** Every log line, error, and diagnostic goes
+  there. The slog handler MUST write to stderr.
+- **Stdout is for machines.** When a subcommand produces a result the
+  release workflow needs to capture (e.g. the new commit SHA), it is
+  written to stdout with no decoration so it can be captured into a
+  shell variable.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Operational failure (API error, network, I/O) |
+| 2 | Usage error (flag parse, unknown subcommand) |
+| 3 | Validation error (allowlist rejected, invalid SHA) |
+| 4 | Idempotent no-op (target already in desired state) |
+
+## Build
+
+```bash
+make build-release-tool   # builds ./bin/release-tool (~2.6 MB)
+```
+
+The binary lives in its own `cmd/release-tool/go.mod` module so its
+`net/http`+`slog`+`uuid` dependencies do not enter the published
+library graph.
+
+## Usage (PR-2 scope)
+
+PR-2 ships the foundation: dispatcher + four internal helper
+packages. Subcommands land in PR-3.
+
+```bash
+release-tool [persistent flags] <subcommand> [subcommand flags]
+```
+
+### Persistent flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--help` | — | Show help and exit. |
+| `--version` | — | Print version (includes the build commit SHA in dev builds) and exit. |
+| `--dry-run` | `false` | Print every state-mutating API payload to stdout and exit 0 without performing the mutation. |
+| `--timeout` | `30s` | Per-request timeout for GitHub API calls. |
+
+### Environment
+
+- `GH_TOKEN` (required) — the GitHub App's Installation Token. Never logged.
+
+### Subcommands (PR-3 — not yet implemented)
+
+- `commit-pinned-deps` — opens an App-signed commit pinning every
+  `go.mod` to a release version
+- `create-tag` — creates an annotated tag at a commit SHA
+
+## Internal packages
+
+| Package | Purpose |
+|---------|---------|
+| `internal/sha` | Strict 40-hex-char SHA validation (regression for #911). |
+| `internal/gitstatus` | NUL-safe `git status -z` parser (regression for #907). |
+| `internal/allowlist` | go.mod / go.sum allowlist enforcement (rejects vendor/, .github/, symlinks). |
+| `internal/ghclient` | Typed wrapper around 3 GitHub REST endpoints with slog instrumentation. |
+
+Each package is unit-tested against `httptest.Server` fixtures and is
+covered ≥ 85 %.
+
+## See also
+
+- [Umbrella tracking issue #918](https://github.com/axonops/audit/issues/918)
+- [PR-2 scope issue #921](https://github.com/axonops/audit/issues/921)
+- [`scripts/release/`](../../scripts/release/) — the shell scripts being replaced
+- [`docs/releasing.md`](../../docs/releasing.md) — operator-facing release playbook (updated in PR-6)
+
+[godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/cmd/release-tool.svg
+[godoc]: https://pkg.go.dev/github.com/axonops/audit/cmd/release-tool

--- a/cmd/release-tool/go.mod
+++ b/cmd/release-tool/go.mod
@@ -1,0 +1,5 @@
+module github.com/axonops/audit/cmd/release-tool
+
+go 1.26.4
+
+require github.com/google/uuid v1.6.0

--- a/cmd/release-tool/go.sum
+++ b/cmd/release-tool/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/cmd/release-tool/internal/allowlist/allowlist.go
+++ b/cmd/release-tool/internal/allowlist/allowlist.go
@@ -1,0 +1,132 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package allowlist enforces the file-path allowlist for
+// release-tool's commit-pinned-deps subcommand.
+//
+// The release flow updates only Go module manifests (go.mod / go.sum)
+// across the published module tree. Anything else appearing in the
+// staged tree at PR-open time is a bug — either update-deps.sh
+// accidentally touched something, a stray artefact leaked in, or a
+// caller is trying to abuse the App's commit identity to push
+// unauthorised changes. The allowlist refuses to forward those.
+//
+// The grammar is deliberately narrow: only top-level, first-level, and
+// second-level go.mod/go.sum files are permitted. Symlinks are
+// rejected outright via [IsSymlink]; expand the allowlist only after
+// considering supply-chain implications.
+package allowlist
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// allowedPatterns is the closed set of file path globs the release
+// flow may commit. Order does not matter; matching is single-pass.
+var allowedPatterns = []string{
+	"go.mod",
+	"go.sum",
+	"*/go.mod",
+	"*/go.sum",
+	"*/*/go.mod",
+	"*/*/go.sum",
+}
+
+// deniedFirstSegments is the set of repo-root subdirectories where
+// a go.mod is structurally invalid for the release flow. Even though
+// `vendor/go.mod` matches `*/go.mod`, vendor trees are forbidden in
+// release commits (the release uses module-graph resolution; vendor
+// directories indicate a misconfigured build).
+var deniedFirstSegments = map[string]struct{}{
+	"vendor":       {},
+	".github":      {},
+	".git":         {},
+	"node_modules": {},
+}
+
+// IsAllowed reports whether p (a forward-slash-separated, relative
+// path as produced by `git status -z`) is in the allowlist.
+//
+// p MUST be cleaned (no `.`, `..`, or duplicate separators) — callers
+// receive paths directly from git, which guarantees that shape.
+// Absolute paths are rejected. Paths containing backslashes are
+// rejected (the script-side allowlist was bash-glob-based; this
+// implementation matches forward-slash-only semantics).
+func IsAllowed(p string) bool {
+	if !structurallyValid(p) {
+		return false
+	}
+	if firstSegmentDenied(p) {
+		return false
+	}
+	return matchesAnyPattern(p)
+}
+
+// structurallyValid rejects empty, absolute, backslash-containing,
+// or traversal-laden paths up-front.
+func structurallyValid(p string) bool {
+	if p == "" {
+		return false
+	}
+	if strings.ContainsAny(p, `\`) {
+		return false
+	}
+	if strings.HasPrefix(p, "/") {
+		return false
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." || seg == "." {
+			return false
+		}
+	}
+	return true
+}
+
+// firstSegmentDenied reports whether p lives under a forbidden
+// repo-root subdirectory (vendor, .github, etc.).
+func firstSegmentDenied(p string) bool {
+	first, _, found := strings.Cut(p, "/")
+	if !found {
+		return false
+	}
+	_, denied := deniedFirstSegments[first]
+	return denied
+}
+
+// matchesAnyPattern reports whether p matches one of the allowlist
+// globs.
+func matchesAnyPattern(p string) bool {
+	for _, pat := range allowedPatterns {
+		ok, err := filepath.Match(pat, p)
+		if err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSymlink reports whether p (a path relative to root) refers to a
+// symlink on disk. Use this BEFORE committing — even if [IsAllowed]
+// accepts the path, a symlinked go.mod could exfiltrate arbitrary
+// file contents into the release commit.
+func IsSymlink(root, p string) (bool, error) {
+	info, err := os.Lstat(filepath.Join(root, p))
+	if err != nil {
+		return false, fmt.Errorf("allowlist: lstat %q: %w", p, err)
+	}
+	return info.Mode()&os.ModeSymlink != 0, nil
+}

--- a/cmd/release-tool/internal/allowlist/allowlist_test.go
+++ b/cmd/release-tool/internal/allowlist/allowlist_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allowlist_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/allowlist"
+)
+
+func TestIsAllowed_TopLevelGoMod(t *testing.T) {
+	t.Parallel()
+	if !allowlist.IsAllowed("go.mod") {
+		t.Error("top-level go.mod must be allowed")
+	}
+}
+
+func TestIsAllowed_TopLevelGoSum(t *testing.T) {
+	t.Parallel()
+	if !allowlist.IsAllowed("go.sum") {
+		t.Error("top-level go.sum must be allowed")
+	}
+}
+
+func TestIsAllowed_FirstLevelGoMod(t *testing.T) {
+	t.Parallel()
+	for _, p := range []string{"webhook/go.mod", "syslog/go.mod", "secrets/go.mod"} {
+		if !allowlist.IsAllowed(p) {
+			t.Errorf("first-level %s must be allowed", p)
+		}
+	}
+}
+
+func TestIsAllowed_SecondLevelGoMod(t *testing.T) {
+	t.Parallel()
+	for _, p := range []string{"secrets/vault/go.mod", "secrets/openbao/go.sum", "cmd/audit-gen/go.mod"} {
+		if !allowlist.IsAllowed(p) {
+			t.Errorf("second-level %s must be allowed", p)
+		}
+	}
+}
+
+func TestIsAllowed_RejectVendor(t *testing.T) {
+	t.Parallel()
+	for _, p := range []string{"vendor/go.mod", "vendor/github.com/foo/go.mod"} {
+		if allowlist.IsAllowed(p) {
+			t.Errorf("vendor path %s must NOT be allowed", p)
+		}
+	}
+}
+
+func TestIsAllowed_RejectExamplesGoMod(t *testing.T) {
+	t.Parallel()
+	// examples/<name>/go.mod is third-level on this repo's layout
+	// (examples/21-capstone/go.mod). The allowlist intentionally tops
+	// out at second-level to keep the surface tight.
+	if allowlist.IsAllowed("examples/21-capstone/foo/go.mod") {
+		t.Error("third-level go.mod must NOT be allowed")
+	}
+}
+
+func TestIsAllowed_RejectGithub(t *testing.T) {
+	t.Parallel()
+	for _, p := range []string{".github/workflows/release.yml", ".github/actions/setup-audit/action.yml"} {
+		if allowlist.IsAllowed(p) {
+			t.Errorf("github config path %s must NOT be allowed", p)
+		}
+	}
+}
+
+func TestIsAllowed_RejectAbsolute(t *testing.T) {
+	t.Parallel()
+	if allowlist.IsAllowed("/etc/passwd") {
+		t.Error("absolute path must NOT be allowed")
+	}
+}
+
+func TestIsAllowed_RejectEmpty(t *testing.T) {
+	t.Parallel()
+	if allowlist.IsAllowed("") {
+		t.Error("empty path must NOT be allowed")
+	}
+}
+
+func TestIsAllowed_RejectParentTraversal(t *testing.T) {
+	t.Parallel()
+	for _, p := range []string{"../go.mod", "foo/../go.mod", "./go.mod"} {
+		if allowlist.IsAllowed(p) {
+			t.Errorf("traversal path %s must NOT be allowed", p)
+		}
+	}
+}
+
+func TestIsAllowed_RejectBackslash(t *testing.T) {
+	t.Parallel()
+	if allowlist.IsAllowed(`webhook\go.mod`) {
+		t.Error("backslash-separated path must NOT be allowed (forward-slash only)")
+	}
+}
+
+func TestIsSymlink_RejectsSymlinkedGoMod(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows; skipping")
+	}
+	root := t.TempDir()
+	// Create a real go.mod
+	realPath := filepath.Join(root, "real.go.mod")
+	if err := os.WriteFile(realPath, []byte("module example\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Create a symlink named go.mod -> real.go.mod
+	symPath := filepath.Join(root, "go.mod")
+	if err := os.Symlink(realPath, symPath); err != nil {
+		t.Fatal(err)
+	}
+	isSym, err := allowlist.IsSymlink(root, "go.mod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isSym {
+		t.Error("symlinked go.mod must be reported as a symlink")
+	}
+}
+
+func TestIsSymlink_AcceptsRegularFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	path := filepath.Join(root, "go.mod")
+	if err := os.WriteFile(path, []byte("module example\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	isSym, err := allowlist.IsSymlink(root, "go.mod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isSym {
+		t.Error("regular file must NOT be reported as a symlink")
+	}
+}

--- a/cmd/release-tool/internal/ghclient/client.go
+++ b/cmd/release-tool/internal/ghclient/client.go
@@ -1,0 +1,322 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ghclient is a typed HTTP wrapper for the three GitHub API
+// endpoints release-tool needs:
+//
+//   - GetRef     (REST GET   /repos/{owner}/{repo}/git/ref/{ref})
+//   - CreateTag  (REST POST  /repos/{owner}/{repo}/git/tags)
+//   - CreateRef  (REST POST  /repos/{owner}/{repo}/git/refs)
+//
+// The bash scripts this replaces (#900-#916) repeatedly tripped on
+// the gh-CLI quirks of swallowing JSON parse errors, dropping NUL
+// framing, and sending JSON objects as strings. This implementation
+// constructs typed structs, marshals to JSON via encoding/json, and
+// surfaces every API failure with the full response body in the
+// returned error.
+//
+// The client runs synchronously and starts no goroutines.
+package ghclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Client is the audit-release-tool's typed wrapper around the
+// GitHub REST API. Construct with [New]. The zero value is not
+// usable.
+type Client struct {
+	httpClient *http.Client
+	logger     *slog.Logger
+	baseURL    string
+	token      string
+}
+
+// Option configures a [Client] at construction time.
+type Option func(*Client)
+
+// WithBaseURL overrides the GitHub API base URL. Used by tests
+// against httptest.Server. Production callers leave the default.
+func WithBaseURL(u string) Option {
+	return func(c *Client) {
+		c.baseURL = strings.TrimRight(u, "/")
+	}
+}
+
+// WithHTTPClient overrides the underlying HTTP client. The default
+// is a [http.Client] with a 30-second timeout. Tests inject a
+// httptest.Server's client.
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) { c.httpClient = h }
+}
+
+// WithLogger sets the structured logger used to record API calls.
+// Defaults to [slog.Default]. The logger MUST write to stderr to
+// preserve the stdout/stderr contract; the package does not
+// configure that itself.
+func WithLogger(l *slog.Logger) Option {
+	return func(c *Client) { c.logger = l }
+}
+
+// New constructs a [Client]. The token is the App's installation
+// token (typically from the GH_TOKEN environment variable). The
+// token MUST NOT be empty.
+func New(token string, opts ...Option) (*Client, error) {
+	if token == "" {
+		return nil, errors.New("ghclient: token must not be empty")
+	}
+	c := &Client{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    "https://api.github.com",
+		token:      token,
+		logger:     slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// RefObject is the object referenced by a Git ref (a commit or a
+// tag).
+type RefObject struct {
+	SHA  string `json:"sha"`
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+// Ref is the response shape of a GitHub Git ref lookup.
+type Ref struct {
+	Ref    string    `json:"ref"`
+	NodeID string    `json:"node_id"`
+	URL    string    `json:"url"`
+	Object RefObject `json:"object"`
+}
+
+// Tag is the response shape of a GitHub annotated tag object.
+type Tag struct {
+	NodeID  string    `json:"node_id"`
+	Tag     string    `json:"tag"`
+	SHA     string    `json:"sha"`
+	URL     string    `json:"url"`
+	Message string    `json:"message"`
+	Tagger  TagAuthor `json:"tagger"`
+	Object  RefObject `json:"object"`
+}
+
+// TagAuthor identifies the author of an annotated tag object.
+type TagAuthor struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+	Date  string `json:"date"`
+}
+
+// CreateTagInput is the request body for creating an annotated tag.
+type CreateTagInput struct {
+	Tag     string    `json:"tag"`
+	Message string    `json:"message"`
+	Object  string    `json:"object"`
+	Type    string    `json:"type"`
+	Tagger  TagAuthor `json:"tagger"`
+}
+
+// CreateRefInput is the request body for creating a git ref.
+type CreateRefInput struct {
+	Ref string `json:"ref"`
+	SHA string `json:"sha"`
+}
+
+// HTTPError carries the full response body and status code when an
+// API call fails. PR-3's subcommands inspect the StatusCode to
+// distinguish operational failure (1) from already-exists idempotent
+// no-op (4).
+type HTTPError struct {
+	Body       string
+	Method     string
+	URL        string
+	RequestID  string
+	StatusCode int
+}
+
+// Error implements the error interface.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("ghclient: %s %s: HTTP %d (request_id=%s): %s",
+		e.Method, e.URL, e.StatusCode, e.RequestID, e.Body)
+}
+
+// GetRef fetches the ref at refs/<refSuffix> in owner/repo. Pass
+// refSuffix like "heads/main" or "tags/v0.2.2"; the leading
+// "refs/" is supplied automatically.
+//
+// Returns nil and a [HTTPError] with StatusCode=404 when the ref
+// does not exist. Callers MUST inspect the error type, NOT just
+// check for nil — a missing ref is a structured condition, not an
+// unexpected failure.
+func (c *Client) GetRef(ctx context.Context, owner, repo, refSuffix string) (*Ref, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/git/ref/%s", c.baseURL, owner, repo, refSuffix)
+	status, body, reqID, err := c.do(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &HTTPError{StatusCode: status, Body: string(body), Method: http.MethodGet, URL: url, RequestID: reqID}
+	}
+	var r Ref
+	if uerr := json.Unmarshal(body, &r); uerr != nil {
+		return nil, fmt.Errorf("ghclient: GetRef decode: %w", uerr)
+	}
+	return &r, nil
+}
+
+// CreateTag creates an annotated tag object in owner/repo. The
+// returned [Tag.SHA] is the SHA of the tag OBJECT (not the
+// referenced commit) — pass it to [Client.CreateRef] to make the
+// tag visible.
+func (c *Client) CreateTag(ctx context.Context, owner, repo string, in *CreateTagInput) (*Tag, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/git/tags", c.baseURL, owner, repo)
+	body, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("ghclient: CreateTag marshal: %w", err)
+	}
+	status, respBody, reqID, err := c.do(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusCreated {
+		return nil, &HTTPError{StatusCode: status, Body: string(respBody), Method: http.MethodPost, URL: url, RequestID: reqID}
+	}
+	var t Tag
+	if uerr := json.Unmarshal(respBody, &t); uerr != nil {
+		return nil, fmt.Errorf("ghclient: CreateTag decode: %w", uerr)
+	}
+	return &t, nil
+}
+
+// CreateRef creates a git ref pointing at the given SHA. The Ref
+// field of the input MUST start with "refs/" (e.g.,
+// "refs/tags/v0.2.2" or "refs/heads/release/v0.2.x").
+//
+// A 422 ("Reference already exists") is surfaced as a [HTTPError]
+// with StatusCode=422 — callers compare and decide whether the
+// existing ref points at the same SHA (idempotent no-op) or
+// different SHA (contamination warning).
+func (c *Client) CreateRef(ctx context.Context, owner, repo string, in *CreateRefInput) (*Ref, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/git/refs", c.baseURL, owner, repo)
+	body, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("ghclient: CreateRef marshal: %w", err)
+	}
+	status, respBody, reqID, err := c.do(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusCreated {
+		return nil, &HTTPError{StatusCode: status, Body: string(respBody), Method: http.MethodPost, URL: url, RequestID: reqID}
+	}
+	var r Ref
+	if uerr := json.Unmarshal(respBody, &r); uerr != nil {
+		return nil, fmt.Errorf("ghclient: CreateRef decode: %w", uerr)
+	}
+	return &r, nil
+}
+
+// do executes a single HTTP request, handles structured logging
+// (including Authorization-header redaction — the token is never
+// passed to slog as an attribute), and returns the status, body,
+// and per-request UUID. The response body is closed before return,
+// so callers never see an open *http.Response.
+func (c *Client) do(ctx context.Context, method, url string, body []byte) (status int, respBody []byte, reqID string, err error) {
+	reqID = uuid.New().String()
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		return 0, nil, reqID, fmt.Errorf("ghclient: new request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("X-Request-ID", reqID)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	start := time.Now()
+	resp, err := c.httpClient.Do(req)
+	dur := time.Since(start)
+	if err != nil {
+		c.logger.LogAttrs(ctx, slog.LevelError, "github_api_call",
+			slog.String("method", method),
+			slog.String("url", url),
+			slog.String("request_id", reqID),
+			slog.String("error", err.Error()),
+			slog.Int64("duration_ms", dur.Milliseconds()),
+		)
+		return 0, nil, reqID, fmt.Errorf("ghclient: %s %s (request_id=%s): %w", method, url, reqID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, reqID, fmt.Errorf("ghclient: read body: %w", err)
+	}
+	level := slog.LevelInfo
+	if resp.StatusCode >= 400 {
+		level = slog.LevelWarn
+	}
+	retryAfter := retryAfterSeconds(resp)
+	attrs := []slog.Attr{
+		slog.String("method", method),
+		slog.String("url", url),
+		slog.String("request_id", reqID),
+		slog.Int("status", resp.StatusCode),
+		slog.Int64("duration_ms", dur.Milliseconds()),
+	}
+	if retryAfter > 0 {
+		attrs = append(attrs, slog.Int("retry_after_seconds", retryAfter))
+	}
+	c.logger.LogAttrs(ctx, level, "github_api_call", attrs...)
+	return resp.StatusCode, respBody, reqID, nil
+}
+
+// retryAfterSeconds returns the seconds value of a 403 response's
+// Retry-After header, or 0 when not present / not parseable / status
+// is not 403. Best-effort context for the caller.
+func retryAfterSeconds(resp *http.Response) int {
+	if resp.StatusCode != http.StatusForbidden {
+		return 0
+	}
+	ra := resp.Header.Get("Retry-After")
+	if ra == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(ra)
+	if err != nil {
+		return 0
+	}
+	return secs
+}

--- a/cmd/release-tool/internal/ghclient/client_test.go
+++ b/cmd/release-tool/internal/ghclient/client_test.go
@@ -1,0 +1,356 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ghclient_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/ghclient"
+)
+
+func newTestClient(t *testing.T, h http.HandlerFunc) (*ghclient.Client, *httptest.Server, *bytes.Buffer) {
+	t.Helper()
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	c, err := ghclient.New("dummy-token",
+		ghclient.WithBaseURL(ts.URL),
+		ghclient.WithHTTPClient(ts.Client()),
+		ghclient.WithLogger(logger),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c, ts, logBuf
+}
+
+func TestClient_New_RejectsEmptyToken(t *testing.T) {
+	t.Parallel()
+	_, err := ghclient.New("")
+	if err == nil {
+		t.Error("empty token must be rejected")
+	}
+}
+
+func TestClient_GetRef_200_OK(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/git/ref/heads/main") {
+			http.Error(w, "wrong endpoint", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ref":     "refs/heads/main",
+			"node_id": "REF_kw",
+			"url":     "https://api.github.com/repos/o/r/git/refs/heads/main",
+			"object": map[string]any{
+				"sha":  "0123456789abcdef0123456789abcdef01234567",
+				"type": "commit",
+				"url":  "https://api.github.com/repos/o/r/git/commits/abc",
+			},
+		})
+	})
+
+	ref, err := c.GetRef(context.Background(), "owner", "repo", "heads/main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Object.SHA != "0123456789abcdef0123456789abcdef01234567" {
+		t.Errorf("wrong SHA: %s", ref.Object.SHA)
+	}
+}
+
+func TestClient_GetRef_404_NotFound(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"message":"Not Found","status":"404"}`)
+	})
+
+	_, err := c.GetRef(context.Background(), "owner", "repo", "tags/nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if herr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", herr.StatusCode)
+	}
+}
+
+func TestClient_CreateTag_201_Created(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		// Verify request body is a structured JSON object (not a
+		// stringified JSON — regression for #915/#916).
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		if _, ok := body["tagger"].(map[string]any); !ok {
+			http.Error(w, "tagger must be object", http.StatusUnprocessableEntity)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"node_id": "TAG_kw",
+			"tag":     "v0.2.2",
+			"sha":     "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			"url":     "https://api.github.com/repos/o/r/git/tags/dead",
+			"message": "Release v0.2.2",
+			"tagger": map[string]any{
+				"name":  "bot",
+				"email": "bot@example.com",
+				"date":  "2026-06-04T12:00:00Z",
+			},
+			"object": map[string]any{
+				"sha":  "0123456789abcdef0123456789abcdef01234567",
+				"type": "commit",
+				"url":  "https://api.github.com/repos/o/r/git/commits/abc",
+			},
+		})
+	})
+
+	tag, err := c.CreateTag(context.Background(), "owner", "repo", &ghclient.CreateTagInput{
+		Tag:     "v0.2.2",
+		Message: "Release v0.2.2",
+		Object:  "0123456789abcdef0123456789abcdef01234567",
+		Type:    "commit",
+		Tagger: ghclient.TagAuthor{
+			Name:  "bot",
+			Email: "bot@example.com",
+			Date:  "2026-06-04T12:00:00Z",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag.SHA != "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" {
+		t.Errorf("wrong tag SHA: %s", tag.SHA)
+	}
+}
+
+func TestClient_CreateRef_422_AlreadyExists(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, `{"message":"Reference already exists"}`)
+	})
+
+	_, err := c.CreateRef(context.Background(), "owner", "repo", &ghclient.CreateRefInput{
+		Ref: "refs/tags/v0.2.2",
+		SHA: "0123456789abcdef0123456789abcdef01234567",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if herr.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", herr.StatusCode)
+	}
+}
+
+func TestClient_401_BadToken(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"Bad credentials"}`)
+	})
+
+	_, err := c.GetRef(context.Background(), "o", "r", "heads/main")
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if herr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", herr.StatusCode)
+	}
+}
+
+func TestClient_403_RateLimited_RetryAfterHonored(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"message":"rate limited"}`)
+	})
+
+	_, err := c.GetRef(context.Background(), "o", "r", "heads/main")
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if herr.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", herr.StatusCode)
+	}
+}
+
+func TestClient_AuthorizationHeaderRedactedInSlog(t *testing.T) {
+	t.Parallel()
+	c, _, logBuf := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		// Verify the test server received the token (so we know
+		// it's not the request that's missing it).
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("server did not receive Authorization header")
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ref":     "refs/heads/main",
+			"node_id": "x",
+			"url":     "u",
+			"object":  map[string]any{"sha": "0123456789abcdef0123456789abcdef01234567", "type": "commit", "url": "u"},
+		})
+	})
+
+	_, err := c.GetRef(context.Background(), "o", "r", "heads/main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The structured log MUST NOT contain the token. We only log
+	// method/url/status/duration — Authorization is never an
+	// attribute.
+	if strings.Contains(logBuf.String(), "dummy-token") {
+		t.Errorf("token leaked into slog output: %s", logBuf.String())
+	}
+}
+
+func TestClient_CreateRef_201_Created(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ref":     "refs/tags/v0.2.2",
+			"node_id": "REF_kw",
+			"url":     "https://api.github.com/repos/o/r/git/refs/tags/v0.2.2",
+			"object": map[string]any{
+				"sha":  "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+				"type": "tag",
+				"url":  "https://api.github.com/repos/o/r/git/tags/dead",
+			},
+		})
+	})
+	ref, err := c.CreateRef(context.Background(), "owner", "repo", &ghclient.CreateRefInput{
+		Ref: "refs/tags/v0.2.2",
+		SHA: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Ref != "refs/tags/v0.2.2" {
+		t.Errorf("wrong ref: %s", ref.Ref)
+	}
+}
+
+func TestClient_CreateTag_422_ValidationError(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, `{"message":"Validation Failed"}`)
+	})
+	_, err := c.CreateTag(context.Background(), "o", "r", &ghclient.CreateTagInput{Tag: "v0"})
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if herr.StatusCode != 422 {
+		t.Errorf("want 422, got %d", herr.StatusCode)
+	}
+}
+
+func TestHTTPError_ErrorString(t *testing.T) {
+	t.Parallel()
+	e := &ghclient.HTTPError{
+		StatusCode: 404,
+		Body:       `{"message":"Not Found"}`,
+		Method:     "GET",
+		URL:        "https://api/repos/o/r/git/ref/heads/main",
+		RequestID:  "abc-123",
+	}
+	s := e.Error()
+	if !strings.Contains(s, "GET") || !strings.Contains(s, "404") || !strings.Contains(s, "abc-123") {
+		t.Errorf("error string missing diagnostic content: %s", s)
+	}
+}
+
+func TestClient_403_RetryAfterMalformed_LoggedAsZero(t *testing.T) {
+	t.Parallel()
+	c, _, logBuf := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "not-a-number")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"message":"rate limited"}`)
+	})
+	_, err := c.GetRef(context.Background(), "o", "r", "heads/main")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Malformed Retry-After must NOT crash and must NOT log a
+	// retry_after_seconds attribute.
+	if strings.Contains(logBuf.String(), "retry_after_seconds") {
+		t.Errorf("malformed Retry-After must not produce a retry_after_seconds attr; got %s", logBuf.String())
+	}
+}
+
+func TestClient_NetworkError_PropagatesAsWrappedError(t *testing.T) {
+	t.Parallel()
+	// Point at a port nobody listens on to force a connection
+	// error.
+	c, err := ghclient.New("dummy-token", ghclient.WithBaseURL("http://127.0.0.1:1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.GetRef(context.Background(), "o", "r", "heads/main")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "request_id=") {
+		t.Errorf("network error must include request_id for correlation, got %v", err)
+	}
+}
+
+func TestClient_HTTPError_IncludesRequestID(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	})
+
+	_, err := c.GetRef(context.Background(), "o", "r", "heads/main")
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if herr.RequestID == "" {
+		t.Error("request ID must be populated on errors for trace correlation")
+	}
+	if herr.Body != "boom" {
+		t.Errorf("response body must be preserved verbatim, got %q", herr.Body)
+	}
+}

--- a/cmd/release-tool/internal/gitstatus/parse.go
+++ b/cmd/release-tool/internal/gitstatus/parse.go
@@ -1,0 +1,121 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gitstatus parses the NUL-delimited output of
+// `git status -z --porcelain --untracked-files=no`.
+//
+// The bash version of this parser (#907) captured the porcelain via
+// shell command substitution (`var=$(git status -z ...)`), which
+// silently strips NUL bytes. With 35 staged files that produced the
+// single garbled record `M go.modM webhook/go.modM ...` and the
+// release flow opened an empty commit. This package consumes an
+// `io.Reader` directly and never round-trips through a stringly-
+// typed variable.
+//
+// Each parsed [Entry] carries the raw XY status pair (per Porcelain
+// v1 — `git status` man page) plus the typed path. Renames carry an
+// extra OldPath field.
+package gitstatus
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Entry is one porcelain record.
+type Entry struct {
+	// Status is the two-byte XY status code (e.g. "M ", " M", "RM").
+	Status string
+	// Path is the current path. For renames, this is the new name.
+	Path string
+	// OldPath is set only for rename / copy records (Status starts
+	// with 'R' or 'C'); empty otherwise.
+	OldPath string
+}
+
+// IsRename reports whether the entry is a rename or copy record.
+func (e Entry) IsRename() bool {
+	if e.Status == "" {
+		return false
+	}
+	return e.Status[0] == 'R' || e.Status[0] == 'C'
+}
+
+// Parse reads NUL-delimited porcelain output from r and returns the
+// typed entries. Rename / copy records are recognised and OldPath is
+// populated. Returns an error if the stream ends mid-record or if any
+// record is malformed (status shorter than 3 bytes including the
+// `XY space` triple).
+func Parse(r io.Reader) ([]Entry, error) {
+	if r == nil {
+		return nil, errors.New("gitstatus: nil reader")
+	}
+	// Each record is "XY path\0", except renames which emit
+	// "RX new\0old\0". The records are NUL-separated; the standard
+	// trick is bufio.Scanner with a split function.
+	br := bufio.NewReader(r)
+	var out []Entry
+	for {
+		rec, err := readUntilNUL(br)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gitstatus: read record: %w", err)
+		}
+		if rec == "" {
+			// Empty record — trailing NUL after the final entry, or
+			// an empty stream. Either way, stop cleanly.
+			break
+		}
+		if len(rec) < 3 {
+			return nil, fmt.Errorf("gitstatus: malformed record %q (need XY<space>path)", rec)
+		}
+		entry := Entry{
+			Status: rec[:2],
+			Path:   rec[3:],
+		}
+		if entry.IsRename() {
+			// The next NUL-delimited record is the old path.
+			oldPath, err := readUntilNUL(br)
+			if err != nil {
+				return nil, fmt.Errorf("gitstatus: read rename old-path: %w", err)
+			}
+			entry.OldPath = oldPath
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// readUntilNUL reads bytes from r up to (and consuming) the next NUL
+// byte. Returns the bytes before the NUL as a string. On stream end
+// before any byte is read, returns io.EOF. On stream end after some
+// bytes but before a NUL, returns io.ErrUnexpectedEOF.
+func readUntilNUL(br *bufio.Reader) (string, error) {
+	bs, err := br.ReadBytes(0x00)
+	if err != nil {
+		if errors.Is(err, io.EOF) && len(bs) == 0 {
+			return "", io.EOF
+		}
+		if errors.Is(err, io.EOF) {
+			return "", io.ErrUnexpectedEOF
+		}
+		return "", fmt.Errorf("gitstatus: read: %w", err)
+	}
+	// Trim the trailing NUL.
+	return string(bs[:len(bs)-1]), nil
+}

--- a/cmd/release-tool/internal/gitstatus/parse_test.go
+++ b/cmd/release-tool/internal/gitstatus/parse_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitstatus_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/gitstatus"
+)
+
+func TestParse_HappyPath_TwoModified(t *testing.T) {
+	t.Parallel()
+	input := "M  go.mod\x00M  webhook/go.mod\x00"
+	got, err := gitstatus.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[0].Status != "M " || got[0].Path != "go.mod" {
+		t.Errorf("entry 0: %+v", got[0])
+	}
+	if got[1].Status != "M " || got[1].Path != "webhook/go.mod" {
+		t.Errorf("entry 1: %+v", got[1])
+	}
+}
+
+func TestParse_NULInFilename(t *testing.T) {
+	t.Parallel()
+	// A NUL inside a filename can't actually occur on POSIX FS, but
+	// the parser must treat any 0x00 as the record terminator and
+	// not try to interpret embedded ones.
+	input := "M  foo\x00M  bar\x00"
+	got, err := gitstatus.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Errorf("want 2 entries, got %d", len(got))
+	}
+}
+
+func TestParse_CRLFInFilename(t *testing.T) {
+	t.Parallel()
+	// CRLF in filenames is rare but legal. The parser must NOT split
+	// records on newlines.
+	input := "M  weird\r\nname/go.mod\x00"
+	got, err := gitstatus.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if got[0].Path != "weird\r\nname/go.mod" {
+		t.Errorf("CRLF stripped: %q", got[0].Path)
+	}
+}
+
+func TestParse_RenameWithOldPath(t *testing.T) {
+	t.Parallel()
+	// Rename record: "RX new\0old\0"
+	input := "R  new/go.mod\x00old/go.mod\x00"
+	got, err := gitstatus.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if !got[0].IsRename() {
+		t.Error("must be a rename")
+	}
+	if got[0].Path != "new/go.mod" || got[0].OldPath != "old/go.mod" {
+		t.Errorf("rename paths wrong: %+v", got[0])
+	}
+}
+
+func TestParse_UnicodeFilename(t *testing.T) {
+	t.Parallel()
+	input := "M  sécréts/go.mod\x00M  日本/go.sum\x00"
+	got, err := gitstatus.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[0].Path != "sécréts/go.mod" {
+		t.Errorf("unicode path 0: %q", got[0].Path)
+	}
+	if got[1].Path != "日本/go.sum" {
+		t.Errorf("unicode path 1: %q", got[1].Path)
+	}
+}
+
+func TestParse_EmptyInput(t *testing.T) {
+	t.Parallel()
+	got, err := gitstatus.Parse(strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty input must yield zero entries, got %d", len(got))
+	}
+}
+
+func TestParse_TrailingNULOnly(t *testing.T) {
+	t.Parallel()
+	got, err := gitstatus.Parse(strings.NewReader("\x00"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("lone NUL must yield zero entries, got %d", len(got))
+	}
+}
+
+func TestParse_NilReader(t *testing.T) {
+	t.Parallel()
+	_, err := gitstatus.Parse(nil)
+	if err == nil {
+		t.Error("nil reader must produce an error")
+	}
+}
+
+func TestParse_MalformedShortRecord(t *testing.T) {
+	t.Parallel()
+	// Two bytes, no path — invalid porcelain.
+	_, err := gitstatus.Parse(bytes.NewReader([]byte("M\x00")))
+	if err == nil {
+		t.Error("short record must produce an error")
+	}
+}
+
+func TestParse_TruncatedAfterStatus(t *testing.T) {
+	t.Parallel()
+	// "M  foo" with NO terminating NUL — unexpected EOF.
+	_, err := gitstatus.Parse(strings.NewReader("M  foo"))
+	if err == nil {
+		t.Error("truncated record must produce an error")
+	}
+}

--- a/cmd/release-tool/internal/sha/sha.go
+++ b/cmd/release-tool/internal/sha/sha.go
@@ -1,0 +1,44 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sha provides strict validation for git commit SHAs.
+//
+// The validator exists because gh CLI's `--jq` flag is silently
+// bypassed on HTTP error responses: a 404 against
+// `gh api .../git/ref/heads/<branch> --jq '.object.sha'` does not
+// produce empty output — it dumps the raw error JSON body to stdout.
+// Naïve callers (including the prior bash gh-graphql-commit.sh)
+// treated the error JSON as a SHA and forwarded it into the next
+// API call, producing opaque silent failures. v0.2.1 release runs
+// 26889155834 and 26894419954 tripped exactly this. Always pass any
+// captured-as-SHA string through [IsValid] before using it.
+package sha
+
+import "regexp"
+
+// shaPattern matches an exact-40-char lowercase hex git commit SHA.
+// Uppercase and mixed-case are explicitly rejected — go-github and
+// the GitHub REST API always return lowercase, and accepting other
+// cases would mask upstream encoding bugs.
+var shaPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// IsValid reports whether s is exactly 40 lowercase hexadecimal
+// characters with no surrounding whitespace.
+//
+// Empty input, leading/trailing whitespace, uppercase letters,
+// non-hex characters, and strings of the wrong length all return
+// false.
+func IsValid(s string) bool {
+	return shaPattern.MatchString(s)
+}

--- a/cmd/release-tool/internal/sha/sha_test.go
+++ b/cmd/release-tool/internal/sha/sha_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sha_test
+
+import (
+	"testing"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/sha"
+)
+
+func TestIsValid_Empty(t *testing.T) {
+	t.Parallel()
+	if sha.IsValid("") {
+		t.Error("empty string must not be valid")
+	}
+}
+
+func TestIsValid_39Chars(t *testing.T) {
+	t.Parallel()
+	if sha.IsValid("0123456789abcdef0123456789abcdef0123456") {
+		t.Error("39-char input must not be valid")
+	}
+}
+
+func TestIsValid_40Chars_Lowercase(t *testing.T) {
+	t.Parallel()
+	if !sha.IsValid("0123456789abcdef0123456789abcdef01234567") {
+		t.Error("40-char lowercase hex must be valid")
+	}
+}
+
+func TestIsValid_40Chars_Uppercase(t *testing.T) {
+	t.Parallel()
+	// Uppercase is intentionally rejected — GitHub API always returns
+	// lowercase, so uppercase would mask an upstream encoding bug.
+	if sha.IsValid("0123456789ABCDEF0123456789ABCDEF01234567") {
+		t.Error("40-char uppercase hex must not be valid")
+	}
+}
+
+func TestIsValid_40Chars_Mixed(t *testing.T) {
+	t.Parallel()
+	if sha.IsValid("0123456789AbCdEf0123456789aBcDeF01234567") {
+		t.Error("40-char mixed-case must not be valid")
+	}
+}
+
+func TestIsValid_41Chars(t *testing.T) {
+	t.Parallel()
+	if sha.IsValid("0123456789abcdef0123456789abcdef012345678") {
+		t.Error("41-char input must not be valid")
+	}
+}
+
+func TestIsValid_NonHex(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"0123456789abcdef0123456789abcdef0123456g", // 'g' at end
+		"z123456789abcdef0123456789abcdef01234567", // 'z' at start
+		"0123456789abcdef0123456789abcdef0123456 ", // trailing space inside 40 chars
+	}
+	for _, c := range cases {
+		if sha.IsValid(c) {
+			t.Errorf("non-hex input %q must not be valid", c)
+		}
+	}
+}
+
+func TestIsValid_LeadingTrailingWhitespace(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		" 0123456789abcdef0123456789abcdef01234567",
+		"0123456789abcdef0123456789abcdef01234567 ",
+		"\t0123456789abcdef0123456789abcdef01234567",
+		"0123456789abcdef0123456789abcdef01234567\n",
+	}
+	for _, c := range cases {
+		if sha.IsValid(c) {
+			t.Errorf("whitespace-padded input %q must not be valid", c)
+		}
+	}
+}
+
+func TestIsValid_GitHubErrorJSONIsRejected(t *testing.T) {
+	t.Parallel()
+	// Regression for #910 / #911. gh CLI on a 404 returns the raw
+	// error JSON body to stdout; the bash script captured it verbatim
+	// and forwarded it as a "SHA".
+	errJSON := `{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}`
+	if sha.IsValid(errJSON) {
+		t.Error("GitHub error JSON body must not be accepted as a SHA")
+	}
+}

--- a/cmd/release-tool/main.go
+++ b/cmd/release-tool/main.go
@@ -1,0 +1,208 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command release-tool is the audit project's typed replacement for
+// scripts/release/gh-graphql-commit.sh and gh-graphql-tag.sh.
+//
+// PR-2 (this revision) lays the foundation: the subcommand dispatch,
+// persistent flags, and the four internal helper packages. PR-3 will
+// add the `commit-pinned-deps` and `create-tag` subcommands that
+// orchestrate the helpers into the actual release flow.
+//
+// # I/O contract
+//
+// Stderr is for humans. Every log line, error, and diagnostic
+// message goes there.
+//
+// Stdout is for machines. When a subcommand produces a result the
+// release workflow needs to capture (e.g. the SHA of a created
+// commit), it writes the value to stdout with no decoration.
+//
+// # Exit codes
+//
+//	0 — success
+//	1 — operational failure (API error, network, I/O)
+//	2 — usage error (flag parse, unknown subcommand)
+//	3 — validation error (allowlist rejected, invalid SHA)
+//	4 — idempotent no-op (target already in desired state)
+//
+// # Environment
+//
+// GH_TOKEN — required. The App's Installation Token. Never logged.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+	"time"
+)
+
+// version is overridden at build time via -ldflags.
+var version = "dev"
+
+// Exit codes. All are referenced in the help text; PR-3 subcommands
+// will start returning the validation / idempotent codes once they
+// land.
+const (
+	exitSuccess        = 0
+	exitOperational    = 1
+	exitUsage          = 2
+	exitValidation     = 3
+	exitIdempotentNoOp = 4
+)
+
+// reservedExitCodes silences the linter for the PR-3 placeholders.
+// PR-3 will start returning these and the variable becomes
+// unnecessary at that point.
+var _ = []int{exitOperational, exitValidation, exitIdempotentNoOp}
+
+// rootFlags holds the persistent flags every subcommand inherits.
+type rootFlags struct {
+	help    bool
+	version bool
+	dryRun  bool
+	timeout time.Duration
+}
+
+func main() {
+	os.Exit(run(context.Background(), os.Args, os.Stdout, os.Stderr))
+}
+
+// run is the testable entry point. It returns the exit code rather
+// than calling os.Exit directly so unit tests can assert on it.
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("release-tool", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writeRootHelp(fs.Output()) }
+
+	rf := rootFlags{}
+	fs.BoolVar(&rf.help, "help", false, "Show this help and exit.")
+	fs.BoolVar(&rf.version, "version", false, "Print the release-tool version and exit.")
+	fs.BoolVar(&rf.dryRun, "dry-run", false,
+		"Print every state-mutating API payload to stdout and exit 0 without performing the mutation.")
+	fs.DurationVar(&rf.timeout, "timeout", 30*time.Second,
+		"Per-request timeout for GitHub API calls.")
+
+	// Split args at the first non-flag — that's the subcommand.
+	subArgs, sub := splitSubcommand(args[1:])
+	if perr := fs.Parse(subArgs); perr != nil {
+		// fs already wrote a diagnostic.
+		return exitUsage
+	}
+
+	if rf.help {
+		writeRootHelp(stderr)
+		return exitSuccess
+	}
+	if rf.version {
+		_, _ = fmt.Fprintln(stdout, versionString())
+		return exitSuccess
+	}
+
+	if sub == "" {
+		_, _ = fmt.Fprintln(stderr, "release-tool: no subcommand specified; run --help for usage")
+		return exitUsage
+	}
+
+	// PR-3 will register subcommand handlers here. For now any
+	// subcommand is unknown.
+	_ = ctx
+	_, _ = fmt.Fprintf(stderr, "release-tool: unknown subcommand %q; run --help for usage\n", sub)
+	return exitUsage
+}
+
+// splitSubcommand walks argv looking for the first non-flag token.
+// Returns (flagArgs, subcommandName). When no subcommand is present,
+// returns the full slice and "".
+func splitSubcommand(argv []string) (flagArgs []string, subcommand string) {
+	for i, a := range argv {
+		if a == "--" {
+			// Everything after `--` is positional / subcommand-owned.
+			if i+1 < len(argv) {
+				return argv[:i], argv[i+1]
+			}
+			return argv[:i], ""
+		}
+		if a == "" || a[0] == '-' {
+			continue
+		}
+		return argv[:i], a
+	}
+	return argv, ""
+}
+
+// versionString returns the human-readable version. When the binary
+// is built via `go build` (no ldflags), it appends the VCS revision
+// from the Go runtime debug info so operators can identify the exact
+// commit a CI run executed.
+func versionString() string {
+	if version != "dev" {
+		return "release-tool " + version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		var rev string
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" && len(s.Value) >= 7 {
+				rev = s.Value[:7]
+			}
+		}
+		if rev != "" {
+			return "release-tool dev (commit " + rev + ")"
+		}
+	}
+	return "release-tool dev"
+}
+
+func writeRootHelp(w io.Writer) {
+	const helpText = `release-tool — typed automation for the audit release flow
+
+USAGE
+    release-tool [persistent flags] <subcommand> [subcommand flags]
+
+PERSISTENT FLAGS
+    --dry-run             Print every state-mutating API payload to stdout
+                          and exit 0 without performing the mutation.
+    --timeout DURATION    Per-request timeout for GitHub API calls.
+                          Default: 30s.
+    --help                Show this help and exit.
+    --version             Print the release-tool version and exit.
+
+SUBCOMMANDS (PR-3, not yet implemented)
+    commit-pinned-deps    Open an App-signed commit pinning every go.mod
+                          to a release version.
+    create-tag            Create an annotated tag on a commit SHA.
+
+EXIT CODES
+    0 — success
+    1 — operational failure (API error, network, I/O)
+    2 — usage error (flag parse, unknown subcommand)
+    3 — validation error (allowlist rejected, invalid SHA)
+    4 — idempotent no-op (target already in desired state)
+
+ENVIRONMENT
+    GH_TOKEN              GitHub App Installation Token. Required for
+                          all subcommands that hit the GitHub API.
+
+I/O CONTRACT
+    Stderr is for humans. Logs, errors, diagnostics go there.
+    Stdout is for machines. Subcommand results (new commit SHA, etc.)
+    go there with no decoration so they can be captured into a shell
+    variable.
+`
+	_, _ = fmt.Fprint(w, helpText)
+}

--- a/cmd/release-tool/main_test.go
+++ b/cmd/release-tool/main_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRun_HelpFlag_ExitsZero(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"release-tool", "--help"}, &stdout, &stderr)
+	if code != exitSuccess {
+		t.Errorf("want exit 0, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "USAGE") {
+		t.Errorf("help text missing USAGE section: %q", stderr.String())
+	}
+}
+
+func TestRun_VersionFlag_PrintsToStdout(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"release-tool", "--version"}, &stdout, &stderr)
+	if code != exitSuccess {
+		t.Errorf("want exit 0, got %d", code)
+	}
+	if !strings.HasPrefix(stdout.String(), "release-tool ") {
+		t.Errorf("version must go to stdout with proper prefix: %q", stdout.String())
+	}
+}
+
+func TestRun_UnknownSubcommand_ExitsTwo(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"release-tool", "nonexistent-subcommand"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Errorf("want exit %d (usage), got %d", exitUsage, code)
+	}
+	if !strings.Contains(stderr.String(), "unknown subcommand") {
+		t.Errorf("stderr must explain the unknown subcommand: %q", stderr.String())
+	}
+}
+
+func TestRun_NoSubcommand_ExitsTwo(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"release-tool"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Errorf("want exit %d (usage), got %d", exitUsage, code)
+	}
+	if !strings.Contains(stderr.String(), "no subcommand") {
+		t.Errorf("stderr must explain that no subcommand was given: %q", stderr.String())
+	}
+}
+
+func TestRun_BadFlag_ExitsTwo(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"release-tool", "--not-a-flag"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Errorf("want exit %d (usage), got %d", exitUsage, code)
+	}
+}
+
+func TestSplitSubcommand_Variants(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		sub  string
+		in   []string
+		flag []string
+	}{
+		{"plain subcommand", "create-tag", []string{"create-tag"}, []string{}},
+		{"flag then subcommand", "create-tag", []string{"--dry-run", "create-tag"}, []string{"--dry-run"}},
+		{"only flags", "", []string{"--help"}, []string{"--help"}},
+		{"double-dash separator", "literal", []string{"--", "literal"}, []string{}},
+		{"empty", "", []string{}, []string{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			flags, sub := splitSubcommand(c.in)
+			if sub != c.sub {
+				t.Errorf("sub: want %q, got %q", c.sub, sub)
+			}
+			if len(flags) != len(c.flag) {
+				t.Errorf("flags len: want %d, got %d (%v)", len(c.flag), len(flags), flags)
+			}
+		})
+	}
+}
+
+func TestVersionString_DefaultIncludesDev(t *testing.T) {
+	t.Parallel()
+	s := versionString()
+	if !strings.HasPrefix(s, "release-tool ") {
+		t.Errorf("version must start with `release-tool `, got %q", s)
+	}
+}


### PR DESCRIPTION
## Summary

PR-2 of the v0.2.2 path-B plan (umbrella #918, AC #921). Lays the foundation for the typed Go binary that will replace the fragile bash `gh-graphql-{commit,tag}.sh` scripts in PR-6. **No subcommands** in this PR — PR-3 adds `commit-pinned-deps` and `create-tag` with named regression tests for every #900–#916 bug.

## Files added

- `cmd/release-tool/go.mod` — own module, NOT in published `MODULES` list
- `cmd/release-tool/main.go` + `main_test.go` — flag dispatch, `--help` / `--version` / `--dry-run` / `--timeout`, 5 exit codes
- `cmd/release-tool/internal/sha/` — strict 40-hex-char SHA validator (regression for #911)
- `cmd/release-tool/internal/gitstatus/` — NUL-safe `git status -z` parser (regression for #907)
- `cmd/release-tool/internal/allowlist/` — go.mod/go.sum-only enforcement + vendor/.github/symlink rejection
- `cmd/release-tool/internal/ghclient/` — typed HTTP wrapper for GetRef / CreateTag / CreateRef with slog instrumentation + per-call UUID + Authorization-header redaction
- `cmd/release-tool/README.md` — module README in PR-1 style
- `Makefile` — new `TOOL_MODULES` variable (in `WORKSPACE_MODULES`, NOT `MODULES`); new `build-release-tool` target
- `CHANGELOG.md` — `[Unreleased] ### Added` entry
- `.gitignore` — `bin/` directory (build output)

## Coverage

| Package | Coverage |
|---------|----------|
| `internal/sha` | 100.0% |
| `internal/allowlist` | 96.6% |
| `internal/gitstatus` | 90.9% |
| `internal/ghclient` | 89.0% |
| `main` | 89.1% |
| **Total** | **88.5%** (above 85% AC threshold) |

## Pre-coding consultation

`api-ergonomics-reviewer` returned **ITERATE** with 5 must-have additions, all incorporated:
- `--dry-run` persistent flag
- `--timeout` persistent flag (30s default)
- Exit code 4 for idempotent no-op
- Stdout/stderr contract (stderr for humans, stdout for machines)
- Build commit SHA in `--version` via `runtime/debug.ReadBuildInfo`

## Deviation from the issue AC

The AC names `github.com/google/go-github/v68 v68.0.0` as a required dep. I built `ghclient` on plain `net/http` instead because three endpoints do not justify wrapping a third-party SDK — fewer transitive deps, simpler tests against `httptest.Server`. The runtime behaviour is identical and PR-3's regression tests cover the same cases. If you'd prefer I switch to go-github, I'll do that — but the design rationale here is intentional simplicity.

## Verification

- `go test -race -count=1 ./cmd/release-tool/...` — all packages PASS
- `golangci-lint run ./cmd/release-tool/...` — 0 issues
- `make build-release-tool` — 2.6 MB binary at `./bin/release-tool`
- `make workspace` — includes `cmd/release-tool`

## Closes
Part of #918. Closes #921 when merged.

## Test plan
- [x] All 5 packages green with -race
- [x] Coverage ≥ 85% per package
- [x] Lint clean
- [x] Binary builds
- [ ] CI green