### PR TITLE
fix(ci): release-scripts job — add Go workspace, strip goreleaser ANSI (#980)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,6 +719,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # #980 fix: bats tests for the regen-schema-artifacts-check
+      # carve-out shell out to `go run ./cmd/audit-gen` which
+      # requires Go + workspace mode (cmd/audit-gen is a separate
+      # go.mod). Without these, the make target fails with
+      # "main module does not contain package
+      # github.com/axonops/audit/cmd/audit-gen" and the carve-out
+      # tests assert non-zero.
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up go.work for workspace-mode bats targets
+        run: make workspace
+
       # Install bats-core directly via its install script, pinned
       # to a specific commit so a compromised upstream cannot inject
       # CI-time code. The install script unpacks to ~/.local/{bin,

--- a/tests/release-scripts/cli-flag-validity.bats
+++ b/tests/release-scripts/cli-flag-validity.bats
@@ -98,7 +98,14 @@ setup() {
     # Trigger an intentional invalid-skip error to extract the
     # valid list from goreleaser's error message — most reliable
     # source-of-truth across goreleaser versions.
-    valid_set="$(goreleaser release --skip=__cli_flag_validity_probe__ 2>&1 \
+    #
+    # #980 fix: goreleaser emits ANSI colour codes around `[ … ]`
+    # when running on a TTY (or whatever GHA tricks it into
+    # thinking is one). The codes break the `[][]` field
+    # separator. Force NO_COLOR=1 AND strip residual escapes
+    # before the awk parse.
+    valid_set="$(NO_COLOR=1 goreleaser release --skip=__cli_flag_validity_probe__ 2>&1 \
+                  | sed 's/\x1b\[[0-9;]*[mK]//g' \
                   | awk -F'[][]' '/Valid options for skip are/ {print $2}')"
 
     if [ -z "$valid_set" ]; then


### PR DESCRIPTION
## Summary

v0.2.4 CI Gate failed at Test - Release Scripts: 5 bats tests fail in CI but pass locally.

**Tests 1–4 (regen-schema-artifacts-check carve-outs)**: invoke `make -s regen-schema-artifacts-check` which shells out to `go run ./cmd/audit-gen`. In CI the release-scripts job had NO Go setup and NO workspace, so `go run` failed with "main module does not contain package github.com/axonops/audit/cmd/audit-gen" because cmd/audit-gen is a separate go.mod that only resolves via the workspace. Locally my go.work masked the bug.

**Test 5 (goreleaser skip values)**: parses goreleaser's "Valid options for skip are [...]" error using `awk -F'[][]'`. In CI, goreleaser emits ANSI colour escapes around the brackets — `valid_set` extracts junk like `1;91m  ⨯`.

## Why this is a real blocker for v0.2.4

CI Gate failure → CI Pass failure → cascade-skip of fuzz-long / mutation-test-release / update-deps-pr / tag-all / goreleaser. The release CANNOT progress.

## Test plan

- [x] `rm -f go.work go.work.sum && make test-release-scripts` → 4 fails locally (matches CI symptom).
- [x] `make workspace && make test-release-scripts` → 116/116 ok.
- [ ] Same on PR #981 CI.
- [ ] v0.2.4 dispatch reaches `tag-all` after this lands.

Closes #980.