### PR TITLE
fix(release): cosign --no-new-bundle-format for v0.2.2 ship

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -139,6 +139,19 @@ signs:
       # forward-compatible.
       - sign-blob
       - '--yes'
+      # PR-9 (#949): cosign ≥ v2.6 made --new-bundle-format the
+      # default, which silently IGNORES --output-signature and
+      # --output-certificate (they print deprecation warnings) and
+      # writes a combined .bundle file at the path passed via
+      # --bundle. With no --bundle path supplied, cosign attempts
+      # `open ""` and fails with "create bundle file: open : no such
+      # file or directory". The v0.2.2 dispatch (run 27194413670)
+      # hit this. We keep the legacy split sig+cert layout — every
+      # consumer's `cosign verify-blob --signature checksums.txt.sig
+      # --certificate checksums.txt.pem` recipe in docs/releasing.md
+      # depends on those two files existing. --no-new-bundle-format
+      # restores cosign v2.5 behaviour.
+      - '--no-new-bundle-format'
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'


### PR DESCRIPTION
## Summary

The v0.2.2 goreleaser dispatch (run 27194413670) built all 4 binaries (audit-gen, audit-validate × linux/darwin/windows × amd64/arm64), archived, checksummed, then failed at the sign step:

\`\`\`
WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
\`\`\`

## Root cause

cosign ≥ v2.6 made \`--new-bundle-format\` the default. It silently ignores \`--output-signature\` / \`--output-certificate\` (with the deprecation warnings above) and writes a combined \`.bundle\` file at the path passed via \`--bundle\`. With no \`--bundle\` path in our config, cosign tries \`open(\"\")\` and fails.

Last successful release was v0.1.10 on 2026-04-17 — cosign broke this contract since then. The release.yml goreleaser job has been skipped on the push:tag path (separate v0.2.3 bug), so we only noticed when dispatching \`goreleaser.yml\` manually.

## Fix

Add \`--no-new-bundle-format\` to keep cosign's pre-v2.6 behaviour. Every consumer's verification recipe in \`docs/releasing.md\` reads:

\`\`\`
cosign verify-blob --signature checksums.txt.sig --certificate checksums.txt.pem checksums.txt
\`\`\`

Those two files MUST exist; switching to the bundle format would break every documented verifier.

## Test plan

- [x] Local edit + commit
- [ ] CI green on this PR (Hygiene + CI Pass will fail same as #948 due to main-state tidy drift — admin-merge expected)
- [ ] After merge: re-dispatch \`goreleaser.yml -f version=v0.2.2\`
- [ ] v0.2.3 follow-up: migrate to bundle format OR pin cosign version

## State

- Library tags: shipped
- Binaries: built locally on the runner but never published (release artifacts were created in /dist but the run aborted before upload)
- Release page: still missing