### PR TITLE
fix: gh pr create does not support --json (v0.2.2 dispatch fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -569,21 +569,27 @@ jobs:
             --message "release: pin inter-module deps to $PUBLISH_VERSION" \
             --auto-create-branch
 
-          # BLOCKER-A fix (#927): `gh pr create | tail | sed` is
-          # exactly the v0.2.1 anti-pattern (#911 class). Use the
-          # typed `--json url` form so we get a structured response —
-          # no progress-line parsing, no shell pipeline that swallows
-          # gh's exit code, and the URL is the source of truth instead
-          # of a regex on stdout.
+          # BLOCKER-A fix (#927, corrected): `gh pr create | tail | sed`
+          # was the v0.2.1 anti-pattern (#911 class). The PR-5 attempt
+          # to replace it with `--json url --jq '.url'` was wrong:
+          # `gh pr create` does NOT support `--json` (that flag only
+          # exists on `gh pr view`/`list`). The v0.2.2 dispatch run
+          # 27149700917 caught this at the call site. On success,
+          # `gh pr create` writes exactly the PR URL to stdout — no
+          # progress lines, no decoration — so the safe pattern is:
           #
-          # Requires gh ≥ 2.25 for `--json` on `pr create`; ubuntu-
-          # latest's preinstalled gh is well past this floor. The
-          # `gh --version` assertion in `preflight` guarantees it.
+          #   1. Capture stdout into PR_URL (no parsing).
+          #   2. Validate the captured string IS a github PR URL.
+          #   3. The validation regex below is the source of truth;
+          #      a malformed value aborts before the URL is used.
+          #
+          # Set -o pipefail isn't needed because there is no pipeline.
+          # The exit code of `gh pr create` propagates directly to the
+          # script's $? via `set -e` at the workflow shell level.
           PR_URL=$(gh pr create \
             --base main --head "$BRANCH" \
             --title "release: $PUBLISH_VERSION" \
-            --body "Automated release PR (#513). Tags every published module at the merge commit. Approve to let auto-merge fire after CI green." \
-            --json url --jq '.url')
+            --body "Automated release PR (#513). Tags every published module at the merge commit. Approve to let auto-merge fire after CI green.")
           if ! [[ "$PR_URL" =~ ^https://github\.com/.+/pull/[0-9]+$ ]]; then
             echo "::error::gh pr create returned an unexpected URL: $PR_URL"
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-08
+
 ### Added
 
 - **v0.2.2 cascade-prevention release-tool + harness + workflow

--- a/tests/release-scripts/release-yml-grep.bats
+++ b/tests/release-scripts/release-yml-grep.bats
@@ -24,11 +24,21 @@ setup() {
 
 @test "test_release_yml_does_not_use_tail_sed_to_parse_pr_create_output" {
     # The v0.2.1 anti-pattern was `gh pr create ... | tail -n1 | sed ...`.
-    # Assert the fixed `--json url --jq '.url'` form is present AND
-    # the bad pattern is absent. Use `--` to separate grep options
-    # from the pattern (the pattern starts with `--`).
-    grep -qF -- "--json url --jq '.url'" "$RELEASE_YML"
+    # The PR-5 (#927) attempt at `--json url --jq '.url'` was wrong:
+    # `gh pr create` does NOT support `--json` — that flag exists
+    # only on `gh pr view`/`list`. The v0.2.2 dispatch run
+    # 27149700917 surfaced this. The correct pattern is to capture
+    # stdout directly (gh pr create writes only the URL on success)
+    # and validate the shape with a regex.
+    #
+    # Assert:
+    #   1. The PR_URL capture has NO sub-command parsing (no tail,
+    #      no sed, no --json, no --jq).
+    #   2. The validation regex on the captured value is present.
     ! grep -qE 'gh pr create.+tail -n.*1' "$RELEASE_YML"
+    ! grep -qF -- "--json url --jq '.url'" "$RELEASE_YML"
+    grep -qF 'PR_URL=$(gh pr create' "$RELEASE_YML"
+    grep -qF -- '[[ "$PR_URL" =~ ^https://github\.com/.+/pull/[0-9]+$ ]]' "$RELEASE_YML"
 }
 
 # --- BLOCKER-B — allow_auto_merge null classified, not silently false ---


### PR DESCRIPTION
## Summary

The v0.2.2 dispatch attempt (run 27149700917) failed at the \"Open release PR with auto-merge\" step:

\`\`\`
unknown flag: --json
Usage:  gh pr create [flags]
\`\`\`

\`gh pr create\` does **not** support \`--json\` — that flag exists only on \`gh pr view\` / \`gh pr list\`. The PR-5 BLOCKER-A fix (#927) shipped a pretend-fix because no test exercised the actual gh CLI invocation; the bats grep test only asserted the literal string \`--json url --jq '.url'\` was present, not that it was a valid flag combination.

## Fix

Drop the \`--json\` arguments. On success \`gh pr create\` writes exactly the PR URL to stdout — no progress lines, no decoration — so capturing the bare output and validating its shape via regex is the correct pattern. The validation step that comes immediately after (the \`[[ \"\$PR_URL\" =~ ^https://github\\.com/.+/pull/[0-9]+\$ ]]\` regex check) is unchanged and remains the source of truth.

The bats regression test is rewritten to lock the corrected pattern:
- positive: \`PR_URL=\$(gh pr create\` is present
- positive: the \`\$PR_URL\` validation regex is present
- negative: the old \`tail -n.*1\` anti-pattern is absent
- negative: the broken \`--json url --jq '.url'\` form is absent

Either the capture-and-validate pair or both negative assertions would catch a regression to either prior pattern.

## State on origin

The release-tool succeeded — commit-pinned-deps created the dep-pinning commit on \`release/v0.2.x\` at SHA \`168f5fbdee86f30b29133967bfc1c260bf37862d\`. No PR was opened against it. The release workflow's \"stale branch\" cleanup at update-deps-pr:496 detects the existing branch on the next dispatch attempt, closes any orphan PRs against it, and deletes it before re-running release-tool commit-pinned-deps with \`--auto-create-branch\`. **No manual cleanup needed before re-dispatch.**

## Test plan

- [x] \`make test-release-scripts\` 83/83 pass with the rewritten bats test
- [ ] CI green
- [ ] Re-dispatch \`gh workflow run release.yml -f version=v0.2.2\` after merge