### PR TITLE
fix(ci): GORELEASER_CURRENT_TAG override for v0.2.2 ship

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -148,6 +148,25 @@ jobs:
           args: release --clean --skip=validate --skip=before
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PR-11 (#951): GoReleaser's `{{ .Tag }}` and `{{ .Version }}`
+          # templates resolve via `git describe --tags`, which prefers
+          # ANNOTATED tags over lightweight ones. v0.2.2 was pushed as
+          # lightweight (release-tool flow timed out at wait-for-pr-
+          # merge, tag had to be created manually via REST), then
+          # tag-all created annotated `file/v0.2.2`, ...,
+          # `webhook/v0.2.2`. git describe picks the lexicographically
+          # last annotated one (`webhook/v0.2.2`) — `{{ .Version }}`
+          # becomes `webhook/v0.2.2`, and docker image-template builds
+          # like `ghcr.io/axonops/audit-gen:{{ .Version }}-amd64`
+          # produce `ghcr.io/...:webhook/v0.2.2-amd64`, an invalid
+          # docker reference (slash in the tag).
+          #
+          # GORELEASER_CURRENT_TAG is goreleaser's documented escape
+          # hatch — overrides the auto-detection. Set it to the
+          # workflow_dispatch `version` input so .Tag / .Version
+          # resolve to v0.2.2 / 0.2.2 regardless of what
+          # `git describe` would pick.
+          GORELEASER_CURRENT_TAG: ${{ inputs.version }}
 
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0


### PR DESCRIPTION
## Summary

4th goreleaser attempt (run 27197924560) progressed past cosign signing (PR #950's pin worked, \`.sig\` + \`.pem\` files written) and reached the docker build step, where it failed:

\`\`\`
invalid tag "ghcr.io/axonops/audit-gen:webhook/v0.2.2-amd64": invalid reference format
\`\`\`

## Root cause

Same chain as the invariants-hook bug: v0.2.2 was pushed as a **lightweight** tag (release-tool flow timed out at wait-for-pr-merge; the tag had to be created manually via REST), then tag-all created **annotated** \`file/v0.2.2\`, ..., \`webhook/v0.2.2\`. \`git describe --tags\` prefers annotated over lightweight and picks the lex-last annotated one — \`webhook/v0.2.2\` — so goreleaser's \`{{ .Version }}\` resolves to \`webhook/v0.2.2\`, the docker image-template builds \`ghcr.io/...:webhook/v0.2.2-amd64\`, and Docker rejects the slash.

## Fix

\`GORELEASER_CURRENT_TAG\` is goreleaser's documented escape hatch — overrides the auto-detection. Set it to the workflow_dispatch \`version\` input so \`.Tag\` and \`.Version\` resolve correctly regardless of what \`git describe\` would pick.

This also incidentally fixes the before-hook template issue that #948 had to work around with \`--skip=before\`. v0.2.3 will revert the \`--skip=before\` bandage.

## Test plan

- [x] Local commit
- [ ] CI will fail Hygiene + CI Pass (tidy drift) — admin-merge expected
- [ ] After merge: re-dispatch \`goreleaser.yml -f version=v0.2.2\`