### PR TITLE
fix(ci): preflight-tidy gate 1 allow indirect-only go.mod (#973)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`preflight-tidy-check` gate 1 now allows indirect-only go.mod
+  changes (#973).** v0.2.4's first dispatch (run 27370455797) failed
+  because tidy adjusted `// indirect` requires across 11 sub-module
+  `go.mod` files (transitive deps shifting after v0.2.2 — adding
+  `axonops/syncmap`, `golang.org/x/crypto`; removing `kr/text`).
+  These are routine Go-toolchain housekeeping, not engineering
+  changes, so gate 1 was over-rejecting them. The gate now classifies
+  every go.mod diff and rejects ONLY direct-require changes or
+  changes to `module` / `go` / `toolchain` / `replace` / `retract` /
+  `exclude` directives. The single `preflight-tidy: go.mod modified
+  — aborting` error string is replaced by two more-specific strings:
+  `preflight-tidy: go.mod direct require modified — aborting` and
+  `preflight-tidy: go.mod module/go/toolchain/replace directive
+  modified — aborting`. 7 new table-driven Go tests pin the
+  classification logic.
 - **Bump `preflight-tidy-check --max-diff-bytes` default from 8 KiB
   to 64 KiB (#971).** v0.2.3's first dispatch (run 27361600829)
   failed at `preflight-tidy` because the diff-size cap was tuned

--- a/cmd/release-tool/cmd_preflight_tidy_check.go
+++ b/cmd/release-tool/cmd_preflight_tidy_check.go
@@ -48,7 +48,8 @@ type preflightTidyArgs struct {
 // bats grep assertions in tests/release-scripts/release-yml-grep.bats.
 const (
 	msgNoDrift             = "preflight-tidy: no drift to absorb"
-	msgGoModModified       = "preflight-tidy: go.mod modified — aborting"
+	msgGoModDirectRequire  = "preflight-tidy: go.mod direct require modified — aborting"
+	msgGoModDirective      = "preflight-tidy: go.mod module/go/toolchain/replace directive modified — aborting"
 	msgGoSumDeletions      = "preflight-tidy: go.sum lines deleted — aborting"
 	msgUnrelatedChecksums  = "preflight-tidy: unrelated checksum lines — aborting"
 	msgSumdbDisagrees      = "preflight-tidy: sum.golang.org disagrees — aborting"
@@ -123,6 +124,8 @@ func runPreflightTidyCheck(ctx context.Context, args []string, stdout, stderr io
 // working-tree diff produced by `make tidy`. Split out from the
 // flag-parsing path so tests can inject a faked sumdb endpoint and
 // workdir.
+//
+//nolint:gocyclo,cyclop // one branch per gate; flatter than helpers.
 func doPreflightTidyCheck(ctx context.Context, in *preflightTidyArgs, publishedModules []string, stdout, stderr io.Writer) int {
 	// Step 1 — capture the uncommitted diff.
 	diffBytes, code := captureDiff(in.workdir, stderr)
@@ -147,10 +150,20 @@ func doPreflightTidyCheck(ctx context.Context, in *preflightTidyArgs, publishedM
 		return exitOperational
 	}
 
-	// Gate 1 — go.sum only (no go.mod changes).
-	if hasGoModChange(files) {
-		emit(stdout, stderr, msgGoModModified)
+	// Gate 1 — go.mod changes classified. Indirect-only changes
+	// (transitive housekeeping after a release) are benign and
+	// allowed through. Direct-require changes and directive
+	// changes (`module`, `go`, `toolchain`, `replace`, etc.) are
+	// real engineering actions and rejected. #973.
+	switch classifyGoModChanges(files) {
+	case goModDirective:
+		emit(stdout, stderr, msgGoModDirective)
 		return exitValidation
+	case goModDirectRequire:
+		emit(stdout, stderr, msgGoModDirectRequire)
+		return exitValidation
+	case goModUnchanged, goModIndirectOnly:
+		// Pass through to gates 2+.
 	}
 
 	// Gate 2 — additions only (no deletions).
@@ -272,10 +285,114 @@ func parseUnifiedDiff(diff []byte) ([]fileDiff, error) {
 	return files, nil
 }
 
-// hasGoModChange reports true if any file in the diff is a go.mod.
-func hasGoModChange(files []fileDiff) bool {
+// goModChangeKind classifies what kind of change appeared in a
+// go.mod diff. Used by gate 1 to allow benign post-release
+// transitive-housekeeping changes while still rejecting real
+// engineering changes.
+type goModChangeKind int
+
+const (
+	// goModUnchanged: no go.mod file appears in the diff at all.
+	goModUnchanged goModChangeKind = iota
+	// goModIndirectOnly: every changed go.mod line is either
+	// structural (require (, ), blank, comment) or carries the
+	// `// indirect` suffix. These are the transitive-deps
+	// adjustments that tidy routinely makes after a release.
+	goModIndirectOnly
+	// goModDirectRequire: the diff includes at least one line
+	// that looks like a require directive WITHOUT `// indirect` —
+	// a real engineering change (new direct dep, version bump on
+	// existing direct dep, dep removal). Gate 1 rejects.
+	goModDirectRequire
+	// goModDirective: the diff includes a change to a top-level
+	// directive (`module`, `go`, `toolchain`, `replace`,
+	// `retract`, or `exclude`). Gate 1 rejects.
+	goModDirective
+)
+
+// classifyGoModChanges walks every go.mod file in the diff and
+// returns the STRONGEST signal across all of them: directive >
+// direct-require > indirect-only > unchanged. Gate 1 allows the
+// first two enum values and rejects the last two.
+//
+// The classifier is intentionally line-oriented (not a full
+// go.mod parser): every line of a `go mod tidy` diff is either a
+// known directive prefix, a require entry with or without
+// `// indirect`, or a structural marker. Anything that doesn't
+// match a known shape is treated as a directive change to fail
+// closed.
+//
+//nolint:gocognit // exhaustive switch over goModChangeKind; clearer inline.
+func classifyGoModChanges(files []fileDiff) goModChangeKind {
+	worst := goModUnchanged
 	for _, f := range files {
-		if isGoModPath(f.path) {
+		if !isGoModPath(f.path) {
+			continue
+		}
+		for _, line := range append(append([]string{}, f.additions...), f.deletions...) {
+			switch classifyGoModLine(line) {
+			case goModDirective:
+				// Strongest signal — short-circuit.
+				return goModDirective
+			case goModDirectRequire:
+				if worst < goModDirectRequire {
+					worst = goModDirectRequire
+				}
+			case goModIndirectOnly:
+				if worst < goModIndirectOnly {
+					worst = goModIndirectOnly
+				}
+			case goModUnchanged:
+				// Structural lines (require (, ), blank,
+				// in-block comment) are noise; ignore.
+			}
+		}
+	}
+	return worst
+}
+
+// classifyGoModLine returns the kind of change a single added or
+// deleted go.mod line represents. Whitespace is trimmed. The
+// classification is deliberately strict: an unrecognised shape
+// returns goModDirective so the gate fails closed.
+func classifyGoModLine(line string) goModChangeKind {
+	trim := strings.TrimSpace(line)
+	if trim == "" || trim == "require (" || trim == ")" {
+		return goModUnchanged
+	}
+	// In-block comment line: ignore.
+	if strings.HasPrefix(trim, "//") {
+		return goModUnchanged
+	}
+	// Block-form require body line: `<module> <version> [// indirect]`
+	// inside a `require (` block. If it carries `// indirect`,
+	// the line is benign; otherwise it's a direct require.
+	if !startsWithGoModDirective(trim) {
+		if strings.Contains(trim, "// indirect") {
+			return goModIndirectOnly
+		}
+		// Looks like a require body but no `// indirect` —
+		// direct dep.
+		return goModDirectRequire
+	}
+	// Single-line `require <module> <version> [// indirect]` form.
+	if rest, ok := strings.CutPrefix(trim, "require "); ok && !strings.HasPrefix(rest, "(") {
+		if strings.Contains(rest, "// indirect") {
+			return goModIndirectOnly
+		}
+		return goModDirectRequire
+	}
+	// Top-level directive (`module`, `go`, `toolchain`, `replace`,
+	// `retract`, `exclude`).
+	return goModDirective
+}
+
+// startsWithGoModDirective reports whether a trimmed go.mod line
+// begins with one of the recognised top-level directive keywords.
+// `require (` is considered structural and is handled above.
+func startsWithGoModDirective(trim string) bool {
+	for _, kw := range []string{"module ", "go ", "toolchain ", "replace ", "retract ", "exclude ", "require "} {
+		if strings.HasPrefix(trim, kw) {
 			return true
 		}
 	}

--- a/cmd/release-tool/cmd_preflight_tidy_check_test.go
+++ b/cmd/release-tool/cmd_preflight_tidy_check_test.go
@@ -130,11 +130,23 @@ func TestPreflightTidyCheck_NoDriftExitsIdempotent(t *testing.T) {
 	}
 }
 
-func TestPreflightTidyCheck_Gate1_GoModModifiedAborts(t *testing.T) {
+// Gate 1 distinguishes three classes of go.mod change (#973):
+//   - direct-require modified → reject with msgGoModDirectRequire
+//   - top-level directive modified → reject with msgGoModDirective
+//   - indirect-only adjustments → benign, pass through to gates 2+
+//
+// Each test fixture writes a go.sum line in the published-modules
+// set so that the test reaches gate 1 (a malformed-line-only diff
+// would short-circuit at gate 3).
+func TestPreflightTidyCheck_Gate1_DirectRequireAddRejected(t *testing.T) {
 	t.Parallel()
-	repo := makeTempRepo(t, map[string]string{"go.mod": "module example\n", "go.sum": ""})
-	// Mutate go.mod (gate 1 trigger).
-	if err := writeFile(filepath.Join(repo, "go.mod"), "module example\n\nrequire foo v0.0.1\n"); err != nil {
+	repo := makeTempRepo(t, map[string]string{
+		"go.mod": "module example\n",
+		"go.sum": "",
+	})
+	// Adding a direct require — real engineering change.
+	if err := writeFile(filepath.Join(repo, "go.mod"),
+		"module example\n\nrequire foo v0.0.1\n"); err != nil {
 		t.Fatalf("write go.mod: %v", err)
 	}
 	srv := fakeSumdb(t, nil)
@@ -142,8 +154,144 @@ func TestPreflightTidyCheck_Gate1_GoModModifiedAborts(t *testing.T) {
 	if code != exitValidation {
 		t.Errorf("exit code: got %d want %d", code, exitValidation)
 	}
-	if !strings.Contains(stdout, msgGoModModified) {
-		t.Errorf("stdout missing %q: %q", msgGoModModified, stdout)
+	if !strings.Contains(stdout, msgGoModDirectRequire) {
+		t.Errorf("stdout missing %q: %q", msgGoModDirectRequire, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate1_DirectRequireBumpRejected(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{
+		"go.mod": "module example\n\nrequire foo v0.0.1\n",
+		"go.sum": "",
+	})
+	if err := writeFile(filepath.Join(repo, "go.mod"),
+		"module example\n\nrequire foo v0.0.2\n"); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgGoModDirectRequire) {
+		t.Errorf("stdout missing %q: %q", msgGoModDirectRequire, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate1_ModuleDirectiveRejected(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{
+		"go.mod": "module example\n",
+		"go.sum": "",
+	})
+	if err := writeFile(filepath.Join(repo, "go.mod"), "module renamed\n"); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgGoModDirective) {
+		t.Errorf("stdout missing %q: %q", msgGoModDirective, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate1_GoDirectiveRejected(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{
+		"go.mod": "module example\n\ngo 1.26\n",
+		"go.sum": "",
+	})
+	if err := writeFile(filepath.Join(repo, "go.mod"),
+		"module example\n\ngo 1.27\n"); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgGoModDirective) {
+		t.Errorf("stdout missing %q: %q", msgGoModDirective, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate1_ToolchainDirectiveRejected(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{
+		"go.mod": "module example\n\ngo 1.26\n",
+		"go.sum": "",
+	})
+	if err := writeFile(filepath.Join(repo, "go.mod"),
+		"module example\n\ngo 1.26\n\ntoolchain go1.26.4\n"); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgGoModDirective) {
+		t.Errorf("stdout missing %q: %q", msgGoModDirective, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate1_ReplaceDirectiveRejected(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{
+		"go.mod": "module example\n",
+		"go.sum": "",
+	})
+	if err := writeFile(filepath.Join(repo, "go.mod"),
+		"module example\n\nreplace foo => bar v0.0.1\n"); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	srv := fakeSumdb(t, nil)
+	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
+	if code != exitValidation {
+		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	}
+	if !strings.Contains(stdout, msgGoModDirective) {
+		t.Errorf("stdout missing %q: %q", msgGoModDirective, stdout)
+	}
+}
+
+func TestPreflightTidyCheck_Gate1_IndirectOnlyAllowed(t *testing.T) {
+	t.Parallel()
+	// Repro of v0.2.4's dispatch failure: tidy adds and removes
+	// `// indirect` lines in the require block. Gate 1 must pass
+	// these through; gates 2+ must run on the unchanged go.sum
+	// half of the diff (here: a valid axonops/audit v0.2.2 line).
+	initialMod := "module example\n\nrequire (\n\tgithub.com/kr/text v0.2.0 // indirect\n)\n"
+	repo := makeTempRepo(t, map[string]string{
+		"go.mod": initialMod,
+		"go.sum": "",
+	})
+	// Same shape as a real `make tidy` post-release diff:
+	// remove kr/text, add syncmap + crypto + a published-modules
+	// reference.
+	mutated := "module example\n\nrequire (\n\tgithub.com/axonops/audit v0.2.2 // indirect\n\tgithub.com/axonops/syncmap v1.0.0 // indirect\n\tgolang.org/x/crypto v0.52.0 // indirect\n)\n"
+	if err := writeFile(filepath.Join(repo, "go.mod"), mutated); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	// Add a valid go.sum addition so gate 3 finds something.
+	if err := writeFile(filepath.Join(repo, "go.sum"),
+		"github.com/axonops/audit v0.2.2 h1:HASH1=\ngithub.com/axonops/audit v0.2.2/go.mod h1:HASH2=\n"); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, map[string][2]string{
+		"github.com/axonops/audit@v0.2.2": {"h1:HASH1=", "h1:HASH2="},
+	})
+	code, stdout, stderr := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitSuccess {
+		t.Errorf("exit code: got %d want %d\nstdout=%q\nstderr=%q",
+			code, exitSuccess, stdout, stderr)
+	}
+	// Gate 1's reject strings must NOT appear.
+	if strings.Contains(stdout, msgGoModDirectRequire) || strings.Contains(stdout, msgGoModDirective) {
+		t.Errorf("gate 1 incorrectly rejected indirect-only changes: %q", stdout)
 	}
 }
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -588,7 +588,7 @@ run — and run-1 is v0.2.3 itself, which couldn't reach tag-all.
 
 | # | Gate | Failure exit string |
 |---|------|---------------------|
-| 1 | Diff is go.sum-only (no go.mod changes) | `preflight-tidy: go.mod modified — aborting` |
+| 1 | go.mod changes are classified — indirect-only adjustments pass; direct require changes or directive (`module`/`go`/`toolchain`/`replace`) changes reject (#973) | `preflight-tidy: go.mod direct require modified — aborting` / `preflight-tidy: go.mod module/go/toolchain/replace directive modified — aborting` |
 | 2 | Additions only (no deletions) | `preflight-tidy: go.sum lines deleted — aborting` |
 | 3 | Lines reference published modules at the last-released version only | `preflight-tidy: unrelated checksum lines — aborting` |
 | 4 | sum.golang.org transparency-log cross-check on every (module, version) | `preflight-tidy: sum.golang.org disagrees — aborting` (mismatch) / `preflight-tidy: sum.golang.org timeout or 5xx — aborting` (transient) |

--- a/tests/release-scripts/release-yml-grep.bats
+++ b/tests/release-scripts/release-yml-grep.bats
@@ -380,13 +380,14 @@ setup() {
     echo "$body" | grep -qF "github.event_name == 'workflow_dispatch'"
 }
 
-@test "test_release_yml_preflight_tidy_enforces_go_sum_only" {
-    # #967 gate 1: msgGoModModified — see
-    # cmd/release-tool/cmd_preflight_tidy_check.go. The exact AC #4
-    # error string must be greppable in the workflow body or the
-    # subcommand wiring so a regression that mis-emits the string
-    # fails the grep.
-    grep -qF 'preflight-tidy: go.mod modified — aborting' \
+@test "test_release_yml_preflight_tidy_rejects_direct_require_changes" {
+    # #967 gate 1 (#973 refinement): the gate distinguishes
+    # direct-require changes (real engineering) from indirect-only
+    # adjustments (benign post-release housekeeping). Each
+    # rejection class has its own exact AC #4 error string.
+    grep -qF 'preflight-tidy: go.mod direct require modified — aborting' \
+        "${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
+    grep -qF 'preflight-tidy: go.mod module/go/toolchain/replace directive modified — aborting' \
         "${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
 }
 
@@ -438,7 +439,8 @@ setup() {
     SUBCMD="${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
     # Strings the SUBCOMMAND emits (idempotent + validation paths).
     grep -qF 'preflight-tidy: no drift to absorb' "$SUBCMD"
-    grep -qF 'preflight-tidy: go.mod modified — aborting' "$SUBCMD"
+    grep -qF 'preflight-tidy: go.mod direct require modified — aborting' "$SUBCMD"
+    grep -qF 'preflight-tidy: go.mod module/go/toolchain/replace directive modified — aborting' "$SUBCMD"
     grep -qF 'preflight-tidy: go.sum lines deleted — aborting' "$SUBCMD"
     grep -qF 'preflight-tidy: unrelated checksum lines — aborting' "$SUBCMD"
     grep -qF 'preflight-tidy: sum.golang.org disagrees — aborting' "$SUBCMD"


### PR DESCRIPTION
## Summary

v0.2.4 dispatch failed at gate 1 with `go.mod modified — aborting` because tidy adjusted `// indirect` requires across 11 sub-module go.mod files (transitive deps shifting after v0.2.2: adding `axonops/syncmap`, `golang.org/x/crypto`; removing `kr/text`). These are routine Go-toolchain housekeeping, not engineering changes.

This refines gate 1 to classify go.mod changes:
- **indirect-only** → pass through to gates 2+
- **direct require** modified → reject with `preflight-tidy: go.mod direct require modified — aborting`
- **module / go / toolchain / replace / retract / exclude** directive modified → reject with `preflight-tidy: go.mod module/go/toolchain/replace directive modified — aborting`

The single `msgGoModModified` constant is replaced by two more-specific constants. Unrecognised line shapes fail closed to the directive reject path.

## Why this is a bug, not a workaround

Gate 1 was designed during #967 to block any go.mod change because a new direct require could introduce a malicious module. But that threat manifests through direct-require changes, not indirect-line shuffles — and gate 4 (sum.golang.org cross-check) catches any axonops/audit/* tampering that would cause those adjustments to be malicious. As written, gate 1 made the release flow unusable: every release naturally produces some transitive churn.

## Test plan

- [x] `go test ./cmd/release-tool/... -race -count=1` — all release-tool tests pass.
- [x] `golangci-lint run ./cmd/release-tool/...` — 0 issues.
- [x] `make test-release-scripts` — 117/117 pass (bats grep anchors updated).
- [x] `make regen-llms-check` — clean.
- [x] 7 new Go tests added: `..._DirectRequireAdd / Bump / ModuleDirective / GoDirective / ToolchainDirective / ReplaceDirective / IndirectOnlyAllowed`. The `IndirectOnlyAllowed` fixture mirrors v0.2.4's actual blocked diff shape.
- [ ] CI green on this PR.
- [ ] v0.2.4 dispatch reaches `tag-all` after this merges.

Closes #973.