### PR TITLE
chore: bump CHANGELOG to v0.2.2 (#918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-08
+
 ### Added
 
 - **v0.2.2 cascade-prevention release-tool + harness + workflow


### PR DESCRIPTION
## Summary

Stamps the v0.2.2 release date ahead of the umbrella plan's dispatch step (#918). Every Added/Breaking/Fixed entry under the v0.2.2 narrative (PRs #921, #923, #925, #927, #929, #943) is already in place from each sub-PR; this PR renames the section header from \`## [Unreleased]\` to \`## [0.2.2] - 2026-06-08\` so the release-tag commit's CHANGELOG reads as a sealed v0.2.2 release rather than an open Unreleased block.

Mirrors the precedent set by the v0.1.13 entry at \`CHANGELOG.md:687\`.

## Diff

\`\`\`diff
 ## [Unreleased]

+## [0.2.2] - 2026-06-08
+
 ### Added
\`\`\`

## Test plan

- [x] \`make fmt-check\` clean
- [ ] CI green
- [ ] Merged before \`gh workflow run release.yml -f version=v0.2.2\` dispatch