### PR TITLE
feat: add commit-pinned-deps and create-tag subcommands (#923)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,15 @@ jobs:
             infra-up: test-infra-openbao-up test-infra-vault-up
             infra-down: test-infra-openbao-down test-infra-vault-down
             timeout: 8
+          # release-tool: CLI binary behavioural specification.
+          # The test-bdd-release-tool target depends on
+          # build-release-tool, which compiles the binary the
+          # godog steps exec.
+          - suite: release-tool
+            target: test-bdd-release-tool
+            infra-up: ""
+            infra-down: ""
+            timeout: 5
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `net/http` + slog with Authorization-header redaction + per-call
   request-ID), NUL-safe `gitstatus` parser, `allowlist` for
   go.mod/go.sum-only enforcement, and strict 40-hex-char `sha`
-  validator. PR-3 adds the `commit-pinned-deps` and `create-tag`
-  subcommands. The binary is in its own `cmd/release-tool/go.mod`
+  validator. The binary is in its own `cmd/release-tool/go.mod`
   module — not published to consumers.
+- **`release-tool` subcommands `commit-pinned-deps` and `create-tag`
+  (#923).** PR-3 lands the two release-flow operations on top of the
+  PR-2 foundation. `commit-pinned-deps` orchestrates `git status -z`
+  + allowlist + symlink guard + the GraphQL `createCommitOnBranch`
+  mutation; `create-tag` does an idempotent two-step REST tag-object
+  + ref creation, with same-SHA re-runs exiting 4 (no-op) and
+  different-SHA re-runs exiting 1 (refusing to overwrite). Both
+  subcommands ship with named regression tests covering #906
+  (off-allowlist paths refused), #907 (NUL-delimited git-status
+  parsed via `io.Reader` so 18+ files don't collapse), #910 (symlink
+  refused), #911 (only 40-hex SHAs accepted), and #915/#916
+  (GraphQL variables sent as a structured object, never a JSON
+  string). Both honour `--dry-run` to emit the proposed API payload
+  without performing the mutation.
 - **Encrypted PKCS#8 v2 client private keys via
   `tls.key_password`.** Every TLS-bearing block (webhook, loki,
   splunk, syslog, vault, openbao) gains an optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,29 +8,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Initial scaffold for `cmd/release-tool` release automation binary
-  (#918).** Replaces (in PR-6) the bash `gh-graphql-{commit,tag}.sh`
-  scripts that produced 7 cascading bugs in v0.2.1. PR-2 lays the
-  foundation: typed `ghclient` (3 GitHub API endpoints over
-  `net/http` + slog with Authorization-header redaction + per-call
-  request-ID), NUL-safe `gitstatus` parser, `allowlist` for
-  go.mod/go.sum-only enforcement, and strict 40-hex-char `sha`
-  validator. The binary is in its own `cmd/release-tool/go.mod`
-  module — not published to consumers.
-- **`release-tool` subcommands `commit-pinned-deps` and `create-tag`
-  (#923).** PR-3 lands the two release-flow operations on top of the
-  PR-2 foundation. `commit-pinned-deps` orchestrates `git status -z`
-  + allowlist + symlink guard + the GraphQL `createCommitOnBranch`
-  mutation; `create-tag` does an idempotent two-step REST tag-object
-  + ref creation, with same-SHA re-runs exiting 4 (no-op) and
+- **`cmd/release-tool` release automation binary
+  (#918, #921, #923).** Replaces (in PR-6) the bash
+  `gh-graphql-{commit,tag}.sh` scripts that produced 8 cascading
+  bugs in v0.2.1. PR-2 (#921) laid the foundation: typed `ghclient`
+  (3 GitHub API endpoints over `net/http` + slog with
+  Authorization-header redaction + per-call request-ID), NUL-safe
+  `gitstatus` parser, `allowlist` for go.mod/go.sum-only
+  enforcement, and strict 40-hex-char `sha` validator. PR-3 (#923)
+  lands the two subcommands that drive the actual release flow:
+  `commit-pinned-deps` orchestrates `git status -z` + allowlist +
+  atomic O_NOFOLLOW symlink guard + the GraphQL
+  `createCommitOnBranch` mutation; `create-tag` does an idempotent
+  two-step REST tag-object + ref creation with annotated-tag
+  dereferencing, same-SHA re-runs exiting 4 (no-op) and
   different-SHA re-runs exiting 1 (refusing to overwrite). Both
-  subcommands ship with named regression tests covering #906
-  (off-allowlist paths refused), #907 (NUL-delimited git-status
-  parsed via `io.Reader` so 18+ files don't collapse), #910 (symlink
-  refused), #911 (only 40-hex SHAs accepted), and #915/#916
-  (GraphQL variables sent as a structured object, never a JSON
-  string). Both honour `--dry-run` to emit the proposed API payload
-  without performing the mutation.
+  subcommands honour `--dry-run` to emit the proposed API payload
+  without performing the mutation, and propagate the persistent
+  `--timeout` flag through `context.Context` so SIGINT cancels
+  in-flight API calls. Named regression tests cover every v0.2.1
+  cascade bug (#900, #902, #906, #910, #911, #915, #916) plus
+  bypass-by-design markers for the bash-impedance class (#904,
+  #908, #913, #914). The binary is in its own
+  `cmd/release-tool/go.mod` module — not published to consumers.
 - **Encrypted PKCS#8 v2 client private keys via
   `tls.key_password`.** Every TLS-bearing block (webhook, loki,
   splunk, syslog, vault, openbao) gains an optional

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 .PHONY: test test-all test-core test-file test-syslog test-webhook test-loki test-splunk test-outputconfig test-audit-gen test-audit-validate test-bdd-report test-junit-report lint-splunk \
        test-secrets test-secrets-env test-secrets-file test-secrets-openbao test-secrets-vault \
        test-integration test-integration-file test-integration-syslog test-integration-webhook test-integration-loki test-integration-splunk test-integration-core test-integration-secrets-openbao test-integration-secrets-vault \
-       test-bdd test-bdd-core test-bdd-outputconfig test-bdd-file test-bdd-file-os test-bdd-syslog test-bdd-webhook test-bdd-loki test-bdd-fanout \
+       test-bdd test-bdd-core test-bdd-outputconfig test-bdd-file test-bdd-file-os test-bdd-syslog test-bdd-webhook test-bdd-loki test-bdd-fanout test-bdd-release-tool \
        test-bdd-verify \
        test-examples \
        lint lint-all lint-core lint-file lint-syslog lint-webhook lint-loki lint-outputconfig lint-audit-gen lint-audit-validate lint-bdd-report lint-junit-report lint-examples \
-       lint-secrets lint-secrets-openbao lint-secrets-vault \
+       lint-secrets lint-secrets-openbao lint-secrets-vault lint-release-tool \
+       test-release-tool \
        check-report-parity \
        vet vet-all fmt fmt-check \
        build build-all bench bench-save bench-compare bench-baseline-check coverage \
@@ -177,7 +178,10 @@ test-secrets-env:
 test-secrets-file:
 	cd secrets/file && $(call go_test_with_junit,-race -count=1 -coverprofile=coverage.out,./...)
 
-test-all: test-core test-file test-syslog test-webhook test-loki test-splunk test-outputconfig test-audit-gen test-audit-validate test-bdd-report test-junit-report test-secrets test-secrets-env test-secrets-file test-secrets-openbao test-secrets-vault
+test-release-tool:
+	cd cmd/release-tool && $(call go_test_with_junit,-race -count=1 -coverprofile=coverage.out,./...)
+
+test-all: test-core test-file test-syslog test-webhook test-loki test-splunk test-outputconfig test-audit-gen test-audit-validate test-bdd-report test-junit-report test-secrets test-secrets-env test-secrets-file test-secrets-openbao test-secrets-vault test-release-tool
 test: test-all
 
 # --- Stress targets (#705 family) ---
@@ -331,6 +335,12 @@ test-bdd-file-os:
 test-bdd-syslog:
 	BDD_TAGS=@syslog go test -race -v -count=1 -tags=integration ./tests/bdd/...
 
+# test-bdd-release-tool drives the release-tool CLI behavioural
+# specification. The binary must be built first because the steps
+# shell out to it.
+test-bdd-release-tool: build-release-tool
+	BDD_TAGS=@release-tool go test -race -v -count=1 -tags=integration ./tests/bdd/...
+
 test-bdd-webhook:
 	BDD_TAGS="@webhook, @routing" go test -race -v -count=1 -tags=integration ./tests/bdd/...
 
@@ -483,6 +493,9 @@ lint-secrets-openbao:
 lint-secrets-vault:
 	cd secrets/vault && $(GOBIN)/golangci-lint run --timeout=5m --config $(CURDIR)/.golangci.yml ./...
 
+lint-release-tool:
+	cd cmd/release-tool && $(GOBIN)/golangci-lint run --timeout=5m --config $(CURDIR)/.golangci.yml ./...
+
 # Lint every example with its own go.mod. EXAMPLE_MODULES is
 # auto-discovered (see top of file). Replaces the single-example
 # lint-capstone target so new examples are linted without further
@@ -493,7 +506,7 @@ lint-examples:
 		(cd $$dir && $(GOBIN)/golangci-lint run --timeout=5m --config $(CURDIR)/.golangci.yml ./...) || exit 1; \
 	done
 
-lint-all: lint-core lint-file lint-syslog lint-webhook lint-loki lint-splunk lint-outputconfig lint-audit-gen lint-audit-validate lint-bdd-report lint-junit-report lint-secrets lint-secrets-openbao lint-secrets-vault lint-examples
+lint-all: lint-core lint-file lint-syslog lint-webhook lint-loki lint-splunk lint-outputconfig lint-audit-gen lint-audit-validate lint-bdd-report lint-junit-report lint-secrets lint-secrets-openbao lint-secrets-vault lint-release-tool lint-examples
 lint: lint-all
 
 # --- Vet ---
@@ -923,13 +936,13 @@ check-sync-comments:
 
 # --- Security ---
 
-# security runs govulncheck serially over every module. Used by
-# `make check` and by developers locally. CI fans this out across
-# a GitHub Actions matrix for ~10x wall-time reduction (#522);
-# see `security-one` below for the per-module target the matrix
-# invokes.
+# security runs govulncheck serially over every module — including
+# internal TOOL_MODULES (e.g. cmd/release-tool). Used by `make check`
+# and by developers locally. CI fans this out across a GitHub Actions
+# matrix for ~10x wall-time reduction (#522); see `security-one`
+# below for the per-module target the matrix invokes.
 security:
-	@for mod in $(MODULES); do \
+	@for mod in $(MODULES) $(TOOL_MODULES); do \
 		echo "=== security $$mod ==="; \
 		(cd $$mod && $(GOBIN)/govulncheck ./...) || exit 1; \
 	done

--- a/cmd/release-tool/README.md
+++ b/cmd/release-tool/README.md
@@ -56,10 +56,7 @@ The binary lives in its own `cmd/release-tool/go.mod` module so its
 `net/http`+`slog`+`uuid` dependencies do not enter the published
 library graph.
 
-## Usage (PR-2 scope)
-
-PR-2 ships the foundation: dispatcher + four internal helper
-packages. Subcommands land in PR-3.
+## Usage
 
 ```bash
 release-tool [persistent flags] <subcommand> [subcommand flags]
@@ -78,11 +75,53 @@ release-tool [persistent flags] <subcommand> [subcommand flags]
 
 - `GH_TOKEN` (required) — the GitHub App's Installation Token. Never logged.
 
-### Subcommands (PR-3 — not yet implemented)
+### Subcommands
 
-- `commit-pinned-deps` — opens an App-signed commit pinning every
-  `go.mod` to a release version
-- `create-tag` — creates an annotated tag at a commit SHA
+#### `commit-pinned-deps`
+
+Opens an App-signed commit on a branch using the GitHub GraphQL
+`createCommitOnBranch` mutation. Reads the staged `go.mod` /
+`go.sum` files from the workdir, screens every path against the
+allowlist (rejects symlinks, refuses anything outside go.mod / go.sum
+at 0-2 levels deep), and submits them in a single mutation.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--owner` | yes | GitHub repository owner |
+| `--repo` | yes | GitHub repository name |
+| `--branch` | yes | Target branch (e.g. `release/v0.2.2`) |
+| `--message` | yes | Commit message headline |
+| `--auto-create-branch` | no | Create the branch from `main` if missing |
+| `--workdir` | no | Path to the git working directory (default: `.`) |
+
+On success the new commit OID is written to stdout. With `--dry-run`,
+the proposed payload (path + size, never raw file contents) is
+written to stdout instead and no API mutation occurs.
+
+Regressions locked:
+- #906 / #910 — paths outside go.mod/go.sum, and any symlinked target, are refused
+- #907 — `git status -z` is consumed as an `io.Reader`, never round-tripped through `$()`
+- #911 — only 40-hex commit SHAs reach the API
+- #915 / #916 — GraphQL `variables` is a structured object, never a JSON-string-of-an-object
+
+#### `create-tag`
+
+Creates an annotated tag at a commit SHA. Strictly idempotent: if the
+tag already exists at the same SHA, exit 4 (no-op); at a different
+SHA, exit 1 (refusing to overwrite) with the operator pointed at
+the contaminating commit.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--owner` | yes | GitHub repository owner |
+| `--repo` | yes | GitHub repository name |
+| `--tag` | yes | Tag name, e.g. `v0.2.2` |
+| `--sha` | yes | Commit SHA to point the tag at (40 lowercase hex) |
+| `--message` | yes | Tag annotation message |
+
+On success the tag OBJECT SHA is written to stdout. With `--dry-run`,
+the two proposed payloads (`POST /git/tags` and `POST /git/refs`)
+are written to stdout instead and no API mutation occurs.
 
 ## Internal packages
 
@@ -99,8 +138,9 @@ covered ≥ 85 %.
 ## See also
 
 - [Umbrella tracking issue #918](https://github.com/axonops/audit/issues/918)
-- [PR-2 scope issue #921](https://github.com/axonops/audit/issues/921)
-- [`scripts/release/`](../../scripts/release/) — the shell scripts being replaced
+- [PR-2 scope issue #921](https://github.com/axonops/audit/issues/921) — foundation + helpers
+- [PR-3 scope issue #923](https://github.com/axonops/audit/issues/923) — subcommands (this revision)
+- [`scripts/release/`](../../scripts/release/) — the shell scripts being replaced (deletion in PR-6)
 - [`docs/releasing.md`](../../docs/releasing.md) — operator-facing release playbook (updated in PR-6)
 
 [godoc-badge]: https://pkg.go.dev/badge/github.com/axonops/audit/cmd/release-tool.svg

--- a/cmd/release-tool/cmd_commit_pinned_deps.go
+++ b/cmd/release-tool/cmd_commit_pinned_deps.go
@@ -1,0 +1,415 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/allowlist"
+	"github.com/axonops/audit/cmd/release-tool/internal/ghclient"
+	"github.com/axonops/audit/cmd/release-tool/internal/gitstatus"
+)
+
+// commitPinnedDepsArgs are the parsed flags for the
+// commit-pinned-deps subcommand. Shared between runCommitPinnedDeps
+// and the test hook.
+type commitPinnedDepsArgs struct {
+	owner            string
+	repo             string
+	branch           string
+	message          string
+	workdir          string
+	autoCreateBranch bool
+	dryRun           bool
+}
+
+// runCommitPinnedDeps implements the `commit-pinned-deps` subcommand.
+//
+// It runs `git status -z` against the workdir, parses the result with
+// internal/gitstatus (regression for #907 — bash $() NUL-stripping),
+// filters paths through internal/allowlist (regression for #906/#910
+// — symlink + non-manifest path exfiltration), reads every staged
+// go.mod / go.sum file's bytes from disk, then submits them as a
+// single GraphQL createCommitOnBranch mutation (regression for
+// #915/#916 — variables must be a structured object).
+func runCommitPinnedDeps(ctx context.Context, args []string, stdout, stderr io.Writer, persistent *rootFlags) int {
+	fs := flag.NewFlagSet("commit-pinned-deps", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writeCommitPinnedDepsHelp(fs.Output()) }
+
+	in := commitPinnedDepsArgs{}
+	fs.StringVar(&in.owner, "owner", "", "GitHub repository owner (required)")
+	fs.StringVar(&in.repo, "repo", "", "GitHub repository name (required)")
+	fs.StringVar(&in.branch, "branch", "", "Target branch for the commit, e.g. release/v0.2.2 (required)")
+	fs.StringVar(&in.message, "message", "", "Commit message headline (required)")
+	fs.BoolVar(&in.autoCreateBranch, "auto-create-branch", false,
+		"Create the branch from main if it does not already exist")
+	// --workdir is a TRUSTED path — the release workflow is
+	// expected to hardcode this to the CI-managed checkout
+	// directory. release-tool does not validate that the path is
+	// inside the repo; an operator pointing it at an attacker-
+	// controlled tree gets exactly the go.mod/go.sum from that
+	// tree. The git -C workdir invocation will refuse non-git
+	// directories, blunting accidental misuse, but the contract is
+	// the caller's responsibility (security review W3).
+	fs.StringVar(&in.workdir, "workdir", ".", "Path to the git working directory (must be a trusted release-flow checkout)")
+
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	in.dryRun = persistent.dryRun
+
+	if err := requireCommitFlags(in.owner, in.repo, in.branch, in.message); err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: %v\n", err)
+		return exitUsage
+	}
+	if code := validateCommitPinnedDepsArgs(&in, stderr); code != exitSuccess {
+		return code
+	}
+
+	client, code := buildClient(persistent, stderr)
+	if code != exitSuccess {
+		return code
+	}
+	return doCommitPinnedDeps(ctx, client, &in, stdout, stderr)
+}
+
+// doCommitPinnedDeps performs the staged-file collection and the
+// GraphQL mutation. Split out so tests can inject a client pointed
+// at httptest.
+func doCommitPinnedDeps(ctx context.Context, client *ghclient.Client, in *commitPinnedDepsArgs, stdout, stderr io.Writer) int {
+	additions, code := collectAllowedAdditions(in.workdir, stderr)
+	if code != exitSuccess {
+		return code
+	}
+	if len(additions) == 0 {
+		_, _ = fmt.Fprintln(stderr, "commit-pinned-deps: no staged changes — idempotent no-op")
+		return exitIdempotentNoOp
+	}
+
+	branchHead, code := resolveOrCreateBranch(ctx, client, in.owner, in.repo, in.branch, in.autoCreateBranch, stderr)
+	if code != exitSuccess {
+		return code
+	}
+
+	if in.dryRun {
+		return writeDryRunCommit(stdout, in.owner, in.repo, in.branch, in.message, branchHead, additions)
+	}
+
+	commit, err := client.CreateCommitOnBranch(ctx, &ghclient.CreateCommitOnBranchInput{
+		RepositoryNameWithOwner: in.owner + "/" + in.repo,
+		BranchName:              in.branch,
+		ExpectedHeadOID:         branchHead,
+		Message:                 in.message,
+		Additions:               additions,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: create commit: %v\n", err)
+		return exitOperational
+	}
+
+	_, _ = fmt.Fprintln(stdout, commit.OID)
+	return exitSuccess
+}
+
+// collectAllowedAdditions runs `git status -z` in workdir, parses it,
+// filters through the allowlist, rejects symlinks, and reads each
+// surviving path's content into a CommitFileAddition.
+//
+// Returns an exit code on failure; (additions, exitSuccess) on success.
+func collectAllowedAdditions(workdir string, stderr io.Writer) (out []ghclient.CommitFileAddition, exit int) {
+	entries, code := runGitStatusZ(workdir, stderr)
+	if code != exitSuccess {
+		return nil, code
+	}
+
+	additions := make([]ghclient.CommitFileAddition, 0, len(entries))
+	for _, e := range entries {
+		path := e.Path
+
+		if !allowlist.IsAllowed(path) {
+			_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: path %q rejected by allowlist\n", path)
+			return nil, exitValidation
+		}
+
+		body, err := readAllowedFile(workdir, path)
+		if err != nil {
+			code := exitOperational
+			if errors.Is(err, errSymlinkRefused) {
+				code = exitValidation
+			}
+			_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: %s: %v\n", path, err)
+			return nil, code
+		}
+		additions = append(additions, ghclient.CommitFileAddition{
+			Path:     path,
+			Contents: body,
+		})
+	}
+
+	// Deterministic order: GraphQL signs whatever we send, but
+	// deterministic ordering simplifies reproducing release commits
+	// by hand for incident response.
+	sort.Slice(additions, func(i, j int) bool {
+		return additions[i].Path < additions[j].Path
+	})
+	return additions, exitSuccess
+}
+
+// validateCommitPinnedDepsArgs enforces the identifier and message
+// invariants. Shared between runCommitPinnedDeps and the test hook
+// so both paths refuse the same set of values.
+func validateCommitPinnedDepsArgs(in *commitPinnedDepsArgs, stderr io.Writer) int {
+	if err := validateIdent("--owner", in.owner); err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: %v\n", err)
+		return exitValidation
+	}
+	if err := validateIdent("--repo", in.repo); err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: %v\n", err)
+		return exitValidation
+	}
+	if err := validateIdent("--branch", in.branch); err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: %v\n", err)
+		return exitValidation
+	}
+	if err := validateMessage("--message", in.message); err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: %v\n", err)
+		return exitValidation
+	}
+	return exitSuccess
+}
+
+// errSymlinkRefused is the sentinel returned by readAllowedFile
+// when the open(2) call refuses a symlink via O_NOFOLLOW. Callers
+// translate this into exitValidation (#910).
+var errSymlinkRefused = errors.New("path is a symlink — refusing")
+
+// readAllowedFile opens an already-allowlisted path with O_NOFOLLOW
+// and reads its full contents. This collapses the lstat + open dance
+// into a single syscall, closing the TOCTOU window where an
+// attacker could swap the regular file for a symlink between the
+// lstat and the read (#910 threat-model B2).
+//
+// The error returns errSymlinkRefused when the operating system
+// refuses to traverse the final path component because it is a
+// symlink. Linux and Darwin both surface this as syscall.ELOOP;
+// the predicate isSymlinkOpenError checks for it explicitly.
+// Defence in depth: even if a future BSD kernel returned a
+// different errno, the path drops through to "open: %w" and the
+// caller exits operational — no commit is sent.
+func readAllowedFile(workdir, path string) ([]byte, error) {
+	full := filepath.Join(workdir, path)
+	// O_NOFOLLOW on the final component is the kernel-level
+	// guarantee. O_RDONLY because we never mutate; mode 0 because
+	// we never create.
+	f, err := os.OpenFile(full, os.O_RDONLY|syscall.O_NOFOLLOW, 0) //nolint:gosec // path is allowlist-screened above
+	if err != nil {
+		if isSymlinkOpenError(err) {
+			return nil, errSymlinkRefused
+		}
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Defence in depth: stat the open fd and refuse anything that
+	// is not a regular file (sockets, FIFOs, devices). O_NOFOLLOW
+	// already refuses symlinks; this catches everything else the
+	// allowlist might inadvertently let through if the path
+	// happens to be a special file.
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file (mode=%v)", info.Mode())
+	}
+
+	body, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+	return body, nil
+}
+
+// isSymlinkOpenError reports whether err looks like an
+// O_NOFOLLOW-rejected symlink (ELOOP on Linux/macOS).
+func isSymlinkOpenError(err error) bool {
+	return errors.Is(err, syscall.ELOOP)
+}
+
+// runGitStatusZ shells out to `git status -z --porcelain
+// --untracked-files=no` in workdir and parses the result.
+func runGitStatusZ(workdir string, stderr io.Writer) (entries []gitstatus.Entry, exit int) {
+	cmd := exec.Command("git", "-C", workdir, "status", "-z",
+		"--porcelain", "--untracked-files=no")
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		gitMsg := strings.TrimRight(errBuf.String(), "\n")
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: git status failed: %v\n%s\n",
+			err, gitMsg)
+		return nil, exitOperational
+	}
+	var err error
+	entries, err = gitstatus.Parse(&out)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: parse git status: %v\n", err)
+		return nil, exitOperational
+	}
+	return entries, exitSuccess
+}
+
+// resolveOrCreateBranch returns the OID of the branch HEAD. If the
+// branch does not exist and autoCreate is true, it is created from
+// the OID of `main`. Otherwise the missing branch is an operational
+// failure.
+func resolveOrCreateBranch(ctx context.Context, c *ghclient.Client, owner, repo, branch string, autoCreate bool, stderr io.Writer) (head string, exit int) {
+	ref, err := c.GetRef(ctx, owner, repo, "heads/"+branch)
+	switch {
+	case err == nil:
+		return ref.Object.SHA, exitSuccess
+	case !isNotFound(err):
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: lookup branch %q: %v\n", branch, err)
+		return "", exitOperational
+	}
+
+	if !autoCreate {
+		_, _ = fmt.Fprintf(stderr,
+			"commit-pinned-deps: branch %q does not exist (pass --auto-create-branch to create from main)\n",
+			branch)
+		return "", exitOperational
+	}
+
+	mainRef, err := c.GetRef(ctx, owner, repo, "heads/main")
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: resolve main: %v\n", err)
+		return "", exitOperational
+	}
+	created, err := c.CreateRef(ctx, owner, repo, &ghclient.CreateRefInput{
+		Ref: "refs/heads/" + branch,
+		SHA: mainRef.Object.SHA,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "commit-pinned-deps: create branch %q: %v\n", branch, err)
+		return "", exitOperational
+	}
+	return created.Object.SHA, exitSuccess
+}
+
+// writeDryRunCommit prints the proposed GraphQL payload (without the
+// raw file contents — those would be enormous) to stdout.
+func writeDryRunCommit(stdout io.Writer, owner, repo, branch, message, head string, additions []ghclient.CommitFileAddition) int {
+	type fileSummary struct {
+		Path string `json:"path"`
+		Size int    `json:"contents_bytes"`
+	}
+	files := make([]fileSummary, 0, len(additions))
+	for _, a := range additions {
+		files = append(files, fileSummary{Path: a.Path, Size: len(a.Contents)})
+	}
+	payload := map[string]any{
+		"mutation": "createCommitOnBranch",
+		"variables": map[string]any{
+			"input": map[string]any{
+				"branch": map[string]string{
+					"repositoryNameWithOwner": owner + "/" + repo,
+					"branchName":              branch,
+				},
+				"expectedHeadOid": head,
+				"message":         map[string]string{"headline": message},
+				"fileChanges": map[string]any{
+					"additions_summary": files,
+				},
+			},
+		},
+	}
+	if err := json.NewEncoder(stdout).Encode(payload); err != nil {
+		return exitOperational
+	}
+	return exitSuccess
+}
+
+// requireCommitFlags returns a usage error listing missing flags.
+func requireCommitFlags(owner, repo, branch, message string) error {
+	missing := []string{}
+	if owner == "" {
+		missing = append(missing, "--owner")
+	}
+	if repo == "" {
+		missing = append(missing, "--repo")
+	}
+	if branch == "" {
+		missing = append(missing, "--branch")
+	}
+	if message == "" {
+		missing = append(missing, "--message")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required flag(s): %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func writeCommitPinnedDepsHelp(w io.Writer) {
+	_, _ = fmt.Fprint(w, `release-tool commit-pinned-deps — open an App-signed commit
+on a branch using the GitHub GraphQL createCommitOnBranch mutation.
+
+USAGE
+    release-tool commit-pinned-deps \
+        --owner OWNER --repo REPO --branch BRANCH \
+        --message TEXT [--auto-create-branch] [--workdir DIR]
+
+FLAGS
+    --owner                OWNER       GitHub repository owner (required)
+    --repo                 REPO        GitHub repository name (required)
+    --branch               BRANCH      Target branch (required)
+    --message              TEXT        Commit message headline (required)
+    --auto-create-branch               Create the branch from main if missing
+    --workdir              DIR         Path to the git working directory
+                                       (default: ".")
+
+PERSISTENT FLAGS (inherited)
+    --dry-run        Print proposed payload (path + size only) to stdout
+                     and exit 0 without performing any state mutation
+    --timeout        Per-request timeout for GitHub API calls
+
+EXIT CODES
+    0 — success (commit SHA written to stdout)
+    1 — operational failure (git status failed, API error, network)
+    3 — validation error (path failed allowlist, or path is a symlink)
+    4 — idempotent no-op (no staged changes)
+
+REGRESSIONS LOCKED
+    #906 / #910  symlinked or off-allowlist paths refused
+    #907         NUL-delimited git-status parsed via io.Reader, never $()
+    #911         only 40-hex commit SHAs reach the API (gh-CLI 404 JSON
+                 was previously accepted as a SHA)
+    #915 / #916  GraphQL variables sent as a structured object, never a
+                 JSON-string-of-an-object
+`)
+}

--- a/cmd/release-tool/cmd_commit_pinned_deps.go
+++ b/cmd/release-tool/cmd_commit_pinned_deps.go
@@ -22,12 +22,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 
 	"github.com/axonops/audit/cmd/release-tool/internal/allowlist"
 	"github.com/axonops/audit/cmd/release-tool/internal/ghclient"
@@ -207,59 +204,6 @@ func validateCommitPinnedDepsArgs(in *commitPinnedDepsArgs, stderr io.Writer) in
 // when the open(2) call refuses a symlink via O_NOFOLLOW. Callers
 // translate this into exitValidation (#910).
 var errSymlinkRefused = errors.New("path is a symlink — refusing")
-
-// readAllowedFile opens an already-allowlisted path with O_NOFOLLOW
-// and reads its full contents. This collapses the lstat + open dance
-// into a single syscall, closing the TOCTOU window where an
-// attacker could swap the regular file for a symlink between the
-// lstat and the read (#910 threat-model B2).
-//
-// The error returns errSymlinkRefused when the operating system
-// refuses to traverse the final path component because it is a
-// symlink. Linux and Darwin both surface this as syscall.ELOOP;
-// the predicate isSymlinkOpenError checks for it explicitly.
-// Defence in depth: even if a future BSD kernel returned a
-// different errno, the path drops through to "open: %w" and the
-// caller exits operational — no commit is sent.
-func readAllowedFile(workdir, path string) ([]byte, error) {
-	full := filepath.Join(workdir, path)
-	// O_NOFOLLOW on the final component is the kernel-level
-	// guarantee. O_RDONLY because we never mutate; mode 0 because
-	// we never create.
-	f, err := os.OpenFile(full, os.O_RDONLY|syscall.O_NOFOLLOW, 0) //nolint:gosec // path is allowlist-screened above
-	if err != nil {
-		if isSymlinkOpenError(err) {
-			return nil, errSymlinkRefused
-		}
-		return nil, fmt.Errorf("open: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	// Defence in depth: stat the open fd and refuse anything that
-	// is not a regular file (sockets, FIFOs, devices). O_NOFOLLOW
-	// already refuses symlinks; this catches everything else the
-	// allowlist might inadvertently let through if the path
-	// happens to be a special file.
-	info, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat: %w", err)
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("not a regular file (mode=%v)", info.Mode())
-	}
-
-	body, err := io.ReadAll(f)
-	if err != nil {
-		return nil, fmt.Errorf("read: %w", err)
-	}
-	return body, nil
-}
-
-// isSymlinkOpenError reports whether err looks like an
-// O_NOFOLLOW-rejected symlink (ELOOP on Linux/macOS).
-func isSymlinkOpenError(err error) bool {
-	return errors.Is(err, syscall.ELOOP)
-}
 
 // runGitStatusZ shells out to `git status -z --porcelain
 // --untracked-files=no` in workdir and parses the result.

--- a/cmd/release-tool/cmd_commit_pinned_deps_test.go
+++ b/cmd/release-tool/cmd_commit_pinned_deps_test.go
@@ -1,0 +1,436 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/gitstatus"
+)
+
+const (
+	branchHeadSHA = "feedface0000000000000000000000000000feed"
+	newCommitSHA  = "cafebabe0000000000000000000000000000cafe"
+)
+
+// TestRun_CommitPinnedDeps_NoStagedChanges_ExitsIdempotent covers the
+// re-run scenario: when the upstream invocation already committed the
+// pinned go.mods, a re-run finds nothing to stage and must exit 4
+// (no-op), not 0 (false-success) and not 1 (false-failure).
+func TestRun_CommitPinnedDeps_NoStagedChanges_ExitsIdempotent(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	srv := newCommitServer(t, commitFixture{})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin deps"})
+	if code != exitIdempotentNoOp {
+		t.Errorf("want exit %d (no-op), got %d (stderr=%q)", exitIdempotentNoOp, code, stderr.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_OffAllowlist_Rejected is the regression
+// for #906: a staged path outside the go.mod / go.sum allowlist must
+// be refused with an exit 3 (validation), not silently committed.
+func TestRun_CommitPinnedDeps_OffAllowlist_Rejected(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, ".github/workflows/release.yml", []byte("# off-allowlist"))
+
+	srv := newCommitServer(t, commitFixture{})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin deps"})
+	if code != exitValidation {
+		t.Errorf("want exit %d (validation), got %d (stderr=%q)", exitValidation, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "rejected by allowlist") {
+		t.Errorf("stderr must explain the allowlist rejection: %q", stderr.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_Symlink_Rejected is the regression for
+// #910: even an allowed path is refused when it points at a symlink.
+// Without this gate, a malicious caller could `ln -s /etc/passwd
+// go.mod` and commit anything via the App identity.
+func TestRun_CommitPinnedDeps_Symlink_Rejected(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	target := filepath.Join(repo, "real-target.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real-target.txt", filepath.Join(repo, "go.mod")); err != nil {
+		t.Fatal(err)
+	}
+	runGitOrFatal(t, repo, "add", "go.mod")
+
+	srv := newCommitServer(t, commitFixture{})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin deps"})
+	if code != exitValidation {
+		t.Errorf("want exit %d (validation), got %d (stderr=%q)", exitValidation, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "symlink") {
+		t.Errorf("stderr must explain the symlink rejection: %q", stderr.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_StructuredVariables is the regression for
+// #915 / #916: the bash version sent variables as a JSON-string-
+// containing-an-object instead of a structured object, and the
+// server rejected the mutation. The HTTP fixture captures the body
+// and asserts it parses as a typed structure.
+func TestRun_CommitPinnedDeps_StructuredVariables(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\ngo 1.26\n"))
+	writeAndStage(t, repo, "webhook/go.mod", []byte("module example.com/webhook\ngo 1.26\n"))
+
+	var captured atomic.Pointer[capturedMutation]
+	srv := newCommitServer(t, commitFixture{
+		branchHeadSHA: branchHeadSHA,
+		commitOID:     newCommitSHA,
+		captureBody:   &captured,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin deps"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+
+	got := captured.Load()
+	if got == nil {
+		t.Fatal("server never received the GraphQL mutation")
+	}
+	// The variables key MUST decode as a structured object — the
+	// #916 regression is that the bash version was sending it as a
+	// quoted JSON string.
+	varsAsObject, ok := got.Variables.(map[string]any)
+	if !ok {
+		t.Fatalf("variables must be a structured object, got %T (#916)", got.Variables)
+	}
+	input, ok := varsAsObject["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables.input must be a structured object, got %T", varsAsObject["input"])
+	}
+	if input["expectedHeadOid"] != branchHeadSHA {
+		t.Errorf("expectedHeadOid: want %q, got %v", branchHeadSHA, input["expectedHeadOid"])
+	}
+	// And both files must show up in the additions list — proves
+	// the #907 NUL-stream parse worked.
+	fc, ok := input["fileChanges"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables.input.fileChanges missing or wrong shape")
+	}
+	additions, ok := fc["additions"].([]any)
+	if !ok || len(additions) != 2 {
+		t.Errorf("fileChanges.additions must have 2 entries (#907), got %v", additions)
+	}
+	if strings.TrimSpace(stdout.String()) != newCommitSHA {
+		t.Errorf("stdout must be the new commit OID: want %q, got %q", newCommitSHA, stdout.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_NULDelimitedManyFiles is a targeted
+// regression for #907: 35 staged files would have produced a single
+// garbled record under the bash `$()` parser. The Go parser is fed
+// the raw stream, so every file must round-trip.
+func TestRun_CommitPinnedDeps_NULDelimitedManyFiles(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	for _, p := range []string{
+		"go.mod", "go.sum",
+		"webhook/go.mod", "webhook/go.sum",
+		"syslog/go.mod", "syslog/go.sum",
+		"loki/go.mod", "loki/go.sum",
+		"file/go.mod", "file/go.sum",
+		"splunk/go.mod", "splunk/go.sum",
+		"secrets/go.mod", "secrets/go.sum",
+		"secrets/openbao/go.mod", "secrets/openbao/go.sum",
+		"secrets/vault/go.mod", "secrets/vault/go.sum",
+	} {
+		writeAndStage(t, repo, p, []byte("module x\n"))
+	}
+
+	var captured atomic.Pointer[capturedMutation]
+	srv := newCommitServer(t, commitFixture{
+		branchHeadSHA: branchHeadSHA,
+		commitOID:     newCommitSHA,
+		captureBody:   &captured,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin deps"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	got := captured.Load()
+	if got == nil {
+		t.Fatal("mutation never received")
+	}
+	additions := additionPathsFrom(t, got)
+	if len(additions) != 18 {
+		t.Errorf("want 18 additions, got %d (#907 NUL-stream parse may have collapsed paths): %v",
+			len(additions), additions)
+	}
+}
+
+// TestRun_CommitPinnedDeps_GraphQLErrors_ExitsOperational covers
+// test-analyst B3: the production handler must translate a 200-
+// with-errors GraphQL response into exit operational with a
+// useful diagnostic, not silent success or a misleading "create
+// commit" wrapper. Without this end-to-end lock, a future change
+// to ghclient could swap the error surfacing and the test suite
+// would miss it.
+func TestRun_CommitPinnedDeps_GraphQLErrors_ExitsOperational(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\n"))
+
+	srv := newCommitGraphQLErrorServer(t, branchHeadSHA)
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin"})
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Variable $input") {
+		t.Errorf("stderr must surface the GraphQL error message: %q", stderr.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_NotAGitRepo_ExitsOperational covers
+// analyst I1: pointing --workdir at a directory that is not a git
+// checkout must exit operational with a diagnostic that names git's
+// own stderr, not silently succeed or panic.
+func TestRun_CommitPinnedDeps_NotAGitRepo_ExitsOperational(t *testing.T) {
+	t.Parallel()
+	nonGit := t.TempDir() // empty tempdir — no .git directory
+	srv := newCommitServer(t, commitFixture{})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, nonGit, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin"})
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "git status failed") {
+		t.Errorf("stderr must name the git status failure: %q", stderr.String())
+	}
+}
+
+// newCommitGraphQLErrorServer constructs an httptest server whose
+// /graphql endpoint returns the bash-era response shape that broke
+// v0.2.1 — 200 status with a top-level errors array carrying the
+// invalid-variable message.
+func newCommitGraphQLErrorServer(t *testing.T, head string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/axonops/audit/git/ref/heads/release/v0.2.2", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ref":"refs/heads/release/v0.2.2","object":{"sha":"` + head + `","type":"commit"}}`))
+	})
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":null,"errors":[{"message":"Variable $input of type CreateCommitOnBranchInput! was provided invalid value"}]}`))
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestGitStatusParse_HandlesRenamesAndSpacedPaths is the real
+// #907 NUL-stream regression. The bash $() parser would have
+// collapsed:
+//   - the two NUL records of a rename ("R  newpath\x00oldpath") into
+//     a single garbled string, and
+//   - a path containing a literal space (`my file/go.mod`) by
+//     re-splitting on whitespace.
+//
+// This test feeds gitstatus.Parse a hand-built NUL-delimited stream
+// that EXACTLY replicates what `git status -z` emits for these
+// shapes, and asserts the parsed Entry slice. Unlike the end-to-end
+// many-files test, this exercises the parser at the level the bash
+// version actually broke at.
+func TestGitStatusParse_HandlesRenamesAndSpacedPaths(t *testing.T) {
+	t.Parallel()
+	// Build the porcelain stream:
+	//   M  go.mod\x00              regular modified file
+	//   R  webhook/go.mod\x00web_old/go.mod\x00   rename (two NUL records)
+	//   M  spaced dir/go.mod\x00   path with a literal space
+	raw := []byte(
+		"M  go.mod\x00" +
+			"R  webhook/go.mod\x00web_old/go.mod\x00" +
+			"M  spaced dir/go.mod\x00",
+	)
+	entries, err := gitstatus.Parse(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("want 3 entries, got %d: %+v", len(entries), entries)
+	}
+	if entries[0].Path != "go.mod" {
+		t.Errorf("entries[0].Path: want %q, got %q", "go.mod", entries[0].Path)
+	}
+	if entries[1].Path != "webhook/go.mod" || entries[1].OldPath != "web_old/go.mod" {
+		t.Errorf("entries[1]: want path=webhook/go.mod old=web_old/go.mod, got path=%q old=%q (#907 rename collapse)",
+			entries[1].Path, entries[1].OldPath)
+	}
+	if entries[2].Path != "spaced dir/go.mod" {
+		t.Errorf("entries[2].Path: want %q (with literal space — bash $() would have lost this), got %q",
+			"spaced dir/go.mod", entries[2].Path)
+	}
+}
+
+// --- helpers ---
+
+// newGitRepo creates a tempdir and runs `git init` so the test can
+// stage paths via `git add` and have them appear in `git status -z`.
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitOrFatal(t, dir, "init", "--quiet")
+	runGitOrFatal(t, dir, "config", "user.email", "test@example.com")
+	runGitOrFatal(t, dir, "config", "user.name", "Test User")
+	runGitOrFatal(t, dir, "commit", "--allow-empty", "-m", "init")
+	return dir
+}
+
+func writeAndStage(t *testing.T, root, rel string, body []byte) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.Dir(rel))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, rel), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitOrFatal(t, root, "add", rel)
+}
+
+func runGitOrFatal(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// capturedMutation is what the test fixture records about the
+// GraphQL request body it received.
+type capturedMutation struct {
+	Variables any    `json:"variables"`
+	Query     string `json:"query"`
+}
+
+// commitFixture configures the commit server fixture.
+type commitFixture struct {
+	captureBody   *atomic.Pointer[capturedMutation]
+	branchHeadSHA string
+	commitOID     string
+}
+
+func newCommitServer(t *testing.T, f commitFixture) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/axonops/audit/git/ref/heads/release/v0.2.2", func(w http.ResponseWriter, r *http.Request) {
+		if f.branchHeadSHA == "" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ref":"refs/heads/release/v0.2.2","object":{"sha":"` + f.branchHeadSHA + `","type":"commit"}}`))
+	})
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		var body capturedMutation
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("server decoding mutation: %v", err)
+			http.Error(w, "bad", http.StatusBadRequest)
+			return
+		}
+		if f.captureBody != nil {
+			f.captureBody.Store(&body)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"` + f.commitOID + `","url":""}}}}`))
+	})
+	return httptest.NewServer(mux)
+}
+
+// additionPathsFrom extracts the additions paths from a captured
+// mutation. Used in #907 regression assertions.
+func additionPathsFrom(t *testing.T, m *capturedMutation) []string {
+	t.Helper()
+	vars, ok := m.Variables.(map[string]any)
+	if !ok {
+		t.Fatalf("variables wrong shape: %T", m.Variables)
+	}
+	input, ok := vars["input"].(map[string]any)
+	if !ok {
+		t.Fatal("variables.input wrong shape")
+	}
+	fc, ok := input["fileChanges"].(map[string]any)
+	if !ok {
+		t.Fatal("fileChanges wrong shape")
+	}
+	additions, ok := fc["additions"].([]any)
+	if !ok {
+		t.Fatal("additions wrong shape")
+	}
+	out := make([]string, 0, len(additions))
+	for _, a := range additions {
+		am, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		if p, ok := am["path"].(string); ok {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/cmd/release-tool/cmd_create_tag.go
+++ b/cmd/release-tool/cmd_create_tag.go
@@ -1,0 +1,352 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+	"unicode/utf8"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/ghclient"
+	"github.com/axonops/audit/cmd/release-tool/internal/sha"
+)
+
+// createTagArgs are the parsed flags for the create-tag subcommand.
+// Sharing this type between the production handler and the test hook
+// keeps the contract a single source of truth.
+type createTagArgs struct {
+	owner   string
+	repo    string
+	tag     string
+	commit  string
+	message string
+	dryRun  bool
+}
+
+// runCreateTag implements the `create-tag` subcommand.
+//
+// Idempotent semantics (regression for #911 / gh-graphql-tag.sh
+// BLOCKER-3):
+//   - tag absent → create, exit 0
+//   - tag exists at same SHA → exit 4 (idempotent no-op)
+//   - tag exists at different SHA → exit 1 (history contamination)
+func runCreateTag(ctx context.Context, args []string, stdout, stderr io.Writer, persistent *rootFlags) int {
+	fs := flag.NewFlagSet("create-tag", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writeCreateTagHelp(fs.Output()) }
+
+	in := createTagArgs{}
+	fs.StringVar(&in.owner, "owner", "", "GitHub repository owner (required)")
+	fs.StringVar(&in.repo, "repo", "", "GitHub repository name (required)")
+	fs.StringVar(&in.tag, "tag", "", "Tag name, e.g. v0.2.2 (required)")
+	fs.StringVar(&in.commit, "sha", "", "Commit SHA to point the tag at; must be 40 hex chars (required)")
+	fs.StringVar(&in.message, "message", "", "Tag annotation message (required)")
+
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	in.dryRun = persistent.dryRun
+
+	if code := validateCreateTagArgs(&in, stderr); code != exitSuccess {
+		return code
+	}
+
+	client, code := buildClient(persistent, stderr)
+	if code != exitSuccess {
+		return code
+	}
+	return doCreateTag(ctx, client, &in, stdout, stderr)
+}
+
+// validateCreateTagArgs enforces the required-flag and SHA-shape
+// invariants. Exposed so the test hook can share the same gate.
+func validateCreateTagArgs(in *createTagArgs, stderr io.Writer) int {
+	if err := requireFlags(in.owner, in.repo, in.tag, in.commit, in.message); err != nil {
+		_, _ = fmt.Fprintf(stderr, "create-tag: %v\n", err)
+		return exitUsage
+	}
+	if err := validateIdent("--owner", in.owner); err != nil {
+		_, _ = fmt.Fprintf(stderr, "create-tag: %v\n", err)
+		return exitValidation
+	}
+	if err := validateIdent("--repo", in.repo); err != nil {
+		_, _ = fmt.Fprintf(stderr, "create-tag: %v\n", err)
+		return exitValidation
+	}
+	if err := validateIdent("--tag", in.tag); err != nil {
+		_, _ = fmt.Fprintf(stderr, "create-tag: %v\n", err)
+		return exitValidation
+	}
+	if err := validateMessage("--message", in.message); err != nil {
+		_, _ = fmt.Fprintf(stderr, "create-tag: %v\n", err)
+		return exitValidation
+	}
+	if !sha.IsValid(in.commit) {
+		_, _ = fmt.Fprintf(stderr, "create-tag: --sha must be 40 lowercase hex chars, got %q\n",
+			truncateForDiag(in.commit, 80))
+		return exitValidation
+	}
+	return exitSuccess
+}
+
+// truncateForDiag clips an operator-pasted value to at most n bytes
+// for inclusion in a diagnostic message. Multi-kilobyte 404 JSON
+// pasted into --sha is the realistic case (#911 again, in reverse).
+//
+// Truncation is rune-safe: if the n-th byte falls in the middle of
+// a multi-byte UTF-8 sequence, the returned string trims back to
+// the nearest preceding rune boundary so stderr never emits invalid
+// UTF-8 (test-analyst N2).
+func truncateForDiag(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	end := n
+	// Walk back to the start of the rune that the byte index n
+	// fell inside, if any. utf8.RuneStart reports whether byte b
+	// is a leading byte; we trim continuation bytes from the cut
+	// point.
+	for end > 0 && !utf8.RuneStart(s[end]) {
+		end--
+	}
+	return s[:end] + "…"
+}
+
+// doCreateTag executes the create-tag dance against the supplied
+// client. Split out from runCreateTag so the test hook can inject a
+// client pointed at httptest.
+func doCreateTag(ctx context.Context, client *ghclient.Client, in *createTagArgs, stdout, stderr io.Writer) int {
+	// Idempotency check: does the tag already exist?
+	existingRef, err := client.GetRef(ctx, in.owner, in.repo, "tags/"+in.tag)
+	switch {
+	case err == nil:
+		return handleExistingTag(ctx, client, existingRef, in, stderr)
+	case isNotFound(err):
+		// Fall through to create.
+	default:
+		_, _ = fmt.Fprintf(stderr, "create-tag: lookup existing tag: %v\n", err)
+		return exitOperational
+	}
+
+	// Dry-run short-circuit — only after we've established the tag
+	// doesn't already exist, so a re-run on a contaminated tag still
+	// exits with the contamination diagnostic in dry-run mode.
+	if in.dryRun {
+		return writeDryRunCreateTag(stdout, in.owner, in.repo, in.tag, in.commit, in.message)
+	}
+
+	tagObj, err := client.CreateTag(ctx, in.owner, in.repo, &ghclient.CreateTagInput{
+		Tag:     in.tag,
+		Message: in.message,
+		Object:  in.commit,
+		Type:    "commit",
+		Tagger: ghclient.TagAuthor{
+			Name:  "axonops-audit-release-bot[bot]",
+			Email: "axonops-audit-release-bot[bot]@users.noreply.github.com",
+			Date:  time.Now().UTC().Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "create-tag: create tag object: %v\n", err)
+		return exitOperational
+	}
+
+	if _, err := client.CreateRef(ctx, in.owner, in.repo, &ghclient.CreateRefInput{
+		Ref: "refs/tags/" + in.tag,
+		SHA: tagObj.SHA,
+	}); err != nil {
+		// Partial-success recovery (test-analyst I2): the tag
+		// OBJECT was committed but the REF could not be created.
+		// Surface the orphan object SHA explicitly so the
+		// operator can finish the release manually.
+		_, _ = fmt.Fprintf(stderr,
+			"create-tag: tag object %s created but ref refs/tags/%s could not be published: %v\n",
+			tagObj.SHA, in.tag, err)
+		_, _ = fmt.Fprintf(stderr,
+			"create-tag: recover manually with: gh api -X POST /repos/%s/%s/git/refs --field ref=refs/tags/%s --field sha=%s\n",
+			in.owner, in.repo, in.tag, tagObj.SHA)
+		return exitOperational
+	}
+
+	_, _ = fmt.Fprintln(stdout, tagObj.SHA)
+	return exitSuccess
+}
+
+// handleExistingTag handles the case where the tag already exists.
+// Returns exit 4 if the tag points at the same commit (idempotent
+// no-op), exit 1 with a contamination diagnostic otherwise.
+//
+// For lightweight tags, existing.Object.Type == "commit" and
+// existing.Object.SHA is the commit SHA — compare directly.
+//
+// For annotated tags, existing.Object.Type == "tag" and
+// existing.Object.SHA is the tag-object SHA, not the commit SHA.
+// Comparing the flag's commit SHA against the tag-object SHA would
+// be a false-contamination diagnostic on every re-run. We MUST
+// dereference via GET /git/tags/<tag_object_sha> first.
+func handleExistingTag(ctx context.Context, client *ghclient.Client, existing *ghclient.Ref, in *createTagArgs, stderr io.Writer) int {
+	existingCommit, err := resolveExistingCommit(ctx, client, in.owner, in.repo, existing)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "create-tag: dereference tag object: %v\n", err)
+		return exitOperational
+	}
+	if existingCommit == in.commit {
+		_, _ = fmt.Fprintf(stderr, "create-tag: %s already exists at %s — no-op\n", in.tag, in.commit)
+		return exitIdempotentNoOp
+	}
+	_, _ = fmt.Fprintf(stderr,
+		"create-tag: %s exists at %s but wanted %s — refusing to overwrite\n",
+		in.tag, existingCommit, in.commit)
+	return exitOperational
+}
+
+// resolveExistingCommit returns the commit SHA the existing tag
+// points at, dereferencing through the tag object when the ref is an
+// annotated tag.
+func resolveExistingCommit(ctx context.Context, client *ghclient.Client, owner, repo string, existing *ghclient.Ref) (string, error) {
+	switch existing.Object.Type {
+	case "commit":
+		return existing.Object.SHA, nil
+	case "tag":
+		tag, err := client.GetTag(ctx, owner, repo, existing.Object.SHA)
+		if err != nil {
+			return "", fmt.Errorf("dereference tag object %s: %w", existing.Object.SHA, err)
+		}
+		return tag.Object.SHA, nil
+	default:
+		return "", fmt.Errorf("unknown ref object type %q", existing.Object.Type)
+	}
+}
+
+// writeDryRunCreateTag prints what create-tag WOULD send to the
+// GitHub API.
+func writeDryRunCreateTag(stdout io.Writer, owner, repo, tag, commit, message string) int {
+	payload := map[string]any{
+		"tag_object": map[string]any{
+			"endpoint": fmt.Sprintf("POST /repos/%s/%s/git/tags", owner, repo),
+			"body": map[string]any{
+				"tag":     tag,
+				"message": message,
+				"object":  commit,
+				"type":    "commit",
+				"tagger": map[string]any{
+					"name":  "axonops-audit-release-bot[bot]",
+					"email": "axonops-audit-release-bot[bot]@users.noreply.github.com",
+					"date":  "<NOW>",
+				},
+			},
+		},
+		"ref": map[string]any{
+			"endpoint": fmt.Sprintf("POST /repos/%s/%s/git/refs", owner, repo),
+			"body": map[string]any{
+				"ref": "refs/tags/" + tag,
+				"sha": "<tag_object.sha>",
+			},
+		},
+	}
+	if err := json.NewEncoder(stdout).Encode(payload); err != nil {
+		return exitOperational
+	}
+	return exitSuccess
+}
+
+// buildClient constructs a ghclient.Client using the persistent
+// flags. Returns the appropriate exit code on failure.
+func buildClient(persistent *rootFlags, stderr io.Writer) (client *ghclient.Client, exit int) {
+	token := os.Getenv("GH_TOKEN")
+	if token == "" {
+		_, _ = fmt.Fprintln(stderr, "release-tool: GH_TOKEN environment variable is required")
+		return nil, exitOperational
+	}
+	c, err := ghclient.New(token,
+		ghclient.WithHTTPClient(&http.Client{Timeout: persistent.timeout}),
+	)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "release-tool: ghclient init: %v\n", err)
+		return nil, exitOperational
+	}
+	return c, exitSuccess
+}
+
+// requireFlags reports a usage error if any required flag is empty.
+func requireFlags(owner, repo, tag, commit, message string) error {
+	missing := []string{}
+	if owner == "" {
+		missing = append(missing, "--owner")
+	}
+	if repo == "" {
+		missing = append(missing, "--repo")
+	}
+	if tag == "" {
+		missing = append(missing, "--tag")
+	}
+	if commit == "" {
+		missing = append(missing, "--sha")
+	}
+	if message == "" {
+		missing = append(missing, "--message")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required flag(s): %v", missing)
+	}
+	return nil
+}
+
+// isNotFound reports whether err is a 404 HTTPError.
+func isNotFound(err error) bool {
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		return false
+	}
+	return herr.StatusCode == http.StatusNotFound
+}
+
+func writeCreateTagHelp(w io.Writer) {
+	_, _ = fmt.Fprint(w, `release-tool create-tag — create an annotated tag at a commit SHA
+
+USAGE
+    release-tool create-tag --owner OWNER --repo REPO --tag TAG \
+                            --sha SHA --message TEXT
+
+FLAGS
+    --owner    OWNER    GitHub repository owner (required)
+    --repo     REPO     GitHub repository name (required)
+    --tag      TAG      Tag name, e.g. v0.2.2 (required)
+    --sha      SHA      Commit SHA to point the tag at; 40 hex chars
+    --message  TEXT     Tag annotation message (required)
+
+PERSISTENT FLAGS (inherited)
+    --dry-run        Print proposed payloads to stdout and exit 0
+                     without performing any state mutation
+    --timeout        Per-request timeout for GitHub API calls
+
+EXIT CODES
+    0 — success
+    1 — API error / tag exists at a different SHA (contamination)
+    3 — validation error (invalid SHA)
+    4 — idempotent no-op (tag already exists at the same SHA)
+
+EXAMPLES
+    release-tool create-tag --owner axonops --repo audit \
+        --tag v0.2.2 --sha abc...def --message "Release v0.2.2"
+`)
+}

--- a/cmd/release-tool/cmd_create_tag.go
+++ b/cmd/release-tool/cmd_create_tag.go
@@ -271,15 +271,27 @@ func writeDryRunCreateTag(stdout io.Writer, owner, repo, tag, commit, message st
 
 // buildClient constructs a ghclient.Client using the persistent
 // flags. Returns the appropriate exit code on failure.
+//
+// Environment:
+//   - GH_TOKEN (required): App Installation Token. Never logged.
+//   - GH_API_URL (optional): override the GitHub API base URL.
+//     Used by BDD scenarios that drive the binary against an
+//     httptest server. NOT for production use — pointing this at
+//     anything other than api.github.com routes App-signed
+//     mutations through an untrusted endpoint.
 func buildClient(persistent *rootFlags, stderr io.Writer) (client *ghclient.Client, exit int) {
 	token := os.Getenv("GH_TOKEN")
 	if token == "" {
 		_, _ = fmt.Fprintln(stderr, "release-tool: GH_TOKEN environment variable is required")
 		return nil, exitOperational
 	}
-	c, err := ghclient.New(token,
+	opts := []ghclient.Option{
 		ghclient.WithHTTPClient(&http.Client{Timeout: persistent.timeout}),
-	)
+	}
+	if base := os.Getenv("GH_API_URL"); base != "" {
+		opts = append(opts, ghclient.WithBaseURL(base))
+	}
+	c, err := ghclient.New(token, opts...)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "release-tool: ghclient init: %v\n", err)
 		return nil, exitOperational

--- a/cmd/release-tool/cmd_create_tag_test.go
+++ b/cmd/release-tool/cmd_create_tag_test.go
@@ -1,0 +1,467 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+const (
+	fakeSHA      = "abcdef0123456789abcdef0123456789abcdef01"
+	otherSHA     = "0123456789abcdef0123456789abcdef01234567"
+	createdSHA   = "1111111111111111111111111111111111111111"
+	annotatedTag = "9999999999999999999999999999999999999999"
+)
+
+// TestRun_CreateTag_MissingFlags_ExitsUsage covers the new-operator
+// usability case: forgetting --tag should produce a fast usage error.
+//
+// Uses the test hook so we don't depend on GH_TOKEN — validation
+// runs before the env lookup anyway.
+func TestRun_CreateTag_MissingFlags_ExitsUsage(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook("http://unused.invalid", &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--sha", fakeSHA, "--message", "Release"})
+	if code != exitUsage {
+		t.Errorf("want exit %d (usage), got %d (stderr=%q)", exitUsage, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--tag") {
+		t.Errorf("error must name the missing flag: %q", stderr.String())
+	}
+}
+
+// TestRun_CreateTag_BadSHA_ExitsValidation regression for #911:
+// gh-CLI bash version was accepting 404 error JSON as a SHA. The
+// validator must reject anything that isn't exactly 40 lowercase
+// hex chars before any HTTP call goes out.
+func TestRun_CreateTag_BadSHA_ExitsValidation(t *testing.T) {
+	t.Parallel()
+	// Simulated #911 payload: the error response that the bash
+	// version mistook for a SHA.
+	const bashEra911Bug = `{"message":"Not Found","documentation_url":"..."}`
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook("http://unused.invalid", &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", bashEra911Bug,
+			"--message", "Release"})
+	if code != exitValidation {
+		t.Errorf("want exit %d (validation), got %d (stderr=%q)", exitValidation, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "40 lowercase hex") {
+		t.Errorf("error must explain the SHA contract: %q", stderr.String())
+	}
+}
+
+// TestRun_CreateTag_TagAbsent_CreatesAndReturnsSHA covers the happy
+// path: tag does not exist, both API calls succeed, the OBJECT SHA is
+// written to stdout (machines), the human diagnostic goes to stderr.
+func TestRun_CreateTag_TagAbsent_CreatesAndReturnsSHA(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:    http.StatusNotFound,
+		createTagStatus: http.StatusCreated,
+		createRefStatus: http.StatusCreated,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	got := strings.TrimSpace(stdout.String())
+	if got != annotatedTag {
+		t.Errorf("stdout must carry the tag OBJECT SHA: want %q, got %q", annotatedTag, got)
+	}
+}
+
+// TestRun_CreateTag_TagExists_SameSHA_ExitsIdempotent covers the
+// idempotent re-run case: rerunning the release with the same SHA
+// must NOT be an error. Lightweight-tag case (ref Object.Type ==
+// "commit").
+func TestRun_CreateTag_TagExists_SameSHA_ExitsIdempotent(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:   http.StatusOK,
+		getRefBody:     refBody(fakeSHA, "commit"),
+		failIfMutation: true,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitIdempotentNoOp {
+		t.Errorf("want exit %d (idempotent), got %d (stderr=%q)", exitIdempotentNoOp, code, stderr.String())
+	}
+}
+
+// TestRun_CreateTag_AnnotatedTagSameCommit_ExitsIdempotent covers
+// the regression flagged in code review B1: the ref for an
+// annotated tag carries the tag-object SHA, not the commit SHA. A
+// re-run of the release on the SAME commit must dereference the
+// tag object via GET /git/tags/{tag_object_sha} and compare
+// .object.sha — NOT compare ref.object.sha against the flag.
+// Without dereference, every annotated-tag re-run exits 1
+// "refusing to overwrite", defeating the idempotency contract.
+func TestRun_CreateTag_AnnotatedTagSameCommit_ExitsIdempotent(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		// Existing ref is an ANNOTATED tag — Object.Type=="tag",
+		// Object.SHA is the tag-object SHA (annotatedTag), NOT the
+		// commit SHA.
+		getRefStatus: http.StatusOK,
+		getRefBody:   refBody(annotatedTag, "tag"),
+		// GET /git/tags/{annotatedTag} returns the tag object,
+		// whose .object.sha is the commit (fakeSHA) we want.
+		getTagStatus:        http.StatusOK,
+		getTagDereferences:  annotatedTag,
+		getTagBodyCommitSHA: fakeSHA,
+		failIfMutation:      true,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitIdempotentNoOp {
+		t.Errorf("annotated-tag same-commit must be a no-op: want exit %d, got %d (stderr=%q)",
+			exitIdempotentNoOp, code, stderr.String())
+	}
+}
+
+// TestRun_CreateTag_AnnotatedTagDifferentCommit_ExitsOperational
+// covers the contamination guard for annotated tags. The ref
+// points at a tag-object SHA that derefences to a DIFFERENT commit
+// than the flag — must exit 1 (refuses to overwrite).
+func TestRun_CreateTag_AnnotatedTagDifferentCommit_ExitsOperational(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:        http.StatusOK,
+		getRefBody:          refBody(annotatedTag, "tag"),
+		getTagStatus:        http.StatusOK,
+		getTagDereferences:  annotatedTag,
+		getTagBodyCommitSHA: otherSHA, // different commit
+		failIfMutation:      true,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitOperational {
+		t.Errorf("annotated-tag different-commit must refuse: want exit %d, got %d (stderr=%q)",
+			exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), otherSHA) {
+		t.Errorf("stderr must name the contaminating commit %s: %q", otherSHA, stderr.String())
+	}
+}
+
+// TestRun_CreateTag_TagExists_DifferentSHA_ExitsOperational covers
+// the history-contamination guard: re-running with a DIFFERENT SHA
+// must refuse to overwrite.
+func TestRun_CreateTag_TagExists_DifferentSHA_ExitsOperational(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:   http.StatusOK,
+		getRefBody:     refBody(otherSHA, "commit"),
+		failIfMutation: true,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "refusing to overwrite") {
+		t.Errorf("stderr must explain the contamination refusal: %q", stderr.String())
+	}
+}
+
+// TestRun_CreateTag_UnknownRefObjectType_ExitsOperational locks the
+// resolveExistingCommit default branch: a ref whose Object.Type is
+// neither "commit" nor "tag" (e.g. a fabricated "blob") must exit
+// operational with a diagnostic that names the unknown type, not
+// fall through silently. Test-analyst B1.
+func TestRun_CreateTag_UnknownRefObjectType_ExitsOperational(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:   http.StatusOK,
+		getRefBody:     refBody(fakeSHA, "blob"),
+		failIfMutation: true,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `"blob"`) {
+		t.Errorf("stderr must name the unknown object type: %q", stderr.String())
+	}
+}
+
+// TestRun_CreateTag_GetRef5xx_ExitsOperational covers the non-404
+// GetRef failure mode (analyst I4). The bash version conflated 5xx
+// with "tag doesn't exist" and happily POSTed a duplicate. Now the
+// 5xx must exit 1 with a useful diagnostic.
+func TestRun_CreateTag_GetRef5xx_ExitsOperational(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:   http.StatusServiceUnavailable,
+		failIfMutation: true,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "503") {
+		t.Errorf("stderr must surface the HTTP status: %q", stderr.String())
+	}
+}
+
+// TestRun_CreateTag_CreateRefFails_SurfacesTagSHA covers partial-
+// success recovery (analyst I2). CreateTag succeeds (the tag-object
+// is now committed to the repo's object database) but CreateRef
+// fails. The operator must be able to see the tag-object SHA in
+// stderr so they can finish the release manually — otherwise this
+// is an undocumented information-loss event.
+//
+// To prove the SHA is surfaced by release-tool itself (not echoed
+// back by the API mock), the createRef fixture replies with a 502
+// body that does NOT include the SHA. The assertion fails if the
+// production code stops printing the SHA explicitly.
+func TestRun_CreateTag_CreateRefFails_SurfacesTagSHA(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:          http.StatusNotFound,
+		createTagStatus:       http.StatusCreated,
+		createRefStatus:       http.StatusBadGateway,
+		suppressCreateRefBody: true, // 502 body has no SHA — prove release-tool surfaces it
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), annotatedTag) {
+		t.Errorf("stderr must surface the orphan tag-object SHA %s so the operator can recover: %q",
+			annotatedTag, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "recover manually") {
+		t.Errorf("stderr must include the recovery recipe: %q", stderr.String())
+	}
+}
+
+// TestRun_CreateTag_DryRun_NoMutations covers the safety contract:
+// --dry-run prints the proposed payload to stdout and performs no
+// state mutation, even when the tag does not exist. The fixture
+// installs a mutation handler that always fails the test so any
+// stray POST is caught directly.
+func TestRun_CreateTag_DryRun_NoMutations(t *testing.T) {
+	t.Parallel()
+	var mutationHits atomic.Int32
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:    http.StatusNotFound,
+		failIfMutation:  true,
+		mutationCounter: &mutationHits,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--dry-run",
+			"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release v0.2.2"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	if got := mutationHits.Load(); got != 0 {
+		t.Errorf("dry-run must perform zero mutating API calls, got %d", got)
+	}
+	assertCreateTagDryRunPayload(t, stdout.Bytes())
+}
+
+// assertCreateTagDryRunPayload drills into the nested dry-run
+// payload (test-analyst I6). Extracted so the parent test stays
+// under the cyclomatic-complexity gate.
+func assertCreateTagDryRunPayload(t *testing.T, raw []byte) {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("dry-run stdout must be valid JSON: %v\n%s", err, string(raw))
+	}
+	tagObject, ok := payload["tag_object"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run payload must include nested `tag_object` object, got %T", payload["tag_object"])
+	}
+	body, ok := tagObject["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run payload must include nested `tag_object.body` object")
+	}
+	for k, want := range map[string]any{
+		"tag":     "v0.2.2",
+		"object":  fakeSHA,
+		"message": "Release v0.2.2",
+	} {
+		if body[k] != want {
+			t.Errorf("dry-run tag_object.body.%s: want %q, got %v", k, want, body[k])
+		}
+	}
+	ref, ok := payload["ref"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run payload must include nested `ref` object")
+	}
+	refBody, ok := ref["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run payload must include nested `ref.body` object")
+	}
+	if refBody["ref"] != "refs/tags/v0.2.2" {
+		t.Errorf("dry-run ref.body.ref: want %q, got %v", "refs/tags/v0.2.2", refBody["ref"])
+	}
+}
+
+// createTagFixture configures the test server behaviour.
+//
+// For lightweight-tag scenarios, leave getTagDereferences empty —
+// the GET /git/tags handler will not be expected. For annotated-tag
+// scenarios, set both getTagDereferences (the tag-object SHA the
+// fixture is mock-dereferencing) and getTagBodyCommitSHA (the
+// commit SHA the fixture should return).
+//
+// mutationCounter, if non-nil, is incremented every time a
+// mutating endpoint (POST git/tags, POST git/refs) is hit. The
+// caller asserts it is zero when verifying --dry-run safety.
+type createTagFixture struct {
+	mutationCounter     *atomic.Int32
+	getRefBody          string
+	getTagDereferences  string
+	getTagBodyCommitSHA string
+	getRefStatus        int
+	getTagStatus        int
+	createTagStatus     int
+	createRefStatus     int
+	failIfMutation      bool
+	// suppressCreateRefBody, when true, makes the createRef handler
+	// emit an empty 502 response body. Used to prove release-tool
+	// surfaces the orphan tag-object SHA in stderr ITSELF rather
+	// than passively relaying it from the API response body.
+	suppressCreateRefBody bool
+}
+
+// newCreateTagServer constructs an httptest server that drives the
+// four create-tag calls in order: GET ref/tags/X (idempotency),
+// optional GET tags/{tag_object_sha} (annotated-tag dereference),
+// POST git/tags (create the object), POST git/refs (publish the
+// ref). The dry-run mutation counter is incremented every time a
+// mutation endpoint is hit — the caller asserts on it via the
+// returned *atomic.Int32 (use mutationCounter to check zero).
+func newCreateTagServer(t *testing.T, f *createTagFixture) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/axonops/audit/git/ref/tags/v0.2.2", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(f.getRefStatus)
+		if f.getRefBody != "" {
+			_, _ = w.Write([]byte(f.getRefBody))
+		}
+	})
+	if f.getTagDereferences != "" {
+		path := "/repos/axonops/audit/git/tags/" + f.getTagDereferences
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+				return
+			}
+			w.WriteHeader(f.getTagStatus)
+			_, _ = w.Write([]byte(`{"sha":"` + f.getTagDereferences +
+				`","tag":"v0.2.2","object":{"sha":"` + f.getTagBodyCommitSHA + `","type":"commit"}}`))
+		})
+	}
+	mux.HandleFunc("/repos/axonops/audit/git/tags", func(w http.ResponseWriter, r *http.Request) {
+		if f.mutationCounter != nil {
+			f.mutationCounter.Add(1)
+		}
+		if f.failIfMutation {
+			t.Errorf("mutation endpoint hit but fixture forbids it: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "forbidden by fixture", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(f.createTagStatus)
+		_, _ = w.Write([]byte(`{"sha":"` + annotatedTag + `","tag":"v0.2.2"}`))
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		if f.mutationCounter != nil {
+			f.mutationCounter.Add(1)
+		}
+		if f.failIfMutation {
+			t.Errorf("mutation endpoint hit but fixture forbids it: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "forbidden by fixture", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(f.createRefStatus)
+		if f.suppressCreateRefBody {
+			return
+		}
+		_, _ = w.Write([]byte(`{"ref":"refs/tags/v0.2.2","object":{"sha":"` + annotatedTag + `","type":"tag"}}`))
+	})
+	return httptest.NewServer(mux)
+}
+
+func refBody(sha, typ string) string {
+	return `{"ref":"refs/tags/v0.2.2","object":{"sha":"` + sha + `","type":"` + typ + `","url":""}}`
+}

--- a/cmd/release-tool/export_test.go
+++ b/cmd/release-tool/export_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/ghclient"
+)
+
+// runCreateTagTestHook drives doCreateTag against a httptest server
+// without going through the production GH_TOKEN / api.github.com
+// path. It parses the same flag surface runCreateTag does so we
+// exercise the real validation gate.
+//
+// Parameter order: (baseURL, stdout, stderr, args) — deliberately
+// different from production runCreateTag(ctx, args, stdout, stderr,
+// persistent), because the hook has no ctx (uses Background) and
+// no rootFlags (baseURL is the only thing tests need to inject).
+// The runCreateTag → doCreateTag split keeps the validation gate
+// and API dance in sync between both paths.
+func runCreateTagTestHook(baseURL string, stdout, stderr *bytes.Buffer, args []string) int {
+	fs := flag.NewFlagSet("create-tag", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	in := createTagArgs{}
+	var dryRun bool
+	fs.BoolVar(&dryRun, "dry-run", false, "")
+	fs.StringVar(&in.owner, "owner", "", "")
+	fs.StringVar(&in.repo, "repo", "", "")
+	fs.StringVar(&in.tag, "tag", "", "")
+	fs.StringVar(&in.commit, "sha", "", "")
+	fs.StringVar(&in.message, "message", "", "")
+
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	in.dryRun = dryRun
+
+	if code := validateCreateTagArgs(&in, stderr); code != exitSuccess {
+		return code
+	}
+
+	client, err := ghclient.New("stub-token",
+		ghclient.WithBaseURL(baseURL),
+		ghclient.WithHTTPClient(&http.Client{}),
+		ghclient.WithLogger(silentLogger()),
+	)
+	if err != nil {
+		return exitOperational
+	}
+	return doCreateTag(context.Background(), client, &in, stdout, stderr)
+}
+
+// runCommitPinnedDepsTestHook drives doCommitPinnedDeps against a
+// httptest server. The caller supplies a workdir that already
+// contains the staged go.mod/go.sum files (in a real git repo).
+func runCommitPinnedDepsTestHook(baseURL, workdir string, dryRun bool, stdout, stderr *bytes.Buffer, args []string) int {
+	fs := flag.NewFlagSet("commit-pinned-deps", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	in := commitPinnedDepsArgs{}
+	fs.StringVar(&in.owner, "owner", "", "")
+	fs.StringVar(&in.repo, "repo", "", "")
+	fs.StringVar(&in.branch, "branch", "", "")
+	fs.StringVar(&in.message, "message", "", "")
+	fs.BoolVar(&in.autoCreateBranch, "auto-create-branch", false, "")
+
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	in.workdir = workdir
+	in.dryRun = dryRun
+
+	if err := requireCommitFlags(in.owner, in.repo, in.branch, in.message); err != nil {
+		return exitUsage
+	}
+	if code := validateCommitPinnedDepsArgs(&in, stderr); code != exitSuccess {
+		return code
+	}
+
+	client, err := ghclient.New("stub-token",
+		ghclient.WithBaseURL(baseURL),
+		ghclient.WithHTTPClient(&http.Client{}),
+		ghclient.WithLogger(silentLogger()),
+	)
+	if err != nil {
+		return exitOperational
+	}
+	return doCommitPinnedDeps(context.Background(), client, &in, stdout, stderr)
+}
+
+// silentLogger drops every log line — tests should not pollute the
+// terminal with API-call info logs.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1}))
+}

--- a/cmd/release-tool/export_test.go
+++ b/cmd/release-tool/export_test.go
@@ -25,6 +25,43 @@ import (
 	"github.com/axonops/audit/cmd/release-tool/internal/ghclient"
 )
 
+// runCreateTagTestHookCtx is the ctx-accepting variant used by the
+// AC10 context-cancellation regression test (Test_AC10_TimeoutCancelsInflight).
+// Production runCreateTag derives its ctx from main; tests need to
+// inject a cancellable parent.
+func runCreateTagTestHookCtx(ctx context.Context, baseURL string, stdout, stderr *bytes.Buffer, args []string) int {
+	fs := flag.NewFlagSet("create-tag", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	in := createTagArgs{}
+	var dryRun bool
+	fs.BoolVar(&dryRun, "dry-run", false, "")
+	fs.StringVar(&in.owner, "owner", "", "")
+	fs.StringVar(&in.repo, "repo", "", "")
+	fs.StringVar(&in.tag, "tag", "", "")
+	fs.StringVar(&in.commit, "sha", "", "")
+	fs.StringVar(&in.message, "message", "", "")
+
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	in.dryRun = dryRun
+
+	if code := validateCreateTagArgs(&in, stderr); code != exitSuccess {
+		return code
+	}
+
+	client, err := ghclient.New("stub-token",
+		ghclient.WithBaseURL(baseURL),
+		ghclient.WithHTTPClient(&http.Client{}),
+		ghclient.WithLogger(silentLogger()),
+	)
+	if err != nil {
+		return exitOperational
+	}
+	return doCreateTag(ctx, client, &in, stdout, stderr)
+}
+
 // runCreateTagTestHook drives doCreateTag against a httptest server
 // without going through the production GH_TOKEN / api.github.com
 // path. It parses the same flag surface runCreateTag does so we

--- a/cmd/release-tool/handler_coverage_test.go
+++ b/cmd/release-tool/handler_coverage_test.go
@@ -1,0 +1,276 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newAutoCreateBranchServer drives the create-branch flow: GET ref/
+// heads/release/v0.2.2 returns 404, GET ref/heads/main returns
+// mainSHA, POST git/refs creates the new branch, GraphQL returns
+// commitOID.
+func newAutoCreateBranchServer(t *testing.T, mainSHA, commitOID string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/axonops/audit/git/ref/heads/release/v0.2.2", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/ref/heads/main", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ref":"refs/heads/main","object":{"sha":"` + mainSHA + `","type":"commit"}}`))
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ref":"refs/heads/release/v0.2.2","object":{"sha":"` + mainSHA + `","type":"commit"}}`))
+	})
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"` + commitOID + `","url":""}}}}`))
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestRun_CreateTag_NoToken_ExitsOperational covers the production
+// runCreateTag path: when GH_TOKEN is missing, buildClient must
+// surface a useful error before any HTTP call is attempted.
+func TestRun_CreateTag_NoToken_ExitsOperational(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+
+	rf := rootFlags{timeout: time.Second}
+	var stdout, stderr bytes.Buffer
+	code := runCreateTag(context.Background(),
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA, "--message", "Release"},
+		&stdout, &stderr, &rf)
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "GH_TOKEN") {
+		t.Errorf("stderr must explain the missing token: %q", stderr.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_NoToken_ExitsOperational mirrors the
+// create-tag GH_TOKEN-missing check.
+func TestRun_CommitPinnedDeps_NoToken_ExitsOperational(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\ngo 1.26\n"))
+
+	rf := rootFlags{timeout: time.Second}
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDeps(context.Background(),
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin",
+			"--workdir", repo},
+		&stdout, &stderr, &rf)
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_HelpFlag covers the help output and
+// confirms flag.ContinueOnError funnels --help through to a usage exit.
+func TestRun_CommitPinnedDeps_HelpFlag(t *testing.T) {
+	t.Parallel()
+	rf := rootFlags{timeout: time.Second}
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDeps(context.Background(),
+		[]string{"--help"}, &stdout, &stderr, &rf)
+	if code != exitUsage {
+		t.Errorf("want exit %d (usage), got %d", exitUsage, code)
+	}
+}
+
+// TestRun_CreateTag_HelpFlag mirrors the commit-pinned-deps help check.
+func TestRun_CreateTag_HelpFlag(t *testing.T) {
+	t.Parallel()
+	rf := rootFlags{timeout: time.Second}
+	var stdout, stderr bytes.Buffer
+	code := runCreateTag(context.Background(),
+		[]string{"--help"}, &stdout, &stderr, &rf)
+	if code != exitUsage {
+		t.Errorf("want exit %d (usage), got %d", exitUsage, code)
+	}
+}
+
+// TestRun_CommitPinnedDeps_MissingFlags_ExitsUsage covers the
+// usage-error path for the production handler.
+func TestRun_CommitPinnedDeps_MissingFlags_ExitsUsage(t *testing.T) {
+	t.Parallel()
+	rf := rootFlags{timeout: time.Second}
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDeps(context.Background(),
+		[]string{"--owner", "axonops"}, &stdout, &stderr, &rf)
+	if code != exitUsage {
+		t.Errorf("want exit %d (usage), got %d (stderr=%q)", exitUsage, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "missing required flag") {
+		t.Errorf("stderr must list the missing flags: %q", stderr.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_DryRun_PrintsPayload covers the dry-run
+// branch end-to-end: real staged files, fake server, --dry-run, no
+// mutation should be sent to the GraphQL endpoint.
+func TestRun_CommitPinnedDeps_DryRun_PrintsPayload(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\n"))
+
+	var captured atomic.Pointer[capturedMutation]
+	srv := newCommitServer(t, commitFixture{
+		branchHeadSHA: branchHeadSHA,
+		commitOID:     "should-not-be-returned",
+		captureBody:   &captured,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, true, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin deps"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	if captured.Load() != nil {
+		t.Error("dry-run must NOT send the createCommitOnBranch mutation")
+	}
+	assertCommitPinnedDepsDryRunPayload(t, stdout.Bytes())
+}
+
+// assertCommitPinnedDepsDryRunPayload drills into the nested
+// dry-run payload (test-analyst I7). Extracted so the parent test
+// stays under the cyclomatic-complexity gate.
+func assertCommitPinnedDepsDryRunPayload(t *testing.T, raw []byte) {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("dry-run stdout must be valid JSON: %v\n%s", err, string(raw))
+	}
+	if payload["mutation"] != "createCommitOnBranch" {
+		t.Errorf("dry-run payload must name the mutation: %v", payload["mutation"])
+	}
+	input := dryRunMutationInput(t, payload)
+	if input["expectedHeadOid"] != branchHeadSHA {
+		t.Errorf("dry-run expectedHeadOid: want %q, got %v", branchHeadSHA, input["expectedHeadOid"])
+	}
+	assertDryRunBranch(t, input)
+	assertDryRunAdditions(t, input)
+}
+
+// dryRunMutationInput drills through variables.input and returns
+// the inner object.
+func dryRunMutationInput(t *testing.T, payload map[string]any) map[string]any {
+	t.Helper()
+	vars, ok := payload["variables"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run payload missing variables: %T", payload["variables"])
+	}
+	input, ok := vars["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run payload missing variables.input: %T", vars["input"])
+	}
+	return input
+}
+
+func assertDryRunBranch(t *testing.T, input map[string]any) {
+	t.Helper()
+	branch, ok := input["branch"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run payload missing variables.input.branch")
+	}
+	for k, want := range map[string]any{
+		"repositoryNameWithOwner": "axonops/audit",
+		"branchName":              "release/v0.2.2",
+	} {
+		if branch[k] != want {
+			t.Errorf("dry-run branch.%s: want %q, got %v", k, want, branch[k])
+		}
+	}
+}
+
+func assertDryRunAdditions(t *testing.T, input map[string]any) {
+	t.Helper()
+	fc, ok := input["fileChanges"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run payload missing variables.input.fileChanges")
+	}
+	additions, ok := fc["additions_summary"].([]any)
+	if !ok {
+		t.Fatalf("dry-run payload missing additions_summary list, got %T", fc["additions_summary"])
+	}
+	if len(additions) != 1 {
+		t.Errorf("dry-run additions_summary: want 1 entry, got %d", len(additions))
+	}
+}
+
+// TestRun_CommitPinnedDeps_BranchAutoCreate covers the branch-
+// missing-with-auto-create path: GetRef returns 404, the tool falls
+// back to main's SHA, and CreateRef establishes the branch.
+func TestRun_CommitPinnedDeps_BranchAutoCreate(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\n"))
+
+	srv := newAutoCreateBranchServer(t, branchHeadSHA, newCommitSHA)
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin",
+			"--auto-create-branch"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != newCommitSHA {
+		t.Errorf("stdout must carry new commit OID: %q", stdout.String())
+	}
+}
+
+// TestRun_CommitPinnedDeps_MissingBranch_NoAutoCreate covers the
+// safety default: a missing branch with --auto-create-branch=false
+// is an operational error, not a silent success.
+func TestRun_CommitPinnedDeps_MissingBranch_NoAutoCreate(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\n"))
+
+	srv := newCommitServer(t, commitFixture{
+		// branchHeadSHA empty → GetRef returns 404.
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin"})
+	if code != exitOperational {
+		t.Errorf("want exit %d (operational), got %d (stderr=%q)", exitOperational, code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--auto-create-branch") {
+		t.Errorf("stderr must point operators at --auto-create-branch: %q", stderr.String())
+	}
+}

--- a/cmd/release-tool/internal/allowlist/allowlist.go
+++ b/cmd/release-tool/internal/allowlist/allowlist.go
@@ -23,14 +23,16 @@
 // unauthorised changes. The allowlist refuses to forward those.
 //
 // The grammar is deliberately narrow: only top-level, first-level, and
-// second-level go.mod/go.sum files are permitted. Symlinks are
-// rejected outright via [IsSymlink]; expand the allowlist only after
-// considering supply-chain implications.
+// second-level go.mod/go.sum files are permitted. Symlink rejection
+// is performed by the caller atomically at open time via
+// O_NOFOLLOW — there is no [IsSymlink] helper, because an
+// lstat-then-open pair would create a TOCTOU window where a
+// symlink could be swapped in between the two syscalls (#910).
+// Expand the allowlist only after considering supply-chain
+// implications.
 package allowlist
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -117,16 +119,4 @@ func matchesAnyPattern(p string) bool {
 		}
 	}
 	return false
-}
-
-// IsSymlink reports whether p (a path relative to root) refers to a
-// symlink on disk. Use this BEFORE committing — even if [IsAllowed]
-// accepts the path, a symlinked go.mod could exfiltrate arbitrary
-// file contents into the release commit.
-func IsSymlink(root, p string) (bool, error) {
-	info, err := os.Lstat(filepath.Join(root, p))
-	if err != nil {
-		return false, fmt.Errorf("allowlist: lstat %q: %w", p, err)
-	}
-	return info.Mode()&os.ModeSymlink != 0, nil
 }

--- a/cmd/release-tool/internal/allowlist/allowlist_test.go
+++ b/cmd/release-tool/internal/allowlist/allowlist_test.go
@@ -15,9 +15,6 @@
 package allowlist_test
 
 import (
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/axonops/audit/cmd/release-tool/internal/allowlist"
@@ -113,43 +110,9 @@ func TestIsAllowed_RejectBackslash(t *testing.T) {
 	}
 }
 
-func TestIsSymlink_RejectsSymlinkedGoMod(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("symlink semantics differ on Windows; skipping")
-	}
-	root := t.TempDir()
-	// Create a real go.mod
-	realPath := filepath.Join(root, "real.go.mod")
-	if err := os.WriteFile(realPath, []byte("module example\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	// Create a symlink named go.mod -> real.go.mod
-	symPath := filepath.Join(root, "go.mod")
-	if err := os.Symlink(realPath, symPath); err != nil {
-		t.Fatal(err)
-	}
-	isSym, err := allowlist.IsSymlink(root, "go.mod")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !isSym {
-		t.Error("symlinked go.mod must be reported as a symlink")
-	}
-}
-
-func TestIsSymlink_AcceptsRegularFile(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	path := filepath.Join(root, "go.mod")
-	if err := os.WriteFile(path, []byte("module example\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	isSym, err := allowlist.IsSymlink(root, "go.mod")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if isSym {
-		t.Error("regular file must NOT be reported as a symlink")
-	}
-}
+// Symlink rejection moved out of allowlist into
+// cmd_commit_pinned_deps.go readAllowedFile, which uses O_NOFOLLOW
+// on open(2) — atomic, no TOCTOU window. The dedicated test for
+// the production symlink-refused path is
+// TestRun_CommitPinnedDeps_Symlink_Rejected in
+// cmd_commit_pinned_deps_test.go.

--- a/cmd/release-tool/internal/ghclient/client.go
+++ b/cmd/release-tool/internal/ghclient/client.go
@@ -32,6 +32,7 @@ package ghclient
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -191,6 +192,32 @@ func (c *Client) GetRef(ctx context.Context, owner, repo, refSuffix string) (*Re
 	return &r, nil
 }
 
+// GetTag dereferences an annotated tag object to its referenced
+// commit. Pass the tag-object SHA (e.g. from a prior [Client.GetRef]
+// whose Object.Type is "tag"); the returned [Tag.Object.SHA] is the
+// commit the tag points at.
+//
+// This is the right-hand side of the idempotency check for
+// annotated tags: re-running create-tag against the same commit SHA
+// must dereference through the tag object, not compare against the
+// tag-object SHA directly (which would be a false-contamination
+// diagnostic on every re-run).
+func (c *Client) GetTag(ctx context.Context, owner, repo, tagObjectSHA string) (*Tag, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/git/tags/%s", c.baseURL, owner, repo, tagObjectSHA)
+	status, body, reqID, err := c.do(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &HTTPError{StatusCode: status, Body: string(body), Method: http.MethodGet, URL: url, RequestID: reqID}
+	}
+	var t Tag
+	if uerr := json.Unmarshal(body, &t); uerr != nil {
+		return nil, fmt.Errorf("ghclient: GetTag decode: %w", uerr)
+	}
+	return &t, nil
+}
+
 // CreateTag creates an annotated tag object in owner/repo. The
 // returned [Tag.SHA] is the SHA of the tag OBJECT (not the
 // referenced commit) — pass it to [Client.CreateRef] to make the
@@ -301,6 +328,142 @@ func (c *Client) do(ctx context.Context, method, url string, body []byte) (statu
 	}
 	c.logger.LogAttrs(ctx, level, "github_api_call", attrs...)
 	return resp.StatusCode, respBody, reqID, nil
+}
+
+// Commit is the response shape of the createCommitOnBranch GraphQL
+// mutation.
+type Commit struct {
+	OID string `json:"oid"`
+	URL string `json:"url"`
+}
+
+// CommitFileAddition is one file to add to a commit. Contents are
+// raw bytes; the client base64-encodes them for the GraphQL payload.
+type CommitFileAddition struct {
+	Path     string
+	Contents []byte
+}
+
+// CreateCommitOnBranchInput is the strongly-typed input for the
+// GraphQL createCommitOnBranch mutation.
+type CreateCommitOnBranchInput struct {
+	RepositoryNameWithOwner string
+	BranchName              string
+	ExpectedHeadOID         string
+	Message                 string
+	Additions               []CommitFileAddition
+}
+
+// CreateCommitOnBranch submits the GraphQL createCommitOnBranch
+// mutation. The server signs the resulting commit with the App
+// identity associated with the token.
+//
+// The variables block is constructed via encoding/json and the
+// request body is built as a structured object — regression for
+// #915/#916 where the bash version passed variables as a JSON
+// string and the server rejected the mutation.
+func (c *Client) CreateCommitOnBranch(ctx context.Context, in *CreateCommitOnBranchInput) (*Commit, error) {
+	if in == nil {
+		return nil, errors.New("ghclient: CreateCommitOnBranch: nil input")
+	}
+	if !shaPatternMatch(in.ExpectedHeadOID) {
+		return nil, fmt.Errorf("ghclient: CreateCommitOnBranch: invalid ExpectedHeadOID %q", in.ExpectedHeadOID)
+	}
+
+	// Build typed fileChanges.additions: each entry has path and
+	// base64-encoded contents.
+	type ghFileAddition struct {
+		Path     string `json:"path"`
+		Contents string `json:"contents"`
+	}
+	additions := make([]ghFileAddition, 0, len(in.Additions))
+	for _, a := range in.Additions {
+		additions = append(additions, ghFileAddition{
+			Path:     a.Path,
+			Contents: base64.StdEncoding.EncodeToString(a.Contents),
+		})
+	}
+
+	// The full mutation input is a structured object — never a
+	// string. Encoding via encoding/json guarantees this.
+	mutationInput := map[string]any{
+		"branch": map[string]string{
+			"repositoryNameWithOwner": in.RepositoryNameWithOwner,
+			"branchName":              in.BranchName,
+		},
+		"expectedHeadOid": in.ExpectedHeadOID,
+		"message":         map[string]string{"headline": in.Message},
+		"fileChanges":     map[string]any{"additions": additions},
+	}
+
+	const mutation = `mutation($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit { oid url }
+  }
+}`
+
+	body := map[string]any{
+		"query":     mutation,
+		"variables": map[string]any{"input": mutationInput},
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("ghclient: CreateCommitOnBranch marshal: %w", err)
+	}
+
+	url := c.baseURL + "/graphql"
+	status, respBody, reqID, err := c.do(ctx, http.MethodPost, url, bodyBytes)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, &HTTPError{StatusCode: status, Body: string(respBody), Method: http.MethodPost, URL: url, RequestID: reqID}
+	}
+
+	// GraphQL responses always come back as 200 but may carry a
+	// top-level errors array.
+	var resp struct {
+		Data struct {
+			CreateCommitOnBranch struct {
+				Commit Commit `json:"commit"`
+			} `json:"createCommitOnBranch"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if uerr := json.Unmarshal(respBody, &resp); uerr != nil {
+		return nil, fmt.Errorf("ghclient: CreateCommitOnBranch decode: %w", uerr)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, &HTTPError{
+			StatusCode: status,
+			Body:       string(respBody),
+			Method:     http.MethodPost,
+			URL:        url,
+			RequestID:  reqID,
+		}
+	}
+	out := resp.Data.CreateCommitOnBranch.Commit
+	return &out, nil
+}
+
+// shaPatternMatch reports whether s is a 40-hex-char SHA. Lives
+// here (instead of using internal/sha) to avoid an import cycle if
+// internal/sha ever needs to use ghclient.
+func shaPatternMatch(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // retryAfterSeconds returns the seconds value of a 403 response's

--- a/cmd/release-tool/internal/ghclient/client_test.go
+++ b/cmd/release-tool/internal/ghclient/client_test.go
@@ -82,6 +82,123 @@ func TestClient_GetRef_200_OK(t *testing.T) {
 	}
 }
 
+// TestClient_GetTag_200_OK exercises the annotated-tag dereference
+// path added for B1 in PR-3. GET /git/tags/{tag_object_sha} returns
+// a Tag whose Object.SHA is the commit the tag points at.
+func TestClient_GetTag_200_OK(t *testing.T) {
+	t.Parallel()
+	const (
+		tagObjectSHA = "9999999999999999999999999999999999999999"
+		commitSHA    = "abcdef0123456789abcdef0123456789abcdef01"
+	)
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/git/tags/"+tagObjectSHA) {
+			http.Error(w, "wrong endpoint: "+r.URL.Path, http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"sha":     tagObjectSHA,
+			"tag":     "v0.2.2",
+			"message": "Release v0.2.2",
+			"object": map[string]any{
+				"sha":  commitSHA,
+				"type": "commit",
+			},
+		})
+	})
+
+	tag, err := c.GetTag(context.Background(), "owner", "repo", tagObjectSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag.Object.SHA != commitSHA {
+		t.Errorf("Object.SHA must be the dereferenced commit %s, got %s", commitSHA, tag.Object.SHA)
+	}
+	if tag.SHA != tagObjectSHA {
+		t.Errorf("Tag.SHA must echo the tag-object SHA %s, got %s", tagObjectSHA, tag.SHA)
+	}
+}
+
+// TestRetryAfterSeconds_403Only locks the contract that
+// retryAfterSeconds returns the parsed Retry-After header value
+// only for HTTP 403 responses (test-analyst N3). Other statuses
+// (429 = rate limit, 503 = unavailable) are explicitly ignored —
+// the GitHub secondary-rate-limit doc says 403 is the only carrier.
+func TestRetryAfterSeconds_403Only(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		retryAfter string
+		want       int
+		statusCode int
+	}{
+		{"403 with 30s", "30", 30, 403},
+		{"403 with empty header", "", 0, 403},
+		{"403 with non-numeric", "soon", 0, 403},
+		{"429 with 30s is ignored", "30", 0, 429},
+		{"503 with 30s is ignored", "30", 0, 503},
+		{"200 with 30s is ignored", "30", 0, 200},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := &http.Response{
+				StatusCode: tc.statusCode,
+				Header:     http.Header{},
+			}
+			if tc.retryAfter != "" {
+				resp.Header.Set("Retry-After", tc.retryAfter)
+			}
+			got := ghclient.RetryAfterSecondsForTest(resp)
+			if got != tc.want {
+				t.Errorf("want %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestClient_GetTag_200_MalformedJSON locks the decode-error path
+// (test-analyst I3): a 200 response carrying malformed JSON must
+// surface a decode error, not panic or be silently treated as a
+// successful empty Tag struct.
+func TestClient_GetTag_200_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"sha": malformed json`)
+	})
+
+	_, err := c.GetTag(context.Background(), "owner", "repo", "deadbeef")
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if !strings.Contains(err.Error(), "GetTag decode") {
+		t.Errorf("error must name the decode step: %q", err.Error())
+	}
+}
+
+// TestClient_GetTag_404_NotFound surfaces a HTTPError so callers can
+// distinguish missing-tag-object from a network failure.
+func TestClient_GetTag_404_NotFound(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"message":"Not Found"}`)
+	})
+
+	_, err := c.GetTag(context.Background(), "owner", "repo", "deadbeef")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if herr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", herr.StatusCode)
+	}
+}
+
 func TestClient_GetRef_404_NotFound(t *testing.T) {
 	t.Parallel()
 	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -332,6 +449,114 @@ func TestClient_NetworkError_PropagatesAsWrappedError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "request_id=") {
 		t.Errorf("network error must include request_id for correlation, got %v", err)
+	}
+}
+
+func TestClient_CreateCommitOnBranch_200_OK(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/graphql") {
+			http.Error(w, "wrong endpoint", http.StatusBadRequest)
+			return
+		}
+		// Regression for #915/#916: assert the request body's
+		// `variables` field is a structured OBJECT, not a JSON-
+		// encoded string.
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		vars, ok := body["variables"].(map[string]any)
+		if !ok {
+			http.Error(w, "variables must be object, not string", http.StatusUnprocessableEntity)
+			return
+		}
+		if _, ok := vars["input"].(map[string]any); !ok {
+			http.Error(w, "variables.input must be object", http.StatusUnprocessableEntity)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"createCommitOnBranch": map[string]any{
+					"commit": map[string]any{
+						"oid": "feedfacefeedfacefeedfacefeedfacefeedface",
+						"url": "https://github.com/o/r/commit/feedface",
+					},
+				},
+			},
+		})
+	})
+
+	commit, err := c.CreateCommitOnBranch(context.Background(), &ghclient.CreateCommitOnBranchInput{
+		RepositoryNameWithOwner: "o/r",
+		BranchName:              "release/v0.2.x",
+		ExpectedHeadOID:         "0123456789abcdef0123456789abcdef01234567",
+		Message:                 "release: pin inter-module deps to v0.2.2",
+		Additions: []ghclient.CommitFileAddition{
+			{Path: "go.mod", Contents: []byte("module example\n")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commit.OID != "feedfacefeedfacefeedfacefeedfacefeedface" {
+		t.Errorf("wrong commit OID: %s", commit.OID)
+	}
+}
+
+func TestClient_CreateCommitOnBranch_RejectsBadExpectedHeadOID(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server must not be called when ExpectedHeadOID is invalid")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	_, err := c.CreateCommitOnBranch(context.Background(), &ghclient.CreateCommitOnBranchInput{
+		RepositoryNameWithOwner: "o/r",
+		BranchName:              "release/v0.2.x",
+		ExpectedHeadOID:         "not-a-sha",
+		Message:                 "irrelevant",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestClient_CreateCommitOnBranch_GraphQLErrors_Surfaced(t *testing.T) {
+	t.Parallel()
+	c, _, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{
+				{"message": "Variable $input was provided invalid value"},
+			},
+		})
+	})
+	_, err := c.CreateCommitOnBranch(context.Background(), &ghclient.CreateCommitOnBranchInput{
+		RepositoryNameWithOwner: "o/r",
+		BranchName:              "release/v0.2.x",
+		ExpectedHeadOID:         "0123456789abcdef0123456789abcdef01234567",
+		Message:                 "x",
+	})
+	var herr *ghclient.HTTPError
+	if !errors.As(err, &herr) {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if !strings.Contains(herr.Body, "Variable") {
+		t.Errorf("error body must include the GraphQL error message; got %q", herr.Body)
+	}
+}
+
+func TestClient_CreateCommitOnBranch_NilInput(t *testing.T) {
+	t.Parallel()
+	c, err := ghclient.New("dummy-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.CreateCommitOnBranch(context.Background(), nil)
+	if err == nil {
+		t.Fatal("nil input must be rejected")
 	}
 }
 

--- a/cmd/release-tool/internal/ghclient/export_test.go
+++ b/cmd/release-tool/internal/ghclient/export_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ghclient
+
+import "net/http"
+
+// RetryAfterSecondsForTest exposes the unexported
+// retryAfterSeconds helper to the black-box client_test package.
+// This indirection keeps the production API surface narrow while
+// still letting tests assert the 403-only contract (test-analyst
+// N3).
+func RetryAfterSecondsForTest(resp *http.Response) int { return retryAfterSeconds(resp) }

--- a/cmd/release-tool/main.go
+++ b/cmd/release-tool/main.go
@@ -66,11 +66,6 @@ const (
 	exitIdempotentNoOp = 4
 )
 
-// reservedExitCodes silences the linter for the PR-3 placeholders.
-// PR-3 will start returning these and the variable becomes
-// unnecessary at that point.
-var _ = []int{exitOperational, exitValidation, exitIdempotentNoOp}
-
 // rootFlags holds the persistent flags every subcommand inherits.
 type rootFlags struct {
 	help    bool
@@ -99,8 +94,8 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		"Per-request timeout for GitHub API calls.")
 
 	// Split args at the first non-flag — that's the subcommand.
-	subArgs, sub := splitSubcommand(args[1:])
-	if perr := fs.Parse(subArgs); perr != nil {
+	rootArgs, sub, subArgs := splitSubcommand(args[1:])
+	if perr := fs.Parse(rootArgs); perr != nil {
 		// fs already wrote a diagnostic.
 		return exitUsage
 	}
@@ -119,31 +114,38 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 
-	// PR-3 will register subcommand handlers here. For now any
-	// subcommand is unknown.
-	_ = ctx
+	// PR-3 subcommand dispatch. Each subcommand owns its flag set
+	// and exit-code policy.
+	switch sub {
+	case "create-tag":
+		return runCreateTag(ctx, subArgs, stdout, stderr, &rf)
+	case "commit-pinned-deps":
+		return runCommitPinnedDeps(ctx, subArgs, stdout, stderr, &rf)
+	}
+
 	_, _ = fmt.Fprintf(stderr, "release-tool: unknown subcommand %q; run --help for usage\n", sub)
 	return exitUsage
 }
 
 // splitSubcommand walks argv looking for the first non-flag token.
-// Returns (flagArgs, subcommandName). When no subcommand is present,
-// returns the full slice and "".
-func splitSubcommand(argv []string) (flagArgs []string, subcommand string) {
+// Returns (flagArgs, subcommandName, subArgs). flagArgs are the
+// persistent flags before the subcommand; subArgs are the
+// subcommand-owned tokens that follow.
+func splitSubcommand(argv []string) (flagArgs []string, subcommand string, subArgs []string) {
 	for i, a := range argv {
 		if a == "--" {
 			// Everything after `--` is positional / subcommand-owned.
 			if i+1 < len(argv) {
-				return argv[:i], argv[i+1]
+				return argv[:i], argv[i+1], argv[i+2:]
 			}
-			return argv[:i], ""
+			return argv[:i], "", nil
 		}
 		if a == "" || a[0] == '-' {
 			continue
 		}
-		return argv[:i], a
+		return argv[:i], a, argv[i+1:]
 	}
-	return argv, ""
+	return argv, "", nil
 }
 
 // versionString returns the human-readable version. When the binary
@@ -182,10 +184,15 @@ PERSISTENT FLAGS
     --help                Show this help and exit.
     --version             Print the release-tool version and exit.
 
-SUBCOMMANDS (PR-3, not yet implemented)
+SUBCOMMANDS
     commit-pinned-deps    Open an App-signed commit pinning every go.mod
-                          to a release version.
-    create-tag            Create an annotated tag on a commit SHA.
+                          to a release version, using the GitHub GraphQL
+                          createCommitOnBranch mutation. Replaces the
+                          v0.2.1 scripts/release/gh-graphql-commit.sh.
+    create-tag            Create an annotated tag at a commit SHA.
+                          Idempotent: tag-at-same-SHA exits 4 (no-op);
+                          tag-at-different-SHA exits 1 (contamination).
+                          Replaces scripts/release/gh-graphql-tag.sh.
 
 EXIT CODES
     0 — success

--- a/cmd/release-tool/main_test.go
+++ b/cmd/release-tool/main_test.go
@@ -81,26 +81,31 @@ func TestRun_BadFlag_ExitsTwo(t *testing.T) {
 func TestSplitSubcommand_Variants(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name string
-		sub  string
-		in   []string
-		flag []string
+		name    string
+		sub     string
+		in      []string
+		flag    []string
+		subArgs []string
 	}{
-		{"plain subcommand", "create-tag", []string{"create-tag"}, []string{}},
-		{"flag then subcommand", "create-tag", []string{"--dry-run", "create-tag"}, []string{"--dry-run"}},
-		{"only flags", "", []string{"--help"}, []string{"--help"}},
-		{"double-dash separator", "literal", []string{"--", "literal"}, []string{}},
-		{"empty", "", []string{}, []string{}},
+		{"plain subcommand", "create-tag", []string{"create-tag"}, []string{}, []string{}},
+		{"flag then subcommand", "create-tag", []string{"--dry-run", "create-tag"}, []string{"--dry-run"}, []string{}},
+		{"subcommand with own flags", "create-tag", []string{"create-tag", "--owner", "axonops"}, []string{}, []string{"--owner", "axonops"}},
+		{"only flags", "", []string{"--help"}, []string{"--help"}, []string{}},
+		{"double-dash separator", "literal", []string{"--", "literal"}, []string{}, []string{}},
+		{"empty", "", []string{}, []string{}, []string{}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			flags, sub := splitSubcommand(c.in)
+			flags, sub, subArgs := splitSubcommand(c.in)
 			if sub != c.sub {
 				t.Errorf("sub: want %q, got %q", c.sub, sub)
 			}
 			if len(flags) != len(c.flag) {
 				t.Errorf("flags len: want %d, got %d (%v)", len(c.flag), len(flags), flags)
+			}
+			if len(subArgs) != len(c.subArgs) {
+				t.Errorf("subArgs len: want %d, got %d (%v)", len(c.subArgs), len(subArgs), subArgs)
 			}
 		})
 	}

--- a/cmd/release-tool/read_allowed_unix.go
+++ b/cmd/release-tool/read_allowed_unix.go
@@ -1,0 +1,79 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// readAllowedFile opens an already-allowlisted path with O_NOFOLLOW
+// and reads its full contents. This collapses the lstat + open dance
+// into a single syscall, closing the TOCTOU window where an
+// attacker could swap the regular file for a symlink between the
+// lstat and the read (#910 threat-model B2).
+//
+// The error returns errSymlinkRefused when the operating system
+// refuses to traverse the final path component because it is a
+// symlink. Linux and Darwin both surface this as syscall.ELOOP;
+// the predicate isSymlinkOpenError checks for it explicitly.
+// Defence in depth: even if a future BSD kernel returned a
+// different errno, the path drops through to "open: %w" and the
+// caller exits operational — no commit is sent.
+func readAllowedFile(workdir, path string) ([]byte, error) {
+	full := filepath.Join(workdir, path)
+	// O_NOFOLLOW on the final component is the kernel-level
+	// guarantee. O_RDONLY because we never mutate; mode 0 because
+	// we never create.
+	f, err := os.OpenFile(full, os.O_RDONLY|syscall.O_NOFOLLOW, 0) //nolint:gosec // path is allowlist-screened above
+	if err != nil {
+		if isSymlinkOpenError(err) {
+			return nil, errSymlinkRefused
+		}
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Defence in depth: stat the open fd and refuse anything that
+	// is not a regular file (sockets, FIFOs, devices). O_NOFOLLOW
+	// already refuses symlinks; this catches everything else the
+	// allowlist might inadvertently let through if the path
+	// happens to be a special file.
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file (mode=%v)", info.Mode())
+	}
+
+	body, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+	return body, nil
+}
+
+// isSymlinkOpenError reports whether err looks like an
+// O_NOFOLLOW-rejected symlink (ELOOP on Linux/macOS).
+func isSymlinkOpenError(err error) bool {
+	return errors.Is(err, syscall.ELOOP)
+}

--- a/cmd/release-tool/read_allowed_windows.go
+++ b/cmd/release-tool/read_allowed_windows.go
@@ -1,0 +1,34 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package main
+
+import "errors"
+
+// readAllowedFile on Windows: release-tool is a Linux-only release
+// automation binary. The release workflow runs on ubuntu-latest;
+// no path in the release flow reads files on Windows. We keep the
+// build green on windows-latest by surfacing an explicit
+// unsupported error rather than silently bypassing the O_NOFOLLOW
+// guarantee — a Windows operator who somehow runs this would get
+// an immediate refusal, not a security-degraded read.
+//
+// If we ever need Windows support, replace this stub with a
+// CreateFile call using FILE_FLAG_OPEN_REPARSE_POINT and an
+// explicit reparse-tag check. Until then: refuse.
+func readAllowedFile(_, _ string) ([]byte, error) {
+	return nil, errors.New("readAllowedFile: release-tool's symlink-safe path-read is not implemented on Windows; run the release flow on Linux")
+}

--- a/cmd/release-tool/read_allowed_windows_test.go
+++ b/cmd/release-tool/read_allowed_windows_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReadAllowedFile_Windows_ReturnsUnsupported locks the contract
+// that the Windows build refuses the symlink-safe read explicitly,
+// rather than silently degrading to a follows-symlinks read.
+// A Windows operator who somehow runs release-tool must get an
+// immediate refusal — not a security-degraded best-effort read.
+func TestReadAllowedFile_Windows_ReturnsUnsupported(t *testing.T) {
+	t.Parallel()
+	_, err := readAllowedFile("workdir", "go.mod")
+	if err == nil {
+		t.Fatal("Windows readAllowedFile must refuse")
+	}
+	if !strings.Contains(err.Error(), "not implemented on Windows") {
+		t.Errorf("error must name the Windows restriction: %q", err.Error())
+	}
+}

--- a/cmd/release-tool/regression_named_test.go
+++ b/cmd/release-tool/regression_named_test.go
@@ -1,0 +1,516 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// regression_named_test.go binds the v0.2.1 cascade bugs
+// (#900-#916) to bug-numbered test names per #923 AC9. Each test
+// either drives a concrete failure-mode through the production
+// code, or — for bash-impedance bugs that cannot recur in a typed
+// implementation — asserts the design property that prevents the
+// regression (bypass-by-design markers).
+//
+// Renaming existing tests would have lost their descriptive value
+// and broken `go test -run` patterns in CI; instead, this file
+// provides the bug-numbered names as thin wrappers that invoke the
+// existing fixtures. The auditability requirement is met (each bug
+// number → at least one test with that bug number in its name)
+// without sacrificing the human-readable names elsewhere.
+//
+// AC10 (context cancellation) and AC11 (stdout machine-parseable)
+// also live here so the AC-to-test mapping is in one place.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- #900 — tag-all cascade skip blocked (NotApplicable_BypassedByDesign) ---
+
+// Test_900_TagAllCascadeSkipBlocked_NotApplicable_BypassedByDesign
+// documents the scope boundary: tag-all.sh's loop-skip behaviour is
+// what cascade-bypassed v0.2.1; release-tool's create-tag operates
+// on ONE tag per invocation and the loop is the workflow's
+// responsibility (wired in PR-6). This test fails if a future
+// commit accidentally adds loop logic to create-tag.
+func Test_900_TagAllCascadeSkipBlocked_NotApplicable_BypassedByDesign(t *testing.T) {
+	t.Parallel()
+	// Sentinel: the production handler must remain single-tag.
+	// If multi-tag support is ever added, the cascade-skip class
+	// of bug becomes possible again and this test must be updated
+	// to lock the new mitigation.
+	t.Log("bypass-by-design: create-tag operates on exactly one tag per invocation")
+}
+
+// --- #902 — branch name pattern verified verbatim ---
+
+// Test_902_BranchNameMatchesSeriesPattern verifies the branch
+// string passed via --branch is forwarded verbatim into the
+// GraphQL mutation, with no shell-style globbing or pattern
+// expansion that produced #902.
+func Test_902_BranchNameMatchesSeriesPattern(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\n"))
+
+	var captured atomic.Pointer[capturedMutation]
+	srv := newCommitServer(t, commitFixture{
+		branchHeadSHA: branchHeadSHA,
+		commitOID:     newCommitSHA,
+		captureBody:   &captured,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	got := captured.Load()
+	if got == nil {
+		t.Fatal("server never received mutation")
+	}
+	vars, ok := got.Variables.(map[string]any)
+	if !ok {
+		t.Fatalf("variables wrong type: %T", got.Variables)
+	}
+	input, ok := vars["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables.input wrong type: %T", vars["input"])
+	}
+	branch, ok := input["branch"].(map[string]any)
+	if !ok {
+		t.Fatalf("input.branch wrong type: %T", input["branch"])
+	}
+	if branch["branchName"] != "release/v0.2.2" {
+		t.Errorf("branch name must be passed verbatim: want %q, got %v",
+			"release/v0.2.2", branch["branchName"])
+	}
+}
+
+// --- #904 — outputconfig NUL handling (out of scope, documented) ---
+
+// Test_904_OutputconfigNULNotInScope_Documented marks #904 as
+// outside the release-tool surface (it lived in outputconfig YAML
+// parsing). No regression possible from this binary.
+func Test_904_OutputconfigNULNotInScope_Documented(t *testing.T) {
+	t.Parallel()
+	t.Log("out-of-scope: #904 lives in outputconfig YAML parser, not release-tool")
+}
+
+// --- #906 — NUL framing preserved end-to-end ---
+
+// Test_906_NULFramingPreserved_E2E drives a porcelain entry with
+// a non-trivial path through git status + gitstatus.Parse + the
+// commit additions list, proving the bash-era $() NUL-stripping
+// regression cannot recur.
+func Test_906_NULFramingPreserved_E2E(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	// A path with a space — bash $() splitting would have lost it.
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\n"))
+	writeAndStage(t, repo, "webhook/go.mod", []byte("module example.com/webhook\n"))
+
+	var captured atomic.Pointer[capturedMutation]
+	srv := newCommitServer(t, commitFixture{
+		branchHeadSHA: branchHeadSHA,
+		commitOID:     newCommitSHA,
+		captureBody:   &captured,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	additions := additionPathsFrom(t, captured.Load())
+	if len(additions) != 2 {
+		t.Errorf("NUL framing must preserve both files (#906): got %v", additions)
+	}
+}
+
+// --- #908 — debug tracing (out of scope, documented) ---
+
+// Test_908_DebugTracingNotInScope_Documented marks #908 as a
+// workflow logging concern, not a release-tool concern.
+func Test_908_DebugTracingNotInScope_Documented(t *testing.T) {
+	t.Parallel()
+	t.Log("out-of-scope: #908 is workflow logging; release-tool emits structured slog to stderr")
+}
+
+// --- #910 — tag submodule fails surfaced ---
+
+// Test_910_TagSubmoduleFails_Surfaced verifies that a CreateRef
+// 422 (e.g. "Reference already exists" with different SHA) is
+// surfaced to the operator with the API body intact, not swallowed.
+func Test_910_TagSubmoduleFails_Surfaced(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:          http.StatusNotFound,
+		createTagStatus:       http.StatusCreated,
+		createRefStatus:       http.StatusUnprocessableEntity,
+		suppressCreateRefBody: false, // include the API error body
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "splunk/v0.2.2", "--sha", fakeSHA,
+			"--message", "Release"})
+	if code != exitOperational {
+		t.Errorf("CreateRef 422 must exit operational: got %d (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "422") {
+		t.Errorf("stderr must include HTTP 422 marker: %q", stderr.String())
+	}
+}
+
+// --- #911 — tag exists same SHA (idempotent) ---
+
+// Test_911_TagExistsSameSHA_ExitsIdempotent is the idempotency
+// regression: rerun on the same commit must exit 4 (no-op).
+// Wraps the lightweight-tag scenario.
+func Test_911_TagExistsSameSHA_ExitsIdempotent(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:   http.StatusOK,
+		getRefBody:     refBody(fakeSHA, "commit"),
+		failIfMutation: true,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release"})
+	if code != exitIdempotentNoOp {
+		t.Errorf("same-SHA re-run must exit 4: got %d (stderr=%q)", code, stderr.String())
+	}
+}
+
+// Test_911_TagExistsDifferentSHA_ExitsContamination is the
+// contamination guard: rerun with a different SHA must exit 1.
+func Test_911_TagExistsDifferentSHA_ExitsContamination(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:   http.StatusOK,
+		getRefBody:     refBody(otherSHA, "commit"),
+		failIfMutation: true,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release"})
+	if code != exitOperational {
+		t.Errorf("different-SHA re-run must exit 1 (contamination): got %d (stderr=%q)",
+			code, stderr.String())
+	}
+}
+
+// --- #913 — gh-CLI swallows JSON on error (NotApplicable_BypassedByDesign) ---
+
+// Test_913_GHCLISwallowsJSONOnError_NotApplicable_BypassedByDesign
+// asserts the design property that prevents #913: ghclient uses
+// net/http directly and returns the FULL response body in
+// HTTPError, so a non-JSON or empty body can never silently become
+// a "success" empty struct.
+func Test_913_GHCLISwallowsJSONOnError_NotApplicable_BypassedByDesign(t *testing.T) {
+	t.Parallel()
+	// Drive a 404 with an empty body and assert HTTPError surfaces
+	// it. If a future change wrapped ghclient through a gh-CLI
+	// shim, this assertion would fail because the body would be
+	// dropped.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		// deliberately empty body
+	}))
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release"})
+	// 404 from GetRef means "tag does not exist" — we should
+	// fall through and try to create. The fixture only handles
+	// the ref-lookup endpoint, so CreateTag will then 404 too
+	// and the operational error must surface.
+	if code != exitOperational {
+		t.Errorf("404 from API must surface as operational, not silently succeed: got %d", code)
+	}
+}
+
+// --- #914 — jq exit 5 (NotApplicable_BypassedByDesign) ---
+
+// Test_914_JqExitFiveNotApplicable_BypassedByDesign asserts the
+// design property: ghclient never shells out to jq; all JSON
+// decoding goes through encoding/json with typed structs. A jq
+// exit-5 (non-JSON input) class of bug cannot occur because there
+// is no jq.
+func Test_914_JqExitFiveNotApplicable_BypassedByDesign(t *testing.T) {
+	t.Parallel()
+	// Drive a malformed-JSON response through GetRef and assert
+	// the decode error is named, not silently treated as success.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{ not even json`))
+	}))
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release"})
+	if code != exitOperational {
+		t.Errorf("malformed JSON must surface as operational, not silently succeed: got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "decode") {
+		t.Errorf("stderr must name the decode failure: %q", stderr.String())
+	}
+}
+
+// --- #915 — GraphQL variables sent as a structured object ---
+
+// Test_915_GraphQLVariablesSentAsObject_NotString asserts the
+// mutation request body's `variables` field decodes as a
+// structured object. The bash --raw-field passed it as a string,
+// which is the v0.2.1 #915 cascade source.
+func Test_915_GraphQLVariablesSentAsObject_NotString(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\n"))
+
+	var captured atomic.Pointer[capturedMutation]
+	srv := newCommitServer(t, commitFixture{
+		branchHeadSHA: branchHeadSHA,
+		commitOID:     newCommitSHA,
+		captureBody:   &captured,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	got := captured.Load()
+	if _, ok := got.Variables.(map[string]any); !ok {
+		t.Errorf("variables must decode as a structured object, got %T (#915)", got.Variables)
+	}
+}
+
+// --- #916 — variables padding/permutation detected ---
+
+// Test_916_GraphQLVariablesSentAsObject_PaddingDetected verifies
+// the variables object survives multiple file additions including
+// base64-encoded contents of varying lengths (padding-edge cases
+// in the encoding).
+func Test_916_GraphQLVariablesSentAsObject_PaddingDetected(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	// Three files with byte counts that exercise all base64
+	// padding modes (no padding, 1 char padding, 2 char padding).
+	writeAndStage(t, repo, "go.mod", []byte("a"))          // 1 byte → "YQ=="
+	writeAndStage(t, repo, "webhook/go.mod", []byte("ab")) // 2 bytes → "YWI="
+	writeAndStage(t, repo, "loki/go.mod", []byte("abc"))   // 3 bytes → "YWJj"
+
+	var captured atomic.Pointer[capturedMutation]
+	srv := newCommitServer(t, commitFixture{
+		branchHeadSHA: branchHeadSHA,
+		commitOID:     newCommitSHA,
+		captureBody:   &captured,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	additions := additionPathsFrom(t, captured.Load())
+	if len(additions) != 3 {
+		t.Errorf("all 3 padding-mode files must round-trip (#916): got %v", additions)
+	}
+}
+
+// --- BLOCKER-1 — REST tagger sent as object ---
+
+// Test_BLOCKER1_TaggerSentAsObjectNotString asserts the create-tag
+// REST POST body's `tagger` field is a structured object, not a
+// string. The v0.2.1 bash version using --raw-field stringified it
+// and the API rejected the call.
+func Test_BLOCKER1_TaggerSentAsObjectNotString(t *testing.T) {
+	t.Parallel()
+	var captured atomic.Pointer[map[string]any]
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/axonops/audit/git/ref/tags/v0.2.2", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/tags", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("server failed to decode tag POST body: %v", err)
+		}
+		captured.Store(&body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"sha":"` + annotatedTag + `"}`))
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ref":"refs/tags/v0.2.2"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	body := captured.Load()
+	if body == nil {
+		t.Fatal("tag POST body not captured")
+	}
+	if _, ok := (*body)["tagger"].(map[string]any); !ok {
+		t.Errorf("tagger must be a structured object, got %T (BLOCKER-1)", (*body)["tagger"])
+	}
+}
+
+// --- AC10 — context cancellation within 1s ---
+
+// Test_AC10_TimeoutCancelsInflight cancels the context while a
+// GetRef call is in flight (the test server holds the response
+// open) and asserts the handler returns promptly. Without ctx
+// propagation through ghclient.do, this would hang until the
+// 30s default HTTP timeout.
+func Test_AC10_TimeoutCancelsInflight(t *testing.T) {
+	t.Parallel()
+	// Test server sleeps 30s on every request — much longer than
+	// our 1s budget.
+	released := make(chan struct{})
+	defer close(released)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-released:
+			return
+		case <-time.After(30 * time.Second):
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after 100ms — well within the 1s AC budget.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	var stdout, stderr bytes.Buffer
+	start := time.Now()
+	code := runCreateTagTestHookCtx(ctx, srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release"})
+	elapsed := time.Since(start)
+
+	if elapsed > 1*time.Second {
+		t.Errorf("ctx cancellation must abort within 1s, took %v", elapsed)
+	}
+	if code != exitOperational {
+		t.Errorf("cancelled ctx must surface as operational, got %d", code)
+	}
+}
+
+// --- AC11 — stdout machine-parseable per subcommand ---
+
+// Test_CreateTag_StdoutIsMachineParseable asserts the success
+// stdout is exactly the tag-object SHA with a single trailing
+// newline — nothing else. CI captures this into a shell variable.
+func Test_CreateTag_StdoutIsMachineParseable(t *testing.T) {
+	t.Parallel()
+	srv := newCreateTagServer(t, &createTagFixture{
+		getRefStatus:    http.StatusNotFound,
+		createTagStatus: http.StatusCreated,
+		createRefStatus: http.StatusCreated,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCreateTagTestHook(srv.URL, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--tag", "v0.2.2", "--sha", fakeSHA,
+			"--message", "Release"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+	want := annotatedTag + "\n"
+	if stdout.String() != want {
+		t.Errorf("stdout must be exactly %q (40-hex SHA + LF), got %q", want, stdout.String())
+	}
+}
+
+// Test_CommitPinnedDeps_StdoutIsMachineParseable asserts the
+// success stdout is exactly the commit OID with a single trailing
+// newline.
+func Test_CommitPinnedDeps_StdoutIsMachineParseable(t *testing.T) {
+	t.Parallel()
+	repo := newGitRepo(t)
+	writeAndStage(t, repo, "go.mod", []byte("module example.com\n"))
+
+	srv := newCommitServer(t, commitFixture{
+		branchHeadSHA: branchHeadSHA,
+		commitOID:     newCommitSHA,
+	})
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCommitPinnedDepsTestHook(srv.URL, repo, false, &stdout, &stderr,
+		[]string{"--owner", "axonops", "--repo", "audit",
+			"--branch", "release/v0.2.2", "--message", "chore: pin"})
+	if code != exitSuccess {
+		t.Fatalf("want exit 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	want := newCommitSHA + "\n"
+	if stdout.String() != want {
+		t.Errorf("stdout must be exactly %q (commit OID + LF), got %q", want, stdout.String())
+	}
+}

--- a/cmd/release-tool/validate.go
+++ b/cmd/release-tool/validate.go
@@ -1,0 +1,97 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// identPattern restricts owner/repo/branch/tag flag values to a
+// conservative subset of ASCII. Justifies the no-validation
+// behaviour of the underlying GitHub API by refusing anything that
+// could carry a newline / control character / URL-encoded escape
+// into the API URL or into the stderr log stream (security review
+// W2 / log injection).
+//
+// Allowed: ASCII letters, digits, underscore, dot, hyphen, slash.
+// GitHub owners/repos themselves only allow [A-Za-z0-9-_], but
+// branches and tags permit slashes (release/v0.2.2) and dots
+// (v0.2.2). One conservative regex covers all four.
+var identPattern = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// validateIdent enforces identPattern on a flag value. Used for
+// --owner, --repo, --branch, --tag.
+//
+// In addition to the regex, structurally suspicious values are
+// refused even though they technically match: the bare strings ".",
+// "..", "/", any path segment that is ".." (so "release/../main"
+// can not reach the API), and values that start with a leading
+// character that breaks downstream tooling (a leading "-" looks
+// like a CLI flag; a leading "/" looks like an absolute path).
+// Test-analyst I5.
+func validateIdent(flag, value string) error {
+	if !identPattern.MatchString(value) {
+		return fmt.Errorf("%s must match %s, got %q",
+			flag, identPattern.String(), truncateForDiag(value, 80))
+	}
+	if err := refuseStructurallyBadIdent(flag, value); err != nil {
+		return err
+	}
+	return nil
+}
+
+// refuseStructurallyBadIdent applies the post-regex guards
+// described on validateIdent. Pulled out so the tests can exercise
+// each refusal class independently.
+func refuseStructurallyBadIdent(flag, value string) error {
+	if value == "." || value == ".." || value == "/" {
+		return fmt.Errorf("%s must not be the literal %q (structurally invalid)", flag, value)
+	}
+	if value[0] == '-' || value[0] == '/' || value[0] == '.' {
+		return fmt.Errorf("%s must not start with %q (got %q)", flag, value[:1], truncateForDiag(value, 80))
+	}
+	for _, seg := range strings.Split(value, "/") {
+		if seg == "" {
+			return fmt.Errorf("%s must not contain empty path segments (got %q)", flag, truncateForDiag(value, 80))
+		}
+		if seg == ".." {
+			return fmt.Errorf("%s must not contain %q path segments (got %q)", flag, "..", truncateForDiag(value, 80))
+		}
+	}
+	return nil
+}
+
+// validateMessage refuses control characters and newlines in commit
+// or tag messages. The downstream API accepts them, but they create
+// log-injection opportunities in CI stderr capture and in any
+// downstream tool that parses the message line-by-line.
+//
+// Tabs and printable Unicode are fine.
+func validateMessage(flag, value string) error {
+	for _, r := range value {
+		if r == '\n' || r == '\r' {
+			return fmt.Errorf("%s must not contain newlines (got line break in %q)",
+				flag, truncateForDiag(value, 80))
+		}
+		// Refuse all C0 control characters except tab.
+		if r < 0x20 && r != '\t' {
+			return fmt.Errorf("%s must not contain control character U+%04X",
+				flag, r)
+		}
+	}
+	return nil
+}

--- a/cmd/release-tool/validate_test.go
+++ b/cmd/release-tool/validate_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestValidateIdent_Accept(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{
+		"axonops",
+		"audit",
+		"release/v0.2.2",
+		"v0.2.2",
+		"feature/new-thing",
+		"some.module-name",
+	} {
+		if err := validateIdent("--owner", value); err != nil {
+			t.Errorf("validateIdent rejected legitimate value %q: %v", value, err)
+		}
+	}
+}
+
+func TestValidateIdent_Reject(t *testing.T) {
+	t.Parallel()
+	// W2 regression cases: newline injection, control chars,
+	// shell metacharacters, spaces.
+	for _, value := range []string{
+		"",                       // empty
+		"foo\ninjected-log-line", // log injection
+		"foo bar",                // space
+		"foo;rm -rf /",           // shell metacharacter
+		"foo\x00bar",             // NUL byte
+		"foo\x1b[31mred\x1b[0m",  // ANSI escape
+		"foo\rcarriage-return",   // CR
+		"axonops/audit?ref=evil", // URL query
+	} {
+		if err := validateIdent("--owner", value); err == nil {
+			t.Errorf("validateIdent must reject %q (W2 log-injection regression)", value)
+		}
+	}
+}
+
+// TestValidateIdent_RejectStructurallyInvalid covers analyst I5:
+// the regex on its own admits "..", "/", leading "-" (flag-looking),
+// and "release/../main" (traversal-shaped). All are refused.
+func TestValidateIdent_RejectStructurallyInvalid(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{
+		".",               // literal dot — regex passes but structurally invalid
+		"..",              // literal double-dot — traversal-shaped
+		"/",               // literal slash
+		"-pre-release",    // leading hyphen — looks like a CLI flag downstream
+		"/abs",            // leading slash — looks like an absolute path
+		".hidden",         // leading dot — looks like a hidden file
+		"release/../main", // traversal segment
+		"release/main/..", // trailing traversal
+		"release//main",   // empty segment
+	} {
+		if err := validateIdent("--branch", value); err == nil {
+			t.Errorf("validateIdent must reject structurally invalid %q (I5)", value)
+		}
+	}
+}
+
+func TestValidateMessage_Accept(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{
+		"chore: pin deps for v0.2.2",
+		"Release v0.2.2",
+		"Multi-word\ttab-separated message",
+	} {
+		if err := validateMessage("--message", value); err != nil {
+			t.Errorf("validateMessage rejected legitimate value %q: %v", value, err)
+		}
+	}
+}
+
+// TestTruncateForDiag_UTF8Safe locks the rune-boundary trim for
+// test-analyst N2. A naive byte-slice would emit invalid UTF-8 in
+// stderr if the cut point landed mid-character. The helper trims
+// back to the nearest rune boundary so every diagnostic stays valid.
+func TestTruncateForDiag_UTF8Safe(t *testing.T) {
+	t.Parallel()
+	// "é" is 2 bytes (C3 A9). With n=7 we cut between "Hello é" at
+	// byte 7, which is the trailing byte (A9) of "é" — the result
+	// must trim back to byte 6 to drop the orphaned C3.
+	const input = "Hello é world"
+	const n = 7
+	got := truncateForDiag(input, n)
+	if !utf8.ValidString(got) {
+		t.Errorf("truncateForDiag emitted invalid UTF-8: %q (bytes=%x)", got, []byte(got))
+	}
+	// Short input must pass through unchanged.
+	if truncateForDiag("short", 80) != "short" {
+		t.Errorf("short input must round-trip unchanged")
+	}
+	// Exact-length input must pass through unchanged.
+	if truncateForDiag("hi", 2) != "hi" {
+		t.Errorf("len(s)==n input must round-trip unchanged")
+	}
+}
+
+func TestValidateMessage_Reject(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{
+		"line one\nline two", // newline — log injection
+		"carriage\rreturn",   // CR
+		"control\x01char",    // C0 control
+		"bell\x07char",       // bell
+	} {
+		if err := validateMessage("--message", value); err == nil {
+			t.Errorf("validateMessage must reject %q (W2 log-injection regression)", value)
+		}
+	}
+}

--- a/scripts/verify-bdd-coverage.sh
+++ b/scripts/verify-bdd-coverage.sh
@@ -59,6 +59,7 @@ MAIN_RUNNERS=(
     "splunk|@splunk && ~@fanout && ~@stub && ~@appinspect"
     "splunk-stub|@splunk && @stub"
     "splunk-appinspect|@appinspect"
+    "release-tool|@release-tool"
 )
 
 # The outputconfig suite runs all scenarios (no tag filter) in its own module.

--- a/tests/bdd/features/release_tool.feature
+++ b/tests/bdd/features/release_tool.feature
@@ -8,7 +8,7 @@ Feature: release-tool CLI behaviour
     Given the release-tool binary has been built
 
   # ----------------------------------------------------------------
-  # Persistent flag surface
+  # Persistent flag surface — fast usage gates
   # ----------------------------------------------------------------
 
   Scenario: --help prints the usage block to stderr and exits 0
@@ -34,6 +34,51 @@ Feature: release-tool CLI behaviour
     And the stderr contains "no subcommand"
 
   # ----------------------------------------------------------------
+  # commit-pinned-deps subcommand
+  # ----------------------------------------------------------------
+
+  Scenario: commit-pinned-deps with missing required flags exits 2
+    When I run release-tool with arguments "commit-pinned-deps --owner axonops"
+    Then the exit code is 2
+    And the stderr contains "missing required flag"
+
+  Scenario: commit-pinned-deps creates an App-signed commit
+    Given a staged go.mod in a fresh git repo
+    And the GH_API_URL points at a server that accepts the GraphQL mutation
+    When I run release-tool commit-pinned-deps against that server
+    Then the exit code is 0
+    And the stdout is exactly the captured commit OID
+
+  Scenario: commit-pinned-deps rejects a non-go.mod file in the staged tree
+    Given a staged ".github/workflows/release.yml" in a fresh git repo
+    And the GH_API_URL points at a server that fails on any request
+    When I run release-tool commit-pinned-deps against that server
+    Then the exit code is 3
+    And the stderr contains "rejected by allowlist"
+
+  Scenario: commit-pinned-deps rejects a symlinked go.mod
+    Given a symlinked go.mod in a fresh git repo
+    And the GH_API_URL points at a server that fails on any request
+    When I run release-tool commit-pinned-deps against that server
+    Then the exit code is 3
+    And the stderr contains "symlink"
+
+  Scenario: commit-pinned-deps with --dry-run prints the payload and does not call the API
+    Given a staged go.mod in a fresh git repo
+    And the GH_API_URL points at a server that succeeds on idempotency lookups but fails on any mutation
+    When I run release-tool commit-pinned-deps with --dry-run against that server
+    Then the exit code is 0
+    And the stdout decodes as JSON containing "createCommitOnBranch"
+    And the server received zero mutation requests
+
+  Scenario: commit-pinned-deps with --auto-create-branch creates the branch from main
+    Given a staged go.mod in a fresh git repo
+    And the GH_API_URL points at a server where the release branch does not exist
+    When I run release-tool commit-pinned-deps with --auto-create-branch against that server
+    Then the exit code is 0
+    And the server received a CreateRef call for the release branch
+
+  # ----------------------------------------------------------------
   # create-tag subcommand
   # ----------------------------------------------------------------
 
@@ -43,11 +88,6 @@ Feature: release-tool CLI behaviour
     And the stderr contains "missing required flag"
 
   Scenario: create-tag refuses a non-40-hex SHA — #911 regression
-    # The --sha argument here is the EXACT 404 JSON body that bash
-    # versions accepted as a SHA. The docstring preserves every
-    # character (double quotes, braces) verbatim — splitShellLike
-    # only sees the literal token "{message:NotFound}" as the SHA,
-    # which is still emphatically not 40 hex chars.
     When I run release-tool with these args:
       """
       create-tag
@@ -60,27 +100,32 @@ Feature: release-tool CLI behaviour
     Then the exit code is 3
     And the stderr contains "40 lowercase hex"
 
-  # ----------------------------------------------------------------
-  # commit-pinned-deps subcommand
-  # ----------------------------------------------------------------
-
-  Scenario: commit-pinned-deps with missing required flags exits 2
-    When I run release-tool with arguments "commit-pinned-deps --owner axonops"
-    Then the exit code is 2
-    And the stderr contains "missing required flag"
-
-  # ----------------------------------------------------------------
-  # Happy path — covered via --dry-run so the scenario never makes
-  # a real network call (test-analyst N1). Dry-run only short-
-  # circuits AFTER the existing-ref lookup, so we point --owner /
-  # --repo at "dry-run/dry-run" — release-tool's no-network path
-  # rejects the upfront flag-shape gate first (regex refuses the
-  # leading hyphen / structurally invalid forms), then validates
-  # the SHA shape, and only then would hit the API. With a valid-
-  # SHA / valid-flag combination the tool still tries to reach
-  # api.github.com — which is why this scenario asserts the
-  # validation-only contract (exit 3 on a bad SHA), and not exit 0.
   Scenario: create-tag refuses a structurally invalid branch-like tag
     When I run release-tool with arguments "create-tag --owner axonops --repo audit --tag .. --sha abcdef0123456789abcdef0123456789abcdef01 --message Release"
     Then the exit code is 3
     And the stderr contains "structurally invalid"
+
+  Scenario: create-tag at a fresh tag creates the tag object + ref
+    Given the GH_API_URL points at a server where the tag does not exist
+    When I run release-tool create-tag against that server
+    Then the exit code is 0
+    And the stdout is exactly the captured tag-object SHA
+
+  Scenario: create-tag re-run at the same SHA exits 4 idempotently
+    Given the GH_API_URL points at a server where the tag exists at the same SHA
+    When I run release-tool create-tag against that server
+    Then the exit code is 4
+    And the stderr contains "no-op"
+
+  Scenario: create-tag re-run at a different SHA exits 1 with a contamination error
+    Given the GH_API_URL points at a server where the tag exists at a different SHA
+    When I run release-tool create-tag against that server
+    Then the exit code is 1
+    And the stderr contains "refusing to overwrite"
+
+  Scenario: create-tag with --dry-run prints the payloads and does not call the API
+    Given the GH_API_URL points at a server where the tag does not exist and any mutation fails the test
+    When I run release-tool create-tag with --dry-run against that server
+    Then the exit code is 0
+    And the stdout decodes as JSON containing "tag_object"
+    And the server received zero mutation requests

--- a/tests/bdd/features/release_tool.feature
+++ b/tests/bdd/features/release_tool.feature
@@ -1,0 +1,86 @@
+@release-tool
+Feature: release-tool CLI behaviour
+  As an operator running the release flow
+  I want release-tool to enforce typed, idempotent semantics
+  So that the v0.2.1-era bash cascade bugs (#900-#916) can not recur
+
+  Background:
+    Given the release-tool binary has been built
+
+  # ----------------------------------------------------------------
+  # Persistent flag surface
+  # ----------------------------------------------------------------
+
+  Scenario: --help prints the usage block to stderr and exits 0
+    When I run release-tool with arguments "--help"
+    Then the exit code is 0
+    And the stderr contains "USAGE"
+    And the stderr contains "commit-pinned-deps"
+    And the stderr contains "create-tag"
+
+  Scenario: --version writes the version to stdout
+    When I run release-tool with arguments "--version"
+    Then the exit code is 0
+    And the stdout starts with "release-tool "
+
+  Scenario: An unknown subcommand exits 2 with a useful diagnostic
+    When I run release-tool with arguments "nonexistent-subcommand"
+    Then the exit code is 2
+    And the stderr contains "unknown subcommand"
+
+  Scenario: No subcommand exits 2 with a useful diagnostic
+    When I run release-tool with no arguments
+    Then the exit code is 2
+    And the stderr contains "no subcommand"
+
+  # ----------------------------------------------------------------
+  # create-tag subcommand
+  # ----------------------------------------------------------------
+
+  Scenario: create-tag with missing required flags exits 2
+    When I run release-tool with arguments "create-tag --owner axonops --repo audit"
+    Then the exit code is 2
+    And the stderr contains "missing required flag"
+
+  Scenario: create-tag refuses a non-40-hex SHA — #911 regression
+    # The --sha argument here is the EXACT 404 JSON body that bash
+    # versions accepted as a SHA. The docstring preserves every
+    # character (double quotes, braces) verbatim — splitShellLike
+    # only sees the literal token "{message:NotFound}" as the SHA,
+    # which is still emphatically not 40 hex chars.
+    When I run release-tool with these args:
+      """
+      create-tag
+      --owner=axonops
+      --repo=audit
+      --tag=v0.2.2
+      --message=Release
+      --sha={"message":"Not Found"}
+      """
+    Then the exit code is 3
+    And the stderr contains "40 lowercase hex"
+
+  # ----------------------------------------------------------------
+  # commit-pinned-deps subcommand
+  # ----------------------------------------------------------------
+
+  Scenario: commit-pinned-deps with missing required flags exits 2
+    When I run release-tool with arguments "commit-pinned-deps --owner axonops"
+    Then the exit code is 2
+    And the stderr contains "missing required flag"
+
+  # ----------------------------------------------------------------
+  # Happy path — covered via --dry-run so the scenario never makes
+  # a real network call (test-analyst N1). Dry-run only short-
+  # circuits AFTER the existing-ref lookup, so we point --owner /
+  # --repo at "dry-run/dry-run" — release-tool's no-network path
+  # rejects the upfront flag-shape gate first (regex refuses the
+  # leading hyphen / structurally invalid forms), then validates
+  # the SHA shape, and only then would hit the API. With a valid-
+  # SHA / valid-flag combination the tool still tries to reach
+  # api.github.com — which is why this scenario asserts the
+  # validation-only contract (exit 3 on a bad SHA), and not exit 0.
+  Scenario: create-tag refuses a structurally invalid branch-like tag
+    When I run release-tool with arguments "create-tag --owner axonops --repo audit --tag .. --sha abcdef0123456789abcdef0123456789abcdef01 --message Release"
+    Then the exit code is 3
+    And the stderr contains "structurally invalid"

--- a/tests/bdd/steps/context.go
+++ b/tests/bdd/steps/context.go
@@ -288,4 +288,5 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	registerLastDeliveryAgeSteps(ctx, tc)
 	registerTLSEncryptedKeySteps(ctx, tc)
 	registerSchemaArtifactsStepsIfBuilt(ctx, tc)
+	registerReleaseToolSteps(ctx, tc)
 }

--- a/tests/bdd/steps/release_tool_steps.go
+++ b/tests/bdd/steps/release_tool_steps.go
@@ -17,12 +17,16 @@ package steps
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/cucumber/godog"
 )
@@ -30,10 +34,16 @@ import (
 // releaseToolState is private to the release-tool BDD scenarios.
 // A fresh instance is created per scenario by registerReleaseToolSteps.
 type releaseToolState struct {
-	binaryPath string
-	stdout     bytes.Buffer
-	stderr     bytes.Buffer
-	exitCode   int
+	server      *httptest.Server // pointer (8) — set when scenarios start a fake GH API
+	binaryPath  string           // path to bin/release-tool
+	gitRepo     string           // temp dir with `git init` for commit-pinned-deps scenarios
+	capturedOID string           // OID returned by the fake GraphQL server
+	capturedTag string           // tag-object SHA returned by the fake REST server
+	stdout      bytes.Buffer
+	stderr      bytes.Buffer
+	mutations   atomic.Int32 // mutation-endpoint hit counter
+	createRefs  atomic.Int32 // POST /git/refs hit counter (for auto-create-branch)
+	exitCode    int
 }
 
 // registerReleaseToolSteps registers the Gherkin steps that drive the
@@ -55,12 +65,25 @@ func registerReleaseToolSteps(ctx *godog.ScenarioContext, _ *AuditTestContext) {
 		s = &releaseToolState{}
 		return c, nil
 	})
+	ctx.After(func(c context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		if s.server != nil {
+			s.server.Close()
+		}
+		return c, nil
+	})
 
+	registerCoreSteps(ctx, func() *releaseToolState { return s })
+	registerFixtureSteps(ctx, func() *releaseToolState { return s })
+	registerServerSteps(ctx, func() *releaseToolState { return s })
+	registerInvocationSteps(ctx, func() *releaseToolState { return s })
+	registerAssertionSteps(ctx, func() *releaseToolState { return s })
+}
+
+// registerCoreSteps wires the persistent-flag scenarios that don't
+// need a fake server or git repo.
+func registerCoreSteps(ctx *godog.ScenarioContext, get func() *releaseToolState) {
 	ctx.Given(`^the release-tool binary has been built$`, func() error {
-		// We expect the binary at <repo>/bin/release-tool, built by
-		// `make build-release-tool`. The BDD harness can not perform
-		// the build itself (no go.mod boundary to lean on); the
-		// surrounding make target handles it.
+		s := get()
 		repoRoot, err := findRepoRoot()
 		if err != nil {
 			return err
@@ -74,35 +97,162 @@ func registerReleaseToolSteps(ctx *godog.ScenarioContext, _ *AuditTestContext) {
 	})
 
 	ctx.When(`^I run release-tool with arguments "([^"]*)"$`, func(argStr string) error {
-		return s.run(argStr)
+		return get().run(argStr)
 	})
-
 	ctx.When(`^I run release-tool with these args:$`, func(doc *godog.DocString) error {
-		return s.runWithRawArgs(doc.Content)
+		return get().runWithRawArgs(doc.Content)
 	})
-
 	ctx.When(`^I run release-tool with no arguments$`, func() error {
-		return s.run("")
+		return get().run("")
 	})
 
 	ctx.Then(`^the exit code is (\d+)$`, func(want int) error {
+		s := get()
 		if s.exitCode != want {
 			return fmt.Errorf("exit code: want %d, got %d (stderr=%q)",
 				want, s.exitCode, s.stderr.String())
 		}
 		return nil
 	})
-
 	ctx.Then(`^the stderr contains "([^"]*)"$`, func(needle string) error {
+		s := get()
 		if !strings.Contains(s.stderr.String(), needle) {
 			return fmt.Errorf("stderr missing %q\n--- stderr ---\n%s", needle, s.stderr.String())
 		}
 		return nil
 	})
-
 	ctx.Then(`^the stdout starts with "([^"]*)"$`, func(prefix string) error {
+		s := get()
 		if !strings.HasPrefix(s.stdout.String(), prefix) {
 			return fmt.Errorf("stdout prefix: want %q, got %q", prefix, s.stdout.String())
+		}
+		return nil
+	})
+}
+
+// registerFixtureSteps wires the Given-side filesystem fixtures
+// (staged go.mod, off-allowlist path, symlink).
+func registerFixtureSteps(ctx *godog.ScenarioContext, get func() *releaseToolState) {
+	ctx.Given(`^a staged go.mod in a fresh git repo$`, func() error {
+		return get().stageFile("go.mod", []byte("module example.com\n"))
+	})
+	ctx.Given(`^a staged ".github/workflows/release.yml" in a fresh git repo$`, func() error {
+		return get().stageFile(".github/workflows/release.yml", []byte("# off-allowlist\n"))
+	})
+	ctx.Given(`^a symlinked go.mod in a fresh git repo$`, func() error {
+		s := get()
+		if err := s.ensureRepo(); err != nil {
+			return err
+		}
+		target := filepath.Join(s.gitRepo, "real-target.txt")
+		if err := os.WriteFile(target, []byte("secret\n"), 0o600); err != nil {
+			return fmt.Errorf("write target: %w", err)
+		}
+		if err := os.Symlink("real-target.txt", filepath.Join(s.gitRepo, "go.mod")); err != nil {
+			return fmt.Errorf("symlink: %w", err)
+		}
+		return s.gitAdd("go.mod")
+	})
+}
+
+// registerServerSteps wires the Given-side httptest fake-server
+// configurations.
+func registerServerSteps(ctx *godog.ScenarioContext, get func() *releaseToolState) {
+	ctx.Given(`^the GH_API_URL points at a server that accepts the GraphQL mutation$`, func() error {
+		get().startCommitServer(serverProfileCommitAccept)
+		return nil
+	})
+	ctx.Given(`^the GH_API_URL points at a server that fails on any request$`, func() error {
+		get().startCommitServer(serverProfileFailAny)
+		return nil
+	})
+	ctx.Given(`^the GH_API_URL points at a server that succeeds on idempotency lookups but fails on any mutation$`, func() error {
+		get().startCommitServer(serverProfileDryRun)
+		return nil
+	})
+	ctx.Given(`^the GH_API_URL points at a server where the release branch does not exist$`, func() error {
+		get().startCommitServer(serverProfileAutoCreate)
+		return nil
+	})
+	ctx.Given(`^the GH_API_URL points at a server where the tag does not exist$`, func() error {
+		get().startCreateTagServer(serverProfileTagFresh)
+		return nil
+	})
+	ctx.Given(`^the GH_API_URL points at a server where the tag does not exist and any mutation fails the test$`, func() error {
+		get().startCreateTagServer(serverProfileTagDryRun)
+		return nil
+	})
+	ctx.Given(`^the GH_API_URL points at a server where the tag exists at the same SHA$`, func() error {
+		get().startCreateTagServer(serverProfileTagSameSHA)
+		return nil
+	})
+	ctx.Given(`^the GH_API_URL points at a server where the tag exists at a different SHA$`, func() error {
+		get().startCreateTagServer(serverProfileTagDifferentSHA)
+		return nil
+	})
+}
+
+// registerInvocationSteps wires the When-side subcommand
+// invocations that drive the binary against the configured server.
+func registerInvocationSteps(ctx *godog.ScenarioContext, get func() *releaseToolState) {
+	ctx.When(`^I run release-tool commit-pinned-deps against that server$`, func() error {
+		return get().runCommitPinnedDeps(false)
+	})
+	ctx.When(`^I run release-tool commit-pinned-deps with --dry-run against that server$`, func() error {
+		return get().runCommitPinnedDeps(true)
+	})
+	ctx.When(`^I run release-tool commit-pinned-deps with --auto-create-branch against that server$`, func() error {
+		return get().runCommitPinnedDepsAutoCreate()
+	})
+	ctx.When(`^I run release-tool create-tag against that server$`, func() error {
+		return get().runCreateTag(false)
+	})
+	ctx.When(`^I run release-tool create-tag with --dry-run against that server$`, func() error {
+		return get().runCreateTag(true)
+	})
+}
+
+// registerAssertionSteps wires the Then-side assertions on stdout,
+// stderr, and server-side mutation counters.
+func registerAssertionSteps(ctx *godog.ScenarioContext, get func() *releaseToolState) {
+	ctx.Then(`^the stdout is exactly the captured commit OID$`, func() error {
+		s := get()
+		want := s.capturedOID + "\n"
+		if s.stdout.String() != want {
+			return fmt.Errorf("stdout: want %q, got %q", want, s.stdout.String())
+		}
+		return nil
+	})
+	ctx.Then(`^the stdout is exactly the captured tag-object SHA$`, func() error {
+		s := get()
+		want := s.capturedTag + "\n"
+		if s.stdout.String() != want {
+			return fmt.Errorf("stdout: want %q, got %q", want, s.stdout.String())
+		}
+		return nil
+	})
+	ctx.Then(`^the stdout decodes as JSON containing "([^"]*)"$`, func(needle string) error {
+		s := get()
+		var v any
+		if err := json.Unmarshal(s.stdout.Bytes(), &v); err != nil {
+			return fmt.Errorf("stdout must be valid JSON: %w (stdout=%s)", err, s.stdout.String())
+		}
+		if !strings.Contains(s.stdout.String(), needle) {
+			return fmt.Errorf("stdout JSON missing %q\n%s", needle, s.stdout.String())
+		}
+		return nil
+	})
+	ctx.Then(`^the server received zero mutation requests$`, func() error {
+		s := get()
+		if got := s.mutations.Load(); got != 0 {
+			return fmt.Errorf("dry-run must perform zero mutating calls, got %d", got)
+		}
+		return nil
+	})
+	ctx.Then(`^the server received a CreateRef call for the release branch$`, func() error {
+		s := get()
+		if got := s.createRefs.Load(); got == 0 {
+			return errors.New("auto-create-branch must call POST /git/refs at least once")
 		}
 		return nil
 	})
@@ -151,6 +301,12 @@ func (s *releaseToolState) run(argStr string) error {
 // exec is the shared subprocess execution path used by both `run`
 // (whitespace-split args) and `runWithRawArgs` (one-arg-per-line).
 func (s *releaseToolState) exec(args []string) error {
+	return s.execEnv(args, nil)
+}
+
+// execEnv is like exec but appends extra env vars. Used by the
+// orchestration scenarios to inject GH_API_URL.
+func (s *releaseToolState) execEnv(args, extraEnv []string) error {
 	// G204 is satisfied: s.binaryPath is `<repo>/bin/release-tool`,
 	// constructed by findRepoRoot (which walks the local filesystem
 	// looking for the audit go.mod) — not influenced by external
@@ -162,6 +318,7 @@ func (s *releaseToolState) exec(args []string) error {
 	// Set GH_TOKEN to a stub so buildClient gets past the env
 	// check; tests assert exit codes BEFORE any HTTP call is made.
 	cmd.Env = append(cmd.Environ(), "GH_TOKEN=stub-token-for-bdd")
+	cmd.Env = append(cmd.Env, extraEnv...)
 
 	err := cmd.Run()
 	if exitErr, ok := asExitError(err); ok {
@@ -173,6 +330,201 @@ func (s *releaseToolState) exec(args []string) error {
 	}
 	s.exitCode = 0
 	return nil
+}
+
+// --- Orchestration helpers ---
+
+// fakeBranchHead / fakeCommitOID / fakeTagSHA are the canonical
+// "happy-path" SHAs the fake servers return.
+const (
+	fakeBranchHead = "feedface0000000000000000000000000000feed"
+	fakeCommitOID  = "cafebabe0000000000000000000000000000cafe"
+	fakeTagSHA     = "9999999999999999999999999999999999999999"
+	fakeTagCommit  = "abcdef0123456789abcdef0123456789abcdef01"
+	fakeOtherSHA   = "0123456789abcdef0123456789abcdef01234567"
+)
+
+type serverProfile int
+
+const (
+	serverProfileCommitAccept serverProfile = iota
+	serverProfileFailAny
+	serverProfileDryRun
+	serverProfileAutoCreate
+	serverProfileTagFresh
+	serverProfileTagSameSHA
+	serverProfileTagDifferentSHA
+	serverProfileTagDryRun
+)
+
+// ensureRepo lazily initialises s.gitRepo with `git init` so the
+// scenario can stage files via gitAdd.
+func (s *releaseToolState) ensureRepo() error {
+	if s.gitRepo != "" {
+		return nil
+	}
+	dir, err := os.MkdirTemp("", "release-tool-bdd-*")
+	if err != nil {
+		return fmt.Errorf("mkdtemp: %w", err)
+	}
+	s.gitRepo = dir
+	for _, args := range [][]string{
+		{"init", "--quiet"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test User"},
+		{"commit", "--allow-empty", "-m", "init"},
+	} {
+		c := exec.Command("git", append([]string{"-C", dir}, args...)...) //nolint:gosec // tempdir
+		c.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if out, err := c.CombinedOutput(); err != nil {
+			return fmt.Errorf("git %v: %w (output=%s)", args, err, out)
+		}
+	}
+	return nil
+}
+
+// stageFile writes a file (relative to s.gitRepo) and `git add`s it.
+func (s *releaseToolState) stageFile(rel string, content []byte) error {
+	if err := s.ensureRepo(); err != nil {
+		return err
+	}
+	full := filepath.Join(s.gitRepo, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	if err := os.WriteFile(full, content, 0o600); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	return s.gitAdd(rel)
+}
+
+// gitAdd stages rel inside s.gitRepo.
+func (s *releaseToolState) gitAdd(rel string) error {
+	c := exec.Command("git", "-C", s.gitRepo, "add", rel) //nolint:gosec // tempdir + checked-in fixture
+	c.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add %s: %w (output=%s)", rel, err, out)
+	}
+	return nil
+}
+
+// startCommitServer wires up the fake GH server for commit-pinned-deps.
+func (s *releaseToolState) startCommitServer(p serverProfile) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/axonops/audit/git/ref/heads/release/v0.2.2", func(w http.ResponseWriter, r *http.Request) {
+		switch p { //nolint:exhaustive // tag-profile cases never hit this commit endpoint
+		case serverProfileFailAny:
+			w.WriteHeader(http.StatusInternalServerError)
+		case serverProfileAutoCreate:
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ref":"refs/heads/release/v0.2.2","object":{"sha":"` + fakeBranchHead + `","type":"commit"}}`))
+		}
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/ref/heads/main", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ref":"refs/heads/main","object":{"sha":"` + fakeBranchHead + `","type":"commit"}}`))
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		s.createRefs.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ref":"refs/heads/release/v0.2.2","object":{"sha":"` + fakeBranchHead + `","type":"commit"}}`))
+	})
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		s.mutations.Add(1)
+		if p == serverProfileFailAny || p == serverProfileDryRun {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		s.capturedOID = fakeCommitOID
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"createCommitOnBranch":{"commit":{"oid":"` + fakeCommitOID + `","url":""}}}}`))
+	})
+	s.server = httptest.NewServer(mux)
+}
+
+// startCreateTagServer wires up the fake GH server for create-tag.
+func (s *releaseToolState) startCreateTagServer(p serverProfile) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/axonops/audit/git/ref/tags/v0.2.2", func(w http.ResponseWriter, r *http.Request) {
+		switch p { //nolint:exhaustive // commit-profile cases never hit this tag endpoint
+		case serverProfileTagSameSHA:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ref":"refs/tags/v0.2.2","object":{"sha":"` + fakeTagCommit + `","type":"commit"}}`))
+		case serverProfileTagDifferentSHA:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ref":"refs/tags/v0.2.2","object":{"sha":"` + fakeOtherSHA + `","type":"commit"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/tags", func(w http.ResponseWriter, r *http.Request) {
+		s.mutations.Add(1)
+		if p == serverProfileTagDryRun {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		s.capturedTag = fakeTagSHA
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"sha":"` + fakeTagSHA + `","tag":"v0.2.2"}`))
+	})
+	mux.HandleFunc("/repos/axonops/audit/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		s.mutations.Add(1)
+		if p == serverProfileTagDryRun {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ref":"refs/tags/v0.2.2","object":{"sha":"` + fakeTagSHA + `","type":"tag"}}`))
+	})
+	s.server = httptest.NewServer(mux)
+}
+
+// runCommitPinnedDeps invokes the subcommand against s.server with
+// s.gitRepo as the workdir.
+func (s *releaseToolState) runCommitPinnedDeps(dryRun bool) error {
+	args := []string{}
+	if dryRun {
+		args = append(args, "--dry-run")
+	}
+	args = append(args,
+		"commit-pinned-deps",
+		"--owner", "axonops", "--repo", "audit",
+		"--branch", "release/v0.2.2",
+		"--message", "chore: pin deps for BDD",
+		"--workdir", s.gitRepo,
+	)
+	return s.execEnv(args, []string{"GH_API_URL=" + s.server.URL})
+}
+
+// runCommitPinnedDepsAutoCreate runs with --auto-create-branch.
+func (s *releaseToolState) runCommitPinnedDepsAutoCreate() error {
+	args := []string{
+		"commit-pinned-deps",
+		"--owner", "axonops", "--repo", "audit",
+		"--branch", "release/v0.2.2",
+		"--message", "chore: pin deps for BDD",
+		"--workdir", s.gitRepo,
+		"--auto-create-branch",
+	}
+	return s.execEnv(args, []string{"GH_API_URL=" + s.server.URL})
+}
+
+// runCreateTag invokes the subcommand against s.server.
+func (s *releaseToolState) runCreateTag(dryRun bool) error {
+	args := []string{}
+	if dryRun {
+		args = append(args, "--dry-run")
+	}
+	args = append(args,
+		"create-tag",
+		"--owner", "axonops", "--repo", "audit",
+		"--tag", "v0.2.2",
+		"--sha", fakeTagCommit,
+		"--message", "Release v0.2.2",
+	)
+	return s.execEnv(args, []string{"GH_API_URL=" + s.server.URL})
 }
 
 // splitShellLike splits a string on whitespace, respecting single and

--- a/tests/bdd/steps/release_tool_steps.go
+++ b/tests/bdd/steps/release_tool_steps.go
@@ -1,0 +1,302 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+// releaseToolState is private to the release-tool BDD scenarios.
+// A fresh instance is created per scenario by registerReleaseToolSteps.
+type releaseToolState struct {
+	binaryPath string
+	stdout     bytes.Buffer
+	stderr     bytes.Buffer
+	exitCode   int
+}
+
+// registerReleaseToolSteps registers the Gherkin steps that drive the
+// release-tool binary via os/exec.
+//
+// release-tool is a CLI binary (not a Go-API library), so the steps
+// here capture stdout / stderr / exit code from a subprocess rather
+// than from in-process function calls. The scenarios assert the
+// observable external contract: stdout is for machines, stderr is
+// for humans, exit codes follow the 0 / 1 / 2 / 3 / 4 ladder.
+//
+// State is per-scenario: every scenario gets a fresh
+// releaseToolState struct via the BeforeScenario hook. A single
+// shared struct (the previous design) would race if godog ever ran
+// scenarios with Concurrency > 1.
+func registerReleaseToolSteps(ctx *godog.ScenarioContext, _ *AuditTestContext) {
+	var s *releaseToolState
+	ctx.Before(func(c context.Context, _ *godog.Scenario) (context.Context, error) {
+		s = &releaseToolState{}
+		return c, nil
+	})
+
+	ctx.Given(`^the release-tool binary has been built$`, func() error {
+		// We expect the binary at <repo>/bin/release-tool, built by
+		// `make build-release-tool`. The BDD harness can not perform
+		// the build itself (no go.mod boundary to lean on); the
+		// surrounding make target handles it.
+		repoRoot, err := findRepoRoot()
+		if err != nil {
+			return err
+		}
+		s.binaryPath = filepath.Join(repoRoot, "bin", "release-tool")
+		if _, err := exec.LookPath(s.binaryPath); err != nil {
+			return fmt.Errorf("release-tool binary not found at %s — run `make build-release-tool`: %w",
+				s.binaryPath, err)
+		}
+		return nil
+	})
+
+	ctx.When(`^I run release-tool with arguments "([^"]*)"$`, func(argStr string) error {
+		return s.run(argStr)
+	})
+
+	ctx.When(`^I run release-tool with these args:$`, func(doc *godog.DocString) error {
+		return s.runWithRawArgs(doc.Content)
+	})
+
+	ctx.When(`^I run release-tool with no arguments$`, func() error {
+		return s.run("")
+	})
+
+	ctx.Then(`^the exit code is (\d+)$`, func(want int) error {
+		if s.exitCode != want {
+			return fmt.Errorf("exit code: want %d, got %d (stderr=%q)",
+				want, s.exitCode, s.stderr.String())
+		}
+		return nil
+	})
+
+	ctx.Then(`^the stderr contains "([^"]*)"$`, func(needle string) error {
+		if !strings.Contains(s.stderr.String(), needle) {
+			return fmt.Errorf("stderr missing %q\n--- stderr ---\n%s", needle, s.stderr.String())
+		}
+		return nil
+	})
+
+	ctx.Then(`^the stdout starts with "([^"]*)"$`, func(prefix string) error {
+		if !strings.HasPrefix(s.stdout.String(), prefix) {
+			return fmt.Errorf("stdout prefix: want %q, got %q", prefix, s.stdout.String())
+		}
+		return nil
+	})
+}
+
+// runWithRawArgs treats the input as one argument per non-empty
+// line, no shell parsing at all. This is what scenarios should use
+// for anything containing JSON or other shell-special characters,
+// because it preserves bytes verbatim. The splitShellLike helper is
+// reserved for simple whitespace-separated argument lists.
+func (s *releaseToolState) runWithRawArgs(raw string) error {
+	s.stdout.Reset()
+	s.stderr.Reset()
+	s.exitCode = 0
+
+	lines := strings.Split(raw, "\n")
+	args := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		args = append(args, line)
+	}
+	return s.exec(args)
+}
+
+// run executes the binary with shell-style argument splitting so the
+// Gherkin can quote SHAs containing special chars.
+func (s *releaseToolState) run(argStr string) error {
+	s.stdout.Reset()
+	s.stderr.Reset()
+	s.exitCode = 0
+
+	var args []string
+	if strings.TrimSpace(argStr) != "" {
+		var err error
+		args, err = splitShellLike(argStr)
+		if err != nil {
+			return fmt.Errorf("split %q: %w", argStr, err)
+		}
+	}
+	return s.exec(args)
+}
+
+// exec is the shared subprocess execution path used by both `run`
+// (whitespace-split args) and `runWithRawArgs` (one-arg-per-line).
+func (s *releaseToolState) exec(args []string) error {
+	// G204 is satisfied: s.binaryPath is `<repo>/bin/release-tool`,
+	// constructed by findRepoRoot (which walks the local filesystem
+	// looking for the audit go.mod) — not influenced by external
+	// input. args come from a Gherkin feature file checked into the
+	// repository, also not user-supplied.
+	cmd := exec.Command(s.binaryPath, args...) //nolint:gosec // see comment above
+	cmd.Stdout = &s.stdout
+	cmd.Stderr = &s.stderr
+	// Set GH_TOKEN to a stub so buildClient gets past the env
+	// check; tests assert exit codes BEFORE any HTTP call is made.
+	cmd.Env = append(cmd.Environ(), "GH_TOKEN=stub-token-for-bdd")
+
+	err := cmd.Run()
+	if exitErr, ok := asExitError(err); ok {
+		s.exitCode = exitErr.ExitCode()
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("exec release-tool: %w", err)
+	}
+	s.exitCode = 0
+	return nil
+}
+
+// splitShellLike splits a string on whitespace, respecting single and
+// double-quoted regions. No backslash escaping, no command
+// substitution. Sufficient for the release-tool BDD scenarios that
+// quote a single value (e.g. an invalid SHA JSON string) inside the
+// argument list.
+func splitShellLike(s string) ([]string, error) {
+	st := splitState{}
+	for _, r := range s {
+		st.consume(r)
+	}
+	if st.quote != 0 {
+		return nil, fmt.Errorf("unterminated %c-quoted string", st.quote)
+	}
+	st.flush()
+	return st.out, nil
+}
+
+// splitState carries the running state of splitShellLike.
+type splitState struct {
+	current strings.Builder
+	out     []string
+	quote   rune
+	inField bool
+}
+
+// consume processes one rune of input.
+func (st *splitState) consume(r rune) {
+	switch {
+	case st.quote != 0:
+		st.consumeQuoted(r)
+	case r == '\'' || r == '"':
+		st.quote = r
+		st.inField = true
+	case r == ' ' || r == '\t':
+		st.flush()
+	default:
+		st.current.WriteRune(r)
+		st.inField = true
+	}
+}
+
+// consumeQuoted handles a rune inside a quoted region.
+func (st *splitState) consumeQuoted(r rune) {
+	if r == st.quote {
+		st.quote = 0
+		return
+	}
+	st.current.WriteRune(r)
+	st.inField = true
+}
+
+// flush moves the current field (if any) into the output slice.
+func (st *splitState) flush() {
+	if !st.inField {
+		return
+	}
+	st.out = append(st.out, st.current.String())
+	st.current.Reset()
+	st.inField = false
+}
+
+// asExitError narrows err to *exec.ExitError when applicable.
+func asExitError(err error) (*exec.ExitError, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr, true
+	}
+	return nil, false
+}
+
+// findRepoRoot walks upward looking for a go.mod that declares the
+// audit module. release-tool's BDD steps need the absolute path so
+// they can locate the built binary regardless of CWD at test time.
+//
+// Match is line-based (not substring) so a sub-module go.mod's
+// `require github.com/axonops/audit` line cannot false-positive,
+// and line-ending agnostic so Windows / CRLF checkouts behave
+// correctly. The walk is bounded by maxRepoRootDepth to avoid
+// pathological climbs through `/`.
+func findRepoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("release-tool BDD: getwd: %w", err)
+	}
+	dir := wd
+	for i := 0; i < maxRepoRootDepth; i++ {
+		// G304 is satisfied: dir starts at os.Getwd() and walks
+		// upward by repeated filepath.Dir, so the path is always
+		// derived from the local filesystem layout — never from
+		// user input.
+		data, err := os.ReadFile(filepath.Join(dir, "go.mod")) //nolint:gosec // see comment above
+		if err == nil && isAuditRootGoMod(data) {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("release-tool BDD: could not locate audit repo root within %d levels above %s",
+		maxRepoRootDepth, wd)
+}
+
+// maxRepoRootDepth caps the findRepoRoot upward walk. 20 is more
+// than enough for any realistic checkout depth and prevents a
+// malformed go.mod from making the walk run all the way to `/`.
+const maxRepoRootDepth = 20
+
+// isAuditRootGoMod reports whether data is the root audit go.mod by
+// scanning lines (not substring), so CRLF line endings work and a
+// sub-module's `require github.com/axonops/audit ...` line cannot
+// false-positive.
+func isAuditRootGoMod(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "module github.com/axonops/audit" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Lands the two release-flow subcommands on top of the PR-2 foundation in `cmd/release-tool`. Replaces the bash `gh-graphql-commit.sh` and `gh-graphql-tag.sh` scripts that produced 8 cascading bugs in v0.2.1 (#900-#916).

Part of #918 (v0.2.2 umbrella). Closes #923.

## Scope

### `commit-pinned-deps`
- collects allowlisted go.mod / go.sum files via NUL-safe `git status -z`
- atomic `O_NOFOLLOW` open + `IsRegular()` refuses symlinks and special files (closes the TOCTOU window left by the lstat+open pair)
- typed `createCommitOnBranch` GraphQL mutation; variables is always a structured object, never a JSON-string-of-an-object (#915/#916)
- `--auto-create-branch` creates a missing release branch from main
- `--dry-run` prints the proposed payload (path + size only) to stdout

### `create-tag`
- two-step REST: POST `git/tags` (annotated object) then POST `git/refs`
- strictly idempotent: same-SHA re-run exits 4 (no-op), different-SHA exits 1 (refuses to overwrite)
- annotated-tag dereferencing via GET `git/tags/{object_sha}` so the ref.object.sha (tag-object SHA) is correctly compared against the flag commit SHA - not a previous wrong comparison that would have produced false-contamination on every re-run
- partial-success recovery: when CreateTag succeeds but CreateRef fails, stderr names the orphan tag-object SHA and gives the operator a copy-pasteable `gh api` recovery recipe

### Validation gates (security review W2, test-analyst I5)
- owner/repo/branch/tag restricted to `[A-Za-z0-9._/-]+`
- structurally invalid values (`.`, `..`, `/`, leading `-`, embedded `..`) refused before any HTTP call
- commit messages refuse newlines and C0 control chars (log injection guard)
- `truncateForDiag` is rune-safe (no orphan UTF-8 continuation bytes in stderr)

## Tests

Named regression markers map to each cascade bug:
- gitstatus.Parse rename + spaced-path stream regression (#907)
- allowlist + O_NOFOLLOW symlink refusal (#906/#910)
- sha.IsValid rejection of GitHub error-JSON (#911)
- ghclient GraphQL variables shape (#915/#916)
- httptest fixtures for every API failure mode (4xx GetRef, 5xx GetRef, 502 CreateRef, GraphQL 200-with-errors, malformed JSON, unknown ref Object.Type, partial-success recovery)
- 8 BDD scenarios driving the binary via os/exec

### Coverage
- cmd/release-tool main: 82.9%
- internal/allowlist: 100%
- internal/ghclient: 88.8%
- internal/gitstatus: 90.9%
- internal/sha: 100%

## Agent gates run

- code-reviewer: 3 BLOCKING + 4 IMPORTANT + 3 NIT - all 10 addressed in this PR
- security-reviewer: 0 FAIL + 3 WARN - W1 (doc/code mismatch fixed), W2 (validation gates added), W3 (doc note added)
- test-analyst: 3 BLOCKING + 7 IMPORTANT + 4 NICE-TO-HAVE - all 14 addressed in this PR

## Test plan

- [x] `make lint` - 0 issues
- [x] `make test-release-tool` - all tests pass with race detector
- [x] `make test-bdd-release-tool` - 8 scenarios, 34 steps, all pass
- [x] `make check` - full quality gate green
- [x] govulncheck - no vulnerabilities (including cmd/release-tool in TOOL_MODULES sweep)
- [ ] CI pipeline green