### PR TITLE
fix(ci): preflight-tidy --max-diff-bytes default → 64 KiB (#971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Bump `preflight-tidy-check --max-diff-bytes` default from 8 KiB
+  to 64 KiB (#971).** v0.2.3's first dispatch (run 27361600829)
+  failed at `preflight-tidy` because the diff-size cap was tuned
+  per-module (~8 KiB) but the actual `make tidy` diff against 15
+  sub-module go.sum files is ~10–12 KiB. The error string is also
+  changed from `preflight-tidy: diff exceeds 8 KiB cap — aborting`
+  to `preflight-tidy: diff exceeds size cap — aborting` so future
+  cap bumps don't require lockstep edits to the AC + bats anchors.
 - **Fix release dispatch failing on post-tag go.sum drift via preflight-tidy job (#967).**
   v0.2.3's dispatch (`workflow_dispatch` run 27325930898) failed at
   the CI Gate's Hygiene job because main's `go.sum` carried v0.2.2's

--- a/cmd/release-tool/cmd_preflight_tidy_check.go
+++ b/cmd/release-tool/cmd_preflight_tidy_check.go
@@ -53,7 +53,7 @@ const (
 	msgUnrelatedChecksums  = "preflight-tidy: unrelated checksum lines — aborting"
 	msgSumdbDisagrees      = "preflight-tidy: sum.golang.org disagrees — aborting"
 	msgSumdbTransient      = "preflight-tidy: sum.golang.org timeout or 5xx — aborting"
-	msgDiffSizeCapExceeded = "preflight-tidy: diff exceeds 8 KiB cap — aborting"
+	msgDiffSizeCapExceeded = "preflight-tidy: diff exceeds size cap — aborting"
 )
 
 // runPreflightTidyCheck implements the `preflight-tidy-check`
@@ -82,7 +82,12 @@ func runPreflightTidyCheck(ctx context.Context, args []string, stdout, stderr io
 		"Last released version, e.g. v0.2.2 — gates 3+4 root their checks here (required)")
 	fs.StringVar(&in.publishedModulesCSV, "published-modules", "",
 		"Comma-separated list of github.com/axonops/audit/<sub> module paths to expect in the diff (required)")
-	fs.Int64Var(&in.maxDiffBytes, "max-diff-bytes", 8192,
+	// #971: default bumped 8 KiB → 64 KiB. The original 8 KiB was a
+	// per-module estimate from the #967 security review; the actual
+	// v0.2.2→v0.2.3 drift is ~10–12 KiB across 15 sub-module go.sum
+	// files. 64 KiB bounds a runaway-diff attack but accommodates
+	// expected drift for ~80 modules of headroom.
+	fs.Int64Var(&in.maxDiffBytes, "max-diff-bytes", 65536,
 		"Hard cap on total diff size in bytes; larger diffs abort with msgDiffSizeCapExceeded")
 	fs.StringVar(&in.sumdbEndpoint, "sumdb-endpoint", sumdb.DefaultEndpoint,
 		"Sigstore checksum database endpoint")

--- a/cmd/release-tool/cmd_preflight_tidy_check_test.go
+++ b/cmd/release-tool/cmd_preflight_tidy_check_test.go
@@ -354,13 +354,25 @@ func TestPreflightTidyCheck_MalformedAddedLineDoesNotSilentlyPass(t *testing.T) 
 func TestPreflightTidyCheck_DiffSizeCapAborts(t *testing.T) {
 	t.Parallel()
 	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
-	// Write a go.sum bigger than the default 8 KiB cap.
-	big := strings.Repeat("a", 9000)
+	// Force a tiny cap and write a go.sum just above it. This
+	// tests the cap mechanism without depending on the
+	// (production) default value.
+	big := strings.Repeat("a", 200)
 	if err := writeFile(filepath.Join(repo, "go.sum"), big); err != nil {
 		t.Fatalf("write big go.sum: %v", err)
 	}
 	srv := fakeSumdb(t, nil)
-	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	code := runPreflightTidyCheck(context.Background(), []string{
+		"--workdir", repo,
+		"--last-released-version", "v0.2.2",
+		"--published-modules", "github.com/axonops/audit",
+		"--sumdb-endpoint", srv.URL,
+		"--skip-sumdb-cross-check",
+		"--max-diff-bytes", "100", // tiny cap — must trip
+	}, outBuf, errBuf, &rootFlags{})
+	stdout := outBuf.String()
 	if code != exitValidation {
 		t.Errorf("exit code: got %d want %d", code, exitValidation)
 	}

--- a/tests/release-scripts/release-yml-grep.bats
+++ b/tests/release-scripts/release-yml-grep.bats
@@ -444,7 +444,7 @@ setup() {
     grep -qF 'preflight-tidy: sum.golang.org disagrees — aborting' "$SUBCMD"
     grep -qF 'preflight-tidy: sum.golang.org timeout or 5xx — aborting' "$SUBCMD"
     # Diff-size-cap defence-in-depth string (test-analyst review).
-    grep -qF 'preflight-tidy: diff exceeds 8 KiB cap — aborting' "$SUBCMD"
+    grep -qF 'preflight-tidy: diff exceeds size cap — aborting' "$SUBCMD"
     # Strings the WORKFLOW emits (PR + skip paths).
     grep -qF 'preflight-tidy: PR opened' "$RELEASE_YML"
     grep -qF 'preflight-tidy: PR auto-merge refused — aborting' "$RELEASE_YML"


### PR DESCRIPTION
## Summary

v0.2.3's first dispatch (run 27361600829) failed at `preflight-tidy` with `preflight-tidy: diff exceeds 8 KiB cap — aborting`. Bumping the default cap from 8 KiB to 64 KiB to match the actual project footprint and templatizing the error string.

## Why

The 8 KiB default I chose in #967 was a per-module estimate from the security-reviewer suggestion, not the repo-wide footprint. With 15 sub-module `go.sum` files each gaining 2-4 lines per published module + diff headers, the actual diff is ~10-12 KiB.

64 KiB still bounds a runaway-diff attack (the threat model #967 cited) but accommodates expected drift for ~80 modules of headroom.

## Test plan

- [x] `go test ./cmd/release-tool/... -count=1` — all release-tool tests pass.
- [x] `golangci-lint run ./cmd/release-tool/...` — 0 issues.
- [x] `make test-release-scripts` — 117/117 pass.
- [ ] CI green on this PR (expect same Hygiene cascade as priors).
- [ ] v0.2.3 dispatch reaches `tag-all` after this merges.

## Risk

- Pure code change to the existing `--max-diff-bytes` default. The cap remains in place; only the threshold moves.
- Test for the cap mechanism reworked to pass an explicit small `--max-diff-bytes` so it doesn't drift with future default bumps.

Closes #971.