### PR TITLE
ci: add `if: always()` to goreleaser/verify/invariants (#956)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -838,6 +838,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [preflight, tag-all]
+    # #956 fix: without `always() && ...`, the implicit `all needs
+    # must succeed` gate treats the *skipped* update-deps-pr +
+    # wait-for-pr-merge jobs (push:tag path) as not-yet-success, so
+    # the whole downstream chain silently skips. v0.2.2's push:tag
+    # run 27181087721 hit exactly this — preflight succeeded,
+    # tag-all succeeded, but goreleaser / verify / invariants all
+    # skipped, leaving the release page empty until the goreleaser.yml
+    # manual rerun was dispatched. Explicit gate: run when this job's
+    # direct upstreams both passed, regardless of branches that were
+    # legitimately skipped for the chosen event_name.
+    if: |
+      always() &&
+      needs.preflight.result == 'success' &&
+      needs.tag-all.result == 'success'
     permissions:
       contents: write
       id-token: write
@@ -995,6 +1009,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [preflight, goreleaser]
+    # #956 fix: same rationale as goreleaser above. The implicit
+    # all-needs-succeed gate would silently skip this job on the
+    # push:tag path because the upstream workflow_dispatch-only
+    # jobs are skipped. Explicit gate keeps the recovery path
+    # self-contained.
+    if: |
+      always() &&
+      needs.preflight.result == 'success' &&
+      needs.goreleaser.result == 'success'
     permissions:
       contents: read
     env:
@@ -1106,6 +1129,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [preflight, tag-all, verify]
+    # #956 fix: same rationale as goreleaser/verify above. The
+    # final sanity check must run on every successful end-to-end
+    # release, not only when the workflow_dispatch upstreams ran.
+    if: |
+      always() &&
+      needs.preflight.result == 'success' &&
+      needs.tag-all.result == 'success' &&
+      needs.verify.result == 'success'
     permissions:
       contents: read
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `tests/release-scripts/check-static-release-pr-tolerant.bats`
   (12 named tests). v0.2.3's release PR can auto-merge without
   admin bypass.
+- **`push: tags: v*` recovery path is now self-contained (#956).** The
+  `goreleaser`, `verify`, and `invariants` jobs in
+  `.github/workflows/release.yml` now carry explicit
+  `if: always() && needs.X.result == 'success' && ...` gates over
+  their direct upstreams. Previously, the implicit "all needs must
+  succeed" gate treated the (legitimately skipped) workflow_dispatch-
+  only `update-deps-pr` + `wait-for-pr-merge` jobs as not-yet-success
+  on the push:tag path, causing the entire downstream chain to silently
+  skip. v0.2.2's push:tag run 27181087721 hit exactly this — recovery
+  created the tags but left the GitHub Release page empty until the
+  `goreleaser.yml` manual rerun was dispatched. Tested by three new
+  `tests/release-scripts/release-yml-grep.bats` assertions
+  (`test_release_yml_goreleaser_uses_if_always`,
+  `..._verify_uses_if_always`, `..._invariants_uses_if_always`).
 
 ## [0.2.2] - 2026-06-08
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -553,6 +553,17 @@ The two triggers serve different purposes:
   the same SHA, aborting on SHA mismatch), and runs GoReleaser. It does
   NOT open a release PR. See "Release recovery playbook" below.
 
+  **Self-contained since #956.** Before #956, the push:tag path reached
+  `tag-all` successfully but the downstream `goreleaser`, `verify`, and
+  `invariants` jobs silently skipped because their implicit "all needs
+  must succeed" gate treated the (legitimately skipped) `update-deps-pr`
+  + `wait-for-pr-merge` jobs as not-yet-success. v0.2.2's push:tag run
+  27181087721 hit exactly this — recovery created the tags but left the
+  GitHub Release page empty until the `goreleaser.yml` manual rerun was
+  dispatched. The three downstream jobs now carry explicit
+  `if: always() && needs.X.result == 'success' && ...` gates over their
+  direct upstreams, so push:tag is a real recovery path.
+
 The `release.yml` workflow uses the `axonops-audit-release-bot` GitHub App for
 every write operation; it does not consume a personal access token.
 

--- a/tests/release-scripts/release-yml-grep.bats
+++ b/tests/release-scripts/release-yml-grep.bats
@@ -285,3 +285,43 @@ setup() {
     grep -qF 'cache-dependency-path: cmd/release-tool/go.sum' "$ACTION"
     grep -qF 'go-version-file: cmd/release-tool/go.mod' "$ACTION"
 }
+
+# --- #956 — goreleaser/verify/invariants run on push:tag recovery ---
+
+@test "test_release_yml_goreleaser_uses_if_always" {
+    # #956 fix: without `always() && needs.X.result == 'success' && ...`
+    # the implicit "all needs must succeed" gate treats the *skipped*
+    # workflow_dispatch-only upstreams as not-yet-success on the
+    # push:tag path, so goreleaser silently skips. v0.2.2's push:tag
+    # run 27181087721 hit exactly this. Verify the goreleaser job's
+    # body contains `always() &&` and gates on preflight + tag-all.
+    body=$(awk '/^  goreleaser:/,/^  verify:/' "$RELEASE_YML")
+    echo "$body" | grep -qF 'always() &&'
+    echo "$body" | grep -qF "needs.preflight.result == 'success'"
+    echo "$body" | grep -qF "needs.tag-all.result == 'success'"
+}
+
+@test "test_release_yml_verify_uses_if_always" {
+    # Same rationale as goreleaser above (#956). The verify job
+    # gates on goreleaser succeeding; without `always() && ...` it
+    # cascade-skipped on the push:tag path.
+    body=$(awk '/^  verify:/,/^  invariants:/' "$RELEASE_YML")
+    echo "$body" | grep -qF 'always() &&'
+    echo "$body" | grep -qF "needs.preflight.result == 'success'"
+    echo "$body" | grep -qF "needs.goreleaser.result == 'success'"
+}
+
+@test "test_release_yml_invariants_uses_if_always" {
+    # The post-release sanity gate (#956). Must run on every
+    # successful end-to-end release, including push:tag recovery.
+    # Extract from `invariants:` to the next top-level job header
+    # (a line starting with two spaces then `[a-z]`-prefixed name).
+    body=$(awk '/^  invariants:/{p=1} p; p && NR > FNR{}' "$RELEASE_YML")
+    # If the file ends before another job appears, the awk slurp is
+    # bounded by EOF — which is fine here since invariants is the
+    # last job in the workflow.
+    echo "$body" | grep -qF 'always() &&'
+    echo "$body" | grep -qF "needs.preflight.result == 'success'"
+    echo "$body" | grep -qF "needs.tag-all.result == 'success'"
+    echo "$body" | grep -qF "needs.verify.result == 'success'"
+}


### PR DESCRIPTION
## Summary

- Adds explicit `if: always() && needs.X.result == 'success' && ...` gates to the `goreleaser`, `verify`, and `invariants` jobs in `.github/workflows/release.yml`.
- Three new `tests/release-scripts/release-yml-grep.bats` assertions lock the pattern in place.
- `docs/releasing.md` push:tag recovery-path note.
- CHANGELOG `[Unreleased] / Fixed` entry.

## Why

v0.2.2 push:tag run 27181087721 reached `tag-all` successfully but the downstream `goreleaser` / `verify` / `invariants` jobs silently skipped. The implicit "all needs must succeed" gate treated the (legitimately skipped) workflow_dispatch-only `update-deps-pr` + `wait-for-pr-merge` jobs as not-yet-success on the push:tag path, so the entire chain cascaded into skip-no-error. Result: empty GitHub Release page until `goreleaser.yml` was manually dispatched.

The fix mirrors the pattern already proven in `tag-all` (#929): each job gates on `always()` plus its direct upstreams' `result == 'success'`. The push:tag recovery path now finishes end-to-end without a follow-up dispatch.

## Test plan

- [x] `make test-release-scripts` — 86/86 pass (3 new under `release-yml-grep.bats`).
- [x] `make release-check` — goreleaser config validation passes.
- [x] `make lint` — 0 issues.
- [ ] CI green on this PR.
- [ ] (Verified at v0.2.3 dispatch) push:tag recovery path completes all three downstream jobs without manual `goreleaser.yml` rerun.

## Risk

- Pure workflow-conditional addition. Each `if:` clause is strictly *more* restrictive than the implicit gate (still requires upstream success), so it cannot run a job that wouldn't have run before — it only prevents the spurious cascade-skip.
- The bats grep tests pin the pattern; removing `always() &&` from any of the three jobs trips a named regression.
- Independent of #953 and #957 (no overlap with their changes); can merge in any order.

Closes #956.

Part of the v0.2.3 fix sequence: #953 → #960 → #957 → #956 → #958 → #959.