### PR TITLE
ci: add post-release auto-tidy job (#959)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1155,6 +1155,124 @@ jobs:
         run: make check-release-invariants VERSION="$PUBLISH_VERSION"
 
   # =====================================================================
+  # Job: post-release-tidy (#959)
+  # =====================================================================
+  # After tag-all publishes the v* tags, `go mod tidy` against every
+  # sub-module's go.mod produces a diff: proxy.golang.org now resolves
+  # the just-published `github.com/axonops/audit vX.Y.Z` and fills in
+  # the corresponding go.sum entries. Before the tag was published,
+  # tidy could not download the version and so could not write the
+  # checksum line. The result: main's Hygiene job's `tidy-check` fails
+  # IMMEDIATELY post-release until a maintainer hand-tidies and pushes
+  # a commit. Every fix PR after v0.2.2 (#948-#955) had to be
+  # admin-merged for this reason.
+  #
+  # This job runs tidy against the just-tagged commit, App-signs the
+  # diff via release-tool commit-pinned-deps (the allowlist already
+  # covers go.mod + go.sum), and opens an auto-merge PR. If tidy
+  # produces no diff the job exits 0 with a log — there is no
+  # post-release drift to absorb on minor-version-bump releases that
+  # only touch already-released module pins.
+  # =====================================================================
+  post-release-tidy:
+    name: Post-release go.sum refresh
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [preflight, tag-all, invariants]
+    # #956 pattern — explicit gate over the direct upstreams so the
+    # push:tag recovery path runs this step too.
+    if: |
+      always() &&
+      needs.preflight.result == 'success' &&
+      needs.tag-all.result == 'success' &&
+      needs.invariants.result == 'success'
+    permissions:
+      contents: read  # App token grants the writes
+    steps:
+      - name: Mint release-bot App token
+        id: app
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v2.1.4
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.app.outputs.token }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build release-tool
+        uses: ./.github/actions/build-release-tool
+
+      - name: Run make tidy
+        # Refresh every published module's go.sum against the just-
+        # tagged version. The Makefile's tidy target shells out to
+        # `go mod tidy` per module (per PUBLISH_MODULES).
+        run: make tidy
+
+      - name: Commit and open auto-merge PR if diff
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PUBLISH_VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet HEAD --; then
+            echo "::notice::make tidy produced no diff — no post-release drift to absorb."
+            exit 0
+          fi
+          BRANCH="chore/post-release-tidy-${PUBLISH_VERSION}"
+          # Recreate the branch idempotently — a previous failed run
+          # may have left a stale branch + open PR. Mirrors the
+          # release-prep PR job's pattern (#927 BLOCKER-F, BLOCKER-D).
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Stale branch $BRANCH exists on origin — closing any open PRs and deleting."
+            stale_prs_file="$(mktemp)"
+            trap 'rm -f "$stale_prs_file"' RETURN
+            gh pr list --head "$BRANCH" --state open --json number --jq '.[].number' \
+              > "$stale_prs_file"
+            while IFS= read -r pr; do
+              [[ -z "$pr" ]] && continue
+              echo "  closing stale PR #$pr"
+              gh pr close "$pr" --delete-branch=false --comment "Superseded by re-run of release workflow."
+            done < "$stale_prs_file"
+            git push origin --delete "$BRANCH"
+          fi
+          git add -A
+          # App-signed commit via release-tool's existing
+          # commit-pinned-deps subcommand — its file allowlist already
+          # covers go.mod + go.sum, which is exactly the post-tidy
+          # diff surface. Reusing the binary avoids a parallel
+          # commit-and-sign code path.
+          "$RELEASE_TOOL" commit-pinned-deps \
+            --owner "${{ github.repository_owner }}" \
+            --repo "${{ github.event.repository.name }}" \
+            --branch "$BRANCH" \
+            --message "chore: post-release go.sum refresh ($PUBLISH_VERSION)" \
+            --auto-create-branch
+          PR_URL=$(gh pr create \
+            --base main --head "$BRANCH" \
+            --title "chore: post-release go.sum refresh ($PUBLISH_VERSION)" \
+            --body "Automated post-release tidy (#959). go.sum entries for ${PUBLISH_VERSION} are now resolvable via proxy.golang.org; this PR commits the refreshed checksums so main's Hygiene tidy-check passes for the next release-prep PR.")
+          if ! [[ "$PR_URL" =~ ^https://github\.com/.+/pull/[0-9]+$ ]]; then
+            echo "::error::gh pr create returned an unexpected URL: $PR_URL"
+            exit 1
+          fi
+          NUM="${PR_URL##*/}"
+          if ! gh pr merge "$NUM" --auto --squash; then
+            echo "::error::gh pr merge --auto --squash refused PR #$NUM."
+            exit 1
+          fi
+          echo "::notice::Post-release tidy PR opened: $PR_URL"
+
+  # =====================================================================
   # Job: summary
   # =====================================================================
   summary:
@@ -1175,6 +1293,7 @@ jobs:
       - mutation-test-attach
       - verify
       - invariants
+      - post-release-tidy
     if: always()
     steps:
       - name: Checkout (for make print-publish-modules)
@@ -1216,6 +1335,7 @@ jobs:
             fi
             echo "| Verify | ${{ needs.verify.result }} |"
             echo "| Invariants | ${{ needs.invariants.result }} |"
+            echo "| Post-release Tidy | ${{ needs.post-release-tidy.result }} |"
             echo
             echo '### Modules'
             echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `test_goreleaser_signs_uses_bundle_format`,
   `test_releasing_docs_uses_bundle_verifier_recipe`) pin the
   collapse against future regression.
+- **Post-release auto-tidy job (#959).** After `tag-all` publishes
+  the v* tags, every sub-module's `go.sum` gains entries for the
+  just-published version (the proxy now resolves them). Without
+  intervention, main's Hygiene `tidy-check` fails immediately
+  post-release and every fix PR must be admin-merged until a
+  maintainer hand-tidies and pushes a commit. v0.2.2 illustrated
+  the failure mode end-to-end — PRs #948-#955 all failed Hygiene's
+  tidy-check on a post-release main. A new `post-release-tidy` job
+  in `release.yml` runs `make tidy` after `invariants`, App-signs
+  any diff via `release-tool commit-pinned-deps` (the existing
+  allowlist already covers go.mod + go.sum), and opens an
+  auto-merge PR titled `chore: post-release go.sum refresh
+  (vX.Y.Z)`. No-diff case exits cleanly. Tested by the new
+  `tests/release-scripts/release-yml-grep.bats`
+  `test_release_yml_post_release_tidy_step_exists` assertion.
 
 ## [0.2.2] - 2026-06-08
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -106,6 +106,27 @@ contributor-facing view of this invariant is documented in
 [release-yml]: ../.github/workflows/release.yml
 [update-deps-sh]: ../scripts/release/update-deps.sh
 
+### Post-release auto-tidy (#959)
+
+After `tag-all` publishes the v* tags, every sub-module's go.sum
+gains entries that did not exist before — `proxy.golang.org` can
+now resolve `github.com/axonops/audit vX.Y.Z` (which the
+release-prep PR's go.mod files pinned) and `go mod tidy` will
+write the corresponding checksum lines. Without intervention,
+main's Hygiene `tidy-check` job fails IMMEDIATELY post-release and
+every fix PR has to be admin-merged until a maintainer hand-tidies
+and pushes a commit. v0.2.2 was the case study: PRs #948–#955 all
+failed Hygiene's tidy-check on a post-release main.
+
+The `post-release-tidy` job in `release.yml` runs `make tidy` on
+main after `invariants` passes, App-signs the diff via the same
+`release-tool commit-pinned-deps` path the release-prep PR uses
+(the existing allowlist covers `go.mod` + `go.sum`, which is
+exactly the post-tidy diff surface), and opens an auto-merge PR
+titled `chore: post-release go.sum refresh (vX.Y.Z)`. If `make
+tidy` produces no diff (e.g. a release that only bumps an
+already-published module), the job exits 0 with a log.
+
 ### v0.x Stability Contract
 
 This library is pre-release (`v0.x`). The Go module system treats v0 the same

--- a/tests/release-scripts/release-yml-grep.bats
+++ b/tests/release-scripts/release-yml-grep.bats
@@ -315,13 +315,43 @@ setup() {
     # The post-release sanity gate (#956). Must run on every
     # successful end-to-end release, including push:tag recovery.
     # Extract from `invariants:` to the next top-level job header
-    # (a line starting with two spaces then `[a-z]`-prefixed name).
-    body=$(awk '/^  invariants:/{p=1} p; p && NR > FNR{}' "$RELEASE_YML")
-    # If the file ends before another job appears, the awk slurp is
-    # bounded by EOF — which is fine here since invariants is the
-    # last job in the workflow.
+    # (`post-release-tidy:` since #959 inserted the new job between
+    # invariants and summary).
+    body=$(awk '/^  invariants:/,/^  post-release-tidy:/' "$RELEASE_YML")
     echo "$body" | grep -qF 'always() &&'
     echo "$body" | grep -qF "needs.preflight.result == 'success'"
     echo "$body" | grep -qF "needs.tag-all.result == 'success'"
     echo "$body" | grep -qF "needs.verify.result == 'success'"
+}
+
+# --- #959 — post-release auto-tidy ---
+
+@test "test_release_yml_post_release_tidy_step_exists" {
+    # #959: after tag-all publishes the v* tags, every sub-module's
+    # go.sum gains entries for the just-published version. Without
+    # an auto-tidy step, main's Hygiene tidy-check fails IMMEDIATELY
+    # post-release and every fix PR has to be admin-merged. The job
+    # runs `make tidy` against main, App-signs the diff via
+    # release-tool commit-pinned-deps, and opens an auto-merge PR.
+    body=$(awk '/^  post-release-tidy:/,/^  summary:/' "$RELEASE_YML")
+    # Job name is the documented anchor for #959.
+    echo "$body" | grep -qF 'post-release-tidy:'
+    # The job must run `make tidy` (the actual fix step).
+    echo "$body" | grep -qF 'run: make tidy'
+    # No-diff path is a clean exit, not a failure.
+    echo "$body" | grep -qF 'no post-release drift to absorb'
+    # Uses the existing release-tool commit-pinned-deps subcommand —
+    # its allowlist already covers go.mod + go.sum, which is exactly
+    # the post-tidy diff surface.
+    echo "$body" | grep -qF 'commit-pinned-deps'
+    # Branch name pattern (#959 documented anchor).
+    echo "$body" | grep -qF 'chore/post-release-tidy-'
+    # #956 pattern — explicit always() gate so push:tag also runs
+    # this job.
+    echo "$body" | grep -qF 'always() &&'
+    echo "$body" | grep -qF "needs.invariants.result == 'success'"
+    # Summary table must list the new job's result.
+    grep -qF 'needs.post-release-tidy.result' "$RELEASE_YML"
+    # Summary `needs:` list must include post-release-tidy.
+    awk '/^  summary:/,/^[^[:space:]]/' "$RELEASE_YML" | grep -qE '^[[:space:]]+- post-release-tidy$'
 }


### PR DESCRIPTION
## Summary

- Adds a new `post-release-tidy` job to `.github/workflows/release.yml` that runs `make tidy` after `invariants`, App-signs any diff via `release-tool commit-pinned-deps`, and opens an auto-merge PR titled `chore: post-release go.sum refresh (vX.Y.Z)`.
- New `tests/release-scripts/release-yml-grep.bats` assertion pins the wiring.
- `docs/releasing.md` § "Post-release auto-tidy (#959)" explains the rationale.
- CHANGELOG `[Unreleased] / Fixed` entry.

## Why

After `tag-all` publishes the v* tags, every sub-module's `go.sum` gains entries that did not exist before — `proxy.golang.org` can now resolve `github.com/axonops/audit vX.Y.Z` (which the release-prep PR's `go.mod` files pinned) and `go mod tidy` writes the corresponding checksum lines. Without an auto-tidy step, main's Hygiene `tidy-check` fails IMMEDIATELY post-release and every subsequent PR has to be admin-merged.

v0.2.2 was the case study: PRs #948–#955 all failed Hygiene's `tidy-check` on a post-release main and required admin-bypass to merge. This was the secondary blocker behind every v0.2.2 fix shipping.

## Test plan

- [x] `make test-release-scripts` — 84/84 pass (1 new).
- [x] `make release-check` — goreleaser config validation passes.
- [ ] CI green on this PR.
- [ ] (Verified at v0.2.3 dispatch) the post-release-tidy job runs after invariants, opens the auto-merge PR, and main's Hygiene `tidy-check` is green for the very next PR.

## Risk

- **Reuses the existing `release-tool commit-pinned-deps` subcommand.** The binary's file allowlist already covers `go.mod` + `go.sum`, which is exactly the post-tidy diff surface. No new release-tool code path.
- **`always()` gate (#956 pattern)** so push:tag recovery runs this job too.
- **No-diff path exits 0** — releases that only bump already-published module pins skip cleanly.
- **Branch protection**: the App-signed commit lands on `chore/post-release-tidy-vX.Y.Z`; the auto-merge PR honours normal branch protection rules. No new bypass surface.
- **Depends on #956** (this PR's `always()` gate inherits the pattern). #956 must merge first or both can merge together — the conditional itself is structurally correct either way.

Closes #959.

Part of the v0.2.3 fix sequence: #953 → #960 → #957 → #956 → #958 → #959.