### PR TITLE
ci: release-PR-tolerant regen + ta-diff check (#957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   same regression that broke v0.2.2's 5th manual dispatch and was
   fixed in `goreleaser.yml` under #950. Pinned to `v2.5.3` to keep
   the `.sig` / `.pem` layout consumers' verifier recipe depends on.
+- **`regen-schema-artifacts-check` + `ta-diff-check` release-PR
+  head-ref carve-out (#957).** Both Makefile targets shell out to
+  `go run ./cmd/audit-gen`, which has to resolve every published
+  sub-module from `go.mod`. On a release PR the cross-module pins
+  point at yet-to-be-tagged versions (`tag-all` runs after PR
+  merge), causing the targets to fail with
+  `unknown revision splunk/vX.Y.Z` and blocking the release PR
+  without admin-bypass. v0.2.2 had to be admin-merged with required-
+  check bypass for exactly this reason — the first crack that
+  triggered the lightweight-tag downstream cascade. The targets now
+  detect `GITHUB_HEAD_REF` matching `release/v<semver>` and skip
+  with a logged reason; non-release PRs still run the full check.
+  Mirrors the existing tidy-check release-PR carve-out described in
+  `docs/releasing.md` § "Unified single-tag release flow". Tested by
+  `tests/release-scripts/check-static-release-pr-tolerant.bats`
+  (12 named tests). v0.2.3's release PR can auto-merge without
+  admin bypass.
 
 ## [0.2.2] - 2026-06-08
 

--- a/Makefile
+++ b/Makefile
@@ -1127,9 +1127,23 @@ regen-schema-artifacts:
 # regen-schema-artifacts-check verifies deploy/schemas/* are in sync
 # with the framework-only taxonomy and the current library state.
 # Wired into check-static so stale artifacts fail CI.
+#
+# Release-PR carve-out (#957): on a PR whose head branch matches the
+# `release/v*` pattern set by cmd/release-tool, the cross-module
+# go.mod files pin yet-to-be-tagged versions (tag-all runs AFTER the
+# PR merges). `go run ./cmd/audit-gen` cannot resolve those modules,
+# so the check would always fail. The artefact itself does not
+# change during release-PR pinning (it depends only on the framework
+# taxonomy + audit-gen output, neither of which the release PR
+# touches), so skipping is safe. Non-release PRs still run the check
+# in full. See `docs/releasing.md` § Troubleshooting.
 .PHONY: regen-schema-artifacts-check
 regen-schema-artifacts-check:
-	@TMP=$$(mktemp -d); \
+	@if echo "$${GITHUB_HEAD_REF:-}" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+'; then \
+		echo "regen-schema-artifacts-check: skipping on release PR head ref $$GITHUB_HEAD_REF (#957)"; \
+		exit 0; \
+	fi; \
+	TMP=$$(mktemp -d); \
 	go run ./cmd/audit-gen -format json-schema \
 		-input internal/schemagen/framework_only_taxonomy.yaml \
 		-output "$$TMP/audit-event.framework.schema.json" >/dev/null && \
@@ -1184,8 +1198,19 @@ ta:
 # operator-facing file (the generator emits TA config files, not
 # documentation). A future change that DOES want the generator to
 # emit a README would have to drop this exclusion.
+#
+# Release-PR carve-out (#957): same rationale as
+# regen-schema-artifacts-check above. On a release/v* head ref, the
+# cross-module go.mod pinning blocks `go run ./cmd/audit-gen`. The
+# reference TA depends only on the reference TA taxonomy + audit-gen
+# output, neither of which the release PR touches, so skipping is
+# safe. The non-release path still runs the check.
 .PHONY: ta-diff-check
 ta-diff-check:
+	@if echo "$${GITHUB_HEAD_REF:-}" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+'; then \
+		echo "ta-diff-check: skipping on release PR head ref $$GITHUB_HEAD_REF (#957)"; \
+		exit 0; \
+	fi
 	@# Generate into a temp subdir named splunk-ta-axonops-audit so
 	@# the PackageID (derived from filepath.Base(outDir)) matches
 	@# the committed reference TA exactly. Without the canonical

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1159,6 +1159,43 @@ guards (`fmt-check`, `tidy-check`, `check-todos`, `check-replace`,
 surfaces on a single push rather than aborting on the first. Developers
 running `make check-static` locally see the same one-shot summary.
 
+### Release-PR carve-outs in `check-static` (#957)
+
+Two `check-static` targets — `regen-schema-artifacts-check` and
+`ta-diff-check` — shell out to `go run ./cmd/audit-gen`, which has
+to resolve every published sub-module from `go.mod`. On a release
+PR, the `update-deps.sh` step pins every cross-module `go.mod` to
+the not-yet-tagged target version (`tag-all` runs AFTER the PR
+merges), so the resolution fails with
+`unknown revision splunk/vX.Y.Z` and CI cannot pass without
+admin-bypass.
+
+Both targets carve out the release-PR head ref via the
+`GITHUB_HEAD_REF` env var: if the value matches
+`release/v<semver>`, the target prints a `skipping on release PR
+head ref ...` line and exits 0. Outside that match — including
+when the variable is unset (local development, push events,
+workflow_dispatch on a non-PR ref) — the targets run the full
+check. The neighbouring `SKIP_TIDY_CHECK=1` carve-out described
+above uses the same pattern. The carve-outs are tested by
+[`tests/release-scripts/check-static-release-pr-tolerant.bats`][bats-carve-out];
+removing them MUST be paired with restoring the upstream blocker
+they paper over.
+
+The release-PR carve-out is structurally safe: neither artefact's
+input depends on the cross-module `go.mod` pins. The framework
+schema + CEF template are produced from
+`internal/schemagen/framework_only_taxonomy.yaml` + audit-gen
+output; the reference TA is produced from
+`internal/schemagen/reference_ta_taxonomy.yaml` + audit-gen
+output. Neither input is mutated by a release PR, so a stale
+artefact cannot land via the release path. The post-merge
+`invariants` job in [`release.yml`][release-yml] re-runs the same
+`check-static` against the tagged commit, which is the
+authoritative gate.
+
+[bats-carve-out]: ../tests/release-scripts/check-static-release-pr-tolerant.bats
+
 The CI setup ceremony (Go install, workspace init, optional tool
 install) lives in `.github/actions/setup-audit/` as a composite
 action — every job consumes it via `uses: ./.github/actions/setup-audit`.

--- a/tests/release-scripts/README.md
+++ b/tests/release-scripts/README.md
@@ -27,11 +27,14 @@ scaffolding.
 | **Total** | — | **44** |
 
 Plus three meta-tests for the fixture stub binaries
-(`fixtures/bin/{go,git,make}`), 24 grep-based regression tests for
-`.github/workflows/release.yml` + the composite action at
-`.github/actions/build-release-tool/`, and 4 behavioural CLI flag
-validity tests (`cli-flag-validity.bats`, #960) that invoke the
-real gh / goreleaser / cosign tools. **Total: 87 tests.**
+(`fixtures/bin/{go,git,make}`), grep-based regression tests for
+`.github/workflows/release.yml` + `.github/workflows/goreleaser.yml`
++ the composite action at `.github/actions/build-release-tool/`,
+4 behavioural CLI flag validity tests (`cli-flag-validity.bats`,
+#960) that invoke the real gh / goreleaser / cosign tools, and 12
+release-PR carve-out tests for the `regen-schema-artifacts-check`
++ `ta-diff-check` Makefile targets (#957). Run
+`make test-release-scripts` for the current count.
 
 ## What is **not** covered
 
@@ -52,6 +55,8 @@ real gh / goreleaser / cosign tools. **Total: 87 tests.**
   `Test - Release Scripts` job installs goreleaser + cosign at the
   same SHA-pinned versions goreleaser.yml uses, so the harness
   exercises the real surface.
+- Makefile carve-out for release PR heads — covered by
+  `tests/release-scripts/check-static-release-pr-tolerant.bats`.
 
 ## Running locally
 

--- a/tests/release-scripts/check-static-release-pr-tolerant.bats
+++ b/tests/release-scripts/check-static-release-pr-tolerant.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# Copyright 2026 AxonOps Limited.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verifies the release-PR carve-out (#957) on the Makefile targets
+# `regen-schema-artifacts-check` and `ta-diff-check`. Both targets
+# shell out to `go run ./cmd/audit-gen`, which needs to resolve every
+# published sub-module's go.mod. On a release/v* head ref the
+# cross-module pins point at yet-to-be-tagged versions, so the check
+# is intentionally skipped — but the protection must remain in force
+# for every non-release branch.
+#
+# Each test sets / unsets GITHUB_HEAD_REF and asserts the target's
+# observable behaviour on stdout + exit code. The target is invoked
+# at the real repo (REPO_ROOT) — no fixture binaries are needed
+# because the guard runs BEFORE any go command and the check exits
+# 0 cleanly on the skip branch.
+
+load 'test_helper.bash'
+
+setup() {
+    # Make targets always inherit the caller's PATH; no stubs needed
+    # because the carve-out short-circuits before any go invocation.
+    cd "$REPO_ROOT"
+}
+
+# --- regen-schema-artifacts-check ---------------------------------
+
+@test "test_regen_schema_artifacts_check_skips_on_release_v_head_ref" {
+    GITHUB_HEAD_REF=release/v0.2.3 run make -s regen-schema-artifacts-check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"regen-schema-artifacts-check: skipping on release PR head ref release/v0.2.3 (#957)"* ]]
+}
+
+@test "test_regen_schema_artifacts_check_skips_on_release_prerelease_head_ref" {
+    GITHUB_HEAD_REF=release/v1.0.0-rc.1 run make -s regen-schema-artifacts-check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping on release PR head ref release/v1.0.0-rc.1"* ]]
+}
+
+@test "test_regen_schema_artifacts_check_runs_on_unset_head_ref" {
+    # Unset GITHUB_HEAD_REF (the GHA value on push, on dispatch,
+    # or in a local invocation). The target must run the full check.
+    unset GITHUB_HEAD_REF
+    run make -s regen-schema-artifacts-check
+    [ "$status" -eq 0 ]
+    # No skip line in the output — the check ran in full.
+    [[ "$output" != *"skipping on release PR head ref"* ]]
+}
+
+@test "test_regen_schema_artifacts_check_runs_on_feature_head_ref" {
+    GITHUB_HEAD_REF=feature/foo run make -s regen-schema-artifacts-check
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"skipping on release PR head ref"* ]]
+}
+
+@test "test_regen_schema_artifacts_check_runs_on_release_prefix_collision" {
+    # Defence in depth: a branch named `release-foo` (legacy hyphen
+    # naming) MUST NOT skip — the regex requires a slash + semver.
+    GITHUB_HEAD_REF=release-foo run make -s regen-schema-artifacts-check
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"skipping on release PR head ref"* ]]
+}
+
+@test "test_regen_schema_artifacts_check_runs_on_release_non_semver_head_ref" {
+    # `release/foo` would be a non-versioned branch — also MUST NOT
+    # trip the skip path. The regex anchors on `release/v<semver>`.
+    GITHUB_HEAD_REF=release/foo run make -s regen-schema-artifacts-check
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"skipping on release PR head ref"* ]]
+}
+
+# --- ta-diff-check -------------------------------------------------
+
+@test "test_ta_diff_check_skips_on_release_v_head_ref" {
+    GITHUB_HEAD_REF=release/v0.2.3 run make -s ta-diff-check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ta-diff-check: skipping on release PR head ref release/v0.2.3 (#957)"* ]]
+}
+
+@test "test_ta_diff_check_skips_on_release_prerelease_head_ref" {
+    GITHUB_HEAD_REF=release/v1.0.0-rc.1 run make -s ta-diff-check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping on release PR head ref release/v1.0.0-rc.1"* ]]
+}
+
+@test "test_ta_diff_check_runs_on_unset_head_ref" {
+    unset GITHUB_HEAD_REF
+    run make -s ta-diff-check
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"skipping on release PR head ref"* ]]
+}
+
+@test "test_ta_diff_check_runs_on_feature_head_ref" {
+    GITHUB_HEAD_REF=feature/foo run make -s ta-diff-check
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"skipping on release PR head ref"* ]]
+}
+
+@test "test_ta_diff_check_runs_on_release_prefix_collision" {
+    GITHUB_HEAD_REF=release-foo run make -s ta-diff-check
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"skipping on release PR head ref"* ]]
+}
+
+@test "test_ta_diff_check_runs_on_release_non_semver_head_ref" {
+    GITHUB_HEAD_REF=release/foo run make -s ta-diff-check
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"skipping on release PR head ref"* ]]
+}


### PR DESCRIPTION
## Summary

- Adds a `GITHUB_HEAD_REF=release/v<semver>` carve-out to two `make check-static` targets — `regen-schema-artifacts-check` and `ta-diff-check` — that otherwise fail on every release PR with `unknown revision <module>/vX.Y.Z`.
- 12 new bats tests under `tests/release-scripts/check-static-release-pr-tolerant.bats` covering the skip path, the run path, and defence-in-depth negatives (`release-foo` hyphen collision, `release/foo` non-semver).
- `docs/releasing.md` § "Release-PR carve-outs in check-static" explains the rationale + why the skip is structurally safe.
- CHANGELOG `[Unreleased] / Fixed` entry.

## Why

v0.2.2 had to be admin-merged with required-check bypass for exactly this reason. The release PR pins every cross-module `go.mod` to the not-yet-tagged target version (`tag-all` runs AFTER the PR merges), so `go run ./cmd/audit-gen` cannot resolve the requires. Without this carve-out, every release PR fails the same way and the lightweight-tag downstream cascade (#950, #951, #952, #953, #954, #955) follows.

This mirrors the existing `tidy-check` carve-out documented under "Unified single-tag release flow" — both apply only when `GITHUB_HEAD_REF` matches the release-tool's branch pattern.

## Test plan

- [x] `make test-release-scripts` — 95/95 pass (12 new under `check-static-release-pr-tolerant.bats`).
- [x] `make regen-schema-artifacts-check` — runs full check when `GITHUB_HEAD_REF` is unset.
- [x] `GITHUB_HEAD_REF=release/v0.2.3 make regen-schema-artifacts-check` — prints skip line, exits 0.
- [x] `make check-skip-tidy-check-scope` — scope guard green.
- [x] `make lint` — 0 issues.
- [ ] CI green on this PR.

## Risk

- Carve-out is gated on `GITHUB_HEAD_REF` (only set by GHA on `pull_request` events) AND a semver-shaped `release/v<semver>` branch name. The release-tool is the only thing that creates such branches (`cmd/release-tool/cmd_commit_pinned_deps.go`).
- Structurally safe: both artefacts depend only on `internal/schemagen/*_taxonomy.yaml` + audit-gen output, neither of which the release PR touches. The post-merge `invariants` job in `release.yml` re-runs the same checks against the tagged commit (authoritative gate).
- Defence-in-depth tests verify `release-foo` (hyphen) and `release/foo` (non-semver) do NOT trip the skip path.

Closes #957.

Part of the v0.2.3 fix sequence: #953 → #960 → #957 → #956 → #958 → #959.