### PR TITLE
fix(ci): goreleaser --skip=before to ship v0.2.2 binaries

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -108,10 +108,28 @@ jobs:
 
       - name: Run GoReleaser
         id: goreleaser
+        # --skip=before added for v0.2.2 (#948): the MAJOR-6 before-hook
+        # added in PR-7 (#943) calls `make check-release-invariants
+        # VERSION={{ .Tag }}`. GoReleaser's `{{ .Tag }}` resolves via
+        # `git describe --tags`, which prefers ANNOTATED tags over
+        # lightweight ones. The v0.2.2 dispatch pushed `v0.2.2` as a
+        # lightweight tag via REST (because release.yml's wait-for-pr-
+        # merge timed out and the tag had to be pushed manually outside
+        # the App-signed release-tool flow). Tag-all then created
+        # annotated `file/v0.2.2`, `syslog/v0.2.2`, ..., `webhook/v0.2.2`
+        # at the same SHA — and `git describe` picks the lexicographically
+        # last annotated one (`webhook/v0.2.2`), which the Makefile
+        # rejects as not matching any module's expected version.
+        #
+        # The proper fix (use $GITHUB_REF_NAME, or replace the
+        # lightweight v0.2.2 tag with an annotated one) is tracked
+        # for v0.2.3. For v0.2.2 we --skip=before — the invariant was
+        # already enforced when PR #947 (the inter-module deps PR)
+        # merged into main, so skipping the hook here is safe.
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           version: 'v2.15.4'
-          args: release --clean --skip=validate
+          args: release --clean --skip=validate --skip=before
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The v0.2.2 goreleaser dispatch (run 27192324924) failed because PR-7's MAJOR-6 before-hook (\`make check-release-invariants VERSION={{ .Tag }}\`) resolved \`{{ .Tag }}\` to \`webhook/v0.2.2\` instead of \`v0.2.2\`.

## Root cause

Three things happened in sequence:

1. **v0.2.2 was pushed as a lightweight tag.** The release.yml \`wait-for-pr-merge\` job timed out (PR #947 was admin-merged after the workflow timed out polling), so the v0.2.2 tag had to be created manually via \`gh api -X POST .../git/refs\` — which creates a lightweight (ref-only) tag, not an annotated one.
2. **tag-all created annotated tags for every sub-module** at the same SHA: \`file/v0.2.2\`, \`syslog/v0.2.2\`, ..., \`webhook/v0.2.2\`.
3. **\`git describe --tags\` prefers annotated over lightweight** and selects the lexicographically last annotated tag. With v0.2.2 lightweight and \`webhook/v0.2.2\` annotated, goreleaser's \`{{ .Tag }}\` template resolved to \`webhook/v0.2.2\`.

The invariant Makefile target then ran \`make check-release-invariants VERSION=webhook/v0.2.2\` against every published go.mod's \`github.com/axonops/audit/* v0.2.2\` require line — and rejected every one of them with \`expected webhook/v0.2.2\`.

## Fix

Add \`--skip=before\` to the goreleaser-action \`args\` so the hook is bypassed for v0.2.2. The invariant the hook enforces was already verified at PR #947's merge time (the inter-module deps PR that pinned every go.mod to v0.2.2).

## Test plan

- [x] Local edit + commit
- [ ] CI green on this PR
- [ ] Merge + re-dispatch \`gh workflow run goreleaser.yml -f version=v0.2.2\`
- [ ] File v0.2.3 issue for the proper template fix (use \`\$GITHUB_REF_NAME\` env var, replace lightweight v0.2.2 tag with annotated, or add \`git.tag.use_annotated_only\` to \`.goreleaser.yml\`)

## State on origin (after this PR merges)

- v0.2.2 library tags: all 17 modules tagged (already published)
- v0.2.2 release page: still missing (this PR + re-dispatch produces it)
- v0.2.3 follow-up issue: to be filed