### PR TITLE
ci: goreleaser.yml BLOCKER-7 concurrency + MAJOR-6 invariants (#943)

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,20 +9,28 @@
 name: GoReleaser
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to (re-)run GoReleaser against, e.g. v0.2.2'
+        type: string
+        required: true
 
 permissions:
   contents: read
 
-# Shared concurrency group with release.yml (#516 devops review).
-# release.yml uses `release-${{ inputs.version || github.ref_name }}`
-# at the workflow level. The goreleaser.yml manual-rerun trigger
-# matches the same group so both workflows queue behind one another
-# rather than racing on the same GitHub Release / Sigstore identity.
+# Shared concurrency group with release.yml (#516 devops review,
+# PR-7 #943 BLOCKER-7 fix). release.yml uses
+# `release-${{ inputs.version || github.ref_name }}` at the workflow
+# level; the manual-rerun trigger here resolves to the SAME group via
+# the required `version` input. Without a required input, dispatching
+# from any branch produced `release-<branch>` (e.g. `release-main`),
+# which did NOT match the automated tag flow's group — two release
+# runs could race on the same GitHub Release / Sigstore identity.
 # cancel-in-progress: false so a manual rerun queues behind an
 # automated tag run rather than killing it mid-flight.
 concurrency:
-  group: release-${{ inputs.version || github.ref_name }}
+  group: release-${{ inputs.version }}
   cancel-in-progress: false
 
 jobs:
@@ -30,16 +38,51 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.ref_type == 'tag'
     permissions:
       contents: write
       id-token: write      # required for attestation OIDC
       attestations: write   # required for attestation upload
     steps:
-      - name: Checkout
+      - name: Validate version input
+        # PR-7 (#943) BLOCKER-7 fix: a malformed version input would
+        # produce `release-junk` as the concurrency group AND fetch
+        # whatever ref happens to resolve. Refuse early with the same
+        # regex tag-all.sh enforces, so a typo can't trigger a build.
+        #
+        # Build metadata (`v1.2.3+abc`) is deliberately rejected: the
+        # Go module proxy treats `v1.2.3+meta` as a distinct version
+        # from `v1.2.3` and downstream tooling (proxy.golang.org,
+        # `go mod download`) breaks on it. The regex matches the
+        # exact set Go's release pipeline accepts.
+        #
+        # The 64-char length cap is defence in depth — without it, a
+        # 16KB string passing the regex would become a 16KB
+        # concurrency-group name (GitHub silently truncates at 255
+        # and groups with the same prefix collide).
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "${#VERSION}" -gt 64 ]; then
+            echo "::error::version input too long (${#VERSION} chars, max 64): '$VERSION'"
+            exit 2
+          fi
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::invalid version input: '$VERSION' (expected vMAJOR.MINOR.PATCH[-PRERELEASE])"
+            exit 2
+          fi
+          echo "version: $VERSION"
+
+      - name: Checkout release tag
+        # PR-7 (#943): pin to the tag commit, NOT the dispatcher's
+        # branch. The previous `fetch-depth: 0` without `ref:` left
+        # GoReleaser building from whatever ref the dispatcher
+        # happened to be on, which for a manual rerun should be the
+        # tag itself.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.version }}
 
       - name: Verify tag is on main
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,10 +39,24 @@ builds:
       - -s -w -X main.version={{.Version}}
 
 before:
-  hooks: []
-  # Before hooks removed — GoReleaser checks out the core tag commit,
-  # which has valid (though not latest-version) go.mod files. The build
-  # works because all referenced module versions are published.
+  hooks:
+    # PR-7 (#943) MAJOR-6 fix: invariant check enabled. Pre-v0.2.0,
+    # before-hooks were disabled because the tag commit's go.mod files
+    # didn't necessarily reference the just-being-released versions.
+    # v0.2.0+ runs the `update-deps-pr` job inside release.yml BEFORE
+    # tagging, so the tag commit reliably has every inter-module
+    # dependency pinned to {{ .Tag }}. Running the invariant check
+    # here aborts the build early (with a clear FAIL line per offending
+    # go.mod) if an out-of-band tag is pushed without going through
+    # the release flow, instead of producing a broken artifact set.
+    #
+    # GoReleaser exec's hooks via `/bin/sh -c`: keep substitutions
+    # whitespace-free. `{{ .Tag }}` (with the `v` prefix) is the
+    # required form — the Makefile target compares string-equality
+    # against `require` lines in every published go.mod, which all
+    # carry the `v` prefix per Go-module convention. `{{ .Version }}`
+    # (no prefix) would never match.
+    - make check-release-invariants VERSION={{ .Tag }}
 
 changelog:
   use: github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **v0.2.2 cascade-prevention release-tool + harness + workflow
-  hardening (#918, #921, #923, #925, #927, #929).** Multi-PR effort
-  spanning the typed-Go release-tool binary, its bats harness, the
-  release.yml hardening pass that should have run before v0.2.1, and
-  the final workflow integration that retires the bash + jq + gh-CLI
-  helpers entirely.
+  hardening (#918, #921, #923, #925, #927, #929, #943).** Multi-PR
+  effort spanning the typed-Go release-tool binary, its bats
+  harness, the release.yml hardening pass that should have run
+  before v0.2.1, the final workflow integration that retires the
+  bash + jq + gh-CLI helpers entirely, and the goreleaser-side
+  concurrency + invariants fixes.
 
   **PR-4 — bats-core test harness for the surviving release
   shell scripts (#925).** Subprocess-driven test suite for
@@ -55,6 +56,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tests in `tests/release-scripts/release-yml-grep.bats` lock each
   fix against future drift, and 1 named bats test in `tag-all.bats`
   locks the recovery-snippet contract.
+
+  **PR-7 — goreleaser concurrency gate + invariants before.hooks
+  (#943).** Closes the BLOCKER-7 + MAJOR-6 findings from the v0.2.1
+  devops audit. `.github/workflows/goreleaser.yml`'s manual-rerun
+  trigger now requires a `version` input matching the tag-format
+  regex, validates it at the first step, pins `actions/checkout`
+  `ref:` to `inputs.version` (not the dispatcher's branch), and
+  derives the concurrency group from `inputs.version` only — the
+  previous fallback to `github.ref_name` meant a manual rerun from
+  any branch ended up in a different group than the automated tag
+  flow, defeating the serialisation gate. `.goreleaser.yml` re-
+  enables `before.hooks` with `make check-release-invariants
+  VERSION={{ .Tag }}` so an out-of-band tag (one pushed without
+  going through `release.yml`'s `update-deps-pr` flow) aborts the
+  build early with a clear per-go.mod FAIL line instead of
+  producing a broken artifact set. Six named bats regression tests
+  in `tests/release-scripts/goreleaser-yml-grep.bats` lock each fix
+  against future drift.
 
   **PR-6 — `release-tool` workflow integration (#929).** Final piece
   of the cascade-prevention plan: `release.yml`'s `update-deps-pr`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -811,10 +811,22 @@ retract the bad one. See "Retracting a Bad Release" below.
 #### GoReleaser failed but tags are pushed
 
 Re-run GoReleaser manually via [Actions →
-GoReleaser](https://github.com/axonops/audit/actions/workflows/goreleaser.yml)
-on the `v*` tag ref. The standalone `goreleaser.yml` workflow exists for
-exactly this case; it runs only the binary-build + attestation step
-without touching tags.
+GoReleaser](https://github.com/axonops/audit/actions/workflows/goreleaser.yml).
+The standalone `goreleaser.yml` workflow exists for exactly this case;
+it runs only the binary-build + attestation step without touching tags.
+
+The dispatch form requires a `version` input — the tag string to
+build against, e.g. `v0.2.2`. The input is validated against
+`^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$` and used as the
+workflow's concurrency group so a manual rerun queues behind any
+in-flight automated run of the same version rather than racing it
+on the GitHub Release / Sigstore identity.
+
+GoReleaser's own `before.hooks` runs `make check-release-invariants
+VERSION=<tag>` to refuse the build outright if any published module's
+`go.mod` doesn't reference the target version — catching the case
+where someone pushes an out-of-band tag without going through the
+`release.yml` `update-deps-pr` flow.
 
 #### App private key compromised mid-release
 

--- a/tests/release-scripts/goreleaser-yml-grep.bats
+++ b/tests/release-scripts/goreleaser-yml-grep.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Grep-based regression tests for .github/workflows/goreleaser.yml
+# and .goreleaser.yml, locking the v0.2.2 PR-7 (#943) BLOCKER-7 +
+# MAJOR-6 fixes. Each test asserts the presence (or absence) of a
+# specific pattern that ties back to one fix in #943's punch list.
+#
+# These tests are intentionally tightly coupled to the workflow and
+# goreleaser-config text so that a regression — someone editing the
+# files later and accidentally re-introducing the bad pattern —
+# fails loudly. The inline `# PR-7 (#943) ... fix` comments on each
+# fix in the source files serve as the canonical anchors.
+
+load 'test_helper.bash'
+
+setup() {
+    GORELEASER_YML="${REPO_ROOT}/.github/workflows/goreleaser.yml"
+    GORELEASER_CONFIG="${REPO_ROOT}/.goreleaser.yml"
+    [ -f "$GORELEASER_YML" ] || skip "goreleaser.yml not present"
+    [ -f "$GORELEASER_CONFIG" ] || skip ".goreleaser.yml not present"
+}
+
+# --- BLOCKER-7 — mandatory version input on workflow_dispatch ---
+
+@test "test_goreleaser_yml_workflow_dispatch_requires_version_input" {
+    # The manual-rerun trigger must declare a required `version`
+    # input. Without it the workflow accepts any dispatch and the
+    # concurrency group falls back to github.ref_name, defeating the
+    # release-yml serialisation.
+    #
+    # awk range: from `^on:` (inclusive) to `^permissions:`
+    # (exclusive) so the on: block is the only thing seen. Using
+    # `^[^[:space:]]` as the end pattern would stop on the `on:`
+    # line itself because awk includes the first line in the range.
+    awk '/^on:/{p=1} /^permissions:/{p=0} p' "$GORELEASER_YML" \
+        | grep -qF 'version:'
+    awk '/^on:/{p=1} /^permissions:/{p=0} p' "$GORELEASER_YML" \
+        | grep -qF 'required: true'
+}
+
+@test "test_goreleaser_yml_concurrency_uses_inputs_version_only" {
+    # The concurrency group must derive from inputs.version with no
+    # github.ref_name fallback. The fallback only existed because the
+    # input wasn't required; now that it is, the fallback would
+    # never be reached AND would hide the regression if someone
+    # dropped `required: true`.
+    grep -qF 'group: release-${{ inputs.version }}' "$GORELEASER_YML"
+    # Negative assertion: the literal fallback expression must not
+    # reappear as the group definition. Comments above the
+    # concurrency block legitimately reference the old fallback
+    # to explain the BLOCKER-7 fix; the regression we care about is
+    # an actual `group:` line re-introducing it.
+    ! grep -qF 'group: release-${{ inputs.version || github.ref_name }}' "$GORELEASER_YML"
+}
+
+@test "test_goreleaser_yml_validates_version_format" {
+    # The validation step must use the same regex as tag-all.sh
+    # (vMAJOR.MINOR.PATCH[-PRE]). The anchor pattern is the exact
+    # `=~` test on $VERSION.
+    grep -qF -- '[[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]' "$GORELEASER_YML"
+    # Backup invariant — survives a YAML reformat that re-quotes
+    # the inner string. Asserts SOME `=~ ^v[0-9]` test exists, even
+    # if the exact line above changes shape.
+    grep -qF -- '=~ ^v[0-9]' "$GORELEASER_YML"
+    # The validation step must exit non-zero on a bad version.
+    grep -qF 'invalid version input' "$GORELEASER_YML"
+}
+
+@test "test_goreleaser_yml_validates_version_length_cap" {
+    # PR-7 (#943) defence-in-depth: a malicious operator with a
+    # leaked PAT could otherwise submit a 16KB string passing the
+    # regex (e.g. `v0.0.0-` + giant valid-character prerelease) and
+    # collide on the GitHub concurrency-group's 255-char silent
+    # truncation. The 64-char cap prevents both that exfil vector
+    # and any future ref-fetch DOS amplification.
+    grep -qF '"${#VERSION}" -gt 64' "$GORELEASER_YML"
+    grep -qF 'version input too long' "$GORELEASER_YML"
+}
+
+@test "test_goreleaser_yml_checks_out_inputs_version_ref" {
+    # Checkout must pin to the tag commit (inputs.version) rather
+    # than the dispatcher's branch. Without this the build runs
+    # against whatever ref the operator's `gh workflow run` happened
+    # to default to.
+    grep -qF 'ref: ${{ inputs.version }}' "$GORELEASER_YML"
+}
+
+@test "test_goreleaser_yml_drops_ref_type_tag_gate" {
+    # The previous `if: github.ref_type == 'tag'` gate was meaningful
+    # while the workflow accepted any dispatch; with a required
+    # version input, the gate is dead code (the inputs.version
+    # validation already constrains to tag-shaped strings, and
+    # checkout pins to that ref). Removing avoids a confusing
+    # "workflow ran but did nothing" outcome when the dispatcher
+    # forgets to dispatch against a tag ref. This test catches
+    # accidental re-introduction.
+    ! grep -qF "github.ref_type == 'tag'" "$GORELEASER_YML"
+}
+
+# --- MAJOR-6 — invariants before.hooks re-enabled ---
+
+@test "test_goreleaser_yml_before_hooks_runs_release_invariants" {
+    # .goreleaser.yml MUST run `make check-release-invariants
+    # VERSION={{ .Tag }}` as a before-hook. Without it, an out-of-
+    # band tag (someone pushes a tag without going through
+    # release.yml's update-deps-pr) would produce a broken artifact
+    # set with no early signal.
+    grep -qF 'check-release-invariants VERSION={{ .Tag }}' "$GORELEASER_CONFIG"
+    # The previous explicitly-empty `hooks: []` form must be gone.
+    ! grep -qE '^[[:space:]]+hooks: \[\]' "$GORELEASER_CONFIG"
+}
+
+@test "test_make_check_release_invariants_fails_without_version" {
+    # Behavioural test: the invariant target the before-hook calls
+    # MUST exit non-zero when invoked without a VERSION arg. This
+    # guards against the Makefile target silently no-op'ing under
+    # GoReleaser's template substitution if `{{ .Tag }}` were ever
+    # to expand to empty (e.g. a tagless snapshot build) — the
+    # release would then proceed without the invariant catching a
+    # bad state.
+    cd "${REPO_ROOT}"
+    run make check-release-invariants
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "VERSION is required" ]]
+}
+
+@test "test_make_check_release_invariants_fails_on_misaligned_version" {
+    # Behavioural test: confirm the invariant target actually BITES
+    # when invoked with a version no go.mod references. This is the
+    # exact failure mode the MAJOR-6 before-hook is meant to catch:
+    # an out-of-band tag (someone tags v0.2.2 on a commit whose
+    # go.mod files still reference v0.2.1). Without this assertion,
+    # the grep-presence test alone would not detect a Makefile
+    # regression where check-release-invariants silently no-ops.
+    cd "${REPO_ROOT}"
+    run make check-release-invariants VERSION=v0.0.0-never-released
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "Release invariants failed" ]]
+}


### PR DESCRIPTION
## Summary

PR-7 of the v0.2.2 cascade-prevention plan (umbrella #918). Closes the two outstanding goreleaser-side findings from the v0.2.1 devops audit that were deferred until PR-6 (#929) landed the release-tool integration.

Closes #943.

## Changes

### BLOCKER-7 — goreleaser.yml dispatch concurrency

- `workflow_dispatch:` gains a required `version` input matching `^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$` (same regex as `tag-all.sh`)
- New validation step at the top of the `release` job rejects malformed values with exit 2 and a clear error message
- 64-character input length cap (defence in depth against the silent 255-char GitHub concurrency-group truncation)
- Concurrency group simplified to `release-${{ inputs.version }}` — drops the dead `|| github.ref_name` fallback that was masking the regression
- `actions/checkout` pinned to `ref: ${{ inputs.version }}` so the build runs against the tag commit regardless of the dispatcher's selected ref
- Dropped the dead `if: github.ref_type == 'tag'` job gate (validation + ref pinning provide stronger constraints)

### MAJOR-6 — invariants before.hooks

- `.goreleaser.yml`'s `before.hooks: []` (with a stale comment) is replaced with `make check-release-invariants VERSION={{ .Tag }}`
- An out-of-band tag (pushed without going through `release.yml`'s `update-deps-pr` flow) now aborts the build early with a clear per-go.mod FAIL line instead of producing a broken artifact set
- Inline comment explains why `{{ .Tag }}` (with `v` prefix) is the correct template variable and why GoReleaser's shell-exec model means substitutions must stay whitespace-free

### Tests

Eight named bats regression tests in `tests/release-scripts/goreleaser-yml-grep.bats`:

- `test_goreleaser_yml_workflow_dispatch_requires_version_input`
- `test_goreleaser_yml_concurrency_uses_inputs_version_only`
- `test_goreleaser_yml_validates_version_format`
- `test_goreleaser_yml_validates_version_length_cap`
- `test_goreleaser_yml_checks_out_inputs_version_ref`
- `test_goreleaser_yml_drops_ref_type_tag_gate`
- `test_goreleaser_yml_before_hooks_runs_release_invariants`
- `test_make_check_release_invariants_fails_without_version` (behavioural)
- `test_make_check_release_invariants_fails_on_misaligned_version` (behavioural)

The two behavioural tests invoke the Makefile target the before-hook calls and verify it actually bites on a missing or misaligned VERSION arg, locking against any future regression that makes the before-hook a tautology.

### Docs

- `docs/releasing.md` — GoReleaser manual-rerun section documents the required `version` input, validation regex, concurrency contract, and before-hooks invariant
- `CHANGELOG.md` — PR-7 entry under the v0.2.2 cascade-prevention narrative

## Reviewer findings addressed in-PR

- code-reviewer: 0 blockers, 3 NITs — all addressed in-PR (length cap comment, build-metadata rejection comment, whitespace-free substitution comment, behavioural test for the invariants hook)
- devops: 0 blockers, 5 MINORs — addressed length cap (M3), behavioural test for hook biting (M4), build-metadata explanation; shared-regex extraction (M1) + actionlint coverage (M5) noted for follow-up if you'd like issues filed

## Test plan

- [x] `make check` passes locally
- [x] `make test-release-scripts` — 83/83 pass
- [x] code-reviewer + devops agents run; every finding addressed
- [ ] CI green on this PR
- [ ] issue-closer verifies AC against #943 before merge
- [ ] After merge: this completes PRs 1-7 of the umbrella plan; PR-8 (`release/v0.2.2-dispatch`) is the final piece