### PR TITLE
fix(ci): pin cosign-installer to v2.5.3 for v0.2.2 ship

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -103,8 +103,24 @@ jobs:
 
       # Sigstore keyless signing (#516). Installs cosign for the
       # GoReleaser `signs:` stanza. Pinned to v4.1.1 commit SHA.
+      #
+      # PR-10 (#950) fix: cosign-installer's default is "latest", which
+      # currently pulls cosign ≥ v2.6. That release made
+      # --new-bundle-format the silent default — --output-signature
+      # and --output-certificate are warned-and-ignored, and cosign
+      # tries to write a combined .bundle to the path passed via
+      # --bundle (which we don't pass), so it fails with
+      # "create bundle file: open : no such file or directory".
+      # The v0.2.2 dispatch (runs 27194413670 + 27196997175) failed
+      # exactly here. Pin to v2.5.3 — the last v2.5 release — so
+      # --output-signature / --output-certificate continue to write
+      # the .sig / .pem layout that docs/releasing.md's verifier
+      # recipe depends on. v0.2.3 will migrate to the bundle format
+      # + update the verifier docs as a proper fix.
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: 'v2.5.3'
 
       - name: Run GoReleaser
         id: goreleaser


### PR DESCRIPTION
## TL;DR

PR #949's \`--no-new-bundle-format\` was a wild guess that doesn't actually fix anything (cosign doesn't recognize that flag; even if it did, v0.2.2's tagged \`.goreleaser.yml\` doesn't have it — only main does).

Real fix: cosign-installer defaults to installing the latest cosign, which is ≥ v2.6 and silently switches to the new bundle format. Pin to v2.5.3 — the last v2.5 release — to preserve the existing \`.sig + .pem\` verifier contract.

## Why this PR applies to the v0.2.2 ship

workflow_dispatch reads workflow files from main, NOT from the dispatched ref. So this patch to \`.github/workflows/goreleaser.yml\` applies immediately on the next \`goreleaser.yml -f version=v0.2.2\` dispatch.

\`.goreleaser.yml\` (read by goreleaser) comes from the checked-out v0.2.2 tag — the tag's \`.goreleaser.yml\` is unchanged from main at #947 merge time, which has the original \`--output-signature\` / \`--output-certificate\` flags. With cosign pinned to v2.5.3 those flags work.

## v0.2.3 follow-ups (additions to the e2e list)

- Properly migrate \`.goreleaser.yml\` to bundle format + update \`docs/releasing.md\` verifier recipe (so we can drop the cosign pin)
- Revert PR #949's bogus \`--no-new-bundle-format\` addition

## Test plan

- [x] Local edit + commit
- [ ] CI will fail Hygiene + CI Pass (main-state tidy drift — admin-merge expected)
- [ ] After merge: re-dispatch \`goreleaser.yml -f version=v0.2.2\`