### PR TITLE
docs: pre-v0.2.3 doc-state corrections from doc-review gate

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -146,8 +146,9 @@ jobs:
           # hatch — overrides the auto-detection. Set it to the
           # workflow_dispatch `version` input so .Tag / .Version
           # resolve to the dispatched value regardless of what
-          # `git describe` would pick. #958 tracks collapsing this
-          # bandage stack into a single fix.
+          # `git describe` would pick. This is the canonical
+          # structural fix for the lightweight-vs-annotated tag
+          # ambiguity (#958 retired the surrounding bandages).
           GORELEASER_CURRENT_TAG: ${{ inputs.version }}
 
       - name: Attest release artifacts

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -110,8 +110,9 @@ checksum:
 # We sign checksums.txt — not every binary — because the checksum
 # file is the cryptographic root of trust for every artifact in the
 # release: a verified checksums.txt plus `sha256sum -c` extends the
-# guarantee to every binary listed inside it. One signature pair
-# (.sig + .pem) protects the entire release manifest.
+# guarantee to every binary listed inside it. One bundle file
+# (.bundle) protects the entire release manifest (#958 — cosign v2.6
+# bundle format; the pre-#958 .sig + .pem split is retired).
 #
 # Identity: https://github.com/axonops/audit/.github/workflows/release.yml@refs/tags/<tag>
 # Issuer:   https://token.actions.githubusercontent.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Cosign signature artefact is now a single bundle file (#958).**
+  The release signature recipe migrates from the split
+  `checksums.txt.sig` + `checksums.txt.pem` layout to the cosign
+  v2.6 bundle format (`checksums.txt.bundle`). The new verifier
+  recipe is:
+
+  ```bash
+  cosign verify-blob \
+    --bundle checksums.txt.bundle \
+    --certificate-identity-regexp '^https://github\.com/axonops/audit/\.github/workflows/release\.yml@refs/tags/v.+$' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-github-workflow-repository axonops/audit \
+    checksums.txt
+  ```
+
+  Requires cosign v2.6+ (the bundle-format flag is the v2.6
+  default). Consumers using cosign v2.5 must upgrade. The
+  `goreleaser.yml` and `release.yml` `cosign-installer` v2.5.3
+  pins added by #950/#953 are removed in the same change.
+  `docs/releasing.md` "Verify a Release with Cosign" rewrites the
+  recipe end-to-end.
+
+### Removed
+
+- **`ghcr.io/axonops/audit-gen` OCI image publishing (#953).** The
+  multi-arch container image added in #610 is no longer published.
+  `audit-gen` is a developer-facing CLI tool whose canonical
+  install path is the Go module proxy
+  (`go install github.com/axonops/audit/cmd/audit-gen@vX.Y.Z`) or
+  the per-release binary tarball at
+  <https://github.com/axonops/audit/releases>. Shipping a docker
+  image added a recurring release tax (login step, cosign-installer
+  flag drift, `.Tag` template ambiguity vs annotated tags, GHCR
+  org-package permission chase) and was not pulling its weight —
+  the v0.2.2 dispatch was blocked across attempts 5–7 on it. The
+  `dockers:` / `docker_manifests:` / `docker_signs:` stanzas, the
+  `cmd/audit-gen/Dockerfile`, and the workflow docker-login + buildx
+  + qemu steps are all removed. The release tarball + checksum +
+  cosign signature + build-provenance attestation paths are
+  unchanged.
+
 ### Fixed
 
 - **Fix release dispatch failing on post-tag go.sum drift via preflight-tidy job (#967).**
@@ -31,64 +74,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `::warning::` + GFM CAUTION audit trail. See `docs/releasing.md`
   § "Preflight tidy (#967)" for the failure-mode table and the
   operator playbook. Tested by 9 named bats assertions
-  (`tests/release-scripts/release-yml-grep.bats`) and 11 table-
+  (`tests/release-scripts/release-yml-grep.bats`) and 19 table-
   driven Go tests (`cmd/release-tool/cmd_preflight_tidy_check_test.go`
   + `cmd/release-tool/internal/sumdb/lookup_test.go`).
-
-### Changed
-
-- **Cosign signature artefact is now a single bundle file (#958).**
-  The release signature recipe migrates from the split
-  `checksums.txt.sig` + `checksums.txt.pem` layout to the cosign
-  v2.6 bundle format (`checksums.txt.bundle`). The new verifier
-  recipe is:
-
-  ```bash
-  cosign verify-blob \
-    --bundle checksums.txt.bundle \
-    --certificate-identity-regexp '^https://github\.com/axonops/audit/\.github/workflows/release\.yml@refs/tags/v.+$' \
-    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-    --certificate-github-workflow-repository axonops/audit \
-    checksums.txt
-  ```
-
-  Requires cosign v2.6+ (the bundle-format flag is the v2.6
-  default). Consumers using cosign v2.5 must upgrade. The
-  `goreleaser.yml` manual-rerun workflow's cosign-installer pin
-  (introduced by #950, mirrored on `release.yml` in #953) is
-  removed in the same change. `docs/releasing.md` "Verify a
-  Release with Cosign" rewrites the recipe end-to-end.
-
-### Removed
-
-- **`ghcr.io/axonops/audit-gen` OCI image publishing (#953).** The
-  multi-arch container image added in #610 is no longer published.
-  `audit-gen` is a developer-facing CLI tool whose canonical
-  install path is the Go module proxy
-  (`go install github.com/axonops/audit/cmd/audit-gen@vX.Y.Z`) or
-  the per-release binary tarball at
-  <https://github.com/axonops/audit/releases>. Shipping a docker
-  image added a recurring release tax (login step, cosign-installer
-  flag drift, `.Tag` template ambiguity vs annotated tags, GHCR
-  org-package permission chase) and was not pulling its weight —
-  the v0.2.2 dispatch was blocked across attempts 5–7 on it. The
-  `dockers:` / `docker_manifests:` / `docker_signs:` stanzas, the
-  `cmd/audit-gen/Dockerfile`, and the workflow docker-login + buildx
-  + qemu steps are all removed. The release tarball + checksum +
-  cosign signature + build-provenance attestation paths are
-  unchanged.
-
-### Fixed
-
-- **`release.yml` cosign binary pin (#953).** The automated tag
-  flow's `sigstore/cosign-installer` step was previously unpinned
-  and defaulted to `cosign latest`, which now resolves to v2.6+
-  with `--new-bundle-format` as the silent default. This is the
-  same regression that broke v0.2.2's 5th manual dispatch and was
-  fixed in `goreleaser.yml` under #950. Pinned to `v2.5.3` to keep
-  the `.sig` / `.pem` layout consumers' verifier recipe depended
-  on at the time of #953; subsequently removed in #958 when the
-  signs: stanza migrated to the cosign v2.6 bundle format.
 - **`regen-schema-artifacts-check` + `ta-diff-check` release-PR
   head-ref carve-out (#957).** Both Makefile targets shell out to
   `go run ./cmd/audit-gen`, which has to resolve every published

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 This library is **pre-release (v0.x)**. The API may change between
 minor versions until v1.0.0. Pin your dependency version
-(e.g. `go get github.com/axonops/audit@v0.2.0`) and read the
+(e.g. `go get github.com/axonops/audit@v0.2.3`) and read the
 CHANGELOG before upgrading.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -360,7 +360,7 @@ The supply-chain primitives we DO provide are stronger for both audiences:
   attestation. Verify any downloaded artifact:
 
   ```bash
-  gh attestation verify audit-gen_v0.1.x_linux_amd64.tar.gz \
+  gh attestation verify audit-gen_v0.2.3_linux_amd64.tar.gz \
       --repo axonops/audit
   ```
 
@@ -391,12 +391,13 @@ Every release publishes a Sigstore-keyless signature over
 `checksums.txt` alongside the existing build-provenance attestation
 (#516). The two mechanisms protect different properties:
 
-- **Cosign signature** (`checksums.txt.sig` + `checksums.txt.pem`)
-  proves the checksum file came from the `axonops/audit`
-  GitHub Actions workflow at the tagged ref. There is no long-lived
-  private key — each signature is bound to the OIDC identity of the
-  workflow run via Sigstore's Fulcio CA, and the signature is
-  recorded in the public Rekor transparency log.
+- **Cosign bundle** (`checksums.txt.bundle`) proves the checksum
+  file came from the `axonops/audit` GitHub Actions workflow at the
+  tagged ref. The bundle is a single file containing the signature,
+  the Fulcio-issued short-lived X.509 certificate, and the Rekor
+  transparency-log entry — the cosign v2.6 default format
+  (migrated in #958). There is no long-lived private key; each
+  signature is bound to the OIDC identity of the workflow run.
 - **Build provenance** (`gh attestation verify ...`) proves the
   artifact was built from a specific commit SHA by that workflow.
 

--- a/cmd/audit-gen/README.md
+++ b/cmd/audit-gen/README.md
@@ -193,7 +193,7 @@ Or pin a specific binary version into a job:
 
 ```yaml
 - name: Install audit-gen
-  run: go install github.com/axonops/audit/cmd/audit-gen@v0.2.0
+  run: go install github.com/axonops/audit/cmd/audit-gen@v0.2.3
 
 - name: Regenerate
   run: audit-gen -input taxonomy.yaml -output audit_generated.go -package mypackage
@@ -204,12 +204,12 @@ Or pin a specific binary version into a job:
 Maintainers triggering proxy.golang.org indexing after a release tag:
 
 ```bash
-make publish-trigger VERSION=v0.2.0
+make publish-trigger VERSION=v0.2.3
 ```
 
 This walks the published modules — including
 `github.com/axonops/audit/cmd/audit-gen` — and forces a proxy
-fetch so `go install …@v0.2.0` resolves immediately.
+fetch so `go install …@v0.2.3` resolves immediately.
 
 ## See also
 

--- a/cmd/audit-validate/README.md
+++ b/cmd/audit-validate/README.md
@@ -177,7 +177,7 @@ jobs:
           go-version: '1.26'
 
       - name: Install audit-validate
-        run: go install github.com/axonops/audit/cmd/audit-validate@v0.2.0
+        run: go install github.com/axonops/audit/cmd/audit-validate@v0.2.3
 
       - name: Validate every env
         run: |

--- a/cmd/release-tool/README.md
+++ b/cmd/release-tool/README.md
@@ -3,10 +3,12 @@
 [![Go Reference][godoc-badge]][godoc]
 
 `release-tool` is the audit project's internal CLI that drives the
-release workflow. It replaces the two failing bash + jq + gh-CLI
-helpers that produced 7 cascading bugs during v0.2.1 (#900–#916).
-PR-6 (#929) deleted those bash scripts; this Go binary is the
-canonical App-signed commit + tag path.
+release workflow. It replaces the bash + jq + gh-CLI helpers that
+produced 7 cascading bugs during v0.2.1 (#900–#916). PR-6 (#929)
+deleted those bash scripts; this Go binary is the canonical
+App-signed commit + tag path. #967 added a third subcommand
+(`preflight-tidy-check`) that validates `make tidy` output against
+6 safety gates before the release dispatch absorbs the diff.
 
 > **Module path**: `github.com/axonops/audit/cmd/release-tool`
 > **Status**: pre-release (v0.x) — internal binary, NOT published to consumers
@@ -124,6 +126,34 @@ On success the tag OBJECT SHA is written to stdout. With `--dry-run`,
 the two proposed payloads (`POST /git/tags` and `POST /git/refs`)
 are written to stdout instead and no API mutation occurs.
 
+#### `preflight-tidy-check`
+
+Validates the working tree's uncommitted diff (presumed to be the
+output of a fresh `make tidy`) against six NON-NEGOTIABLE safety
+gates before the release.yml `preflight-tidy` job (#967) commits
+it. Each gate failure exits with an exact operator-facing error
+string declared in #967 AC #4 (see `docs/releasing.md` § "Preflight
+tidy (#967)" for the failure-mode table).
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--last-released-version` | yes | The last released `vX.Y.Z` — gates 3 + 4 root their checks here |
+| `--published-modules` | yes | Comma-separated list of published module paths (derived from `make print-publish-modules`) |
+| `--workdir` | no | Path to the git working directory (default: `.`) |
+| `--max-diff-bytes` | no | Hard cap on diff size (default: `8192`) |
+| `--sumdb-endpoint` | no | Override the sum.golang.org endpoint (test-only) |
+| `--sumdb-timeout` | no | Per-module sumdb lookup timeout (default: `30s`) |
+| `--skip-sumdb-cross-check` | no | DANGER — skip gate 4 (test-only) |
+
+Exit codes (additions to the project-wide table above):
+- `0` — every gate passed; stdout lists `<module> <version>` per validated pair.
+- `3` — a safety gate aborted; stdout + stderr carry the AC #4 string.
+- `4` — no diff (idempotent no-op).
+
+The subcommand performs the sum.golang.org transparency-log lookup
+directly via HTTPS — `GOPROXY` is not consulted on the verification
+path. See `internal/sumdb/` for the signed-note threat model.
+
 ## Internal packages
 
 | Package | Purpose |
@@ -132,6 +162,7 @@ are written to stdout instead and no API mutation occurs.
 | `internal/gitstatus` | NUL-safe `git status -z` parser (regression for #907). |
 | `internal/allowlist` | go.mod / go.sum allowlist enforcement (rejects vendor/, .github/, symlinks). |
 | `internal/ghclient` | Typed wrapper around 3 GitHub REST endpoints with slog instrumentation. |
+| `internal/sumdb` | Direct sum.golang.org transparency-log lookup for `preflight-tidy-check` gate 4 (#967). |
 
 Each package is unit-tested against `httptest.Server` fixtures and is
 covered ≥ 85 %.

--- a/cmd/release-tool/main.go
+++ b/cmd/release-tool/main.go
@@ -57,9 +57,8 @@ import (
 // version is overridden at build time via -ldflags.
 var version = "dev"
 
-// Exit codes. All are referenced in the help text; PR-3 subcommands
-// will start returning the validation / idempotent codes once they
-// land.
+// Exit codes. All are referenced in the help text and returned by
+// the subcommands below.
 const (
 	exitSuccess        = 0
 	exitOperational    = 1

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -35,7 +35,7 @@ small binaries).
 
 ```bash
 # Pin the version to keep CI reproducible:
-go install github.com/axonops/audit/cmd/audit-validate@v0.1.11
+go install github.com/axonops/audit/cmd/audit-validate@v0.2.3
 
 # Or, for ad-hoc local use:
 go install github.com/axonops/audit/cmd/audit-validate@latest
@@ -44,7 +44,7 @@ go install github.com/axonops/audit/cmd/audit-validate@latest
 Released versions are also published as pre-built binaries by
 GoReleaser alongside `audit-gen`; see the GitHub Releases page.
 
-In CI, **always pin to a specific version** (`@v0.1.11`, not
+In CI, **always pin to a specific version** (`@v0.2.3`, not
 `@latest`). `@latest` resolves to whatever the proxy serves at run
 time and makes validation results non-reproducible across runs.
 
@@ -162,7 +162,7 @@ jobs:
           cache: true
       - name: Install audit-validate
         # Pin the version; never use @latest in CI.
-        run: go install github.com/axonops/audit/cmd/audit-validate@v0.1.11
+        run: go install github.com/axonops/audit/cmd/audit-validate@v0.2.3
       - name: Validate audit configuration
         run: |
           audit-validate \

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -328,7 +328,7 @@ Code / Continue / RAG tools), see [llms-full.txt](llms-full.txt).
 
 This library is **pre-release (v0.x)**. The API may change between
 minor versions until v1.0.0. Pin your dependency version
-(e.g. `go get github.com/axonops/audit@v0.2.0`) and read the
+(e.g. `go get github.com/axonops/audit@v0.2.3`) and read the
 CHANGELOG before upgrading.
 
 ---
@@ -14582,7 +14582,7 @@ small binaries).
 
 ```bash
 # Pin the version to keep CI reproducible:
-go install github.com/axonops/audit/cmd/audit-validate@v0.1.11
+go install github.com/axonops/audit/cmd/audit-validate@v0.2.3
 
 # Or, for ad-hoc local use:
 go install github.com/axonops/audit/cmd/audit-validate@latest
@@ -14591,7 +14591,7 @@ go install github.com/axonops/audit/cmd/audit-validate@latest
 Released versions are also published as pre-built binaries by
 GoReleaser alongside `audit-gen`; see the GitHub Releases page.
 
-In CI, **always pin to a specific version** (`@v0.1.11`, not
+In CI, **always pin to a specific version** (`@v0.2.3`, not
 `@latest`). `@latest` resolves to whatever the proxy serves at run
 time and makes validation results non-reproducible across runs.
 
@@ -14709,7 +14709,7 @@ jobs:
           cache: true
       - name: Install audit-validate
         # Pin the version; never use @latest in CI.
-        run: go install github.com/axonops/audit/cmd/audit-validate@v0.1.11
+        run: go install github.com/axonops/audit/cmd/audit-validate@v0.2.3
       - name: Validate audit configuration
         run: |
           audit-validate \


### PR DESCRIPTION
## Summary

Pre-v0.2.3-dispatch documentation corrections surfaced by the doc-review gate (user-guide-reviewer + code-reviewer agents run on main after #969 merged). 1 BLOCKER + 4 MAJOR + 5 polish-class fixes consolidated into one PR so v0.2.3 ships with internally-consistent docs.

## What's in here

- **SECURITY.md** — cosign bullet migrated from `.sig` + `.pem` to `.bundle`; `gh attestation verify` example pinned to `v0.2.3`. **The BLOCKER**: consumers reading the security policy would hunt for files v0.2.3 will not ship.
- **docs/validation.md** — bump `@v0.1.11` → `@v0.2.3` at all 3 narrative pin examples.
- **README.md** + **cmd/audit-gen/README.md** + **cmd/audit-validate/README.md** — bump `@v0.2.0` → `@v0.2.3` install snippets and the `make publish-trigger` example.
- **cmd/release-tool/README.md** — add the #967 `preflight-tidy-check` subcommand section (was entirely missing); add `internal/sumdb` to the internal-packages table; update lead paragraph for the third subcommand.
- **cmd/release-tool/main.go** — drop stale "will start returning" forward-looking comment on the exit-codes block.
- **.goreleaser.yml** — rewrite the "One signature pair (.sig + .pem)" comment for the .bundle format.
- **.github/workflows/goreleaser.yml** — drop the stale "#958 tracks collapsing this bandage stack" forward-looking sentence; #958 IS the collapse and merged.
- **CHANGELOG.md** — consolidate duplicate `### Fixed` sections under `[Unreleased]`; reorder to Keep-a-Changelog (Changed / Removed / Fixed); fold the redundant `release.yml` cosign-pin entry (added + removed in the same Unreleased window).
- **llms-full.txt** — regenerated.

## Test plan

- [x] `goreleaser check` — config valid.
- [x] `go test ./cmd/release-tool/...` — clean.
- [x] `make test-release-scripts` — 117/117 pass.
- [x] `make regen-llms` — clean.
- [ ] CI green on this PR (expect the same Hygiene cascade as the prior 6 PRs since this is yet another non-tidy commit before v0.2.3 dispatch).

## Risk

- Pure doc + comment changes plus the `cmd/release-tool/main.go` exit-codes godoc cleanup (no behavioural change). No code paths touched.
- No issue reference — this is a meta-fix from the doc-review gate. Merging this unblocks the v0.2.3 dispatch.