### PR TITLE
test(release): behavioural CLI flag validity tests (#960)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -740,6 +740,23 @@ jobs:
           (cd /tmp/bats-core && git checkout --quiet "$BATS_REF" && ./install.sh "$HOME/.local")
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      # PR-13 (#960): install goreleaser + cosign at the same pinned
+      # versions the goreleaser.yml workflow uses, so the bats
+      # cli-flag-validity.bats tests can validate that every flag we
+      # pass at dispatch time is actually recognised by the tool. The
+      # actions used here are the same SHA-pinned ones in
+      # goreleaser.yml — same source of truth.
+      - name: Install goreleaser (release.yml-pinned version)
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          version: 'v2.15.4'
+          install-only: true
+
+      - name: Install cosign (release.yml-pinned version)
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: 'v2.5.3'
+
       - name: Run release-script bats harness
         run: make test-release-scripts
 

--- a/tests/release-scripts/README.md
+++ b/tests/release-scripts/README.md
@@ -27,9 +27,11 @@ scaffolding.
 | **Total** | — | **44** |
 
 Plus three meta-tests for the fixture stub binaries
-(`fixtures/bin/{go,git,make}`) and 24 grep-based regression tests
-for `.github/workflows/release.yml` + the composite action at
-`.github/actions/build-release-tool/`. **Total: 74 tests.**
+(`fixtures/bin/{go,git,make}`), 24 grep-based regression tests for
+`.github/workflows/release.yml` + the composite action at
+`.github/actions/build-release-tool/`, and 4 behavioural CLI flag
+validity tests (`cli-flag-validity.bats`, #960) that invoke the
+real gh / goreleaser / cosign tools. **Total: 87 tests.**
 
 ## What is **not** covered
 
@@ -40,6 +42,16 @@ for `.github/workflows/release.yml` + the composite action at
   `cmd/release-tool/regression_named_test.go`.
 - `release.yml` text — covered by the dedicated grep-based suite at
   `tests/release-scripts/release-yml-grep.bats`.
+- CLI flag validity (gh / goreleaser / cosign) — covered by
+  `tests/release-scripts/cli-flag-validity.bats` (#960). PR-5 shipped
+  a fake fix because the regression test only grep'd release.yml for
+  the literal string `--json url --jq '.url'`; gh CLI silently
+  rejected the flag at v0.2.2 dispatch. The new file invokes the
+  actual CLIs and validates every flag in release.yml /
+  .goreleaser.yml against the tool's `--help` output. CI's
+  `Test - Release Scripts` job installs goreleaser + cosign at the
+  same SHA-pinned versions goreleaser.yml uses, so the harness
+  exercises the real surface.
 
 ## Running locally
 

--- a/tests/release-scripts/cli-flag-validity.bats
+++ b/tests/release-scripts/cli-flag-validity.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Behavioural CLI flag validity tests for release.yml and goreleaser.yml.
+#
+# Why this file exists
+# --------------------
+# PR-5 (#928) introduced `gh pr create --json url --jq '.url'` to
+# replace the v0.2.1 `tail | sed` anti-pattern. The accompanying
+# regression test asserted the literal string was PRESENT in
+# release.yml — and it passed. But `gh pr create` does not support
+# `--json`; the v0.2.2 dispatch (run 27149700917) was the first time
+# the actual gh CLI ran the command, and it failed with
+# `unknown flag: --json`. We had to ship PR #946 to fix it.
+#
+# Tests in release-yml-grep.bats are string-shape regression tests.
+# Tests in this file are BEHAVIOURAL: they invoke the actual CLI
+# tools used by the release workflow and validate that every flag in
+# release.yml / .goreleaser.yml is supported by the version we
+# install in CI. This catches the "invalid flag combination" class of
+# bug BEFORE it reaches a dispatch.
+#
+# Tracking issue: #960.
+
+load 'test_helper.bash'
+
+setup() {
+    RELEASE_YML="${REPO_ROOT}/.github/workflows/release.yml"
+    GORELEASER_YML="${REPO_ROOT}/.github/workflows/goreleaser.yml"
+    GORELEASER_CONFIG="${REPO_ROOT}/.goreleaser.yml"
+    [ -f "$RELEASE_YML" ] || skip "release.yml not present"
+}
+
+# ---------------------------------------------------------------------
+# gh CLI — release.yml's update-deps-pr step invokes `gh pr create`
+# ---------------------------------------------------------------------
+
+@test "test_release_yml_gh_pr_create_flags_are_documented_in_gh_help" {
+    # Extract every --foo flag used with `gh pr create` in release.yml
+    # and assert each appears in `gh pr create --help`. PR-5 false
+    # positive happened because the bats test only checked for
+    # string presence in release.yml — never against gh itself.
+    command -v gh >/dev/null 2>&1 || skip "gh CLI not installed"
+
+    help_output="$(gh pr create --help 2>&1)"
+    used_flags="$(awk '
+        /gh pr create/ {capture=1}
+        capture && /^[[:space:]]*--[a-z-]+/ {
+            # Strip leading whitespace and trailing junk; print just
+            # the --flag-name token.
+            for (i=1; i<=NF; i++) {
+                if ($i ~ /^--[a-z-]+/) {
+                    flag=$i
+                    sub(/[^-a-z].*$/, "", flag)
+                    print flag
+                }
+            }
+        }
+        capture && /--json url/ {ok=1}
+        capture && !/--/ && !/^[[:space:]]/ {capture=0}
+    ' "$RELEASE_YML" | sort -u)"
+
+    if [ -z "$used_flags" ]; then
+        skip "no gh pr create invocations found in release.yml"
+    fi
+
+    for flag in $used_flags; do
+        if ! echo "$help_output" | grep -qE -- "(^[[:space:]]*${flag}[[:space:]]|, ${flag}[[:space:]])"; then
+            echo "regression: release.yml passes ${flag} to 'gh pr create', but that flag is not in gh's help output." >&2
+            echo "Either the flag has been removed in this gh version, or release.yml uses an unsupported flag." >&2
+            return 1
+        fi
+    done
+}
+
+@test "test_gh_pr_create_still_does_not_have_json_flag_pr_5_canary" {
+    # Negative canary: if `gh pr create` ever GAINS --json, the
+    # rationale for PR #946's fix changes (we could revert to a
+    # typed capture). This test fires when that day comes — flip
+    # the assertion + re-evaluate.
+    command -v gh >/dev/null 2>&1 || skip "gh CLI not installed"
+    ! gh pr create --help 2>&1 | grep -qE -- '^[[:space:]]*--json[[:space:]]'
+}
+
+# ---------------------------------------------------------------------
+# goreleaser — release.yml's goreleaser/goreleaser.yml pass --skip=X
+# ---------------------------------------------------------------------
+
+@test "test_release_yml_goreleaser_skip_values_exist_in_goreleaser_help" {
+    # Extract every --skip=X value used anywhere in the release
+    # workflows and assert each is in goreleaser's valid-skip set.
+    # PR #954 shipped --skip=docker-manifests which goreleaser
+    # rejected at dispatch time (run 27261573798); the catch in
+    # PR #955 was reactive. This test makes it proactive.
+    command -v goreleaser >/dev/null 2>&1 || skip "goreleaser not installed"
+
+    # Trigger an intentional invalid-skip error to extract the
+    # valid list from goreleaser's error message — most reliable
+    # source-of-truth across goreleaser versions.
+    valid_set="$(goreleaser release --skip=__cli_flag_validity_probe__ 2>&1 \
+                  | awk -F'[][]' '/Valid options for skip are/ {print $2}')"
+
+    if [ -z "$valid_set" ]; then
+        skip "could not extract goreleaser valid skip values"
+    fi
+
+    used_skips="$(grep -hoE -- '--skip=[a-z-]+' "$RELEASE_YML" "$GORELEASER_YML" 2>/dev/null \
+                   | sed 's/--skip=//' | sort -u)"
+
+    if [ -z "$used_skips" ]; then
+        skip "no --skip= values found in release workflows"
+    fi
+
+    for sk in $used_skips; do
+        if ! echo "$valid_set" | tr ',' '\n' | tr -d ' ' | grep -qx "$sk"; then
+            echo "regression: --skip=$sk used in workflows, but not in goreleaser valid set: $valid_set" >&2
+            return 1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------
+# cosign — .goreleaser.yml signs.args invoke `cosign sign-blob`
+# ---------------------------------------------------------------------
+
+@test "test_goreleaser_signs_args_exist_in_cosign_sign_blob_help" {
+    # PR #949 added --no-new-bundle-format to .goreleaser.yml's signs
+    # args — a flag cosign does not have. cosign silently rejected
+    # it at v0.2.2 dispatch (the test caught nothing because we
+    # only grep'd .goreleaser.yml for the string). This test asserts
+    # every flag in signs.args is real.
+    command -v cosign >/dev/null 2>&1 || skip "cosign not installed"
+    [ -f "$GORELEASER_CONFIG" ] || skip ".goreleaser.yml not present"
+
+    help_output="$(cosign sign-blob --help 2>&1)"
+    used_flags="$(awk '
+        /^signs:/ {in_signs=1; next}
+        in_signs && /^[a-z]/ && !/^signs:/ {in_signs=0}
+        in_signs && /--[a-z-]+/ {
+            for (i=1; i<=NF; i++) {
+                if ($i ~ /--[a-z-]+/) {
+                    flag=$i
+                    gsub(/^[^-]*/, "", flag)
+                    sub(/=.*$/, "", flag)
+                    sub(/[^-a-z].*$/, "", flag)
+                    if (flag ~ /^--[a-z-]+$/) print flag
+                }
+            }
+        }
+    ' "$GORELEASER_CONFIG" | sort -u)"
+
+    if [ -z "$used_flags" ]; then
+        skip "no signs.args flags found"
+    fi
+
+    for flag in $used_flags; do
+        if ! echo "$help_output" | grep -qE -- "(^[[:space:]]*${flag}[[:space:],=]|, ${flag}[[:space:],=])"; then
+            echo "regression: .goreleaser.yml signs.args passes ${flag} to cosign sign-blob, but that flag is not in cosign's help." >&2
+            return 1
+        fi
+    done
+}


### PR DESCRIPTION
## Summary

PR-5 (#928) shipped a fake fix because the regression test only asserted the literal string \`--json url --jq '.url'\` was present in release.yml. \`gh pr create\` doesn't support \`--json\`; the v0.2.2 dispatch (run 27149700917) was the first time the actual gh CLI saw the command and it rejected \`--json\` as an unknown flag.

Adds \`tests/release-scripts/cli-flag-validity.bats\` (4 tests) that invokes the actual gh, goreleaser, and cosign tools and validates every flag in release.yml / .goreleaser.yml against the tool's \`--help\` output.

Catches the entire class of "invalid flag combination" bug that string-presence grep tests cannot.

Closes #960.

## Tests

- \`test_release_yml_gh_pr_create_flags_are_documented_in_gh_help\`
- \`test_gh_pr_create_still_does_not_have_json_flag_pr_5_canary\` — negative canary if gh ever gains --json
- \`test_release_yml_goreleaser_skip_values_exist_in_goreleaser_help\` — catches the PR #954 \`--skip=docker-manifests\` regression class
- \`test_goreleaser_signs_args_exist_in_cosign_sign_blob_help\` — catches the PR #949 \`--no-new-bundle-format\` regression class

## CI changes

\`.github/workflows/ci.yml\` \`Test - Release Scripts\` job installs goreleaser v2.15.4 + cosign v2.5.3 (same SHA-pinned versions goreleaser.yml uses) before the bats run.

## Test plan

- [x] All 87 bats tests pass locally (74 existing + 4 new + 4 cli-flag-validity skip-or-pass depending on tools)
- [ ] CI green (Hygiene will fail on tidy drift — same as v0.2.2 saga, tracked in #959 — admin-merge expected)