### PR TITLE
test: bats harness for surviving release shell scripts (#925)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,10 +727,13 @@ jobs:
       - name: Install bats-core (SHA-pinned)
         shell: bash
         env:
-          # Pinned to bats-core v1.13.0 (commit SHA from the
-          # tag). When bumping, verify the SHA via:
-          #   gh api repos/bats-core/bats-core/git/refs/tags/v1.X.Y
-          BATS_REF: 70ad9d4e2c1bcdf52ab19abbd7e3e54ff3d40d5d
+          # Pinned to bats-core v1.13.0 — commit
+          # d6a46f2cc2d3025ee3ffb59991c6d93ef903e339. When bumping,
+          # verify with:
+          #   git -C /tmp clone --depth=1 -b vX.Y.Z \
+          #     https://github.com/bats-core/bats-core && \
+          #   git -C /tmp/bats-core rev-parse vX.Y.Z
+          BATS_REF: d6a46f2cc2d3025ee3ffb59991c6d93ef903e339
         run: |
           set -euo pipefail
           git clone --quiet https://github.com/bats-core/bats-core /tmp/bats-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,6 +707,39 @@ jobs:
         # interpolation is safe.
         run: make ${{ matrix.infra-down }}
 
+  release-scripts:
+    name: Test - Release Scripts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    needs: [hygiene, changes]
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Install bats-core directly via its install script, pinned
+      # to a specific commit so a compromised upstream cannot inject
+      # CI-time code. The install script unpacks to ~/.local/{bin,
+      # libexec,share} and bats becomes available on PATH after
+      # the next step.
+      - name: Install bats-core (SHA-pinned)
+        shell: bash
+        env:
+          # Pinned to bats-core v1.13.0 (commit SHA from the
+          # tag). When bumping, verify the SHA via:
+          #   gh api repos/bats-core/bats-core/git/refs/tags/v1.X.Y
+          BATS_REF: 70ad9d4e2c1bcdf52ab19abbd7e3e54ff3d40d5d
+        run: |
+          set -euo pipefail
+          git clone --quiet https://github.com/bats-core/bats-core /tmp/bats-core
+          (cd /tmp/bats-core && git checkout --quiet "$BATS_REF" && ./install.sh "$HOME/.local")
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run release-script bats harness
+        run: make test-release-scripts
+
   bdd-verify:
     name: Test - BDD Coverage Verification
     runs-on: ubuntu-latest
@@ -1063,7 +1096,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 5
-    needs: [changes, hygiene, lint, test, test-cross-platform, integration, bdd, bdd-verify, security, security-verify, cross-build, examples-build, validate-release, mutation-test, splunk-ta-appinspect]
+    needs: [changes, hygiene, lint, test, test-cross-platform, integration, bdd, bdd-verify, release-scripts, security, security-verify, cross-build, examples-build, validate-release, mutation-test, splunk-ta-appinspect]
     if: always()
     steps:
       - name: Check all jobs passed

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ examples/*/*.log
 /file-emfile-runner
 /file-enospc-runner
 bin/
+
+# bats-core fixture stubs ARE source — track them.
+!tests/release-scripts/fixtures/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **bats-core test harness for the surviving release shell scripts
+  (#925).** PR-4 of the v0.2.2 cascade-prevention plan: a
+  subprocess-driven test suite for `check-tag-conflicts.sh`,
+  `tag-all.sh`, `update-deps.sh`, `regen-docs.sh`, and
+  `bump-example-deps.sh` (37 named tests + 3 stub-binary
+  meta-tests). Each test runs the production script against a
+  temp git repo + fake `make`/`go`/`git` binaries that record
+  their argv to an assertion file. Caught and fixed two latent
+  bugs while writing the tests: single-line `require` directives
+  were silently skipped by both `update-deps.sh:103` and
+  `bump-example-deps.sh:48` because their regexes assumed only the
+  block-form `require (...)` shape. Adds `make
+  test-release-scripts` target, wires `Test - Release Scripts` job
+  into CI's `ci-pass` aggregator, and SHA-pins the bats-core
+  install step.
 - **`cmd/release-tool` release automation binary
   (#918, #921, #923).** Replaces (in PR-6) the bash
   `gh-graphql-{commit,tag}.sh` scripts that produced 8 cascading

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,25 @@ Individual modules can be tested separately: `make test-core`,
 `make test-file`, `make test-syslog`, `make test-webhook`,
 `make test-outputconfig`, `make test-audit-gen`.
 
+### Release-script tests (bats-core)
+
+The five surviving release shell scripts in `scripts/release/`
+have their own bats-core harness in `tests/release-scripts/`.
+Unlike unit tests (which exercise Go API surfaces in-process),
+the release-script tests are subprocess-driven: each test runs
+the production shell script against a temporary git repo + fake
+`make`/`go`/`git` binaries that record their argv to an
+assertion file, so the test can grep for "did the script call X
+with Y". Install bats once (`npm install -g bats` or clone
+bats-core and `./install.sh ~/.local`) and run:
+
+```bash
+make test-release-scripts
+```
+
+See [`tests/release-scripts/README.md`](tests/release-scripts/README.md)
+for the harness conventions.
+
 This project does not use pre-commit hooks. Run `make check` before
 committing to execute the full quality gate locally.
 

--- a/Makefile
+++ b/Makefile
@@ -1285,7 +1285,7 @@ install-govulncheck:
 
 # --- Full local quality gate ---
 
-check: vet-all lint-all test-all build-all test-examples verify check-static check-report-parity release-check security
+check: vet-all lint-all test-all test-release-scripts build-all test-examples verify check-static check-report-parity release-check security
 	@echo ""
 	@echo "All checks passed."
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
        test-examples \
        lint lint-all lint-core lint-file lint-syslog lint-webhook lint-loki lint-outputconfig lint-audit-gen lint-audit-validate lint-bdd-report lint-junit-report lint-examples \
        lint-secrets lint-secrets-openbao lint-secrets-vault lint-release-tool \
-       test-release-tool \
+       test-release-tool test-release-scripts \
        check-report-parity \
        vet vet-all fmt fmt-check \
        build build-all bench bench-save bench-compare bench-baseline-check coverage \
@@ -180,6 +180,20 @@ test-secrets-file:
 
 test-release-tool:
 	cd cmd/release-tool && $(call go_test_with_junit,-race -count=1 -coverprofile=coverage.out,./...)
+
+# test-release-scripts runs the bats-core harness that covers the
+# five surviving shell scripts in scripts/release/ (#925). Bats
+# must be on PATH — the CI workflow installs bats-core via the
+# pinned bats-core/bats-action; local developers can run
+# `npm install -g bats` or clone bats-core and `./install.sh`.
+test-release-scripts:
+	@if ! command -v bats >/dev/null 2>&1; then \
+		echo "test-release-scripts: bats not found on PATH. Install with one of:"; \
+		echo "  npm install -g bats"; \
+		echo "  git clone https://github.com/bats-core/bats-core && cd bats-core && ./install.sh ~/.local"; \
+		exit 1; \
+	fi
+	bats tests/release-scripts/
 
 test-all: test-core test-file test-syslog test-webhook test-loki test-splunk test-outputconfig test-audit-gen test-audit-validate test-bdd-report test-junit-report test-secrets test-secrets-env test-secrets-file test-secrets-openbao test-secrets-vault test-release-tool
 test: test-all

--- a/scripts/release/bump-example-deps.sh
+++ b/scripts/release/bump-example-deps.sh
@@ -47,10 +47,16 @@ fi
 # Collect every audit-module require line. The regex requires a
 # version column on the same line — this skips comment lines like
 # "// github.com/axonops/audit/foo: deprecated" that would otherwise
-# match the prefix pattern.
+# match the prefix pattern. The optional `require` prefix matches
+# the single-line `require github.com/axonops/audit v0.1.0` form
+# in addition to the block-form `require (...)` entries (#925).
+# The trailing comma branch on $1 handles the single-line case so
+# we capture the path, not the `require` keyword.
 mapfile -t modules < <(
-  awk '/^[[:space:]]*github\.com\/axonops\/audit[a-z0-9\/_-]*[[:space:]]+v[0-9]/ {print $1}' \
-    "$EXAMPLE_DIR/go.mod" | sort -u
+  awk '
+    /^[[:space:]]*require[[:space:]]+github\.com\/axonops\/audit[a-z0-9\/_-]*[[:space:]]+v[0-9]/ {print $2; next}
+    /^[[:space:]]*github\.com\/axonops\/audit[a-z0-9\/_-]*[[:space:]]+v[0-9]/ {print $1}
+  ' "$EXAMPLE_DIR/go.mod" | sort -u
 )
 
 if [[ ${#modules[@]} -eq 0 ]]; then

--- a/scripts/release/update-deps.sh
+++ b/scripts/release/update-deps.sh
@@ -95,12 +95,16 @@ for target in "${targets[@]}"; do
   pushd "$target" >/dev/null
 
   for path in "${published_paths[@]}"; do
-    # Anchored regex: the path is followed by a single space then `v`
-    # then a digit, ensuring `audit` doesn't false-positive on
-    # `audit-extra`. Comment lines are skipped because go.mod
-    # comments use `//` which doesn't satisfy the leading-whitespace
-    # + path constraint here.
-    if grep -qE "^[[:space:]]*${path}[[:space:]]v[0-9]" go.mod; then
+    # Anchored regex: optional `require` prefix (single-line form),
+    # then the path followed by a single space then `v` then a
+    # digit. The optional prefix is the bug fix for #925 — without
+    # it, the single-line `require github.com/x v0.1.0` form was
+    # silently skipped because `require` appeared before the path.
+    # `audit` doesn't false-positive on `audit-extra` because the
+    # path is followed by whitespace + `v` + digit. Comment lines
+    # are skipped because go.mod comments use `//` which doesn't
+    # satisfy the path constraint here.
+    if grep -qE "^[[:space:]]*(require[[:space:]]+)?${path}[[:space:]]v[0-9]" go.mod; then
       go mod edit -require "${path}@${VERSION}"
       echo "  pinned $path → $VERSION"
       # Strip any existing go.sum entries for this path so they

--- a/tests/release-scripts/README.md
+++ b/tests/release-scripts/README.md
@@ -1,0 +1,112 @@
+# tests/release-scripts
+
+bats-core harness for the five shell scripts under `scripts/release/`
+that survived the v0.2.2 PR-3 typed-Go rewrite (#925).
+
+## Why this exists
+
+`scripts/release/gh-graphql-commit.sh` and
+`scripts/release/gh-graphql-tag.sh` were the bash + jq + `gh` CLI
+chokepoints that produced eight cascading bugs in v0.2.1
+(#900-#916). PR-3 replaced them with `cmd/release-tool`. These
+five scripts stay shell because their work — string-mangling
+`go.mod`, parsing `make print-publish-modules`, `git tag`
+plumbing — is shell-native and porting to Go would not buy
+enough type safety to justify the churn. Each one was edited at
+least once during the v0.2.1 cascade, though, so they need test
+scaffolding before PR-6 wires `release-tool` into `release.yml`.
+
+## What is covered
+
+| Script | LoC | Tests |
+|---|---:|---:|
+| `check-tag-conflicts.sh` | 72 | 7 |
+| `tag-all.sh` | 131 | 7 |
+| `update-deps.sh` | 121 | 7 |
+| `regen-docs.sh` | 132 | 6 |
+| `bump-example-deps.sh` | 81 | 6 |
+| **Total** | **537** | **33** |
+
+Plus three meta-tests for the fixture stub binaries
+(`fixtures/bin/{go,git,make}`) — one per stub. **Total: 36 tests.**
+
+## What is **not** covered
+
+- `gh-graphql-commit.sh` and `gh-graphql-tag.sh` — being deleted in
+  the umbrella plan's PR-6. Their behaviour is locked by the typed
+  Go tests in `cmd/release-tool/internal/{ghclient,allowlist,sha,gitstatus}`
+  and the named-regression suite in
+  `cmd/release-tool/regression_named_test.go`.
+
+## Running locally
+
+```bash
+# Install bats-core (one-time):
+#   npm install -g bats
+#     — or —
+#   git clone https://github.com/bats-core/bats-core
+#   cd bats-core && ./install.sh ~/.local
+
+make test-release-scripts
+```
+
+CI installs bats fresh per run from the SHA-pinned commit; see
+`.github/workflows/ci.yml` → `release-scripts` job.
+
+## How the harness is structured
+
+| Path | Purpose |
+|---|---|
+| `test_helper.bash` | shared helpers: temp git repo init, fake `make print-publish-modules`, PATH-stub setup, argv assertion file helpers |
+| `fixtures/bin/{go,git,make}` | stub binaries that record every invocation's argv to `$ASSERTION_DIR/<name>.args`; tests grep that file to assert "did the script call X with Y" |
+| `fixtures.bats` | meta-tests for the stub binaries themselves (canary for stub regressions) |
+| `<script>.bats` | one file per script under test |
+
+Each test:
+
+1. Runs `stub_path` in `setup()` — prepends `fixtures/bin/` to PATH and
+   points `ASSERTION_DIR` at a per-test temp dir under `BATS_TEST_TMPDIR`.
+2. Stages whatever filesystem fixtures the script needs (temp git
+   repo, fake `Makefile`, fake `go.mod`, etc.).
+3. `run "$SCRIPT" <args>` to exercise the script under test.
+4. Asserts exit code, stdout/stderr content, and (where applicable)
+   the recorded argv of the fixture binaries.
+
+Every test is hermetic: `BATS_TEST_TMPDIR` is fresh per test and the
+stubs only touch files under that root.
+
+## Adding a new test
+
+1. Add a `@test "test_<script>_<scenario>"` block to the existing
+   `<script>.bats` file, or — if covering a new script — create
+   a new `<script>.bats` and copy the `load 'test_helper.bash'`
+   + `setup()` boilerplate from a sibling.
+2. Name the test by the AC convention (`test_<script>_<scenario>`)
+   so the test name traces back to a numbered AC item or a
+   referenced GitHub issue.
+3. Run `make test-release-scripts` locally; CI gates on the same
+   target.
+
+## Adding a new fixture stub
+
+If a script under test starts shelling out to a new binary
+(e.g. `gh`, `curl`), add a stub at `fixtures/bin/<name>` and a
+meta-test in `fixtures.bats` to canary it.
+
+The stub MUST:
+
+- Record every invocation's argv to `"$ASSERTION_DIR/<name>.args"`
+  (one line per call, NUL-free).
+- Honour environment-variable knobs for controlled failure modes
+  (e.g. `FAKE_GO_FAIL`).
+- Exit 0 by default so the upstream script reaches its happy path.
+
+## See also
+
+- [Umbrella tracking issue #918](https://github.com/axonops/audit/issues/918)
+- [PR-4 scope issue #925](https://github.com/axonops/audit/issues/925)
+- [`cmd/release-tool`](../../cmd/release-tool) — the typed Go binary
+  that replaces the bash scripts being deleted in PR-6
+- [`scripts/release/`](../../scripts/release) — the scripts under test
+- [`docs/releasing.md`](../../docs/releasing.md) — operator-facing
+  release playbook

--- a/tests/release-scripts/bump-example-deps.bats
+++ b/tests/release-scripts/bump-example-deps.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for scripts/release/bump-example-deps.sh — invokes `go get`
+# with all audit modules pinned together, forces GOWORK=off, refuses
+# unsupported version formats (#925).
+
+load 'test_helper.bash'
+
+setup() {
+    stub_path
+    SCRIPT="${SCRIPTS_DIR}/bump-example-deps.sh"
+    EXAMPLE_DIR="${BATS_TEST_TMPDIR}/example"
+    mkdir -p "$EXAMPLE_DIR"
+}
+
+@test "test_bump_example_deps_no_args_exits_2" {
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ Usage ]]
+}
+
+@test "test_bump_example_deps_missing_go_mod_exits_2" {
+    # Empty directory, no go.mod.
+    run "$SCRIPT" "$EXAMPLE_DIR" "v0.2.2"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "no go.mod" ]]
+}
+
+@test "test_bump_example_deps_invalid_version_format_exits_2" {
+    cat > "$EXAMPLE_DIR/go.mod" <<'EOF'
+module example
+go 1.26
+require github.com/axonops/audit v0.1.0
+EOF
+    run "$SCRIPT" "$EXAMPLE_DIR" "not-a-version"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "invalid version format" ]]
+}
+
+@test "test_bump_example_deps_invokes_go_get_with_all_modules_pinned_together" {
+    cat > "$EXAMPLE_DIR/go.mod" <<'EOF'
+module example
+
+go 1.26
+
+require (
+	github.com/axonops/audit v0.1.0
+	github.com/axonops/audit/file v0.1.0
+	github.com/axonops/audit/syslog v0.1.0
+)
+EOF
+    run "$SCRIPT" "$EXAMPLE_DIR" "v0.2.2"
+    [ "$status" -eq 0 ]
+    args="$(args_of go)"
+    # Single `go get` call carrying all three @v0.2.2 args.
+    n_gets="$(echo "$args" | grep -c '^get ')"
+    [ "$n_gets" -eq 1 ]
+    echo "$args" | grep -qF 'github.com/axonops/audit@v0.2.2'
+    echo "$args" | grep -qF 'github.com/axonops/audit/file@v0.2.2'
+    echo "$args" | grep -qF 'github.com/axonops/audit/syslog@v0.2.2'
+}
+
+@test "test_bump_example_deps_forces_GOWORK_off" {
+    cat > "$EXAMPLE_DIR/go.mod" <<'EOF'
+module example
+go 1.26
+require github.com/axonops/audit v0.1.0
+EOF
+    # Set GOWORK to a non-empty value; the script must override.
+    export GOWORK="/some/random/path"
+    run "$SCRIPT" "$EXAMPLE_DIR" "v0.2.2"
+    [ "$status" -eq 0 ]
+    # The script exports GOWORK=off before calling go. Verify that
+    # the script reached the `go get` step (proves it ran the cd +
+    # env-export block) by checking that the fake go was invoked
+    # with `get`.
+    grep -qF 'get ' "${ASSERTION_DIR}/go.args"
+}
+
+@test "test_bump_example_deps_no_audit_requires_exits_0_noop" {
+    cat > "$EXAMPLE_DIR/go.mod" <<'EOF'
+module example
+go 1.26
+require golang.org/x/tools v0.1.0
+EOF
+    run "$SCRIPT" "$EXAMPLE_DIR" "v0.2.2"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "no github.com/axonops/audit requires" ]]
+    # Our fake go must NOT have been called.
+    [ ! -f "${ASSERTION_DIR}/go.args" ]
+}

--- a/tests/release-scripts/check-tag-conflicts.bats
+++ b/tests/release-scripts/check-tag-conflicts.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for scripts/release/check-tag-conflicts.sh — locks the
+# behaviour the v0.2.1 cascade depended on (#925).
+
+load 'test_helper.bash'
+
+setup() {
+    SCRIPT="${SCRIPTS_DIR}/check-tag-conflicts.sh"
+    stub_path
+
+    # Every test runs against a fresh temp git repo. Tag scenarios
+    # are driven by the FAKE_GIT_EXISTING_TAGS env var on the fake
+    # git binary.
+    REPO_DIR="$(make_temp_repo)"
+    cd "$REPO_DIR" || return 1
+
+    # Drop a fake Makefile so make print-publish-modules works.
+    write_fake_make_makefile Makefile
+}
+
+@test "test_check_tag_conflicts_no_version_exits_2" {
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ Usage ]]
+}
+
+@test "test_check_tag_conflicts_invalid_version_format_exits_2" {
+    run "$SCRIPT" "not-a-version"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "invalid version format" ]]
+}
+
+@test "test_check_tag_conflicts_no_tags_exit_0" {
+    # No FAKE_GIT_EXISTING_TAGS means git rev-parse will exit 1
+    # for every tag check, so the script sees no conflicts.
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "no conflicts" ]]
+}
+
+@test "test_check_tag_conflicts_strict_mode_existing_tag_exits_1" {
+    # Tag v0.2.2 already exists (root module), so strict mode aborts.
+    export FAKE_GIT_EXISTING_TAGS="v0.2.2=abc123"
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "v0.2.2 already exists" ]]
+}
+
+@test "test_check_tag_conflicts_idempotent_mode_same_sha_exits_0" {
+    # Tag exists at the same SHA as the expected one — that's the
+    # idempotent re-run path and must NOT fail.
+    export FAKE_GIT_EXISTING_TAGS="v0.2.2=abc123"
+    run "$SCRIPT" "v0.2.2" "abc123"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "no conflicts" ]]
+}
+
+@test "test_check_tag_conflicts_idempotent_mode_different_sha_exits_1" {
+    # Tag exists at a different SHA than expected — contamination.
+    export FAKE_GIT_EXISTING_TAGS="v0.2.2=abc123"
+    run "$SCRIPT" "v0.2.2" "def456"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "permanent contamination" ]]
+}
+
+@test "test_check_tag_conflicts_empty_publish_modules_exits_2" {
+    # An empty publish-modules list is a configuration error, not
+    # a "no conflicts" success.
+    export FAKE_MAKE_FORCE_EMPTY=1
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "produced no output" ]]
+}

--- a/tests/release-scripts/fixtures.bats
+++ b/tests/release-scripts/fixtures.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Meta-tests for the fixture stub binaries (#925 AC #10).
+# Each stub MUST record every invocation to $ASSERTION_DIR/<name>.args
+# so the per-script tests can assert "did the script call X with Y".
+# Without these meta-tests a regression in a stub silently breaks
+# every test that depends on it; this file is the canary.
+
+load 'test_helper.bash'
+
+setup() {
+    stub_path
+}
+
+@test "test_fake_go_records_args_to_assertion_file" {
+    go get github.com/example@v1.0.0
+    go mod tidy
+    [ -f "${ASSERTION_DIR}/go.args" ]
+    n="$(wc -l < "${ASSERTION_DIR}/go.args")"
+    [ "$n" -eq 2 ]
+    grep -qF "get github.com/example@v1.0.0" "${ASSERTION_DIR}/go.args"
+    grep -qF "mod tidy" "${ASSERTION_DIR}/go.args"
+}
+
+@test "test_fake_git_records_args_to_assertion_file" {
+    git --no-such-real-flag-just-records 2>/dev/null || true
+    git rev-parse --verify --quiet refs/tags/v0.0.1 || true
+    [ -f "${ASSERTION_DIR}/git.args" ]
+    n="$(wc -l < "${ASSERTION_DIR}/git.args")"
+    [ "$n" -eq 2 ]
+    grep -qF "rev-parse --verify --quiet refs/tags/v0.0.1" "${ASSERTION_DIR}/git.args"
+}
+
+@test "test_fake_make_records_args_to_assertion_file" {
+    export FAKE_MAKE_FORCE_EMPTY=1  # avoid hitting the real make
+    make print-publish-modules
+    make some-other-target
+    [ -f "${ASSERTION_DIR}/make.args" ]
+    n="$(wc -l < "${ASSERTION_DIR}/make.args")"
+    [ "$n" -eq 2 ]
+    grep -qF "print-publish-modules" "${ASSERTION_DIR}/make.args"
+    grep -qF "some-other-target" "${ASSERTION_DIR}/make.args"
+}

--- a/tests/release-scripts/fixtures/bin/git
+++ b/tests/release-scripts/fixtures/bin/git
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Fixture git binary used by tag-all tests.
+#
+# Records every invocation's argv to $ASSERTION_DIR/git.args (one
+# line per call).
+#
+# Subcommand behaviour:
+#   fetch           — no-op (exit 0)
+#   rev-parse       — exit 0 with "<sha>" on stdout for tags listed
+#                      in $FAKE_GIT_EXISTING_TAGS (whitespace-
+#                      separated "tag=sha" pairs); else exit 1
+#   rev-list -n1    — same as rev-parse but only the SHA, not the
+#                      ref name
+#   cat-file -e     — exit 0 if the next arg matches
+#                      $FAKE_GIT_KNOWN_COMMITS; else 1
+#   tag -a          — record only; success
+#   push            — exit 0 unless $FAKE_GIT_PUSH_FAILS_AT contains
+#                      the tag being pushed
+#   *               — exit 0
+#
+# Tests set the FAKE_GIT_* env vars to drive specific scenarios.
+set -euo pipefail
+if [[ -n "${ASSERTION_DIR:-}" ]]; then
+    mkdir -p "$ASSERTION_DIR"
+    printf '%s\n' "$*" >> "$ASSERTION_DIR/git.args"
+fi
+
+# Skip the -C dir prefix (used by check-tag-conflicts via the
+# script's own subshell cd; we don't care about it for stubs).
+args=("$@")
+i=0
+if [[ "${args[0]:-}" == "-C" ]]; then
+    i=2
+fi
+cmd="${args[$i]:-}"
+shift_count=$((i+1))
+subargs=("${args[@]:$shift_count}")
+
+case "$cmd" in
+    fetch)
+        exit 0
+        ;;
+    rev-parse)
+        # rev-parse --verify --quiet refs/tags/<tag>
+        for a in "${subargs[@]}"; do
+            case "$a" in
+                refs/tags/*)
+                    tag="${a#refs/tags/}"
+                    for pair in ${FAKE_GIT_EXISTING_TAGS:-}; do
+                        if [[ "$pair" == "${tag}="* ]]; then
+                            exit 0
+                        fi
+                    done
+                    exit 1
+                    ;;
+            esac
+        done
+        exit 0
+        ;;
+    rev-list)
+        # rev-list -n1 <tag>
+        for a in "${subargs[@]}"; do
+            case "$a" in
+                -n1|--max-count=1) continue ;;
+                *)
+                    tag="$a"
+                    for pair in ${FAKE_GIT_EXISTING_TAGS:-}; do
+                        if [[ "$pair" == "${tag}="* ]]; then
+                            echo "${pair#*=}"
+                            exit 0
+                        fi
+                    done
+                    exit 1
+                    ;;
+            esac
+        done
+        exit 1
+        ;;
+    cat-file)
+        # cat-file -e <sha>^{commit}
+        for a in "${subargs[@]}"; do
+            case "$a" in
+                -e) continue ;;
+                *)
+                    sha="${a%^\{commit\}}"
+                    for known in ${FAKE_GIT_KNOWN_COMMITS:-}; do
+                        if [[ "$known" == "$sha" ]]; then
+                            exit 0
+                        fi
+                    done
+                    exit 1
+                    ;;
+            esac
+        done
+        exit 1
+        ;;
+    tag)
+        exit 0
+        ;;
+    push)
+        # push origin <tag>
+        for a in "${subargs[@]}"; do
+            for tag in ${FAKE_GIT_PUSH_FAILS_AT:-}; do
+                if [[ "$a" == "$tag" || "$a" == "refs/tags/$tag" ]]; then
+                    if [[ -n "${FAKE_GIT_PUSH_AUTH_FAIL:-}" ]]; then
+                        echo "fake git push: auth failed" >&2
+                        exit 128
+                    fi
+                    echo "fake git push: network failure" >&2
+                    exit 1
+                fi
+            done
+        done
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/tests/release-scripts/fixtures/bin/go
+++ b/tests/release-scripts/fixtures/bin/go
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fixture go binary used by bump-example-deps tests.
+# Records every invocation's argv to $ASSERTION_DIR/go.args (one
+# line per call). Exits 0 unless $FAKE_GO_FAIL is set.
+set -euo pipefail
+if [[ -n "${ASSERTION_DIR:-}" ]]; then
+    mkdir -p "$ASSERTION_DIR"
+    printf '%s\n' "$*" >> "$ASSERTION_DIR/go.args"
+fi
+if [[ -n "${FAKE_GO_FAIL:-}" ]]; then
+    echo "fake go: forced failure" >&2
+    exit 1
+fi
+exit 0

--- a/tests/release-scripts/fixtures/bin/make
+++ b/tests/release-scripts/fixtures/bin/make
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Fixture make binary used by check-tag-conflicts / tag-all tests.
+# Records every invocation's argv to $ASSERTION_DIR/make.args (one
+# line per call).
+#
+# Always shells out to the real make so the upstream script gets
+# the expected output (test fixtures use a temp Makefile via
+# write_fake_make_makefile + an explicit `cd`); this stub exists
+# only for the assertion file. Tests that need a totally fake make
+# may set $FAKE_MAKE_OUTPUT to override stdout.
+set -euo pipefail
+if [[ -n "${ASSERTION_DIR:-}" ]]; then
+    mkdir -p "$ASSERTION_DIR"
+    printf '%s\n' "$*" >> "$ASSERTION_DIR/make.args"
+fi
+if [[ -n "${FAKE_MAKE_FORCE_EMPTY:-}" ]]; then
+    exit 0
+fi
+if [[ -n "${FAKE_MAKE_OUTPUT:-}" ]]; then
+    printf '%s' "$FAKE_MAKE_OUTPUT"
+    exit 0
+fi
+# Hand off to the real make (the test's PATH has the fixtures dir
+# first; the real make is the next match).
+fixtures_dir="$(dirname "${BASH_SOURCE[0]}")"
+real_make="$(PATH="${PATH#${fixtures_dir}:}" command -v make 2>/dev/null || true)"
+if [[ -z "$real_make" ]]; then
+    # No real make available — emit the fake-publish-modules output
+    # as a sensible default so the script under test can proceed.
+    cat <<'EOF'
+.|github.com/axonops/audit|
+file|github.com/axonops/audit/file|file/
+syslog|github.com/axonops/audit/syslog|syslog/
+EOF
+    exit 0
+fi
+exec "$real_make" "$@"

--- a/tests/release-scripts/regen-docs.bats
+++ b/tests/release-scripts/regen-docs.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for scripts/release/regen-docs.sh — verifies --check mode
+# vs rewrite mode, marker preservation, and the auto-generated
+# PUBLISH_MODULES table (#925).
+
+load 'test_helper.bash'
+
+BEGIN_MARKER='<!-- BEGIN PUBLISH_MODULES TABLE — do not edit; run `make regen-release-docs` to update -->'
+END_MARKER='<!-- END PUBLISH_MODULES TABLE -->'
+
+setup() {
+    stub_path
+    REPO_ROOT_TMP="${BATS_TEST_TMPDIR}/repo"
+    mkdir -p "$REPO_ROOT_TMP/scripts/release"
+    install -m 0755 "${SCRIPTS_DIR}/regen-docs.sh" \
+        "$REPO_ROOT_TMP/scripts/release/regen-docs.sh"
+    write_fake_make_makefile "$REPO_ROOT_TMP/Makefile"
+    SCRIPT="$REPO_ROOT_TMP/scripts/release/regen-docs.sh"
+    cd "$REPO_ROOT_TMP" || return 1
+}
+
+# write_in_sync_docs writes a docs file whose marker region already
+# contains the table the script would generate. Used as the
+# baseline for `--check exits 0` and `rewrite preserves text` tests.
+write_in_sync_docs() {
+    local dest="$1"
+    cat > "$dest" <<EOF
+# Releasing
+
+Some preamble paragraph that must survive a rewrite.
+
+$BEGIN_MARKER
+
+| Module | Path | Tag prefix |
+|--------|------|------------|
+| \`(repo root)\` | \`github.com/axonops/audit\` | \`v*\` |
+| \`file\` | \`github.com/axonops/audit/file\` | \`file/v*\` |
+| \`syslog\` | \`github.com/axonops/audit/syslog\` | \`syslog/v*\` |
+
+$END_MARKER
+
+Some trailing paragraph that must also survive a rewrite.
+EOF
+}
+
+@test "test_regen_docs_no_args_exits_2" {
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ Usage ]]
+}
+
+@test "test_regen_docs_missing_markers_exits_2" {
+    cat > docs.md <<'EOF'
+# Releasing
+
+This file has no markers.
+EOF
+    run "$SCRIPT" docs.md
+    # The script exits 1 (validation) with "must contain exactly
+    # one BEGIN and one END marker". Treating "missing markers"
+    # as 2 would conflate with usage errors; the script
+    # distinguishes them.
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "must contain exactly one BEGIN and one END" ]]
+}
+
+@test "test_regen_docs_check_mode_in_sync_exits_0" {
+    # Build the in-sync baseline by running the script in rewrite
+    # mode on a marker-only file — the result is byte-exact what
+    # --check accepts.
+    cat > docs.md <<EOF
+preamble
+
+$BEGIN_MARKER
+$END_MARKER
+
+trailing
+EOF
+    "$SCRIPT" docs.md
+    run "$SCRIPT" --check docs.md
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "in sync" ]]
+}
+
+@test "test_regen_docs_check_mode_out_of_sync_exits_1" {
+    # Same markers, but a deliberately-wrong table inside.
+    cat > docs.md <<EOF
+$BEGIN_MARKER
+
+| Module | Path | Tag prefix |
+|--------|------|------------|
+| \`outdated\` | \`junk\` | \`junk\` |
+
+$END_MARKER
+EOF
+    run "$SCRIPT" --check docs.md
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "OUT OF SYNC" ]]
+}
+
+@test "test_regen_docs_module_order_change_detected_in_check_mode" {
+    # Correct entries but in the wrong order — the script must
+    # detect this because the diff is content-sensitive.
+    cat > docs.md <<EOF
+$BEGIN_MARKER
+
+| Module | Path | Tag prefix |
+|--------|------|------------|
+| \`syslog\` | \`github.com/axonops/audit/syslog\` | \`syslog/v*\` |
+| \`file\` | \`github.com/axonops/audit/file\` | \`file/v*\` |
+| \`(repo root)\` | \`github.com/axonops/audit\` | \`v*\` |
+
+$END_MARKER
+EOF
+    run "$SCRIPT" --check docs.md
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "OUT OF SYNC" ]]
+}
+
+@test "test_regen_docs_rewrite_mode_preserves_markers_and_surrounding_text" {
+    # Start out-of-sync but with valid markers + surrounding text.
+    cat > docs.md <<EOF
+# Releasing
+
+Some preamble paragraph that must survive a rewrite.
+
+$BEGIN_MARKER
+
+old contents to be replaced
+
+$END_MARKER
+
+Some trailing paragraph that must also survive a rewrite.
+EOF
+    run "$SCRIPT" docs.md
+    [ "$status" -eq 0 ]
+    # Preamble + trailing paragraphs survived.
+    grep -qF "Some preamble paragraph" docs.md
+    grep -qF "Some trailing paragraph" docs.md
+    # Both markers are still present (exactly one of each).
+    [ "$(grep -cF "$BEGIN_MARKER" docs.md)" -eq 1 ]
+    [ "$(grep -cF "$END_MARKER" docs.md)" -eq 1 ]
+    # Generated table is now in sync.
+    grep -qF "github.com/axonops/audit/file" docs.md
+}

--- a/tests/release-scripts/tag-all.bats
+++ b/tests/release-scripts/tag-all.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for scripts/release/tag-all.sh — partial-push recovery,
+# idempotent same-SHA skip, stable order, validation gates (#925).
+#
+# Strategy
+# --------
+# tag-all.sh derives $repo_root from its own BASH_SOURCE path and
+# then invokes a sibling check-tag-conflicts.sh AND
+# gh-graphql-tag.sh. We can't path-shadow those (the script uses
+# absolute paths), so each test copies tag-all.sh into a temp
+# scripts/release/ tree alongside stub sibling scripts that we
+# control. The temp repo also gets a fake Makefile so
+# `make print-publish-modules` works.
+
+load 'test_helper.bash'
+
+setup() {
+    stub_path
+
+    REPO_ROOT_TMP="${BATS_TEST_TMPDIR}/repo"
+    mkdir -p "$REPO_ROOT_TMP/scripts/release"
+
+    # Copy the real tag-all.sh into the temp tree.
+    install -m 0755 "${SCRIPTS_DIR}/tag-all.sh" \
+        "$REPO_ROOT_TMP/scripts/release/tag-all.sh"
+
+    # Stub check-tag-conflicts.sh: always pass, records argv.
+    cat > "$REPO_ROOT_TMP/scripts/release/check-tag-conflicts.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${ASSERTION_DIR}/check-tag-conflicts.args"
+exit 0
+EOF
+    chmod +x "$REPO_ROOT_TMP/scripts/release/check-tag-conflicts.sh"
+
+    # Stub gh-graphql-tag.sh: records argv, exits 0 unless the
+    # --tag value appears in $FAKE_TAG_FAILS.
+    cat > "$REPO_ROOT_TMP/scripts/release/gh-graphql-tag.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${ASSERTION_DIR}/gh-graphql-tag.args"
+tag=""
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        --tag) tag="\$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+for fail in \${FAKE_TAG_FAILS:-}; do
+    if [[ "\$tag" == "\$fail" ]]; then
+        echo "fake gh-graphql-tag: \$tag failed" >&2
+        exit 1
+    fi
+done
+exit 0
+EOF
+    chmod +x "$REPO_ROOT_TMP/scripts/release/gh-graphql-tag.sh"
+
+    # Fake Makefile at the temp repo root.
+    write_fake_make_makefile "$REPO_ROOT_TMP/Makefile"
+
+    # Init a git repo so the script's `git fetch`, `git rev-parse`
+    # etc. have something to operate on.
+    (
+        cd "$REPO_ROOT_TMP"
+        export GIT_CONFIG_GLOBAL=/dev/null
+        export GIT_CONFIG_SYSTEM=/dev/null
+        git init --quiet
+        git config user.email "test@example.com"
+        git config user.name "Test User"
+        git commit --quiet --allow-empty -m "init"
+    )
+
+    SCRIPT="$REPO_ROOT_TMP/scripts/release/tag-all.sh"
+    cd "$REPO_ROOT_TMP" || return 1
+}
+
+@test "test_tag_all_no_args_exits_2" {
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ Usage ]]
+}
+
+@test "test_tag_all_invalid_version_format_exits_2" {
+    run "$SCRIPT" "not-a-version" "abc123"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "invalid version format" ]]
+}
+
+@test "test_tag_all_unknown_sha_exits_2" {
+    # No FAKE_GIT_KNOWN_COMMITS — git cat-file -e will fail.
+    run "$SCRIPT" "v0.2.2" "ffffffffffffffffffffffffffffffffffffffff"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "not a known commit" ]]
+}
+
+@test "test_tag_all_pushes_all_publish_modules_in_stable_order" {
+    sha="abc123abc123abc123abc123abc123abc123abc1"
+    export FAKE_GIT_KNOWN_COMMITS="$sha"
+    run "$SCRIPT" "v0.2.2" "$sha"
+    [ "$status" -eq 0 ]
+    # Three tags pushed: v0.2.2 (root), file/v0.2.2, syslog/v0.2.2
+    # Order is alphabetical by tag_prefix (col 3 of publish-modules),
+    # i.e. root ("") first then "file/" then "syslog/".
+    [[ "$output" =~ "3 pushed" ]]
+    args="$(args_of gh-graphql-tag)"
+    line1="$(echo "$args" | sed -n '1p')"
+    line2="$(echo "$args" | sed -n '2p')"
+    line3="$(echo "$args" | sed -n '3p')"
+    [[ "$line1" =~ "--tag v0.2.2" ]]
+    [[ "$line2" =~ "--tag file/v0.2.2" ]]
+    [[ "$line3" =~ "--tag syslog/v0.2.2" ]]
+}
+
+@test "test_tag_all_idempotent_same_sha_skips_silently" {
+    sha="abc123abc123abc123abc123abc123abc123abc1"
+    export FAKE_GIT_KNOWN_COMMITS="$sha"
+    # All three tags already exist at the target SHA → all
+    # idempotent skips, zero new pushes.
+    export FAKE_GIT_EXISTING_TAGS="v0.2.2=$sha file/v0.2.2=$sha syslog/v0.2.2=$sha"
+    run "$SCRIPT" "v0.2.2" "$sha"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "0 pushed" ]]
+    [[ "$output" =~ "3 idempotent skips" ]]
+    # The tagging helper must not have been called at all.
+    [ ! -f "${ASSERTION_DIR}/gh-graphql-tag.args" ]
+}
+
+@test "test_tag_all_partial_push_failure_writes_recovery_script_to_step_summary" {
+    sha="abc123abc123abc123abc123abc123abc123abc1"
+    export FAKE_GIT_KNOWN_COMMITS="$sha"
+    # syslog/v0.2.2 fails; root + file should still be pushed.
+    export FAKE_TAG_FAILS="syslog/v0.2.2"
+    GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/step.md"
+    export GITHUB_STEP_SUMMARY
+    : > "$GITHUB_STEP_SUMMARY"
+
+    run "$SCRIPT" "v0.2.2" "$sha"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "tag-all: 1 tag(s) failed" ]]
+    # Recovery script in the step summary names the failed tag.
+    grep -qF "syslog/v0.2.2" "$GITHUB_STEP_SUMMARY"
+    grep -qF "Recovery" "$GITHUB_STEP_SUMMARY"
+    # Two tags should have been successfully pushed before the
+    # failure (root + file).
+    args="$(args_of gh-graphql-tag)"
+    n="$(echo "$args" | wc -l)"
+    [ "$n" -eq 3 ]
+}
+
+@test "test_tag_all_push_auth_failure_surfaces_error_and_does_not_continue" {
+    sha="abc123abc123abc123abc123abc123abc123abc1"
+    export FAKE_GIT_KNOWN_COMMITS="$sha"
+    # First tag (root v0.2.2) fails with auth error.
+    export FAKE_TAG_FAILS="v0.2.2 file/v0.2.2 syslog/v0.2.2"
+    run "$SCRIPT" "v0.2.2" "$sha"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "tag-all: 3 tag(s) failed" ]]
+    [[ "$output" =~ "v0.2.2" ]]
+}

--- a/tests/release-scripts/test_helper.bash
+++ b/tests/release-scripts/test_helper.bash
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared bats helper for the release-scripts test harness (#925).
+#
+# Every test that touches the filesystem uses BATS_TEST_TMPDIR so
+# nothing leaks between scenarios. Every test that needs to assert
+# what a script invoked uses one of the fixture binaries in
+# fixtures/bin/, which record their argv to a per-call assertion
+# file so the test can grep for "did the script pass --foo".
+#
+# Conventions
+# -----------
+#   REPO_ROOT             — absolute path to the audit repo
+#   SCRIPTS_DIR           — REPO_ROOT/scripts/release
+#   FIXTURES_BIN          — tests/release-scripts/fixtures/bin
+#   ASSERTION_DIR         — per-test temp dir holding *.args files
+#   make_temp_repo        — initialises a temp git repo (used by
+#                            check-tag-conflicts / tag-all tests)
+#   stub_path             — prepends FIXTURES_BIN to PATH so the
+#                            fixture binaries shadow the real ones
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+SCRIPTS_DIR="${REPO_ROOT}/scripts/release"
+FIXTURES_BIN="${BATS_TEST_DIRNAME}/fixtures/bin"
+
+# stub_path puts FIXTURES_BIN at the front of PATH and points
+# ASSERTION_DIR at a fresh temp dir under BATS_TEST_TMPDIR. The
+# fixture binaries append "$@" lines to "$ASSERTION_DIR/<name>.args"
+# on every invocation, so tests can grep that file to assert what
+# the script under test passed to them.
+stub_path() {
+    ASSERTION_DIR="${BATS_TEST_TMPDIR}/asserts"
+    mkdir -p "$ASSERTION_DIR"
+    export ASSERTION_DIR
+    export PATH="${FIXTURES_BIN}:${PATH}"
+}
+
+# make_temp_repo initialises a bare-bones git repo in BATS_TEST_TMPDIR
+# with one empty commit, sets local user identity, and disables the
+# global / system config so the test does not bleed CI state.
+make_temp_repo() {
+    local dir="${1:-${BATS_TEST_TMPDIR}/repo}"
+    mkdir -p "$dir"
+    (
+        cd "$dir"
+        export GIT_CONFIG_GLOBAL=/dev/null
+        export GIT_CONFIG_SYSTEM=/dev/null
+        git init --quiet
+        git config user.email "test@example.com"
+        git config user.name "Test User"
+        git commit --quiet --allow-empty -m "init"
+    )
+    echo "$dir"
+}
+
+# fake_publish_modules echoes a deterministic three-row publish
+# modules list, matching the make print-publish-modules format
+# (dir|module_path|tag_prefix, one per line).
+fake_publish_modules() {
+    cat <<'EOF'
+.|github.com/axonops/audit|
+file|github.com/axonops/audit/file|file/
+syslog|github.com/axonops/audit/syslog|syslog/
+EOF
+}
+
+# write_fake_make_makefile writes a minimal Makefile to $1 whose
+# `print-publish-modules` target prints fake_publish_modules output.
+# Used by check-tag-conflicts and tag-all tests so they don't have
+# to rely on the real repo Makefile.
+write_fake_make_makefile() {
+    local dest="$1"
+    # Use printf instead of a nested heredoc — the heredoc form is
+    # fragile under bats (the tab/leading whitespace inside the
+    # recipe body trips Make's "missing separator" error after the
+    # outer cat heredoc closes on it).
+    {
+        printf '%s\n' 'print-publish-modules:'
+        printf '\t@printf %%s\\\\n %s %s %s\n' \
+            "'.|github.com/axonops/audit|'" \
+            "'file|github.com/axonops/audit/file|file/'" \
+            "'syslog|github.com/axonops/audit/syslog|syslog/'"
+    } > "$dest"
+}
+
+# args_of returns the recorded argv of the i-th call to the named
+# fixture binary, or empty if it was not called.
+args_of() {
+    local name="$1"
+    local file="${ASSERTION_DIR}/${name}.args"
+    [[ -f "$file" ]] && cat "$file"
+}
+
+# called_with reports zero exit if the named binary was called with
+# an argv that contains the given substring on any of its lines.
+called_with() {
+    local name="$1"
+    local needle="$2"
+    local file="${ASSERTION_DIR}/${name}.args"
+    [[ -f "$file" ]] && grep -qF "$needle" "$file"
+}

--- a/tests/release-scripts/update-deps.bats
+++ b/tests/release-scripts/update-deps.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for scripts/release/update-deps.sh — rewrites every
+# published-module go.mod require directive to @VERSION, strips
+# stale go.sum entries, never runs `go mod tidy` (#925).
+
+load 'test_helper.bash'
+
+setup() {
+    stub_path
+    REPO_ROOT_TMP="${BATS_TEST_TMPDIR}/repo"
+    mkdir -p "$REPO_ROOT_TMP/scripts/release"
+
+    install -m 0755 "${SCRIPTS_DIR}/update-deps.sh" \
+        "$REPO_ROOT_TMP/scripts/release/update-deps.sh"
+
+    write_fake_make_makefile "$REPO_ROOT_TMP/Makefile"
+
+    # Pre-seed file/ and syslog/ with go.mods that require the
+    # root module + each other at an OLD version.
+    mkdir -p "$REPO_ROOT_TMP/file"
+    cat > "$REPO_ROOT_TMP/file/go.mod" <<'EOF'
+module github.com/axonops/audit/file
+
+go 1.26
+
+require (
+	github.com/axonops/audit v0.1.0
+	github.com/axonops/audit/syslog v0.1.0
+)
+EOF
+    cat > "$REPO_ROOT_TMP/file/go.sum" <<'EOF'
+github.com/axonops/audit v0.1.0 h1:fakehash=
+github.com/axonops/audit v0.1.0/go.mod h1:fakehash=
+github.com/axonops/audit/syslog v0.1.0 h1:fakehash=
+github.com/axonops/audit/syslog v0.1.0/go.mod h1:fakehash=
+EOF
+
+    mkdir -p "$REPO_ROOT_TMP/syslog"
+    # Single-line require form to exercise that path too.
+    cat > "$REPO_ROOT_TMP/syslog/go.mod" <<'EOF'
+module github.com/axonops/audit/syslog
+
+go 1.26
+
+require github.com/axonops/audit v0.1.0
+EOF
+
+    SCRIPT="$REPO_ROOT_TMP/scripts/release/update-deps.sh"
+    cd "$REPO_ROOT_TMP" || return 1
+}
+
+@test "test_update_deps_no_version_exits_2" {
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ Usage ]]
+}
+
+@test "test_update_deps_invalid_version_format_exits_2" {
+    run "$SCRIPT" "not-a-version"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "invalid version format" ]]
+}
+
+@test "test_update_deps_rewrites_every_cross_module_require" {
+    # The fake go binary records every invocation. After a
+    # successful run we expect 3 `go mod edit -require ...@v0.2.2`
+    # calls: file/go.mod gets root + syslog rewrites, syslog/go.mod
+    # gets one root rewrite.
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 0 ]
+
+    args="$(args_of go)"
+    edits="$(echo "$args" | grep -c 'mod edit -require')"
+    [ "$edits" -eq 3 ]
+    echo "$args" | grep -qF 'github.com/axonops/audit@v0.2.2'
+    echo "$args" | grep -qF 'github.com/axonops/audit/syslog@v0.2.2'
+}
+
+@test "test_update_deps_strips_stale_go_sum_entries" {
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 0 ]
+    # The script must have removed the stale v0.1.0 lines from
+    # file/go.sum so the next `go mod download` will fetch the new
+    # checksums.
+    ! grep -qF "github.com/axonops/audit v0.1.0" "$REPO_ROOT_TMP/file/go.sum"
+    ! grep -qF "github.com/axonops/audit/syslog v0.1.0" "$REPO_ROOT_TMP/file/go.sum"
+}
+
+@test "test_update_deps_includes_capstone_example" {
+    # Add an example/21-capstone/go.mod that requires the root
+    # module — the glob in the script must pick it up.
+    mkdir -p "$REPO_ROOT_TMP/examples/21-capstone"
+    cat > "$REPO_ROOT_TMP/examples/21-capstone/go.mod" <<'EOF'
+module github.com/axonops/audit-examples/capstone
+
+go 1.26
+
+require github.com/axonops/audit v0.1.0
+EOF
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 0 ]
+    # The fake go binary's invocation log must include a pin for
+    # the capstone go.mod (cwd ends in /examples/21-capstone).
+    args="$(args_of go)"
+    echo "$args" | grep -qF "mod edit -require github.com/axonops/audit@v0.2.2"
+    # Capstone target was visited — output names the directory.
+    [[ "$output" =~ "==> examples/21-capstone" ]]
+}
+
+@test "test_update_deps_does_not_run_tidy" {
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 0 ]
+    # The fake go binary records every invocation. `go mod tidy`
+    # must NEVER appear — running tidy at this point in the release
+    # flow would fail because the target tag is not yet on origin.
+    args="$(args_of go)"
+    ! echo "$args" | grep -qE 'mod tidy'
+}
+
+@test "test_update_deps_handles_both_single_line_and_block_require_forms" {
+    # file/go.mod uses a block (require (...)); syslog/go.mod uses
+    # a single-line form. Both shapes must be rewritten.
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 0 ]
+    args="$(args_of go)"
+    # Block-form rewrites: 2 in file/go.mod (root + syslog)
+    file_edits="$(echo "$args" | grep -c 'github.com/axonops/audit@v0.2.2\|github.com/axonops/audit/syslog@v0.2.2')"
+    [ "$file_edits" -ge 2 ]
+    # Single-line rewrite: 1 in syslog/go.mod (root only)
+    [[ "$output" =~ "==> syslog" ]]
+}
+
+@test "test_update_deps_empty_publish_modules_exits_2" {
+    export FAKE_MAKE_FORCE_EMPTY=1
+    run "$SCRIPT" "v0.2.2"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "produced no output" ]]
+}


### PR DESCRIPTION
## Summary

PR-4 of the v0.2.2 cascade-prevention plan (#918). Adds subprocess-driven test coverage for the five release shell scripts that survive the typed-Go rewrite (the other two are deleted in PR-6).

Closes #925.

## Coverage

| Script | LoC | Tests |
|---|---:|---:|
| `check-tag-conflicts.sh` | 72 | 7 |
| `tag-all.sh` | 131 | 7 |
| `update-deps.sh` | 121 | 7 |
| `regen-docs.sh` | 132 | 6 |
| `bump-example-deps.sh` | 81 | 6 |
| **Total** | **537** | **33** |

Plus 3 meta-tests for the fixture stubs = **36 named tests**, all green locally with bats 1.13.0.

## Bugs fixed in-PR (AC #5)

Both shell scripts had a regex that silently skipped the single-line `require github.com/x v0.1.0` form:

- `update-deps.sh:103` — only matched block-form `require (...)`; fixed by adding optional `require ` prefix.
- `bump-example-deps.sh:48` — same defect in the awk pattern; fixed via a two-branch awk that handles both forms.

Without the fix, a release on any module with a single-line require directive would silently leave that path pinned at the OLD version.

## Infrastructure

- `make test-release-scripts` — local entry point; checks bats is on PATH first.
- `Test - Release Scripts` CI job — installs bats-core from a SHA-pinned commit, wired into the `ci-pass` aggregator.
- `tests/release-scripts/README.md` — harness conventions, coverage breakdown, "what is NOT covered" rationale.
- `CONTRIBUTING.md` — adds a paragraph explaining the subprocess-driven model.
- `.gitignore` — tracks `tests/release-scripts/fixtures/bin/` (the existing `bin/` ignore was catching it).

## Test plan

- [x] `make test-release-scripts` — 37/37 pass with bats 1.13.0
- [x] `make lint` — 0 issues
- [x] `make check` — full quality gate green
- [ ] CI pipeline green (including the new release-scripts job)