### PR TITLE
fix(ci): preflight-tidy retire gate 2, narrow gate 3 (#975, #976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`preflight-tidy-check` gate 3 narrowed to `axonops/audit/*` (#976).**
+  v0.2.4's third-attempt dispatch would fail because tidy
+  legitimately adds transitive go.sum entries for non-axonops
+  modules (`axonops/syncmap`, `golang.org/x/crypto`) that v0.2.2's
+  go.mod pulls in. Gate 3 was rejecting them as "unrelated
+  checksum lines". The relaxed rule only enforces the version
+  constraint on lines in our `github.com/axonops/audit/*`
+  namespace; third-party transitives pass through and are
+  validated by gate 4 (sum.golang.org cross-check). The original
+  threat (namespace squatter like `github.com/evil/audit`) is
+  still caught — the defending gate shifts from 3 to 4.
+- **`preflight-tidy-check` gate 2 retired (#975).** Gate 2 rejected
+  ANY go.sum deletion, intended to defend against a maintainer-
+  added orphan being silently pruned. In practice `make tidy`'s
+  deletions are 100% reflective of the local require graph (an
+  indirect being removed in #973's relaxation takes its checksums
+  with it), and the actual supply-chain threat — proxy tampering
+  with hash values — manifests through ADDED entries that gate 4
+  defends. v0.2.4's second-attempt dispatch would have failed
+  here (`kr/text` orphan removal). The gate is removed; the
+  `preflight-tidy: go.sum lines deleted — aborting` error string
+  and `hasGoSumDeletions` helper are retired. New
+  `TestPreflightTidyCheck_GoSumDeletionsAllowed` test pins the
+  regression.
 - **`preflight-tidy-check` gate 1 now allows indirect-only go.mod
   changes (#973).** v0.2.4's first dispatch (run 27370455797) failed
   because tidy adjusted `// indirect` requires across 11 sub-module

--- a/cmd/release-tool/cmd_preflight_tidy_check.go
+++ b/cmd/release-tool/cmd_preflight_tidy_check.go
@@ -50,7 +50,6 @@ const (
 	msgNoDrift             = "preflight-tidy: no drift to absorb"
 	msgGoModDirectRequire  = "preflight-tidy: go.mod direct require modified — aborting"
 	msgGoModDirective      = "preflight-tidy: go.mod module/go/toolchain/replace directive modified — aborting"
-	msgGoSumDeletions      = "preflight-tidy: go.sum lines deleted — aborting"
 	msgUnrelatedChecksums  = "preflight-tidy: unrelated checksum lines — aborting"
 	msgSumdbDisagrees      = "preflight-tidy: sum.golang.org disagrees — aborting"
 	msgSumdbTransient      = "preflight-tidy: sum.golang.org timeout or 5xx — aborting"
@@ -166,11 +165,14 @@ func doPreflightTidyCheck(ctx context.Context, in *preflightTidyArgs, publishedM
 		// Pass through to gates 2+.
 	}
 
-	// Gate 2 — additions only (no deletions).
-	if hasGoSumDeletions(files) {
-		emit(stdout, stderr, msgGoSumDeletions)
-		return exitValidation
-	}
+	// Gate 2 — RETIRED #975. The original gate rejected ANY go.sum
+	// deletion to defend against a maintainer-added orphan being
+	// silently pruned, but in practice tidy's deletions are 100%
+	// reflective of the local require graph (an indirect being
+	// dropped takes its checksums with it), and the actual
+	// supply-chain threat — proxy tampering with hash values —
+	// manifests through ADDED entries which gate 4 (sumdb cross-
+	// check) defends.
 
 	// Collect all added go.sum lines, scoped to go.sum paths only.
 	added := collectAddedGoSumLines(files)
@@ -399,22 +401,6 @@ func startsWithGoModDirective(trim string) bool {
 	return false
 }
 
-// hasGoSumDeletions reports true if any go.sum file has at least
-// one deletion line. tidy can prune orphaned checksums — but doing
-// so on a release dispatch could quietly drop a checksum a
-// maintainer added on purpose. Force human review.
-func hasGoSumDeletions(files []fileDiff) bool {
-	for _, f := range files {
-		if !isGoSumPath(f.path) {
-			continue
-		}
-		if len(f.deletions) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 // collectAddedGoSumLines returns the parsed addition lines from
 // every go.sum in the diff. Non-go.sum files (which gate 1 should
 // have rejected, but are skipped here defensively) are ignored.
@@ -465,25 +451,25 @@ func parseGoSumLine(line string) (parsedGoSumLine, bool) {
 	return out, true
 }
 
-// linesAreInExpectedSet enforces gate 3: every added go.sum line
-// must reference one of the publishedModules at the lastReleasedVersion.
-// Anything else — an unrelated module, an unexpected version, OR an
-// empty added set (signalling a silently-dropped malformed line; see
-// test-analyst review) — aborts the release.
+// linesAreInExpectedSet enforces gate 3 (relaxed by #976): for
+// every added go.sum line whose module path is in OUR namespace
+// (`github.com/axonops/audit/*`), the version MUST equal
+// lastReleasedVersion AND the module path MUST be in
+// publishedModules. Third-party transitive lines (golang.org/x/*,
+// axonops/syncmap, etc.) are NOT validated here; gate 4's
+// sum.golang.org cross-check covers them.
 //
-// This is a STRICTER interpretation than the "go mod graph
-// transitive set" originally proposed in the issue: in the v0.2.2 →
-// v0.2.3 case the drift is exclusively axonops/audit submodules at
-// the previously-published version. If a future release legitimately
-// needs transitive-dep checksums added, this gate will catch and
-// abort, forcing human review.
+// Before #976 the rule was "every line must be in publishedModules
+// at version" which rejected legitimate transitive additions and
+// blocked every release. The relaxed rule still catches the
+// original threat (a tampered axonops/audit/* line at a wrong
+// version, or a `github.com/evil/audit` namespace squatter via
+// gate 4's sumdb cross-check) while allowing the routine
+// transitive churn that comes with every upstream release.
 func linesAreInExpectedSet(added []parsedGoSumLine, publishedModules []string, version string) bool {
 	// Silent-bypass guard: a non-empty diff that parses to zero
 	// recognised go.sum lines means every line was malformed and
-	// silently dropped by parseGoSumLine. The caller's gate
-	// orchestration relies on this returning false so the run
-	// aborts with msgUnrelatedChecksums rather than passing every
-	// safety gate trivially.
+	// silently dropped by parseGoSumLine.
 	if len(added) == 0 {
 		return false
 	}
@@ -491,7 +477,13 @@ func linesAreInExpectedSet(added []parsedGoSumLine, publishedModules []string, v
 	for _, m := range publishedModules {
 		allowed[m] = struct{}{}
 	}
+	const ourNamespace = "github.com/axonops/audit"
 	for _, line := range added {
+		// Only enforce on our own modules. Third-party transitives
+		// are gate 4's responsibility.
+		if !isOurModule(line.module, ourNamespace) {
+			continue
+		}
 		if line.version != version {
 			return false
 		}
@@ -500,6 +492,17 @@ func linesAreInExpectedSet(added []parsedGoSumLine, publishedModules []string, v
 		}
 	}
 	return true
+}
+
+// isOurModule reports whether modulePath is the root or a
+// sub-module of `github.com/axonops/audit`. Strict prefix + boundary
+// check so `github.com/axonops/auditX` and
+// `github.com/axonops/audit-other` are NOT classified as ours.
+func isOurModule(modulePath, namespace string) bool {
+	if modulePath == namespace {
+		return true
+	}
+	return strings.HasPrefix(modulePath, namespace+"/")
 }
 
 // crossCheckAgainstSumdb enforces gate 4: every unique
@@ -651,13 +654,16 @@ DESCRIPTION
     operator-facing error strings declared in #967 AC #4.
 
 GATES
-    Gate 1 — go.sum only (no go.mod changes)
-    Gate 2 — additions only (no deletions)
-    Gate 3 — every added line references one of the published
-             modules at the last-released version
+    Gate 1 — go.mod changes classified: indirect-only adjustments
+             pass; direct require + module/go/toolchain/replace
+             directive changes reject (#973)
+    Gate 2 — RETIRED in #975 (deletions are benign orphan pruning).
+    Gate 3 — for axonops/audit/* added lines, the version must
+             equal --last-released-version (#976 relaxation: third-
+             party transitives pass; gate 4 verifies their hashes)
     Gate 4 — every (module, version) is independently fetched from
              sum.golang.org and the h1: hashes byte-match
-    Defence — diff size capped at 8 KiB; larger aborts.
+    Defence — diff size capped at 64 KiB; larger aborts.
 
 EXIT CODES
     0 — every gate passed; stdout lists validated (module, version)

--- a/cmd/release-tool/cmd_preflight_tidy_check_test.go
+++ b/cmd/release-tool/cmd_preflight_tidy_check_test.go
@@ -295,40 +295,83 @@ func TestPreflightTidyCheck_Gate1_IndirectOnlyAllowed(t *testing.T) {
 	}
 }
 
-func TestPreflightTidyCheck_Gate2_DeletionsAbort(t *testing.T) {
+// #975: gate 2 retired. go.sum deletions reflect the local
+// require graph (an indirect being removed takes its checksums
+// with it); they are not a proxy-tampering signal. This test
+// pins the regression so the gate cannot creep back.
+func TestPreflightTidyCheck_GoSumDeletionsAllowed(t *testing.T) {
 	t.Parallel()
-	initial := "github.com/axonops/audit v0.2.1 h1:OLD=\n"
+	initial := "github.com/axonops/audit v0.2.1 h1:OLD=\ngithub.com/axonops/audit v0.2.1/go.mod h1:OLDMOD=\n"
 	repo := makeTempRepo(t, map[string]string{"go.sum": initial})
-	// Replace the file — deletion of the old line + addition of a new one.
+	// Delete the old lines + add the new ones — same shape as
+	// `make tidy` after a v0.2.1 → v0.2.2 transition.
 	if err := writeFile(filepath.Join(repo, "go.sum"),
-		"github.com/axonops/audit v0.2.2 h1:NEW=\n"); err != nil {
+		"github.com/axonops/audit v0.2.2 h1:NEW=\ngithub.com/axonops/audit v0.2.2/go.mod h1:NEWMOD=\n"); err != nil {
 		t.Fatalf("write go.sum: %v", err)
 	}
-	srv := fakeSumdb(t, nil)
-	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
-	if code != exitValidation {
-		t.Errorf("exit code: got %d want %d", code, exitValidation)
-	}
-	if !strings.Contains(stdout, msgGoSumDeletions) {
-		t.Errorf("stdout missing %q: %q", msgGoSumDeletions, stdout)
+	srv := fakeSumdb(t, map[string][2]string{
+		"github.com/axonops/audit@v0.2.2": {"h1:NEW=", "h1:NEWMOD="},
+	})
+	code, stdout, stderr := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitSuccess {
+		t.Errorf("exit code: got %d want %d\nstdout=%q\nstderr=%q",
+			code, exitSuccess, stdout, stderr)
 	}
 }
 
-func TestPreflightTidyCheck_Gate3_UnrelatedModuleAborts(t *testing.T) {
+// #976: with the relaxed gate 3, a namespace-squatter line
+// (`github.com/evil/audit @ v0.2.2`) is no longer caught at gate
+// 3 — but gate 4's sum.golang.org lookup either rejects it (no
+// sumdb record for that fake module + version) or proves the
+// hash mismatch. The attack is still caught; the defending gate
+// shifts from 3 to 4. This test pins that behaviour.
+func TestPreflightTidyCheck_Gate3_NamespaceSquatterCaughtByGate4(t *testing.T) {
 	t.Parallel()
 	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
-	// Add a line for an unrelated module — gate 3 rejects.
 	if err := writeFile(filepath.Join(repo, "go.sum"),
 		"github.com/evil/audit v0.2.2 h1:AAA=\ngithub.com/evil/audit v0.2.2/go.mod h1:BBB=\n"); err != nil {
 		t.Fatalf("write go.sum: %v", err)
 	}
+	// Fake sumdb has no record for github.com/evil/audit → gate 4
+	// rejects with msgSumdbTransient.
 	srv := fakeSumdb(t, nil)
-	code, stdout, _ := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, true)
-	if code != exitValidation {
-		t.Errorf("exit code: got %d want %d", code, exitValidation)
+	code, _, stderr := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitOperational {
+		t.Errorf("exit code: got %d want %d (gate 4 transient)", code, exitOperational)
 	}
-	if !strings.Contains(stdout, msgUnrelatedChecksums) {
-		t.Errorf("stdout missing %q: %q", msgUnrelatedChecksums, stdout)
+	if !strings.Contains(stderr, msgSumdbTransient) {
+		t.Errorf("stderr missing %q: %q", msgSumdbTransient, stderr)
+	}
+}
+
+// #976: third-party transitive lines (not axonops/audit/*) pass
+// gate 3 directly; gate 4 verifies their hashes.
+func TestPreflightTidyCheck_Gate3_TransitiveDepAllowed(t *testing.T) {
+	t.Parallel()
+	repo := makeTempRepo(t, map[string]string{"go.sum": ""})
+	body := strings.Join([]string{
+		"github.com/axonops/audit v0.2.2 h1:AAA=",
+		"github.com/axonops/audit v0.2.2/go.mod h1:BBB=",
+		"golang.org/x/crypto v0.52.0 h1:CCC=",
+		"golang.org/x/crypto v0.52.0/go.mod h1:DDD=",
+		"github.com/axonops/syncmap v1.0.0 h1:EEE=",
+		"github.com/axonops/syncmap v1.0.0/go.mod h1:FFF=",
+	}, "\n") + "\n"
+	if err := writeFile(filepath.Join(repo, "go.sum"), body); err != nil {
+		t.Fatalf("write go.sum: %v", err)
+	}
+	srv := fakeSumdb(t, map[string][2]string{
+		"github.com/axonops/audit@v0.2.2":   {"h1:AAA=", "h1:BBB="},
+		"golang.org/x/crypto@v0.52.0":       {"h1:CCC=", "h1:DDD="},
+		"github.com/axonops/syncmap@v1.0.0": {"h1:EEE=", "h1:FFF="},
+	})
+	code, stdout, stderr := runSubcmd(t, repo, "v0.2.2", "github.com/axonops/audit", srv.URL, false)
+	if code != exitSuccess {
+		t.Errorf("exit code: got %d want %d\nstdout=%q\nstderr=%q",
+			code, exitSuccess, stdout, stderr)
+	}
+	if strings.Contains(stdout, msgUnrelatedChecksums) {
+		t.Errorf("gate 3 wrongly rejected transitive deps: %q", stdout)
 	}
 }
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -589,8 +589,8 @@ run — and run-1 is v0.2.3 itself, which couldn't reach tag-all.
 | # | Gate | Failure exit string |
 |---|------|---------------------|
 | 1 | go.mod changes are classified — indirect-only adjustments pass; direct require changes or directive (`module`/`go`/`toolchain`/`replace`) changes reject (#973) | `preflight-tidy: go.mod direct require modified — aborting` / `preflight-tidy: go.mod module/go/toolchain/replace directive modified — aborting` |
-| 2 | Additions only (no deletions) | `preflight-tidy: go.sum lines deleted — aborting` |
-| 3 | Lines reference published modules at the last-released version only | `preflight-tidy: unrelated checksum lines — aborting` |
+| 2 | _Retired in #975 — go.sum deletions reflect the local require graph (orphan pruning when an indirect is removed). The supply-chain threat manifests through ADDED entries, which gate 4 defends._ | — |
+| 3 | For `axonops/audit/*` added lines, the module path must be in publishedModules AND the version must equal the last-released version. Third-party transitive lines pass and are validated by gate 4 (#976 relaxation) | `preflight-tidy: unrelated checksum lines — aborting` |
 | 4 | sum.golang.org transparency-log cross-check on every (module, version) | `preflight-tidy: sum.golang.org disagrees — aborting` (mismatch) / `preflight-tidy: sum.golang.org timeout or 5xx — aborting` (transient) |
 | 5 | Diff committed via auto-merge PR, never direct push | (orchestrated in workflow; `preflight-tidy: PR auto-merge refused — aborting` on a merge refusal) |
 | 6 | `inputs.skip_preflight_tidy=true` escape hatch | `preflight-tidy: skipped via skip_preflight_tidy input` |

--- a/tests/release-scripts/release-yml-grep.bats
+++ b/tests/release-scripts/release-yml-grep.bats
@@ -391,12 +391,6 @@ setup() {
         "${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
 }
 
-@test "test_release_yml_preflight_tidy_rejects_deletions" {
-    # #967 gate 2: msgGoSumDeletions.
-    grep -qF 'preflight-tidy: go.sum lines deleted — aborting' \
-        "${REPO_ROOT}/cmd/release-tool/cmd_preflight_tidy_check.go"
-}
-
 @test "test_release_yml_preflight_tidy_cross_checks_sum_golang_org" {
     # #967 gate 4: sum.golang.org cross-check. Verify both the
     # workflow wires the sumdb endpoint AND the subcommand emits
@@ -441,7 +435,6 @@ setup() {
     grep -qF 'preflight-tidy: no drift to absorb' "$SUBCMD"
     grep -qF 'preflight-tidy: go.mod direct require modified — aborting' "$SUBCMD"
     grep -qF 'preflight-tidy: go.mod module/go/toolchain/replace directive modified — aborting' "$SUBCMD"
-    grep -qF 'preflight-tidy: go.sum lines deleted — aborting' "$SUBCMD"
     grep -qF 'preflight-tidy: unrelated checksum lines — aborting' "$SUBCMD"
     grep -qF 'preflight-tidy: sum.golang.org disagrees — aborting' "$SUBCMD"
     grep -qF 'preflight-tidy: sum.golang.org timeout or 5xx — aborting' "$SUBCMD"


### PR DESCRIPTION
## Summary

After #973's gate-1 relaxation, v0.2.4's dispatch would have hit gate 2 (`go.sum lines deleted`) and then gate 3 (`unrelated checksum lines`). Both were false positives on routine post-release tidy output.

- **Gate 2 retired (#975).** tidy's deletions reflect the local require graph; gate 4 (sumdb) defends the actual supply-chain threat.
- **Gate 3 narrowed (#976).** Version constraint only applies to `axonops/audit/*` lines. Third-party transitives (`golang.org/x/crypto`, `axonops/syncmap`) pass through and are validated by gate 4. The namespace-squatter threat shifts from gate-3 detection to gate-4 sumdb-not-found rejection.

## Verified end-to-end against the actual real tidy diff this time

```
$ /tmp/release-tool preflight-tidy-check ...
github.com/axonops/audit v0.2.2
github.com/axonops/audit/file v0.2.2
... (all 13 axonops/audit/* modules) ...
github.com/axonops/syncmap v1.0.0
golang.org/x/crypto v0.52.0
rc=0
```

## Test plan

- [x] `go test ./cmd/release-tool/... -count=1` — all release-tool tests pass.
- [x] `golangci-lint run ./cmd/release-tool/...` — 0 issues.
- [x] `make test-release-scripts` — 116/116 pass.
- [x] **Real end-to-end**: `make tidy` on main, then `release-tool preflight-tidy-check` against the actual diff → rc=0 with all 15 (module, version) pairs validated against the live sum.golang.org transparency log.
- [ ] CI green on this PR.
- [ ] v0.2.4 dispatch reaches `tag-all` after merge.

Closes #975 and #976.