### PR TITLE
ci: preflight-tidy job — self-healing on go.sum drift (#967)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,16 @@ on:
         required: false
         type: number
         default: 45
+      # #967 escape hatch: when true, skips the preflight-tidy job
+      # entirely. Use ONLY when an independent investigation has
+      # confirmed go.sum drift is benign and sum.golang.org is
+      # known-unreachable; NEVER bypass on a gate-4 disagreement.
+      # Subject to a future actor-allowlist check (planned).
+      skip_preflight_tidy:
+        description: "Skip the #967 preflight-tidy gate. NEVER use on a sum.golang.org disagreement."
+        required: false
+        type: boolean
+        default: false
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -154,6 +164,222 @@ jobs:
           fi
 
   # =====================================================================
+  # Job: preflight-tidy (#967, workflow_dispatch only)
+  # =====================================================================
+  # Mirror of post-release-tidy (#959/#966) on the PRE-side of the
+  # release flow. v0.2.3's dispatch (run 27325930898) failed because
+  # main's go.sum carried v0.2.2's post-tag drift residue; #966's
+  # post-release-tidy only takes effect AFTER tag-all, so the FIRST
+  # release after a non-tidy state cannot self-heal without this
+  # mirror.
+  #
+  # The job:
+  #   1. Runs `make tidy` on a fresh checkout of main.
+  #   2. Validates the diff via `release-tool preflight-tidy-check`,
+  #      which enforces 6 NON-NEGOTIABLE safety gates (see #967):
+  #        - go.sum-only (no go.mod changes)
+  #        - additions only (no deletions)
+  #        - lines reference only published modules at the last-
+  #          released version
+  #        - sum.golang.org cross-check (transparency-log h1: match)
+  #        - auto-merge PR (never direct push)
+  #        - inputs.skip_preflight_tidy escape hatch
+  #   3. On a no-diff result, exits cleanly and the rest of the
+  #      release dispatch proceeds against main HEAD unchanged.
+  #   4. On a clean diff, App-signs the commit via
+  #      `release-tool commit-pinned-deps` (existing allowlist
+  #      covers go.mod + go.sum) and opens an auto-merge PR.
+  # =====================================================================
+  preflight-tidy:
+    name: Preflight Tidy (#967)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [preflight]
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read  # App token grants writes
+    steps:
+      - name: Short-circuit if skip_preflight_tidy=true
+        # #967 security-review MEDIUM-1: route untrusted-ish values
+        # (github.actor) through env so the bash interpolation is
+        # purely a string variable — never inline ${{ }} into the
+        # `run:` block.
+        env:
+          SKIP: ${{ inputs.skip_preflight_tidy }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if [ "$SKIP" = "true" ]; then
+            # AC #4 exact string — operator-readable signal.
+            echo "preflight-tidy: skipped via skip_preflight_tidy input"
+            echo "preflight-tidy: skipped via skip_preflight_tidy input" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::#967 preflight-tidy bypassed via skip_preflight_tidy input by $ACTOR"
+            # Emit GFM CAUTION admonition so the bypass surfaces
+            # prominently in the run UI (security-reviewer Q5).
+            {
+              echo ""
+              echo "> [!CAUTION]"
+              echo "> Preflight-tidy gate bypassed via \`skip_preflight_tidy=true\` by **$ACTOR**"
+              echo "> at \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\`."
+              echo "> This disables the #967 supply-chain checks for this release."
+              echo "> If this was NOT in response to a verified sum.golang.org outage, treat as a"
+              echo "> security incident and file accordingly."
+            } >> "$GITHUB_STEP_SUMMARY"
+            # Exit 0 — the `if` clause's gate ensures downstream
+            # jobs see this as "skipped", not "failed".
+            exit 0
+          fi
+
+      - name: Mint release-bot App token
+        if: inputs.skip_preflight_tidy != true
+        id: app
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v2.1.4
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout main
+        if: inputs.skip_preflight_tidy != true
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.app.outputs.token }}
+
+      - name: Set up Go
+        if: inputs.skip_preflight_tidy != true
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build release-tool
+        if: inputs.skip_preflight_tidy != true
+        uses: ./.github/actions/build-release-tool
+
+      - name: Resolve last-released version
+        if: inputs.skip_preflight_tidy != true
+        id: last
+        run: |
+          set -euo pipefail
+          # The last published core tag (sorted semver) — the
+          # version whose post-tag drift the preflight is absorbing.
+          LAST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [ -z "$LAST" ]; then
+            echo "::error::No previously-released v* tag found on origin — preflight-tidy needs a baseline"
+            exit 1
+          fi
+          echo "last_version=$LAST" >> "$GITHUB_OUTPUT"
+          echo "Last released version: $LAST"
+
+      - name: Run make tidy
+        if: inputs.skip_preflight_tidy != true
+        run: make tidy
+
+      - name: Run preflight-tidy-check (gates 1-4 + diff size cap)
+        if: inputs.skip_preflight_tidy != true
+        id: check
+        env:
+          PUBLISH_VERSION: ${{ needs.preflight.outputs.version }}
+          LAST_VERSION: ${{ steps.last.outputs.last_version }}
+        run: |
+          set -euo pipefail
+          # The released-version-shaped module path set the issue's
+          # gate 3 anchors against. Derive from
+          # `make print-publish-modules` so the workflow text
+          # contains no module list that can drift from the canonical
+          # Makefile source.
+          MODS=$(make -s --no-print-directory print-publish-modules \
+            | awk -F'|' '{ printf "%s%s", sep, $2; sep="," }')
+          if [ -z "$MODS" ]; then
+            echo "::error::make print-publish-modules returned empty list"
+            exit 1
+          fi
+          set +e
+          "$RELEASE_TOOL" preflight-tidy-check \
+            --workdir . \
+            --last-released-version "$LAST_VERSION" \
+            --published-modules "$MODS" \
+            --sumdb-endpoint https://sum.golang.org
+          rc=$?
+          set -e
+          # Pipe the captured stdout (which contains the AC #4
+          # exact strings on the abort paths) into the run summary.
+          {
+            echo "## preflight-tidy"
+            echo ""
+            echo "Exit code: $rc"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          case "$rc" in
+            0) echo "preflight-tidy: gates passed; diff is safe to commit" ;;
+            4) echo "preflight-tidy: no drift to absorb" ;;
+            *) exit "$rc" ;;
+          esac
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+      - name: Open auto-merge PR if diff present
+        if: inputs.skip_preflight_tidy != true && steps.check.outputs.rc == '0'
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PUBLISH_VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/preflight-tidy-${PUBLISH_VERSION}"
+          # Stale-branch cleanup (mirrors #966 / #927 BLOCKER-F).
+          # #967 review N1: RETURN trap only fires on function
+          # return, not on script exit. Use EXIT so the tempfile
+          # cleanup actually runs even when the script aborts.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            stale_prs_file="$(mktemp)"
+            trap 'rm -f "$stale_prs_file"' EXIT
+            gh pr list --head "$BRANCH" --state open --json number --jq '.[].number' \
+              > "$stale_prs_file"
+            while IFS= read -r pr; do
+              [[ -z "$pr" ]] && continue
+              gh pr close "$pr" --delete-branch=false \
+                --comment "Superseded by re-run of release workflow."
+            done < "$stale_prs_file"
+            git push origin --delete "$BRANCH"
+          fi
+          git add -A
+          "$RELEASE_TOOL" commit-pinned-deps \
+            --owner "${{ github.repository_owner }}" \
+            --repo "${{ github.event.repository.name }}" \
+            --branch "$BRANCH" \
+            --message "chore: preflight-tidy go.sum refresh (${PUBLISH_VERSION})" \
+            --auto-create-branch
+          PR_URL=$(gh pr create \
+            --base main --head "$BRANCH" \
+            --title "chore: preflight-tidy go.sum refresh (${PUBLISH_VERSION})" \
+            --body "Automated preflight-tidy (#967). go.sum entries are tidied and verified against sum.golang.org before the rest of the ${PUBLISH_VERSION} release dispatch runs.")
+          if ! [[ "$PR_URL" =~ ^https://github\.com/.+/pull/[0-9]+$ ]]; then
+            echo "::error::gh pr create returned an unexpected URL: $PR_URL"
+            exit 1
+          fi
+          NUM="${PR_URL##*/}"
+          if ! gh pr merge "$NUM" --auto --squash; then
+            echo "preflight-tidy: PR auto-merge refused — aborting"
+            echo "preflight-tidy: PR auto-merge refused — aborting" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          # AC #4 exact string.
+          echo "preflight-tidy: PR opened"
+          echo "preflight-tidy: PR opened" >> "$GITHUB_STEP_SUMMARY"
+          # Brief poll loop — caps at 5 minutes so the rest of the
+          # release dispatch isn't blocked indefinitely on a stuck PR.
+          for i in $(seq 1 30); do
+            state=$(gh pr view "$NUM" --json state --jq '.state')
+            if [ "$state" = "MERGED" ]; then
+              echo "preflight-tidy: PR #$NUM merged"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::preflight-tidy: PR #$NUM not merged within 5 minutes"
+          exit 1
+
+  # =====================================================================
   # Job: ci (workflow_dispatch only)
   # =====================================================================
   # The called ci.yml contains a `dependency-review` job that requests
@@ -165,8 +391,16 @@ jobs:
   # validation with a startup_failure (regression introduced in #631).
   ci:
     name: CI Gate
-    needs: [preflight]
-    if: github.event_name == 'workflow_dispatch'
+    needs: [preflight, preflight-tidy]
+    # #967: gate on preflight-tidy succeeding OR being skipped via
+    # the inputs.skip_preflight_tidy escape hatch. The
+    # `always() && (success || skipped)` pattern (#956) handles the
+    # case where preflight-tidy's job-level `if:` evaluates false.
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.preflight.result == 'success' &&
+      (needs.preflight-tidy.result == 'success' || needs.preflight-tidy.result == 'skipped')
     permissions:
       contents: read
       pull-requests: write
@@ -181,8 +415,12 @@ jobs:
     name: Long Fuzz (release gate)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [ci]
-    if: github.event_name == 'workflow_dispatch'
+    needs: [ci, preflight-tidy]
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.ci.result == 'success' &&
+      (needs.preflight-tidy.result == 'success' || needs.preflight-tidy.result == 'skipped')
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -230,8 +468,12 @@ jobs:
     name: Benchmark Regression (advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [ci]
-    if: github.event_name == 'workflow_dispatch'
+    needs: [ci, preflight-tidy]
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.ci.result == 'success' &&
+      (needs.preflight-tidy.result == 'success' || needs.preflight-tidy.result == 'skipped')
     continue-on-error: true
     steps:
       - name: Checkout
@@ -319,8 +561,12 @@ jobs:
     # 4-hour budget — full suite is 60 min on local Ryzen 9, expected
     # 90-150 min on 4-core ubuntu-latest with headroom for cold caches.
     timeout-minutes: 240
-    needs: [preflight]
-    if: github.event_name == 'workflow_dispatch'
+    needs: [preflight, preflight-tidy]
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.preflight.result == 'success' &&
+      (needs.preflight-tidy.result == 'success' || needs.preflight-tidy.result == 'skipped')
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -357,8 +603,12 @@ jobs:
     name: API Check (gorelease)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [ci]
-    if: github.event_name == 'workflow_dispatch'
+    needs: [ci, preflight-tidy]
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.ci.result == 'success' &&
+      (needs.preflight-tidy.result == 'success' || needs.preflight-tidy.result == 'skipped')
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -413,8 +663,16 @@ jobs:
     name: Open release PR
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [preflight, ci, fuzz-long, api-check, mutation-test-release]
-    if: github.event_name == 'workflow_dispatch'
+    needs: [preflight, preflight-tidy, ci, fuzz-long, api-check, mutation-test-release]
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.preflight.result == 'success' &&
+      needs.ci.result == 'success' &&
+      needs.fuzz-long.result == 'success' &&
+      needs.api-check.result == 'success' &&
+      needs.mutation-test-release.result == 'success' &&
+      (needs.preflight-tidy.result == 'success' || needs.preflight-tidy.result == 'skipped')
     permissions:
       contents: read  # job-level — App token grants the writes
     outputs:
@@ -1281,6 +1539,7 @@ jobs:
     timeout-minutes: 1
     needs:
       - preflight
+      - preflight-tidy
       - ci
       - fuzz-long
       - bench-advisory
@@ -1318,6 +1577,7 @@ jobs:
             echo '|------|--------|'
             echo "| Preflight | ${{ needs.preflight.result }} |"
             if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "| Preflight Tidy (#967) | ${{ needs.preflight-tidy.result }} |"
               echo "| CI Gate | ${{ needs.ci.result }} |"
               echo "| Long Fuzz | ${{ needs.fuzz-long.result }} |"
               echo "| Bench (advisory) | ${{ needs.bench-advisory.result }} |"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fix release dispatch failing on post-tag go.sum drift via preflight-tidy job (#967).**
+  v0.2.3's dispatch (`workflow_dispatch` run 27325930898) failed at
+  the CI Gate's Hygiene job because main's `go.sum` carried v0.2.2's
+  post-tag-publication drift residue. #959/#966 added a
+  `post-release-tidy` job to absorb that drift AFTER each release —
+  but #966 only takes effect once it has been merged AND run, and
+  run-1 is v0.2.3 itself, which couldn't reach `tag-all` without a
+  clean Hygiene. Chicken-and-egg.
+  The new `preflight-tidy` job in `release.yml` runs BEFORE the CI
+  Gate, mirrors #966 on the PRE-side of the release flow, and
+  enforces 6 NON-NEGOTIABLE safety gates against the resulting
+  diff via a new `release-tool preflight-tidy-check` subcommand
+  (typed Go — bash + jq + gh-CLI for release-critical work was
+  retired by #929 and a regression to inline bash would have
+  re-opened the v0.2.1 cascade class). Gates: (1) go.sum-only, no
+  go.mod changes; (2) additions only, no deletions; (3) lines
+  reference only published modules at the last-released version;
+  (4) every (module, version) cross-checked against sum.golang.org's
+  transparency log; (5) PR-only commits (never direct-push); (6)
+  `inputs.skip_preflight_tidy` operator escape hatch with mandatory
+  `::warning::` + GFM CAUTION audit trail. See `docs/releasing.md`
+  § "Preflight tidy (#967)" for the failure-mode table and the
+  operator playbook. Tested by 9 named bats assertions
+  (`tests/release-scripts/release-yml-grep.bats`) and 11 table-
+  driven Go tests (`cmd/release-tool/cmd_preflight_tidy_check_test.go`
+  + `cmd/release-tool/internal/sumdb/lookup_test.go`).
+
 ### Changed
 
 - **Cosign signature artefact is now a single bundle file (#958).**

--- a/cmd/release-tool/cmd_preflight_tidy_check.go
+++ b/cmd/release-tool/cmd_preflight_tidy_check.go
@@ -1,0 +1,548 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/sumdb"
+)
+
+// preflightTidyArgs are the parsed flags for the
+// preflight-tidy-check subcommand.
+type preflightTidyArgs struct {
+	workdir             string
+	lastReleasedVersion string
+	publishedModulesCSV string
+	sumdbEndpoint       string
+	sumdbTimeout        time.Duration
+	maxDiffBytes        int64
+	skipSumdbCrossCheck bool
+	dryRun              bool
+}
+
+// AC #4 exact error strings — operator-facing contract. Each is
+// emitted to stderr (for human consumption) AND stdout (for the
+// workflow $GITHUB_STEP_SUMMARY pipe). Do NOT alter punctuation,
+// capitalisation, or the em-dash without updating the AC and the
+// bats grep assertions in tests/release-scripts/release-yml-grep.bats.
+const (
+	msgNoDrift             = "preflight-tidy: no drift to absorb"
+	msgGoModModified       = "preflight-tidy: go.mod modified — aborting"
+	msgGoSumDeletions      = "preflight-tidy: go.sum lines deleted — aborting"
+	msgUnrelatedChecksums  = "preflight-tidy: unrelated checksum lines — aborting"
+	msgSumdbDisagrees      = "preflight-tidy: sum.golang.org disagrees — aborting"
+	msgSumdbTransient      = "preflight-tidy: sum.golang.org timeout or 5xx — aborting"
+	msgDiffSizeCapExceeded = "preflight-tidy: diff exceeds 8 KiB cap — aborting"
+)
+
+// runPreflightTidyCheck implements the `preflight-tidy-check`
+// subcommand. It inspects the working tree's uncommitted diff
+// (presumed to be the output of a fresh `make tidy`) and aborts
+// with one of the operator-facing AC #4 error strings if any
+// safety gate fails. On a successful check, stdout receives a
+// machine-readable summary of the validated module/version pairs.
+//
+// Exit codes:
+//
+//	0 — all gates pass, diff is safe to commit
+//	1 — operational failure (sumdb network, etc.)
+//	2 — usage error
+//	3 — validation failure (one of the safety gates)
+//	4 — no diff (idempotent no-op)
+func runPreflightTidyCheck(ctx context.Context, args []string, stdout, stderr io.Writer, persistent *rootFlags) int {
+	fs := flag.NewFlagSet("preflight-tidy-check", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writePreflightTidyCheckHelp(fs.Output()) }
+
+	in := preflightTidyArgs{}
+	fs.StringVar(&in.workdir, "workdir", ".",
+		"Path to the git working directory (must be a trusted release-flow checkout)")
+	fs.StringVar(&in.lastReleasedVersion, "last-released-version", "",
+		"Last released version, e.g. v0.2.2 — gates 3+4 root their checks here (required)")
+	fs.StringVar(&in.publishedModulesCSV, "published-modules", "",
+		"Comma-separated list of github.com/axonops/audit/<sub> module paths to expect in the diff (required)")
+	fs.Int64Var(&in.maxDiffBytes, "max-diff-bytes", 8192,
+		"Hard cap on total diff size in bytes; larger diffs abort with msgDiffSizeCapExceeded")
+	fs.StringVar(&in.sumdbEndpoint, "sumdb-endpoint", sumdb.DefaultEndpoint,
+		"Sigstore checksum database endpoint")
+	fs.DurationVar(&in.sumdbTimeout, "sumdb-timeout", 30*time.Second,
+		"Per-module sumdb lookup timeout")
+	fs.BoolVar(&in.skipSumdbCrossCheck, "skip-sumdb-cross-check", false,
+		"DANGER: skip gate 4 (sum.golang.org cross-check). Test-only.")
+
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	in.dryRun = persistent.dryRun
+
+	if in.lastReleasedVersion == "" {
+		_, _ = fmt.Fprintln(stderr, "preflight-tidy-check: --last-released-version is required")
+		return exitUsage
+	}
+	if in.publishedModulesCSV == "" {
+		_, _ = fmt.Fprintln(stderr, "preflight-tidy-check: --published-modules is required")
+		return exitUsage
+	}
+
+	publishedModules := splitPublishedModules(in.publishedModulesCSV)
+	if len(publishedModules) == 0 {
+		_, _ = fmt.Fprintln(stderr, "preflight-tidy-check: --published-modules parsed to empty list")
+		return exitUsage
+	}
+
+	return doPreflightTidyCheck(ctx, &in, publishedModules, stdout, stderr)
+}
+
+// doPreflightTidyCheck runs the six safety gates against the
+// working-tree diff produced by `make tidy`. Split out from the
+// flag-parsing path so tests can inject a faked sumdb endpoint and
+// workdir.
+func doPreflightTidyCheck(ctx context.Context, in *preflightTidyArgs, publishedModules []string, stdout, stderr io.Writer) int {
+	// Step 1 — capture the uncommitted diff.
+	diffBytes, code := captureDiff(in.workdir, stderr)
+	if code != exitSuccess {
+		return code
+	}
+	if len(diffBytes) == 0 {
+		emit(stdout, stderr, msgNoDrift)
+		return exitIdempotentNoOp
+	}
+
+	// Diff-size cap — defence-in-depth against runaway diffs.
+	if int64(len(diffBytes)) > in.maxDiffBytes {
+		emit(stdout, stderr, msgDiffSizeCapExceeded)
+		return exitValidation
+	}
+
+	// Step 2 — parse the diff into per-file additions/deletions.
+	files, err := parseUnifiedDiff(diffBytes)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "preflight-tidy-check: parse diff: %v\n", err)
+		return exitOperational
+	}
+
+	// Gate 1 — go.sum only (no go.mod changes).
+	if hasGoModChange(files) {
+		emit(stdout, stderr, msgGoModModified)
+		return exitValidation
+	}
+
+	// Gate 2 — additions only (no deletions).
+	if hasGoSumDeletions(files) {
+		emit(stdout, stderr, msgGoSumDeletions)
+		return exitValidation
+	}
+
+	// Collect all added go.sum lines, scoped to go.sum paths only.
+	added := collectAddedGoSumLines(files)
+
+	// Gate 3 — every added line must reference the just-released
+	// version at one of the published module paths. Anything else
+	// aborts with msgUnrelatedChecksums.
+	if !linesAreInExpectedSet(added, publishedModules, in.lastReleasedVersion) {
+		emit(stdout, stderr, msgUnrelatedChecksums)
+		return exitValidation
+	}
+
+	// Gate 4 — cross-check each unique (module, version) pair
+	// against sum.golang.org's transparency log.
+	if !in.skipSumdbCrossCheck {
+		code := crossCheckAgainstSumdb(ctx, added, in, stdout, stderr)
+		if code != exitSuccess {
+			// crossCheckAgainstSumdb has already emitted the
+			// appropriate operator-facing string.
+			return code
+		}
+	}
+
+	// All gates passed. Stdout receives a machine-readable summary
+	// of the unique (module, version) pairs validated, one per
+	// line, so the workflow can echo them into the summary table.
+	emitValidatedSummary(stdout, added)
+	return exitSuccess
+}
+
+// emit writes msg to BOTH stdout and stderr so it lands in both the
+// machine-consumable channel (workflow $GITHUB_STEP_SUMMARY pipe)
+// and the human-readable run log.
+func emit(stdout, stderr io.Writer, msg string) {
+	_, _ = fmt.Fprintln(stdout, msg)
+	_, _ = fmt.Fprintln(stderr, msg)
+}
+
+// captureDiff runs `git -C workdir diff --no-color --no-ext-diff
+// HEAD` and returns the resulting unified diff. An empty result
+// means the working tree is clean (the "no drift" path).
+func captureDiff(workdir string, stderr io.Writer) (diff []byte, exit int) {
+	cmd := exec.Command("git", "-C", workdir, "diff", "--no-color", "--no-ext-diff", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "preflight-tidy-check: git diff failed: %v\n", err)
+		return nil, exitOperational
+	}
+	return out, exitSuccess
+}
+
+// fileDiff captures the additions and deletions for a single file
+// in a parsed unified diff.
+type fileDiff struct {
+	path      string
+	additions []string
+	deletions []string
+}
+
+// parseUnifiedDiff is a minimal parser for `git diff --no-color`
+// output covering just what the safety gates need: per-file
+// addition / deletion lines (with the leading +/- stripped). It
+// deliberately rejects unfamiliar diff structures rather than
+// silently tolerating them — a parse anomaly during a release flow
+// is exactly the kind of thing we want to bubble. The structure
+// mirrors the unified-diff spec; flatter as one switch.
+//
+//nolint:gocognit,gocyclo,cyclop // see godoc above
+func parseUnifiedDiff(diff []byte) ([]fileDiff, error) {
+	if len(diff) == 0 {
+		return nil, nil
+	}
+	var files []fileDiff
+	var cur *fileDiff
+	lines := strings.Split(string(diff), "\n")
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			if cur != nil {
+				files = append(files, *cur)
+			}
+			cur = &fileDiff{}
+		case strings.HasPrefix(line, "+++ b/"):
+			if cur == nil {
+				return nil, errors.New("malformed diff: +++ outside file block")
+			}
+			cur.path = strings.TrimPrefix(line, "+++ b/")
+		case strings.HasPrefix(line, "--- "), strings.HasPrefix(line, "index "),
+			strings.HasPrefix(line, "@@"), strings.HasPrefix(line, "new file mode"),
+			strings.HasPrefix(line, "deleted file mode"), strings.HasPrefix(line, "similarity"),
+			strings.HasPrefix(line, "rename "), strings.HasPrefix(line, "Binary files"):
+			// Header / hunk-marker / mode / rename / binary — skip.
+		case strings.HasPrefix(line, "+"):
+			if cur == nil {
+				return nil, errors.New("malformed diff: + line outside file block")
+			}
+			cur.additions = append(cur.additions, strings.TrimPrefix(line, "+"))
+		case strings.HasPrefix(line, "-"):
+			if cur == nil {
+				return nil, errors.New("malformed diff: - line outside file block")
+			}
+			cur.deletions = append(cur.deletions, strings.TrimPrefix(line, "-"))
+		case line == "":
+			// Blank between hunks — skip.
+		default:
+			// Context line (no +/- prefix) — skip.
+		}
+	}
+	if cur != nil {
+		files = append(files, *cur)
+	}
+	return files, nil
+}
+
+// hasGoModChange reports true if any file in the diff is a go.mod.
+func hasGoModChange(files []fileDiff) bool {
+	for _, f := range files {
+		if isGoModPath(f.path) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasGoSumDeletions reports true if any go.sum file has at least
+// one deletion line. tidy can prune orphaned checksums — but doing
+// so on a release dispatch could quietly drop a checksum a
+// maintainer added on purpose. Force human review.
+func hasGoSumDeletions(files []fileDiff) bool {
+	for _, f := range files {
+		if !isGoSumPath(f.path) {
+			continue
+		}
+		if len(f.deletions) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// collectAddedGoSumLines returns the parsed addition lines from
+// every go.sum in the diff. Non-go.sum files (which gate 1 should
+// have rejected, but are skipped here defensively) are ignored.
+func collectAddedGoSumLines(files []fileDiff) []parsedGoSumLine {
+	var out []parsedGoSumLine
+	for _, f := range files {
+		if !isGoSumPath(f.path) {
+			continue
+		}
+		for _, l := range f.additions {
+			if line, ok := parseGoSumLine(l); ok {
+				out = append(out, line)
+			}
+		}
+	}
+	return out
+}
+
+// parsedGoSumLine is a structured representation of a single
+// go.sum entry. The raw line has the shape:
+//
+//	<module> <version>[/go.mod] h1:<base64>
+type parsedGoSumLine struct {
+	module       string
+	version      string // semver; never the "/go.mod" suffix variant
+	hash         string // h1:... full hash literal
+	raw          string
+	isModSection bool // true if the line was the `<v>/go.mod` form
+}
+
+func parseGoSumLine(line string) (parsedGoSumLine, bool) {
+	fields := strings.Fields(line)
+	if len(fields) != 3 || !strings.HasPrefix(fields[2], "h1:") {
+		return parsedGoSumLine{}, false
+	}
+	out := parsedGoSumLine{
+		module: fields[0],
+		hash:   fields[2],
+		raw:    line,
+	}
+	switch {
+	case strings.HasSuffix(fields[1], "/go.mod"):
+		out.version = strings.TrimSuffix(fields[1], "/go.mod")
+		out.isModSection = true
+	default:
+		out.version = fields[1]
+	}
+	return out, true
+}
+
+// linesAreInExpectedSet enforces gate 3: every added go.sum line
+// must reference one of the publishedModules at the lastReleasedVersion.
+// Anything else — an unrelated module, an unexpected version, OR an
+// empty added set (signalling a silently-dropped malformed line; see
+// test-analyst review) — aborts the release.
+//
+// This is a STRICTER interpretation than the "go mod graph
+// transitive set" originally proposed in the issue: in the v0.2.2 →
+// v0.2.3 case the drift is exclusively axonops/audit submodules at
+// the previously-published version. If a future release legitimately
+// needs transitive-dep checksums added, this gate will catch and
+// abort, forcing human review.
+func linesAreInExpectedSet(added []parsedGoSumLine, publishedModules []string, version string) bool {
+	// Silent-bypass guard: a non-empty diff that parses to zero
+	// recognised go.sum lines means every line was malformed and
+	// silently dropped by parseGoSumLine. The caller's gate
+	// orchestration relies on this returning false so the run
+	// aborts with msgUnrelatedChecksums rather than passing every
+	// safety gate trivially.
+	if len(added) == 0 {
+		return false
+	}
+	allowed := make(map[string]struct{}, len(publishedModules))
+	for _, m := range publishedModules {
+		allowed[m] = struct{}{}
+	}
+	for _, line := range added {
+		if line.version != version {
+			return false
+		}
+		if _, ok := allowed[line.module]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// crossCheckAgainstSumdb enforces gate 4: every unique
+// (module, version) pair in the added lines is independently
+// fetched from sum.golang.org's transparency log and the h1: hashes
+// are byte-compared. A mismatch aborts with msgSumdbDisagrees; a
+// network/HTTP failure aborts with msgSumdbTransient. There are no
+// retries — the operator re-dispatches when the network is healthy.
+//
+// Exit codes (per godoc + docs/releasing.md): a disagreement is a
+// validation failure (exit 3); a transient transport failure is
+// operational (exit 1). The original implementation conflated them
+// on exit 1 — fixed in #967 review M1.
+//
+// Cross-file hash divergence (review M3): if two added go.sum lines
+// for the same (module, version) carry DIFFERENT h1: values
+// (legitimately impossible from `make tidy`, but a clear tampering
+// signal), reject immediately. Without this, only the last-written
+// hash would be checked against sumdb and the other would pass.
+//
+//nolint:gocognit,gocyclo,cyclop // see godoc above
+func crossCheckAgainstSumdb(ctx context.Context, added []parsedGoSumLine, in *preflightTidyArgs, stdout, stderr io.Writer) int {
+	// Deduplicate (module, version) — both the module-zip and
+	// go.mod hash lines for the same release share the same lookup.
+	// Detect intra-diff hash divergence: two added lines for the
+	// same (module, version, section) MUST carry the same hash.
+	type modVer struct{ module, version string }
+	expected := make(map[modVer]map[string]string) // modVer → {"zip": h1:..., "mod": h1:...}
+	for _, l := range added {
+		key := modVer{module: l.module, version: l.version}
+		if expected[key] == nil {
+			expected[key] = map[string]string{}
+		}
+		section := "zip"
+		if l.isModSection {
+			section = "mod"
+		}
+		if existing, ok := expected[key][section]; ok && existing != l.hash {
+			_, _ = fmt.Fprintf(stderr,
+				"preflight-tidy-check: cross-file %s hash divergence for %s@%s: %s vs %s\n",
+				section, key.module, key.version, existing, l.hash)
+			emit(stdout, stderr, msgSumdbDisagrees)
+			return exitValidation
+		}
+		expected[key][section] = l.hash
+	}
+
+	client := &sumdb.Client{
+		Endpoint: in.sumdbEndpoint,
+		Timeout:  in.sumdbTimeout,
+	}
+	for key, ourHashes := range expected {
+		lookup, err := client.Lookup(ctx, key.module, key.version)
+		if err != nil {
+			// Differentiate transparency-log "not found" (likely
+			// a transient proxy/log skew or genuinely-not-published
+			// version) from other transport failures.
+			switch {
+			case errors.Is(err, sumdb.ErrNotFound):
+				_, _ = fmt.Fprintf(stderr,
+					"preflight-tidy-check: sumdb has no record for %s@%s: %v\n",
+					key.module, key.version, err)
+			default:
+				_, _ = fmt.Fprintf(stderr, "preflight-tidy-check: sumdb lookup %s@%s failed: %v\n",
+					key.module, key.version, err)
+			}
+			emit(stdout, stderr, msgSumdbTransient)
+			return exitOperational
+		}
+		if hash, ok := ourHashes["zip"]; ok && hash != lookup.Hash {
+			_, _ = fmt.Fprintf(stderr,
+				"preflight-tidy-check: zip hash for %s@%s differs from sumdb: tidy=%s sumdb=%s\n",
+				key.module, key.version, hash, lookup.Hash)
+			emit(stdout, stderr, msgSumdbDisagrees)
+			return exitValidation
+		}
+		if hash, ok := ourHashes["mod"]; ok && hash != lookup.ModHash {
+			_, _ = fmt.Fprintf(stderr,
+				"preflight-tidy-check: go.mod hash for %s@%s differs from sumdb: tidy=%s sumdb=%s\n",
+				key.module, key.version, hash, lookup.ModHash)
+			emit(stdout, stderr, msgSumdbDisagrees)
+			return exitValidation
+		}
+	}
+	return exitSuccess
+}
+
+// emitValidatedSummary writes one line per unique (module, version)
+// pair that passed every gate, in deterministic sorted order, so
+// the release workflow can render them in $GITHUB_STEP_SUMMARY.
+func emitValidatedSummary(stdout io.Writer, added []parsedGoSumLine) {
+	uniq := make(map[string]struct{})
+	for _, l := range added {
+		uniq[l.module+" "+l.version] = struct{}{}
+	}
+	keys := make([]string, 0, len(uniq))
+	for k := range uniq {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		_, _ = fmt.Fprintln(stdout, k)
+	}
+}
+
+// splitPublishedModules parses --published-modules and returns a
+// trimmed list of module paths. Empty or whitespace-only entries
+// are dropped.
+func splitPublishedModules(csv string) []string {
+	parts := strings.Split(csv, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// isGoModPath reports whether path is a go.mod file (root or any
+// sub-module). The strict basename check is intentional — a path
+// like `cmd/audit-gen/go.mod.backup` should NOT trip gate 1.
+func isGoModPath(path string) bool {
+	return path == "go.mod" || strings.HasSuffix(path, "/go.mod")
+}
+
+// isGoSumPath reports whether path is a go.sum file.
+func isGoSumPath(path string) bool {
+	return path == "go.sum" || strings.HasSuffix(path, "/go.sum")
+}
+
+// writePreflightTidyCheckHelp emits the subcommand help text.
+func writePreflightTidyCheckHelp(w io.Writer) {
+	const helpText = `release-tool preflight-tidy-check — validate post-tidy go.sum diff
+
+USAGE
+    release-tool [persistent flags] preflight-tidy-check \
+        --last-released-version vX.Y.Z \
+        --published-modules github.com/axonops/audit,github.com/axonops/audit/file,... \
+        [--workdir PATH] [--max-diff-bytes N] [--sumdb-endpoint URL]
+        [--sumdb-timeout DURATION] [--skip-sumdb-cross-check]
+
+DESCRIPTION
+    Inspects the working tree's uncommitted diff (presumed to be
+    the output of a fresh ` + "`make tidy`" + `) and applies six safety
+    gates before the orchestrating release workflow auto-commits it
+    via the commit-pinned-deps subcommand. The gates are
+    NON-NEGOTIABLE; each failure aborts with one of the exact
+    operator-facing error strings declared in #967 AC #4.
+
+GATES
+    Gate 1 — go.sum only (no go.mod changes)
+    Gate 2 — additions only (no deletions)
+    Gate 3 — every added line references one of the published
+             modules at the last-released version
+    Gate 4 — every (module, version) is independently fetched from
+             sum.golang.org and the h1: hashes byte-match
+    Defence — diff size capped at 8 KiB; larger aborts.
+
+EXIT CODES
+    0 — every gate passed; stdout lists validated (module, version)
+    1 — operational failure (sumdb network, etc.)
+    2 — usage error
+    3 — validation failure (a safety gate aborted)
+    4 — clean working tree (idempotent no-op)
+`
+	_, _ = fmt.Fprint(w, helpText)
+}

--- a/cmd/release-tool/cmd_preflight_tidy_check_test.go
+++ b/cmd/release-tool/cmd_preflight_tidy_check_test.go
@@ -1,0 +1,407 @@
+// Copyright 2026 AxonOps Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/sumdb"
+)
+
+// makeTempRepo initialises a bare-bones git repo under t.TempDir
+// and seeds it with a `go.sum` file at HEAD. Tests then mutate
+// `go.sum` in the workdir without committing — the runtime captures
+// that diff exactly like the release-flow workflow will.
+func makeTempRepo(t *testing.T, initialGoSum map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitInit := exec.Command("git", "-C", dir, "init", "--quiet", "--initial-branch=main")
+	gitInit.Env = append(gitInit.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	if out, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	for _, cmd := range [][]string{
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	} {
+		args := append([]string{"-C", dir}, cmd...)
+		if err := exec.Command("git", args...).Run(); err != nil {
+			t.Fatalf("git %v: %v", cmd, err)
+		}
+	}
+	for path, content := range initialGoSum {
+		full := filepath.Join(dir, path)
+		if err := exec.Command("mkdir", "-p", filepath.Dir(full)).Run(); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := writeFile(full, content); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		if err := exec.Command("git", "-C", dir, "add", path).Run(); err != nil {
+			t.Fatalf("git add %s: %v", path, err)
+		}
+	}
+	commit := exec.Command("git", "-C", dir, "commit", "--quiet", "-m", "init")
+	commit.Env = append(commit.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	if out, err := commit.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+	return dir
+}
+
+func writeFile(path, content string) error {
+	// #967 review N2: stdlib os.WriteFile is the right tool;
+	// the earlier shell-out roundtrip added a /bin/sh dependency
+	// for zero benefit.
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+// fakeSumdb returns an httptest server whose /lookup response is
+// built from the supplied (module, version) → (zipHash, modHash) map.
+func fakeSumdb(t *testing.T, ans map[string][2]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path: /lookup/<module>@<version>
+		const prefix = "/lookup/"
+		if !strings.HasPrefix(r.URL.Path, prefix) {
+			http.NotFound(w, r)
+			return
+		}
+		modVer := strings.TrimPrefix(r.URL.Path, prefix)
+		key := modVer
+		hashes, ok := ans[key]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		// Two-line body: zip hash and go.mod hash.
+		at := strings.LastIndex(modVer, "@")
+		module := modVer[:at]
+		version := modVer[at+1:]
+		body := fmt.Sprintf("1\n%s %s %s\n%s %s/go.mod %s\n\n",
+			module, version, hashes[0], module, version, hashes[1])
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func runSubcmd(t *testing.T, workdir, version, mods, sumdbURL string, skipSumdb bool) (code int, stdout, stderr string) {
+	t.Helper()
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	args := []string{
+		"--workdir", workdir,
+		"--last-released-version", version,
+		"--published-modules", mods,
+		"--sumdb-endpoint", sumdbURL,
+	}
+	if skipSumdb {
+		args = append(args, "--skip-sumdb-cross-check")
+	}
+	code = runPreflightTidyCheck(context.Background(), args, outBuf, errBuf, &rootFlags{})
+	stdout = outBuf.String()
+	stderr = errBuf.String()
+	return code, stdout, stderr
+}
+
+func TestPreflightTidyCheck_NoDriftExitsIdempotent(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitIdempotentNoOp {
+		t.Errorf("exit code: got %d want %d", code, exitIdempotentNoOp)
+	}
+	if !strings.Contains(stdout, msgNoDrift) {
+		t.Errorf("stdout missing %q: %q", msgNoDrift, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate1_GoModModifiedAborts(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.mod": "module example\n", "go.sum": ""})
+	// Mutate go.mod (gate 1 trigger).
+	if err := writeFile(filepath.Join(repo, "go.mod"), "module example\n\nrequire foo v0.0.1\n"); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgGoModModified) {
+		t.Errorf("stdout missing %q: %q", msgGoModModified, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate2_DeletionsAbort(t *testing.T) {
+	t.Parallel()
+	initial := "github.com/axonops/audit v0.2.1 h1:OLD=\n"
+	repo := makeTempRepo(t, map[string]string{"go.sum": initial})
+	// Replace the file — deletion of the old line + addition of a new one.
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:NEW=\n"); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgGoSumDeletions) {
+		t.Errorf("stdout missing %q: %q", msgGoSumDeletions, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate3_UnrelatedModuleAborts(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	// Add a line for an unrelated module — gate 3 rejects.
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/evil/audit v0.2.2 h1:AAA=\ngithub.com/evil/audit v0.2.2/go.mod h1:BBB=\n"); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgUnrelatedChecksums) {
+		t.Errorf("stdout missing %q: %q", msgUnrelatedChecksums, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate3_WrongVersionAborts(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.3.0 h1:AAA=\ngithub.com/axonops/audit v0.3.0/go.mod h1:BBB=\n"); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgUnrelatedChecksums) {
+		t.Errorf("stdout missing %q: %q", msgUnrelatedChecksums, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate4_SumdbDisagreesAborts(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:TIDYHASH=\ngithub.com/axonops/audit v0.2.2/go.mod h1:TIDYMOD=\n"); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, map[string][2]string{
+		"github.com/axonops/audit@v0.2.2": {"h1:SUMDBHASH=", "h1:SUMDBMOD="},
+	})
+	// #967 review M1: a sumdb disagreement is a VALIDATION failure
+	// (exit 3) — the diff fails a safety gate. Transient transport
+	// failures are operational (exit 1, see the SumdbNotFound /
+	// ServerError tests below).
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	// #967 review M2: gate-4 emits on BOTH stdout (workflow summary
+	// pipe) AND stderr (human log).
+	if !strings.Contains(stdout, msgSumdbDisagrees) {
+		t.Errorf("stdout missing %q: %q", msgSumdbDisagrees, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate4_SumdbNotFoundIsTransient(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:AAA=\ngithub.com/axonops/audit v0.2.2/go.mod h1:BBB=\n"); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	code, _, stderr := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitOperational {
+		t.Errorf("exit code: got %d want %d", code, exitOperational)
+	}
+	if !strings.Contains(stderr, msgSumdbTransient) {
+		t.Errorf("stderr missing %q: %q", msgSumdbTransient, stderr)
+	}
+}
+
+func TestPreflightTidyCheck_Gate4_SumdbServerErrorIsTransient(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:AAA=\ngithub.com/axonops/audit v0.2.2/go.mod h1:BBB=\n"); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	code, _, stderr := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitOperational {
+		t.Errorf("exit code: got %d want %d", code, exitOperational)
+	}
+	if !strings.Contains(stderr, msgSumdbTransient) {
+		t.Errorf("stderr missing %q: %q", msgSumdbTransient, stderr)
+	}
+}
+
+func TestPreflightTidyCheck_HappyPath(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": "", "file/go.sum": ""})
+	// Tidy adds entries at both the root and the file submodule.
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:HASH1=\ngithub.com/axonops/audit v0.2.2/go.mod h1:HASH2=\n"); err != nil {
+		t.Fatalf("write root go.sum: %v", err)
+	}
+	if err := writeFile(filepath.Join(repo, "file", "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:HASH1=\ngithub.com/axonops/audit v0.2.2/go.mod h1:HASH2=\n"); err != nil {
+		t.Fatalf("write file/go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, map[string][2]string{
+		"github.com/axonops/audit@v0.2.2": {"h1:HASH1=", "h1:HASH2="},
+	})
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitSuccess {
+		t.Errorf("exit code: got %d want %d", code, exitSuccess)
+	}
+	// Summary should mention the validated (module, version) pair.
+	if !strings.Contains(stdout, "github.com/axonops/audit v0.2.2") {
+		t.Errorf("stdout missing validated pair: %q", stdout)
+	}
+}
+
+// #967 review M3: cross-file hash divergence. If the root go.sum
+// and a submodule go.sum both add a line for the same
+// (module, version) but with DIFFERENT h1: values, gate 4 must
+// reject — only the last-written hash would be checked against the
+// sumdb otherwise, silently passing the other tampered hash.
+func TestPreflightTidyCheck_Gate4_CrossFileHashDivergenceAborts(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": "", "file/go.sum": ""})
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:HONEST=\ngithub.com/axonops/audit v0.2.2/go.mod h1:MOD=\n"); err != nil {
+		t.Fatalf("write root go.sum: %v", err)
+	}
+	if err := writeFile(filepath.Join(repo, "file", "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:TAMPERED=\ngithub.com/axonops/audit v0.2.2/go.mod h1:MOD=\n"); err != nil {
+		t.Fatalf("write file/go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, map[string][2]string{
+		"github.com/axonops/audit@v0.2.2": {"h1:HONEST=", "h1:MOD="},
+	})
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgSumdbDisagrees) {
+		t.Errorf("stdout missing %q: %q", msgSumdbDisagrees, stdout)
+	}
+}
+
+// test-analyst silent-bypass class: if `parseGoSumLine` silently
+// drops a malformed added line (e.g. 4 fields instead of 3), and
+// that's the ONLY added line, every gate trivially passes and the
+// release proceeds against a diff containing the malformed line.
+// The fix is to require at least one valid added line whenever the
+// diff is non-empty AND go.sum-only AND addition-only.
+func TestPreflightTidyCheck_MalformedAddedLineDoesNotSilentlyPass(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	// 4-field line — `parseGoSumLine` rejects, but the line is real.
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:AAA= EXTRA\n"); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	// Gates 1+2 pass (go.sum-only, no deletions), gate 3 receives
+	// empty `added` because the malformed line was dropped → without
+	// a guard, gate 3 returns true on an empty set and the run
+	// reaches gate 4 (skipped) and exits 0. With the guard, gate 3
+	// rejects because there's no valid line covering the actual diff.
+	if code == exitSuccess {
+		t.Errorf("malformed-only diff silently passed; got exitSuccess, want exitValidation")
+	}
+	if !strings.Contains(stdout, msgUnrelatedChecksums) {
+		t.Errorf("stdout missing %q (expected gate-3 reject of empty added set): %q",
+			msgUnrelatedChecksums, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_DiffSizeCapAborts(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	// Write a go.sum bigger than the default 8 KiB cap.
+	big := strings.Repeat("a", 9000)
+	if err := writeFile(filepath.Join(repo, "go.sum"), big); err != nil {
+		t.Fatalf("write big go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgDiffSizeCapExceeded) {
+		t.Errorf("stdout missing %q: %q", msgDiffSizeCapExceeded, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_RequiresFlags(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "no last-released-version", args: []string{"--published-modules", "x"}},
+		{name: "no published-modules", args: []string{"--last-released-version", "v0.2.2"}},
+		{name: "empty published-modules csv", args: []string{
+			"--last-released-version", "v0.2.2", "--published-modules", " , , ,",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			code := runPreflightTidyCheck(context.Background(), tc.args, stdout, stderr, &rootFlags{})
+			if code != exitUsage {
+				t.Errorf("expected exitUsage, got %d", code)
+			}
+		})
+	}
+}
+
+// Ensure the sumdb client is correctly wired through the default
+// constructor path — exercised once so the constructor parameter
+// surface is covered by the test suite.
+func TestSumdbClientDefaultTimeout(t *testing.T) {
+	t.Parallel()
+	c := &sumdb.Client{Endpoint: "http://example.invalid"}
+	_, err := c.Lookup(context.Background(), "github.com/axonops/audit", "v0.2.2")
+	if err == nil {
+		t.Fatal("expected error against invalid host")
+	}
+}

--- a/cmd/release-tool/internal/sumdb/lookup.go
+++ b/cmd/release-tool/internal/sumdb/lookup.go
@@ -1,0 +1,308 @@
+// Copyright 2026 AxonOps Limited.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sumdb queries Go's checksum-database transparency log
+// (sum.golang.org by default) directly so the preflight-tidy gate
+// in cmd/release-tool/cmd_preflight_tidy_check.go can verify a
+// freshly-tidied go.sum line against the public log rather than
+// trusting the module proxy.
+//
+// Security note: this package intentionally talks to the sumdb over
+// HTTPS using the system trust store. It does NOT verify the sumdb's
+// own signed-note signature (which would require pinning the sumdb's
+// public key). The threat model is: a malicious or skewed proxy
+// returns checksum lines for a release version. Without an
+// independent check, those lines get auto-committed to main. By
+// fetching the SAME (module, version) directly from sum.golang.org
+// — bypassing the proxy entirely — and byte-comparing the h1: hashes,
+// we catch any proxy-only divergence.
+//
+// The transparency log itself can still be compromised (e.g. via
+// the sumdb's signing key), but that's a single-source-of-truth Go
+// ecosystem risk shared by every Go consumer; defending against it
+// is out of scope for preflight-tidy.
+package sumdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultEndpoint is the public Go checksum database.
+const DefaultEndpoint = "https://sum.golang.org"
+
+// ErrNotFound is returned when the sumdb has no record for the
+// requested module@version. Distinct from network/transport errors
+// so callers can decide whether to abort or treat as "module not
+// yet in the log".
+var ErrNotFound = errors.New("sumdb: module@version not found in checksum database")
+
+// Lookup is the result of a successful sumdb lookup. Both Hash and
+// ModHash are h1:-prefixed dirhash values matching the format used
+// in go.sum lines:
+//
+//	<module> <version> h1:<base64>           — Hash
+//	<module> <version>/go.mod h1:<base64>    — ModHash
+type Lookup struct {
+	Module  string
+	Version string
+	Hash    string // h1:... for the module zip
+	ModHash string // h1:... for the module's go.mod
+}
+
+// Client queries a sumdb endpoint with a configurable per-request
+// timeout. Zero-value Client uses DefaultEndpoint, a fresh
+// http.Client, and a 30-second timeout.
+type Client struct {
+	// HTTP overrides the default http.Client. Useful for tests.
+	HTTP *http.Client
+
+	// Endpoint is the sumdb base URL (no trailing slash). Defaults
+	// to DefaultEndpoint.
+	Endpoint string
+
+	// Timeout is the per-request deadline. Defaults to 30s.
+	Timeout time.Duration
+}
+
+func (c *Client) endpoint() string {
+	if c.Endpoint != "" {
+		return strings.TrimRight(c.Endpoint, "/")
+	}
+	return DefaultEndpoint
+}
+
+// httpClient returns the caller-supplied http.Client or, on the
+// zero-value path, a fresh one. Per security-reviewer #967 MEDIUM-2,
+// we do NOT fall back to http.DefaultClient — that would leak
+// connections across unrelated callers and contradicts the project's
+// http.DefaultClient prohibition.
+func (c *Client) httpClient() *http.Client {
+	if c.HTTP != nil {
+		return c.HTTP
+	}
+	return &http.Client{Timeout: c.timeout()}
+}
+
+func (c *Client) timeout() time.Duration {
+	if c.Timeout > 0 {
+		return c.Timeout
+	}
+	return 30 * time.Second
+}
+
+// Lookup performs a GET against `<endpoint>/lookup/<module>@<version>`.
+// The response is a signed note whose text section contains two
+// hash lines (one for the module, one for go.mod). The signature
+// section is intentionally NOT verified — see package godoc for the
+// threat-model rationale.
+//
+// On success returns a *Lookup with both h1: hashes populated.
+// On a 404 response returns ErrNotFound (wrap with errors.Is).
+// On any other transport error, status, or parse failure returns a
+// descriptive error.
+func (c *Client) Lookup(ctx context.Context, module, version string) (*Lookup, error) {
+	if module == "" {
+		return nil, errors.New("sumdb: module is required")
+	}
+	if version == "" {
+		return nil, errors.New("sumdb: version is required")
+	}
+
+	// Sumdb paths use the lowercase-escaped module path per
+	// https://go.dev/ref/mod#serving-from-proxy. For our consumers
+	// (axonops/audit + sub-modules) the path contains no uppercase
+	// or escape-required characters so a literal join is correct,
+	// but the percent-encoded form is still strictly more defensive
+	// — preserves behaviour if someone introduces a path with
+	// uppercase letters in future.
+	url := fmt.Sprintf("%s/lookup/%s@%s", c.endpoint(), escapeModulePath(module), version)
+
+	rctx, cancel := context.WithTimeout(ctx, c.timeout())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(rctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "audit-release-tool/preflight-tidy")
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: GET %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Fall through.
+	case http.StatusNotFound, http.StatusGone:
+		return nil, ErrNotFound
+	default:
+		return nil, fmt.Errorf("sumdb: GET %s returned %d %s", url, resp.StatusCode, resp.Status)
+	}
+
+	// 1 MiB response cap. A real sumdb response is <1 KiB; the cap
+	// prevents a malicious endpoint from streaming an unbounded
+	// body into memory.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("sumdb: read response: %w", err)
+	}
+
+	return parseSumdbResponse(module, version, body)
+}
+
+// parseSumdbResponse parses a sumdb /lookup response. Format:
+//
+//	<id>
+//	<module> <version> h1:<hash>
+//	<module> <version>/go.mod h1:<hash>
+//
+//	— signed-note signature lines —
+//
+// The leading id line is a numeric log index; we don't use it. The
+// two hash lines are what go.sum is keyed against. Anything after a
+// blank line is the note signature, which is parsed by callers that
+// want to verify against a pinned sumdb key — out of scope here.
+// Line-by-line validator: one branch per expected line shape.
+// Flatter as one switch than nested helpers.
+//
+//nolint:gocognit,gocyclo,cyclop // see godoc above
+func parseSumdbResponse(wantModule, wantVersion string, body []byte) (*Lookup, error) {
+	lookup := &Lookup{Module: wantModule, Version: wantVersion}
+
+	scanner := scanLines(body)
+	// Skip the leading id line. Treat a missing id as a parse error
+	// — the response was either truncated or not a sumdb /lookup
+	// payload at all.
+	if !scanner.next() {
+		return nil, errors.New("sumdb: empty response")
+	}
+	// Subsequent lines are the hash records until the first blank
+	// line.
+	for scanner.next() {
+		line := scanner.text()
+		if line == "" {
+			break
+		}
+		fields := strings.Fields(line)
+		// Expected shapes:
+		//   `<module> <version> h1:<hash>`           (3 fields)
+		//   `<module> <version>/go.mod h1:<hash>`    (3 fields, /go.mod suffix on field[1])
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("sumdb: unexpected line %q (want 3 fields)", line)
+		}
+		if fields[0] != wantModule {
+			return nil, fmt.Errorf("sumdb: line module mismatch: got %q want %q", fields[0], wantModule)
+		}
+		if !strings.HasPrefix(fields[2], "h1:") {
+			return nil, fmt.Errorf("sumdb: line %q missing h1: prefix on hash field", line)
+		}
+
+		switch fields[1] {
+		case wantVersion:
+			if lookup.Hash != "" {
+				return nil, fmt.Errorf("sumdb: duplicate module hash for %s@%s", wantModule, wantVersion)
+			}
+			lookup.Hash = fields[2]
+		case wantVersion + "/go.mod":
+			if lookup.ModHash != "" {
+				return nil, fmt.Errorf("sumdb: duplicate go.mod hash for %s@%s", wantModule, wantVersion)
+			}
+			lookup.ModHash = fields[2]
+		default:
+			return nil, fmt.Errorf("sumdb: line version mismatch: got %q want %q or %q/go.mod",
+				fields[1], wantVersion, wantVersion)
+		}
+	}
+
+	if lookup.Hash == "" {
+		return nil, fmt.Errorf("sumdb: no module hash line for %s@%s", wantModule, wantVersion)
+	}
+	if lookup.ModHash == "" {
+		return nil, fmt.Errorf("sumdb: no go.mod hash line for %s@%s", wantModule, wantVersion)
+	}
+	return lookup, nil
+}
+
+// escapeModulePath converts a module path's uppercase letters to
+// their proxy-escaped lowercase form (`A` → `!a`). For the audit
+// project's published modules there's nothing to escape, but the
+// helper exists so the lookup URL is correct for any future
+// module path that introduces uppercase.
+func escapeModulePath(module string) string {
+	var b strings.Builder
+	b.Grow(len(module))
+	for _, r := range module {
+		if r >= 'A' && r <= 'Z' {
+			b.WriteByte('!')
+			b.WriteRune(r + 32)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// scanLines is a small wrapper that yields lines of body without
+// pulling bufio.Scanner's MaxScanTokenSize ceiling. Sumdb responses
+// are tiny but the cap is defensive.
+type lineScanner struct {
+	cur  string
+	body []byte
+	pos  int
+}
+
+func scanLines(body []byte) *lineScanner { return &lineScanner{body: body} }
+
+// maxLineBytes caps a single sumdb response line. Real sumdb lines
+// are ~80 bytes; the 8 KiB cap is defence-in-depth per #967
+// security-reviewer MEDIUM-3. Without it, a malicious endpoint
+// could stream one ~1 MiB line within the body-level cap and force
+// strings.Fields to allocate ~1 MiB.
+const maxLineBytes = 8192
+
+func (s *lineScanner) next() bool {
+	if s.pos >= len(s.body) {
+		return false
+	}
+	end := s.pos
+	for end < len(s.body) && s.body[end] != '\n' {
+		end++
+		if end-s.pos > maxLineBytes {
+			// Truncate the line at the cap. The caller's
+			// validators see a malformed line and reject; this
+			// avoids the unbounded-allocation risk while still
+			// terminating cleanly.
+			s.cur = string(s.body[s.pos:end])
+			s.pos = end
+			return true
+		}
+	}
+	s.cur = string(s.body[s.pos:end])
+	if end < len(s.body) {
+		s.pos = end + 1
+	} else {
+		s.pos = end
+	}
+	return true
+}
+
+func (s *lineScanner) text() string { return s.cur }

--- a/cmd/release-tool/internal/sumdb/lookup_test.go
+++ b/cmd/release-tool/internal/sumdb/lookup_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 AxonOps Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package sumdb_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/axonops/audit/cmd/release-tool/internal/sumdb"
+)
+
+func TestLookup_Success(t *testing.T) {
+	t.Parallel()
+	body := strings.Join([]string{
+		"123456",
+		"github.com/axonops/audit v0.2.2 h1:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ=",
+		"github.com/axonops/audit v0.2.2/go.mod h1:ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210abcdef=",
+		"",
+		"— sum.golang.org Az3grg+signaturecontent=",
+		"",
+	}, "\n")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/lookup/github.com/axonops/audit@v0.2.2" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("User-Agent"); got == "" {
+			t.Error("missing User-Agent header")
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &sumdb.Client{Endpoint: srv.URL}
+	lookup, err := c.Lookup(context.Background(), "github.com/axonops/audit", "v0.2.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := lookup.Module, "github.com/axonops/audit"; got != want {
+		t.Errorf("Module: got %q want %q", got, want)
+	}
+	if got, want := lookup.Version, "v0.2.2"; got != want {
+		t.Errorf("Version: got %q want %q", got, want)
+	}
+	if got, want := lookup.Hash, "h1:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ="; got != want {
+		t.Errorf("Hash: got %q want %q", got, want)
+	}
+	if got, want := lookup.ModHash, "h1:ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210abcdef="; got != want {
+		t.Errorf("ModHash: got %q want %q", got, want)
+	}
+}
+
+func TestLookup_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &sumdb.Client{Endpoint: srv.URL}
+	_, err := c.Lookup(context.Background(), "github.com/axonops/audit", "v9.9.9")
+	if !errors.Is(err, sumdb.ErrNotFound) {
+		t.Fatalf("got %v want ErrNotFound", err)
+	}
+}
+
+func TestLookup_Gone(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &sumdb.Client{Endpoint: srv.URL}
+	_, err := c.Lookup(context.Background(), "github.com/axonops/audit", "v0.0.0-retracted")
+	if !errors.Is(err, sumdb.ErrNotFound) {
+		t.Fatalf("got %v want ErrNotFound (Gone should map to ErrNotFound)", err)
+	}
+}
+
+func TestLookup_Non2xxStatusReturnsError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &sumdb.Client{Endpoint: srv.URL}
+	_, err := c.Lookup(context.Background(), "github.com/axonops/audit", "v0.2.2")
+	if err == nil {
+		t.Fatal("expected error on 500 response")
+	}
+	if errors.Is(err, sumdb.ErrNotFound) {
+		t.Errorf("500 should NOT map to ErrNotFound: %v", err)
+	}
+}
+
+func TestLookup_TimeoutAborts(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &sumdb.Client{Endpoint: srv.URL, Timeout: 50 * time.Millisecond}
+	_, err := c.Lookup(context.Background(), "github.com/axonops/audit", "v0.2.2")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestLookup_RejectsEmptyArgs(t *testing.T) {
+	t.Parallel()
+	c := &sumdb.Client{Endpoint: "http://unused"}
+	if _, err := c.Lookup(context.Background(), "", "v0.2.2"); err == nil {
+		t.Error("expected error on empty module")
+	}
+	if _, err := c.Lookup(context.Background(), "github.com/axonops/audit", ""); err == nil {
+		t.Error("expected error on empty version")
+	}
+}
+
+func TestParseSumdbResponse_TableCases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		module    string
+		version   string
+		body      string
+		wantHash  string
+		wantMod   string
+		wantError string
+	}{
+		{
+			name:     "well-formed response",
+			module:   "github.com/axonops/audit",
+			version:  "v0.2.2",
+			body:     "1\ngithub.com/axonops/audit v0.2.2 h1:AAA=\ngithub.com/axonops/audit v0.2.2/go.mod h1:BBB=\n\n",
+			wantHash: "h1:AAA=",
+			wantMod:  "h1:BBB=",
+		},
+		{
+			name:      "missing leading id line",
+			module:    "github.com/axonops/audit",
+			version:   "v0.2.2",
+			body:      "",
+			wantError: "empty response",
+		},
+		{
+			name:      "module mismatch in line",
+			module:    "github.com/axonops/audit",
+			version:   "v0.2.2",
+			body:      "1\ngithub.com/evil/audit v0.2.2 h1:AAA=\n",
+			wantError: "line module mismatch",
+		},
+		{
+			name:      "version mismatch in line",
+			module:    "github.com/axonops/audit",
+			version:   "v0.2.2",
+			body:      "1\ngithub.com/axonops/audit v0.3.0 h1:AAA=\n",
+			wantError: "line version mismatch",
+		},
+		{
+			name:      "missing h1 prefix",
+			module:    "github.com/axonops/audit",
+			version:   "v0.2.2",
+			body:      "1\ngithub.com/axonops/audit v0.2.2 sha256:bare=\n",
+			wantError: "missing h1: prefix",
+		},
+		{
+			name:      "wrong field count",
+			module:    "github.com/axonops/audit",
+			version:   "v0.2.2",
+			body:      "1\ngithub.com/axonops/audit v0.2.2 h1:AAA= EXTRA\n",
+			wantError: "want 3 fields",
+		},
+		{
+			name:      "no module hash line",
+			module:    "github.com/axonops/audit",
+			version:   "v0.2.2",
+			body:      "1\ngithub.com/axonops/audit v0.2.2/go.mod h1:BBB=\n",
+			wantError: "no module hash line",
+		},
+		{
+			name:      "no go.mod hash line",
+			module:    "github.com/axonops/audit",
+			version:   "v0.2.2",
+			body:      "1\ngithub.com/axonops/audit v0.2.2 h1:AAA=\n",
+			wantError: "no go.mod hash line",
+		},
+		{
+			name:      "duplicate module hash rejected",
+			module:    "github.com/axonops/audit",
+			version:   "v0.2.2",
+			body:      "1\ngithub.com/axonops/audit v0.2.2 h1:AAA=\ngithub.com/axonops/audit v0.2.2 h1:CCC=\n",
+			wantError: "duplicate module hash",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(srv.Close)
+
+			c := &sumdb.Client{Endpoint: srv.URL}
+			lookup, err := c.Lookup(context.Background(), tc.module, tc.version)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("got err=%v want substring %q", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got, want := lookup.Hash, tc.wantHash; got != want {
+				t.Errorf("Hash: got %q want %q", got, want)
+			}
+			if got, want := lookup.ModHash, tc.wantMod; got != want {
+				t.Errorf("ModHash: got %q want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestLookup_EscapesUppercaseModulePath(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &sumdb.Client{Endpoint: srv.URL}
+	_, _ = c.Lookup(context.Background(), "github.com/AxonOps/Audit", "v0.2.2")
+	want := "/lookup/github.com/!axon!ops/!audit@v0.2.2"
+	if gotPath != want {
+		t.Errorf("escaped path: got %q want %q", gotPath, want)
+	}
+}

--- a/cmd/release-tool/main.go
+++ b/cmd/release-tool/main.go
@@ -123,6 +123,8 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		return runCreateTag(ctx, subArgs, stdout, stderr, &rf)
 	case "commit-pinned-deps":
 		return runCommitPinnedDeps(ctx, subArgs, stdout, stderr, &rf)
+	case "preflight-tidy-check":
+		return runPreflightTidyCheck(ctx, subArgs, stdout, stderr, &rf)
 	}
 
 	_, _ = fmt.Fprintf(stderr, "release-tool: unknown subcommand %q; run --help for usage\n", sub)
@@ -195,6 +197,12 @@ SUBCOMMANDS
                           Idempotent: tag-at-same-SHA exits 4 (no-op);
                           tag-at-different-SHA exits 1 (contamination).
                           Replaces the v0.2.1 bash tag helper.
+    preflight-tidy-check  Validate the working-tree diff produced by
+                          ` + "`make tidy`" + ` against the six #967 safety gates
+                          before the release.yml preflight-tidy job
+                          commits it. Exits non-zero with an exact
+                          operator-facing error string on any gate
+                          failure.
 
 EXIT CODES
     0 — success

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -546,6 +546,81 @@ configuration in the UI before tagging the release.
 
 ## For Maintainers: Cutting a Release
 
+### Preflight tidy (#967)
+
+Every `workflow_dispatch` of `release.yml` starts with a
+`preflight-tidy` job that runs `make tidy` on the dispatched main
+ref BEFORE the CI Gate runs, then absorbs any benign go.sum drift
+into an App-signed auto-merge PR. This mirrors `post-release-tidy`
+(#959/#966) on the PRE-side of the release flow, closing the
+chicken-and-egg gap where the very first release after a
+non-tidy-state cannot self-heal.
+
+**Why it exists.** v0.2.3's dispatch (run 27325930898) failed at
+the CI Gate's Hygiene job because main's `go.sum` carried v0.2.2's
+post-tag drift. `make tidy` produced a diff, `tidy-check` failed,
+the whole CI Gate cascaded into failure, and tag-all never ran.
+#966's `post-release-tidy` was meant to prevent this AFTER each
+release, but it only takes effect once it has been merged AND
+run — and run-1 is v0.2.3 itself, which couldn't reach tag-all.
+#967 closes that gap.
+
+**What the job does.**
+
+1. Mints a release-bot App token; checks out main.
+2. Runs `make tidy` against every published module.
+3. Invokes `release-tool preflight-tidy-check` to enforce 6
+   NON-NEGOTIABLE safety gates against the resulting diff. The
+   subcommand is typed Go (`cmd/release-tool/cmd_preflight_tidy_check.go`)
+   — bash + jq + gh-CLI for release-critical work was retired by
+   #929 and a regression to inline bash would have re-opened the
+   v0.2.1 cascade class.
+4. On no-diff, exits with `preflight-tidy: no drift to absorb` and
+   the rest of the release dispatch proceeds against main HEAD
+   unchanged.
+5. On a clean diff, App-signs the commit via
+   `release-tool commit-pinned-deps` (existing allowlist already
+   covers go.mod + go.sum), opens an auto-merge PR titled
+   `chore: preflight-tidy go.sum refresh (vX.Y.Z)`, polls until
+   the PR merges, then continues with the release dispatch.
+
+**The 6 safety gates.**
+
+| # | Gate | Failure exit string |
+|---|------|---------------------|
+| 1 | Diff is go.sum-only (no go.mod changes) | `preflight-tidy: go.mod modified — aborting` |
+| 2 | Additions only (no deletions) | `preflight-tidy: go.sum lines deleted — aborting` |
+| 3 | Lines reference published modules at the last-released version only | `preflight-tidy: unrelated checksum lines — aborting` |
+| 4 | sum.golang.org transparency-log cross-check on every (module, version) | `preflight-tidy: sum.golang.org disagrees — aborting` (mismatch) / `preflight-tidy: sum.golang.org timeout or 5xx — aborting` (transient) |
+| 5 | Diff committed via auto-merge PR, never direct push | (orchestrated in workflow; `preflight-tidy: PR auto-merge refused — aborting` on a merge refusal) |
+| 6 | `inputs.skip_preflight_tidy=true` escape hatch | `preflight-tidy: skipped via skip_preflight_tidy input` |
+
+A successful no-drift run emits `preflight-tidy: no drift to
+absorb`; a successful drift-absorbed run emits
+`preflight-tidy: PR opened`. Every emit goes to both stdout AND
+`$GITHUB_STEP_SUMMARY` so operators can audit the dispatch trail.
+
+**`inputs.skip_preflight_tidy` escape hatch.**
+
+The workflow_dispatch input bypasses the preflight-tidy gate
+entirely. Set it ONLY when:
+
+- An independent investigation has confirmed the go.sum drift is
+  benign AND
+- sum.golang.org is known to be unreachable (verified via an
+  alternate channel — not just "the gate failed and we want to
+  ship").
+
+**NEVER** set the flag in response to a `gate 4` disagreement.
+A `sum.golang.org disagrees` message means the proxy is returning
+a hash the transparency log does not have — that is a supply-chain
+anomaly to investigate, not bypass.
+
+A bypass is logged as a `::warning::` workflow annotation AND
+emits a GFM `> [!CAUTION]` admonition to the run summary
+containing the actor login + timestamp. Bypassing leaves an
+auditable trail; do not use it casually.
+
 ### Release Workflow Overview
 
 Two GitHub Actions workflows participate in releases. The primary workflow

--- a/tests/release-scripts/release-yml-grep.bats
+++ b/tests/release-scripts/release-yml-grep.bats
@@ -355,3 +355,106 @@ setup() {
     # Summary `needs:` list must include post-release-tidy.
     awk '/^  summary:/,/^[^[:space:]]/' "$RELEASE_YML" | grep -qE '^[[:space:]]+- post-release-tidy$'
 }
+
+# --- #967 — preflight-tidy self-healing on go.sum drift ---
+
+@test "test_release_yml_preflight_tidy_job_exists" {
+    # #967 fix: the preflight-tidy job mirrors post-release-tidy
+    # (#959/#966) on the PRE-side of the release flow. v0.2.3's
+    # dispatch (run 27325930898) failed because main's go.sum
+    # carried v0.2.2's post-tag drift residue; this job runs
+    # `make tidy` and absorbs the diff via release-tool's existing
+    # commit-pinned-deps subcommand.
+    body=$(awk '/^  preflight-tidy:/,/^  ci:/' "$RELEASE_YML")
+    echo "$body" | grep -qF 'preflight-tidy:'
+    echo "$body" | grep -qF 'run: make tidy'
+    echo "$body" | grep -qF 'preflight-tidy-check'
+    echo "$body" | grep -qF 'commit-pinned-deps'
+    echo "$body" | grep -qF 'chore/preflight-tidy-'
+}
+
+@test "test_release_yml_preflight_tidy_gated_on_workflow_dispatch" {
+    # #967: the recovery push:tag path assumes a clean tag-commit
+    # state; preflight-tidy is workflow_dispatch only.
+    body=$(awk '/^  preflight-tidy:/,/^  ci:/' "$RELEASE_YML")
+    echo "$body" | grep -qF "github.event_name == 'workflow_dispatch'"
+}
+
+@test "test_release_yml_preflight_tidy_enforces_go_sum_only" {
+    # #967 gate 1: msgGoModModified — see
+    # cmd/release-tool/cmd_preflight_tidy_check.go. The exact AC #4
+    # error string must be greppable in the workflow body or the
+    # subcommand wiring so a regression that mis-emits the string
+    # fails the grep.
+    grep -qF 'preflight-tidy: go.mod modified — aborting' \
+        "${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
+}
+
+@test "test_release_yml_preflight_tidy_rejects_deletions" {
+    # #967 gate 2: msgGoSumDeletions.
+    grep -qF 'preflight-tidy: go.sum lines deleted — aborting' \
+        "${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
+}
+
+@test "test_release_yml_preflight_tidy_cross_checks_sum_golang_org" {
+    # #967 gate 4: sum.golang.org cross-check. Verify both the
+    # workflow wires the sumdb endpoint AND the subcommand emits
+    # the AC #4 disagree + transient strings.
+    body=$(awk '/^  preflight-tidy:/,/^  ci:/' "$RELEASE_YML")
+    echo "$body" | grep -qF 'https://sum.golang.org'
+    grep -qF 'preflight-tidy: sum.golang.org disagrees — aborting' \
+        "${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
+    grep -qF 'preflight-tidy: sum.golang.org timeout or 5xx — aborting' \
+        "${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
+}
+
+@test "test_release_yml_preflight_tidy_opens_auto_merge_pr" {
+    # #967 gate 5: PR-not-direct-push. The workflow must use
+    # release-tool's App-signed commit-pinned-deps subcommand,
+    # then gh pr create + gh pr merge --auto.
+    body=$(awk '/^  preflight-tidy:/,/^  ci:/' "$RELEASE_YML")
+    echo "$body" | grep -qF 'commit-pinned-deps'
+    echo "$body" | grep -qF 'gh pr create'
+    echo "$body" | grep -qF -- '--auto --squash'
+    echo "$body" | grep -qF 'preflight-tidy: PR opened'
+    echo "$body" | grep -qF 'preflight-tidy: PR auto-merge refused — aborting'
+}
+
+@test "test_release_yml_preflight_tidy_honours_skip_input" {
+    # #967 gate 6: inputs.skip_preflight_tidy escape hatch. The
+    # workflow must declare the input AND emit the AC #4 string
+    # when set, plus surface a ::warning:: and a GFM CAUTION block.
+    grep -qF 'skip_preflight_tidy:' "$RELEASE_YML"
+    body=$(awk '/^  preflight-tidy:/,/^  ci:/' "$RELEASE_YML")
+    echo "$body" | grep -qF 'preflight-tidy: skipped via skip_preflight_tidy input'
+    echo "$body" | grep -qF '::warning::'
+    echo "$body" | grep -qF '[!CAUTION]'
+}
+
+@test "test_release_yml_preflight_tidy_emits_exact_error_strings" {
+    # Property-style: every AC #4 exact string must appear at least
+    # once in the workflow body OR the subcommand source. Any miss
+    # means the operator-facing contract is broken.
+    SUBCMD="${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
+    # Strings the SUBCOMMAND emits (idempotent + validation paths).
+    grep -qF 'preflight-tidy: no drift to absorb' "$SUBCMD"
+    grep -qF 'preflight-tidy: go.mod modified — aborting' "$SUBCMD"
+    grep -qF 'preflight-tidy: go.sum lines deleted — aborting' "$SUBCMD"
+    grep -qF 'preflight-tidy: unrelated checksum lines — aborting' "$SUBCMD"
+    grep -qF 'preflight-tidy: sum.golang.org disagrees — aborting' "$SUBCMD"
+    grep -qF 'preflight-tidy: sum.golang.org timeout or 5xx — aborting' "$SUBCMD"
+    # Diff-size-cap defence-in-depth string (test-analyst review).
+    grep -qF 'preflight-tidy: diff exceeds 8 KiB cap — aborting' "$SUBCMD"
+    # Strings the WORKFLOW emits (PR + skip paths).
+    grep -qF 'preflight-tidy: PR opened' "$RELEASE_YML"
+    grep -qF 'preflight-tidy: PR auto-merge refused — aborting' "$RELEASE_YML"
+    grep -qF 'preflight-tidy: skipped via skip_preflight_tidy input' "$RELEASE_YML"
+}
+
+@test "test_release_yml_preflight_tidy_in_summary_needs" {
+    # AC #6: summary lists preflight-tidy in needs and its result
+    # in the status table.
+    awk '/^  summary:/,/^[^[:space:]]/' "$RELEASE_YML" \
+        | grep -qE '^[[:space:]]+- preflight-tidy$'
+    grep -qF 'needs.preflight-tidy.result' "$RELEASE_YML"
+}


### PR DESCRIPTION
## Summary

Adds a `preflight-tidy` job to `release.yml` that runs `make tidy` BEFORE the CI Gate and absorbs any benign go.sum drift via an App-signed auto-merge PR. New typed-Go subcommand `release-tool preflight-tidy-check` enforces 6 NON-NEGOTIABLE safety gates including a direct sum.golang.org transparency-log cross-check. Mirror of #966 on the PRE-side of the release flow.

## Why

v0.2.3's dispatch (run 27325930898) failed at the CI Gate's Hygiene job because main's go.sum carried v0.2.2's post-tag drift residue. #966's `post-release-tidy` was meant to prevent this but only takes effect AFTER tag-all of a release that has already merged AND run #966 — chicken-and-egg with v0.2.3 itself.

## Architecture

Pre-coding consults (devops + security-reviewer + code-reviewer + test-writer) drove:
- **Typed Go subcommand** (not bash) — project memory explicitly retires bash + jq + gh-CLI for release-critical work (#929).
- **Direct sum.golang.org HTTPS** (not `go mod download`) — `go mod download`'s `Sum` field check is proxy-against-proxy when go.sum already has the line or the cache is warm. Real transparency-log verification requires the raw HTTPS GET.
- **Gate 3 rooted at last-released version** (not dispatched) — the dispatched version isn't on the proxy yet at preflight time.
- **6 safety gates** with exact AC #4 operator-facing error strings.

## Test plan

- [x] `go test ./cmd/release-tool/... -race -count=1` — 0 fail (19 new table-driven tests).
- [x] `golangci-lint run ./cmd/release-tool/...` — 0 issues.
- [x] `make test-release-scripts` — 117/117 pass (9 new under `release-yml-grep.bats`).
- [x] `make release-check` — valid.
- [x] `gofmt`, `goimports`, `go vet`, `go mod tidy` — all clean.
- [ ] CI green on this PR.
- [ ] After merge: v0.2.3 dispatch reaches `tag-all` for the first time without admin-bypass on Hygiene.

## Risk

- Auto-mutation of main on every dispatch — mitigated by the 6 safety gates + PR-only commits + auto-merge (never direct push) + diff-size cap.
- Sumdb cross-check is the load-bearing supply-chain control — directly tested in `internal/sumdb/lookup_test.go`.
- Post-coding reviews flagged M1/M2/M3 (correctness) + MEDIUM-1/2/3 (security) — all fixed in this commit. Polish items (goleak integration, edge-case test expansion, weak-assertion strengthening, mutation pass) deferred to follow-up #968.

Closes #967. Follow-up: #968.