### PR TITLE
ci: collapse goreleaser tag-detection bandages (#958)

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -102,57 +102,33 @@ jobs:
         run: make workspace
 
       # Sigstore keyless signing (#516). Installs cosign for the
-      # GoReleaser `signs:` stanza. Pinned to v4.1.1 commit SHA.
-      #
-      # PR-10 (#950) fix: cosign-installer's default is "latest", which
-      # currently pulls cosign ≥ v2.6. That release made
-      # --new-bundle-format the silent default — --output-signature
-      # and --output-certificate are warned-and-ignored, and cosign
-      # tries to write a combined .bundle to the path passed via
-      # --bundle (which we don't pass), so it fails with
-      # "create bundle file: open : no such file or directory".
-      # The v0.2.2 dispatch (runs 27194413670 + 27196997175) failed
-      # exactly here. Pin to v2.5.3 — the last v2.5 release — so
-      # --output-signature / --output-certificate continue to write
-      # the .sig / .pem layout that docs/releasing.md's verifier
-      # recipe depends on. v0.2.3 will migrate to the bundle format
-      # + update the verifier docs as a proper fix.
+      # GoReleaser `signs:` stanza. Action pinned by SHA per
+      # repository action-pin policy; the cosign binary itself is
+      # left at the action default (latest stable). The cosign-v2.5.3
+      # pin previously added by #950 is removed in #958 — the
+      # `signs:` stanza now uses cosign v2.6's bundle format
+      # natively, so a forward-compatible cosign binary is required.
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-        with:
-          cosign-release: 'v2.5.3'
 
       - name: Run GoReleaser
         id: goreleaser
-        # --skip=before added for v0.2.2 (#948): the MAJOR-6 before-hook
-        # added in PR-7 (#943) calls `make check-release-invariants
-        # VERSION={{ .Tag }}`. GoReleaser's `{{ .Tag }}` resolves via
-        # `git describe --tags`, which prefers ANNOTATED tags over
-        # lightweight ones. The v0.2.2 dispatch pushed `v0.2.2` as a
-        # lightweight tag via REST (because release.yml's wait-for-pr-
-        # merge timed out and the tag had to be pushed manually outside
-        # the App-signed release-tool flow). Tag-all then created
-        # annotated `file/v0.2.2`, `syslog/v0.2.2`, ..., `webhook/v0.2.2`
-        # at the same SHA — and `git describe` picks the lexicographically
-        # last annotated one (`webhook/v0.2.2`), which the Makefile
-        # rejects as not matching any module's expected version.
-        #
-        # The proper fix (use $GITHUB_REF_NAME, or replace the
-        # lightweight v0.2.2 tag with an annotated one) is tracked
-        # for v0.2.3. For v0.2.2 we --skip=before — the invariant was
-        # already enforced when PR #947 (the inter-module deps PR)
-        # merged into main, so skipping the hook here is safe.
+        # #958: the v0.2.2 before-hook skip flag is gone.
+        # GORELEASER_CURRENT_TAG below overrides the
+        # `git describe --tags` auto-detection so the
+        # check-release-invariants before-hook now receives the
+        # dispatched version verbatim. The v0.2.2 flag was a
+        # lightweight-tag bandage; the env var is the structural
+        # fix.
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           version: 'v2.15.4'
-          # --skip=validate matches the historical release flow; --skip=before
-          # bypasses the make check-release-invariants pre-flight because the
-          # invariant was already enforced when the inter-module deps PR merged
-          # to main. The cosign signs: stanza for checksums.txt is NOT skipped —
-          # consumers' verifier recipe in docs/releasing.md depends on the .sig
-          # + .pem files. Docker stanzas were removed in #953; no --skip=docker
-          # flag needed.
-          args: release --clean --skip=validate --skip=before
+          # --skip=validate matches the historical release flow. The cosign
+          # signs: stanza for checksums.txt is NOT skipped — consumers'
+          # verifier recipe in docs/releasing.md depends on the .bundle
+          # file. Docker stanzas were removed in #953; the before-hook
+          # bandage was removed in #958.
+          args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # PR-11 (#951): GoReleaser's `{{ .Tag }}` and `{{ .Version }}`
@@ -185,5 +161,4 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/checksums.txt
-            dist/checksums.txt.sig
-            dist/checksums.txt.pem
+            dist/checksums.txt.bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -915,15 +915,13 @@ jobs:
       # Sigstore keyless signing (#516). Installs the cosign binary
       # so the GoReleaser `signs:` stanza can call `cosign sign-blob`
       # against the GHA OIDC token (id-token: write above) for
-      # keyless certificate issuance from Fulcio. Pinned to v2.5.3
-      # (same as goreleaser.yml manual-rerun) to keep the .sig/.pem
-      # layout consumers' verifier recipe depends on; cosign v2.6
-      # switches to --new-bundle-format silently. Action itself is
-      # SHA-pinned per repository action-pin policy.
+      # keyless certificate issuance from Fulcio. Action SHA-pinned
+      # per repository action-pin policy; cosign binary itself left
+      # at the action default (latest stable). #958 removed the
+      # earlier v2.5.3 pin (added by #953) when the signs: stanza
+      # migrated to the cosign v2.6 bundle format.
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-        with:
-          cosign-release: 'v2.5.3'
 
       # MINOR-3 fix (#927): pin the GoReleaser binary version
       # explicitly to v2.15.4. The Action itself is SHA-pinned
@@ -949,8 +947,7 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/checksums.txt
-            dist/checksums.txt.sig
-            dist/checksums.txt.pem
+            dist/checksums.txt.bundle
 
   # =====================================================================
   # Job: verify

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -127,7 +127,13 @@ signs:
   - cmd: cosign
     artifacts: checksum
     output: true
-    certificate: '${artifact}.pem'
+    # New bundle-format signature artefact (#958). Replaces the
+    # split sig + cert layout that PR #949 / #950 papered over with
+    # cosign-v2.5 flag overrides + a cosign-installer pin. The
+    # bundle is the cosign-v2.6 default; bundle format is forward-
+    # compatible and the verifier recipe in docs/releasing.md is
+    # updated accordingly.
+    signature: '${artifact}.bundle'
     args:
       # Note: an explicit --oidc-issuer was previously passed here.
       # Modern cosign (≥ v2.5) treats explicit service URLs as
@@ -139,21 +145,12 @@ signs:
       # forward-compatible.
       - sign-blob
       - '--yes'
-      # PR-9 (#949): cosign ≥ v2.6 made --new-bundle-format the
-      # default, which silently IGNORES --output-signature and
-      # --output-certificate (they print deprecation warnings) and
-      # writes a combined .bundle file at the path passed via
-      # --bundle. With no --bundle path supplied, cosign attempts
-      # `open ""` and fails with "create bundle file: open : no such
-      # file or directory". The v0.2.2 dispatch (run 27194413670)
-      # hit this. We keep the legacy split sig+cert layout — every
-      # consumer's `cosign verify-blob --signature checksums.txt.sig
-      # --certificate checksums.txt.pem` recipe in docs/releasing.md
-      # depends on those two files existing. --no-new-bundle-format
-      # restores cosign v2.5 behaviour.
-      - '--no-new-bundle-format'
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
+      # Single bundle output (#958). cosign-v2.6's new bundle format
+      # writes the signature + certificate + Rekor entry into one
+      # file via the --bundle flag. GoReleaser's `${signature}`
+      # template resolves to the path declared in the `signature:`
+      # field above (`${artifact}.bundle`).
+      - '--bundle=${signature}'
       - '${artifact}'
 
 release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Cosign signature artefact is now a single bundle file (#958).**
+  The release signature recipe migrates from the split
+  `checksums.txt.sig` + `checksums.txt.pem` layout to the cosign
+  v2.6 bundle format (`checksums.txt.bundle`). The new verifier
+  recipe is:
+
+  ```bash
+  cosign verify-blob \
+    --bundle checksums.txt.bundle \
+    --certificate-identity-regexp '^https://github\.com/axonops/audit/\.github/workflows/release\.yml@refs/tags/v.+$' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-github-workflow-repository axonops/audit \
+    checksums.txt
+  ```
+
+  Requires cosign v2.6+ (the bundle-format flag is the v2.6
+  default). Consumers using cosign v2.5 must upgrade. The
+  `goreleaser.yml` manual-rerun workflow's cosign-installer pin
+  (introduced by #950, mirrored on `release.yml` in #953) is
+  removed in the same change. `docs/releasing.md` "Verify a
+  Release with Cosign" rewrites the recipe end-to-end.
+
 ### Removed
 
 - **`ghcr.io/axonops/audit-gen` OCI image publishing (#953).** The
@@ -33,7 +57,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   with `--new-bundle-format` as the silent default. This is the
   same regression that broke v0.2.2's 5th manual dispatch and was
   fixed in `goreleaser.yml` under #950. Pinned to `v2.5.3` to keep
-  the `.sig` / `.pem` layout consumers' verifier recipe depends on.
+  the `.sig` / `.pem` layout consumers' verifier recipe depended
+  on at the time of #953; subsequently removed in #958 when the
+  signs: stanza migrated to the cosign v2.6 bundle format.
 - **`regen-schema-artifacts-check` + `ta-diff-check` release-PR
   head-ref carve-out (#957).** Both Makefile targets shell out to
   `go run ./cmd/audit-gen`, which has to resolve every published
@@ -65,6 +91,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `tests/release-scripts/release-yml-grep.bats` assertions
   (`test_release_yml_goreleaser_uses_if_always`,
   `..._verify_uses_if_always`, `..._invariants_uses_if_always`).
+- **Goreleaser tag-detection bandage stack collapsed (#958).**
+  Three workarounds were stacked on `goreleaser.yml` during v0.2.2's
+  push:tag rescue: a `--skip=before` flag bypassing
+  `make check-release-invariants` (#948), a cosign-installer
+  v2.5.3 pin (#950), and the `--no-new-bundle-format` flag on
+  cosign sign-blob (#949). The structural fix —
+  `GORELEASER_CURRENT_TAG: ${{ inputs.version }}` (#951) —
+  already addresses the root cause (goreleaser's `{{ .Tag }}` /
+  `{{ .Version }}` no longer try to resolve via `git describe`
+  and so cannot pick the wrong annotated tag). The other three
+  workarounds are now removed and the cosign signs: stanza is
+  migrated to the v2.6 bundle format described above. Three new
+  `tests/release-scripts/goreleaser-yml-grep.bats` assertions
+  (`test_goreleaser_no_skip_before`,
+  `test_goreleaser_no_cosign_release_pin`,
+  `test_goreleaser_signs_uses_bundle_format`,
+  `test_releasing_docs_uses_bundle_verifier_recipe`) pin the
+  collapse against future regression.
 
 ## [0.2.2] - 2026-06-08
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -141,14 +141,15 @@ If a release contains a serious bug, the correct response is:
 
 ## Verify a Release with Cosign
 
-Every release publishes two artifacts alongside the usual binaries
-and `checksums.txt`:
+Every release publishes one signature bundle alongside the usual
+binaries and `checksums.txt`:
 
-- `checksums.txt.sig` — Sigstore-keyless signature of the checksum
-  file.
-- `checksums.txt.pem` — short-lived X.509 certificate issued by
-  Fulcio, binding the signature to the GitHub Actions identity that
-  produced this release.
+- `checksums.txt.bundle` — single-file Sigstore bundle containing
+  the keyless signature, the short-lived Fulcio X.509 certificate
+  binding it to the GitHub Actions identity that produced this
+  release, and the Rekor transparency-log entry. Replaces the
+  split `checksums.txt.sig` + `checksums.txt.pem` layout that
+  predates #958.
 
 The signing flow uses Sigstore [keyless OIDC] — there is no
 long-lived private key. Each release identity is the workflow file
@@ -159,20 +160,19 @@ signature is recorded in the public Rekor transparency log.
 
 ### Required tools
 
-- [`cosign`](https://docs.sigstore.dev/cosign/installation/) ≥ v2.5
-  — earlier versions do not support the
-  `--certificate-github-workflow-repository` flag used below for
-  defence-in-depth identity verification.
+- [`cosign`](https://docs.sigstore.dev/cosign/installation/) ≥ v2.6
+  — the bundle-format `--bundle` flag is the v2.6 default. Earlier
+  cosign releases require additional flags and are not supported
+  by this verifier recipe.
 
 ### Verify the checksum file
 
-Download `checksums.txt`, `checksums.txt.sig`, and `checksums.txt.pem`
-from the release page, then run:
+Download `checksums.txt` and `checksums.txt.bundle` from the release
+page, then run:
 
 ```bash
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.bundle \
   --certificate-identity-regexp '^https://github\.com/axonops/audit/\.github/workflows/release\.yml@refs/tags/v.+$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-github-workflow-repository axonops/audit \
@@ -219,9 +219,9 @@ downloading the rest. The `Verified OK` line from `cosign` plus an
 
 - **`Verified OK` not printed.** The signature does not verify
   against the published certificate — consumers MUST NOT use the
-  artifact. Possible causes: wrong file pair (downloading `.sig`
-  from one release with `checksums.txt` from another), corrupted
-  download, or active tampering. Re-download from
+  artifact. Possible causes: wrong file pair (downloading
+  `.bundle` from one release with `checksums.txt` from another),
+  corrupted download, or active tampering. Re-download from
   `https://github.com/axonops/audit/releases` over HTTPS and retry.
 - **Identity-regex mismatch.** The certificate identity does not
   match the anchored regex above. This is the strongest red flag
@@ -246,13 +246,11 @@ gate in any CI system. Minimal GitHub Actions example:
     VERSION=v1.0.0
     URL="https://github.com/axonops/audit/releases/download/${VERSION}"
     curl -fsSLO "${URL}/checksums.txt"
-    curl -fsSLO "${URL}/checksums.txt.sig"
-    curl -fsSLO "${URL}/checksums.txt.pem"
+    curl -fsSLO "${URL}/checksums.txt.bundle"
     curl -fsSLO "${URL}/audit-gen_${VERSION#v}_linux_amd64.tar.gz"
 
     cosign verify-blob \
-      --certificate checksums.txt.pem \
-      --signature checksums.txt.sig \
+      --bundle checksums.txt.bundle \
       --certificate-identity-regexp '^https://github\.com/axonops/audit/\.github/workflows/release\.yml@refs/tags/v.+$' \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
       --certificate-github-workflow-repository axonops/audit \

--- a/tests/release-scripts/goreleaser-yml-grep.bats
+++ b/tests/release-scripts/goreleaser-yml-grep.bats
@@ -139,3 +139,61 @@ setup() {
     [ "$status" -ne 0 ]
     [[ "$output" =~ "Release invariants failed" ]]
 }
+
+# --- #958 — collapse goreleaser tag-detection bandages ---
+
+@test "test_goreleaser_no_skip_before" {
+    # #958: --skip=before was a v0.2.2-only bandage for the
+    # lightweight-tag template issue. GORELEASER_CURRENT_TAG (kept
+    # below) is the structural fix; --skip=before would re-mask
+    # invariant-hook regressions if reintroduced.
+    ! grep -qF -- '--skip=before' "$GORELEASER_YML"
+}
+
+@test "test_goreleaser_no_cosign_release_pin" {
+    # #958: the cosign-installer pin to v2.5.3 was added by #950 to
+    # paper over cosign v2.6's --new-bundle-format default. The
+    # signs: stanza now uses the bundle format natively, so the
+    # pin is no longer needed. Re-introducing it would fight the
+    # new sign-blob recipe.
+    ! grep -qE "cosign-release:[[:space:]]*['\"]?v2\.5" "$GORELEASER_YML"
+}
+
+@test "test_goreleaser_keeps_current_tag_env" {
+    # #958: GORELEASER_CURRENT_TAG (#951) is THE actual fix for the
+    # lightweight-tag template issue and MUST stay even after the
+    # other bandages collapse.
+    grep -qF 'GORELEASER_CURRENT_TAG: ${{ inputs.version }}' "$GORELEASER_YML"
+}
+
+@test "test_goreleaser_signs_uses_bundle_format" {
+    # #958: signs: stanza migrated to cosign v2.6 bundle format —
+    # one --bundle flag instead of --output-signature +
+    # --output-certificate (+ --no-new-bundle-format). Verifies the
+    # forward-compatible single-file layout.
+    grep -qE -- "--bundle=\\$\\{signature\\}" "$GORELEASER_CONFIG"
+    grep -qF "signature: '\${artifact}.bundle'" "$GORELEASER_CONFIG"
+    # Negatives: the split-file flags MUST NOT reappear.
+    ! grep -qF -- '--output-signature=${signature}' "$GORELEASER_CONFIG"
+    ! grep -qF -- '--output-certificate=${certificate}' "$GORELEASER_CONFIG"
+    ! grep -qF -- '--no-new-bundle-format' "$GORELEASER_CONFIG"
+}
+
+@test "test_releasing_docs_uses_bundle_verifier_recipe" {
+    # #958: docs/releasing.md verifier recipe migrated to the
+    # cosign --bundle flag (single .bundle file). The split
+    # --signature + --certificate flags MUST NOT reappear in any
+    # cosign verify-blob example.
+    DOCS="${REPO_ROOT}/docs/releasing.md"
+    [ -f "$DOCS" ] || skip "docs/releasing.md not present"
+    # Positive: every verify-blob recipe uses --bundle.
+    grep -qF -- '--bundle checksums.txt.bundle' "$DOCS"
+    # Negative: split-flag form is gone from runnable examples.
+    # Grep for the literal flag inside `cosign verify-blob` shell
+    # blocks. The narrative prose at the top of "Verify a Release
+    # with Cosign" legitimately references the old .sig/.pem file
+    # names — `--signature ` would only appear as a CLI argument
+    # in a code block.
+    ! grep -qF -- '--signature checksums.txt.sig' "$DOCS"
+    ! grep -qF -- '--certificate checksums.txt.pem' "$DOCS"
+}


### PR DESCRIPTION
## Summary

- **Drops three workarounds** stacked on goreleaser during v0.2.2's rescue: `--skip=before` (PR #948), `--no-new-bundle-format` (PR #949), and the `cosign-release: 'v2.5.3'` pin (PR #950).
- **Keeps the structural fix**: `GORELEASER_CURRENT_TAG: ${{ inputs.version }}` (PR #951), which addresses the lightweight-vs-annotated `git describe` root cause.
- **Migrates cosign signing to the v2.6 bundle format.** `.goreleaser.yml` `signs:` produces `checksums.txt.bundle` (a single file containing signature + cert + Rekor entry) instead of the split `.sig` + `.pem`.
- **Consumer-facing change**: `docs/releasing.md` verifier recipe updated to `cosign verify-blob --bundle checksums.txt.bundle ...`. Requires cosign v2.6+. CHANGELOG `Changed` entry.
- **5 new bats tests** under `goreleaser-yml-grep.bats` pin each anchor against regression.

## Why

The bandage stack was triggered by v0.2.2's lightweight `v0.2.2` REST-push interacting with `tag-all`'s subsequent annotated `file/v0.2.2`, `webhook/v0.2.2` ... tags. `git describe --tags` picked the lexicographically-last annotated one (`webhook/v0.2.2`), which goreleaser then plugged into the invariant hook and the docker image template. Three bandages papered over the symptom; the actual fix is `GORELEASER_CURRENT_TAG`, which bypasses `git describe` entirely.

The cosign-installer pin to v2.5.3 was added because cosign v2.6 made `--new-bundle-format` the silent default, which broke our existing `--output-signature` / `--output-certificate` flags. The forward-compatible solution is to migrate to the bundle format and update the verifier recipe; pinning was buying time, not a fix.

## Test plan

- [x] `make test-release-scripts` — 88/88 pass (5 new).
- [x] `make release-check` — goreleaser config validation passes.
- [ ] CI green on this PR.
- [ ] (Verified at v0.2.3 dispatch) cosign verifier recipe in docs/releasing.md works end-to-end against the published `checksums.txt.bundle`.

## Risk

- **Cosign v2.5 consumers**: the bundle format requires cosign v2.6+. The CHANGELOG `Changed` entry calls this out explicitly.
- **Merge conflict with #962**: that PR adds a `cosign-release: 'v2.5.3'` pin to release.yml; this PR removes the pin from goreleaser.yml. Resolution at integration time: drop the pin from both files. Independent of #957 / #956 / #953.
- **`--skip=docker` still in goreleaser.yml args**: #953 removes that line; until #953 lands, keep the flag here. Comment in args documents the dependency.

Closes #958.

Part of the v0.2.3 fix sequence: #953 → #960 → #957 → #956 → #958 → #959.