### PR TITLE
fix(ci): use --skip=docker (singular)

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -171,7 +171,7 @@ jobs:
           # cosign signs: stanza for checksums.txt is NOT skipped —
           # consumers' verifier recipe in docs/releasing.md still
           # needs the .sig + .pem files.
-          args: release --clean --skip=validate --skip=before --skip=docker --skip=docker-manifests
+          args: release --clean --skip=validate --skip=before --skip=docker
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # PR-11 (#951): GoReleaser's `{{ .Tag }}` and `{{ .Version }}`


### PR DESCRIPTION
PR #954 used invalid --skip=docker-manifests. goreleaser v2.15.4 rejected it. Plain --skip=docker covers both dockers + manifests.