### PR TITLE
fix(release): update-deps.sh rewrites root go.mod cross-refs (#984)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Root `go.mod` is now rewritten by the release `update-deps.sh`
+  script (#984).** Previously the script skipped the core module
+  (`scripts/release/update-deps.sh:53` carried
+  `[[ "$dir" == "." ]] && continue` under a wrong "core has no
+  axonops/audit require directives" comment). In reality the root
+  module requires 7 published sub-modules directly plus 2 indirect.
+  v0.2.4 release shipped Go-module tags successfully but goreleaser
+  refused to build the GitHub Release artifacts + cosign bundle
+  because `make check-release-invariants` correctly flagged the
+  stale `v0.1.11` / `v0.0.0-pseudo` references that survived the
+  release-prep PR. The fix removes the `.` skip — root is now
+  rewritten the same way every other published module is. 7 new
+  bats tests in `tests/release-scripts/update-deps.bats` lock the
+  contract for the 5 supported require shapes (block-form,
+  pseudo-version, indirect suffix, single-line, mixed indentation)
+  plus a no-op regression anchor plus the latent `/go.mod` go.sum
+  sibling-line bug devops surfaced during the #984 review.
 - **`preflight-tidy-check` gate 3 narrowed to `axonops/audit/*` (#976).**
   v0.2.4's third-attempt dispatch would fail because tidy
   legitimately adds transitive go.sum entries for non-axonops

--- a/scripts/release/update-deps.sh
+++ b/scripts/release/update-deps.sh
@@ -44,13 +44,22 @@ if (( ${#published_paths[@]} == 0 )); then
   exit 2
 fi
 
-# Modules to rewrite: every published module + the capstone example.
-# Skip the core module itself (`.`) — core has no axonops/audit
-# require directives to update.
+# Modules to rewrite: every published module (INCLUDING the root
+# `.`) + every example with its own go.mod. The root module's
+# go.mod requires 7 published sub-modules directly + 2 indirect
+# (see grep output of axonops/audit/ require lines in root go.mod
+# at any release boundary). Before #984, root was unconditionally
+# skipped here under a misleading comment that "core has no
+# axonops/audit require directives to update". That was wrong and
+# blocked v0.2.4's artifacts. The fix: the script now rewrites
+# root the same way it rewrites every other published module —
+# the per-target grep on line 107 naturally no-ops when no
+# axonops/audit require line is present, so re-introducing the
+# root module to the loop is safe even for modules that legitimately
+# have no cross-references.
 targets=()
 while IFS='|' read -r dir module_path tag_prefix; do
   [[ -z "$dir" ]] && continue
-  [[ "$dir" == "." ]] && continue
   targets+=("$dir")
 done < <(make -s --no-print-directory print-publish-modules)
 
@@ -104,6 +113,14 @@ for target in "${targets[@]}"; do
     # path is followed by whitespace + `v` + digit. Comment lines
     # are skipped because go.mod comments use `//` which doesn't
     # satisfy the path constraint here.
+    #
+    # Supported require shapes (all rewrite cleanly via the regex
+    # below + `go mod edit -require`):
+    #   1. Block-form direct:    `\tpath v0.1.11`
+    #   2. Block-form indirect:  `\tpath v0.1.11 // indirect`
+    #   3. Block-form pseudo:    `\tpath v0.0.0-YYYYMMDDhhmmss-abcdef`
+    #   4. Single-line:          `require path v0.1.11`
+    #   5. Mixed indentation:    `    path v0.1.11` (spaces or tabs)
     if grep -qE "^[[:space:]]*(require[[:space:]]+)?${path}[[:space:]]v[0-9]" go.mod; then
       go mod edit -require "${path}@${VERSION}"
       echo "  pinned $path → $VERSION"
@@ -112,9 +129,14 @@ for target in "${targets[@]}"; do
       # `go mod download` after the new tag publishes will re-add
       # the correct entries.
       if [[ -f go.sum ]]; then
-        # Match the path at the start of the line followed by space
-        # — same anchoring as above.
-        sed -i "/^${path//\//\\/} /d" go.sum
+        # Match the path at the start of the line followed by:
+        #   - a space (covers `path v0.1.11 h1:...`), OR
+        #   - `/go.mod ` (covers `path/go.mod v0.1.11 h1:...`)
+        # Pre-#984 the script only stripped the first form,
+        # leaving `path/go.mod` hash lines with the previous
+        # release's checksum (devops MEDIUM finding).
+        escaped_path="${path//\//\\/}"
+        sed -i "/^${escaped_path} /d; /^${escaped_path}\\/go\\.mod /d" go.sum
       fi
     fi
   done

--- a/tests/release-scripts/update-deps.bats
+++ b/tests/release-scripts/update-deps.bats
@@ -139,3 +139,149 @@ EOF
     [ "$status" -eq 2 ]
     [[ "$output" =~ "produced no output" ]]
 }
+
+# --- #984: root go.mod is now in scope ---
+
+# The setup() above pre-seeds file/ and syslog/ but NOT the root
+# go.mod. Each of the 5 shape tests below writes its own root go.mod
+# fixture (file `$REPO_ROOT_TMP/go.mod`) into the repo, runs the
+# script, and asserts the fake `go` binary's recorded argv shows a
+# `go mod edit -require <path>@v0.2.5` call for the seeded path.
+
+@test "test_rewrites_v01x_block_form" {
+    # Block-form direct: tab-indented require body, normal semver.
+    cat > "$REPO_ROOT_TMP/go.mod" <<'EOF2'
+module github.com/axonops/audit
+
+go 1.26
+
+require (
+	github.com/axonops/audit/file v0.1.11
+)
+EOF2
+    run "$SCRIPT" "v0.2.5"
+    [ "$status" -eq 0 ]
+    args="$(args_of go)"
+    echo "$args" | grep -qF 'mod edit -require github.com/axonops/audit/file@v0.2.5'
+}
+
+@test "test_rewrites_v00_pseudo_version" {
+    # Block-form pseudo: v0.0.0-YYYYMMDDhhmmss-abcdef shape.
+    # Uses `audit/file` because the bats fake `make
+    # print-publish-modules` only knows `.`, `file`, and `syslog`;
+    # the SHAPE under test (pseudo version) is what matters.
+    cat > "$REPO_ROOT_TMP/go.mod" <<'EOF2'
+module github.com/axonops/audit
+
+go 1.26
+
+require (
+	github.com/axonops/audit/file v0.0.0-20260520183351-bad90dd00155
+)
+EOF2
+    run "$SCRIPT" "v0.2.5"
+    [ "$status" -eq 0 ]
+    args="$(args_of go)"
+    echo "$args" | grep -qF 'mod edit -require github.com/axonops/audit/file@v0.2.5'
+}
+
+@test "test_rewrites_indirect_suffix" {
+    # Block-form indirect: trailing ` // indirect` must be preserved
+    # by `go mod edit` (it parses the AST). The script must still
+    # detect the require line and emit the rewrite call. Path is
+    # `audit/syslog` because the bats fake knows it; the SHAPE
+    # under test is the `// indirect` suffix.
+    cat > "$REPO_ROOT_TMP/go.mod" <<'EOF2'
+module github.com/axonops/audit
+
+go 1.26
+
+require (
+	github.com/axonops/audit/syslog v0.1.11 // indirect
+)
+EOF2
+    run "$SCRIPT" "v0.2.5"
+    [ "$status" -eq 0 ]
+    args="$(args_of go)"
+    echo "$args" | grep -qF 'mod edit -require github.com/axonops/audit/syslog@v0.2.5'
+}
+
+@test "test_rewrites_single_line_require" {
+    # Single-line require: `require <path> <version>` at module
+    # scope (no parens).
+    cat > "$REPO_ROOT_TMP/go.mod" <<'EOF2'
+module github.com/axonops/audit
+
+go 1.26
+
+require github.com/axonops/audit/syslog v0.1.0
+EOF2
+    run "$SCRIPT" "v0.2.5"
+    [ "$status" -eq 0 ]
+    args="$(args_of go)"
+    echo "$args" | grep -qF 'mod edit -require github.com/axonops/audit/syslog@v0.2.5'
+}
+
+@test "test_rewrites_mixed_indentation" {
+    # Tab-indented + space-indented require lines in the same block.
+    # The regex `[[:space:]]*` covers both. `go mod edit` will
+    # canonicalise to tab in the output, but the script's job is
+    # only to call `go mod edit -require` — the existing fake-go
+    # records the call regardless of whatever Go does to the file.
+    # Both paths are in the bats fake's published_paths.
+    printf 'module github.com/axonops/audit\n\ngo 1.26\n\nrequire (\n\tgithub.com/axonops/audit/file v0.1.11\n    github.com/axonops/audit/syslog v0.1.11\n)\n' \
+        > "$REPO_ROOT_TMP/go.mod"
+    run "$SCRIPT" "v0.2.5"
+    [ "$status" -eq 0 ]
+    args="$(args_of go)"
+    echo "$args" | grep -qF 'mod edit -require github.com/axonops/audit/file@v0.2.5'
+    echo "$args" | grep -qF 'mod edit -require github.com/axonops/audit/syslog@v0.2.5'
+}
+
+@test "test_root_with_no_axonops_require_is_no_op" {
+    # Regression anchor (code-reviewer recommendation): if the root
+    # go.mod has no axonops/audit require lines, the script must
+    # visit the root target (`==> .` in stdout) but emit no
+    # `pinned` log lines while inside it. Other targets (file/ and
+    # syslog/) still get pinned — this asserts root processing is
+    # a true no-op when there's nothing to rewrite.
+    cat > "$REPO_ROOT_TMP/go.mod" <<'EOF2'
+module github.com/axonops/audit
+
+go 1.26
+
+require gopkg.in/yaml.v3 v3.0.1
+EOF2
+    run "$SCRIPT" "v0.2.5"
+    [ "$status" -eq 0 ]
+    # Root is visited.
+    [[ "$output" =~ "==> ." ]]
+    # Extract the root-section output: everything between `==> .`
+    # and the next `==> ` header. Assert no `  pinned ` line in it.
+    root_section="$(printf '%s\n' "$output" | awk '/^==> \./{f=1;next} /^==> /{f=0} f')"
+    if echo "$root_section" | grep -qE '^  pinned '; then
+        echo "Root section had unexpected pinned line:" >&2
+        echo "$root_section" >&2
+        return 1
+    fi
+}
+
+@test "test_strips_stale_go_mod_hash_lines_too" {
+    # devops MEDIUM finding folded into #984: the pre-fix sed
+    # pattern stripped `<path> ...` go.sum lines but missed the
+    # `<path>/go.mod ...` siblings, leaving the previous release's
+    # go.mod hash behind. Verify both are now removed.
+    mkdir -p "$REPO_ROOT_TMP/.dummy-scope-anchor" # ensure go.sum context
+    cat > "$REPO_ROOT_TMP/file/go.sum" <<'EOF2'
+github.com/axonops/audit v0.1.0 h1:fakehash=
+github.com/axonops/audit v0.1.0/go.mod h1:fakemodhash=
+github.com/axonops/audit/syslog v0.1.0 h1:fakehash=
+github.com/axonops/audit/syslog v0.1.0/go.mod h1:fakemodhash=
+EOF2
+    run "$SCRIPT" "v0.2.5"
+    [ "$status" -eq 0 ]
+    ! grep -qF "github.com/axonops/audit v0.1.0 " "$REPO_ROOT_TMP/file/go.sum"
+    ! grep -qF "github.com/axonops/audit v0.1.0/go.mod " "$REPO_ROOT_TMP/file/go.sum"
+    ! grep -qF "github.com/axonops/audit/syslog v0.1.0 " "$REPO_ROOT_TMP/file/go.sum"
+    ! grep -qF "github.com/axonops/audit/syslog v0.1.0/go.mod " "$REPO_ROOT_TMP/file/go.sum"
+}


### PR DESCRIPTION
## Summary

- Removes the unconditional root-module skip from `scripts/release/update-deps.sh` (line 53).
- 7 new bats tests cover the 5 named shape cases + 2 regression anchors.
- Folds in a latent `/go.mod` go.sum sibling-line bug devops flagged.
- CHANGELOG entry.

## Why

v0.2.4 release shipped tags but goreleaser refused to build artifacts because `make check-release-invariants` correctly flagged stale `v0.1.11` and `v0.0.0-pseudo` cross-references in the root go.mod. The script's comment claimed "core has no axonops/audit require directives to update" — false; root requires 7 directly + 2 indirect.

Every release since these references existed has shipped with the stale state; v0.2.4 is the first dispatch where the invariant before-hook fired (`--skip=before` was retired by #958).

## Empirical verification

Ran the fixed script against main's actual root go.mod with v0.2.5:

```
$ bash scripts/release/update-deps.sh v0.2.5
...
update-deps: pinned v0.2.5 in 36 go.mod files.

$ grep -E "axonops/audit" go.mod
module github.com/axonops/audit
        github.com/axonops/audit/file v0.2.5
        github.com/axonops/audit/loki v0.2.5
        github.com/axonops/audit/outputconfig v0.2.5
        github.com/axonops/audit/secrets/openbao v0.2.5
        github.com/axonops/audit/splunk v0.2.5     <-- pseudo replaced cleanly
        github.com/axonops/audit/syslog v0.2.5
        github.com/axonops/audit/webhook v0.2.5
        github.com/axonops/audit/secrets v0.2.5 // indirect
        github.com/axonops/audit/secrets/vault v0.2.5 // indirect

$ make check-release-invariants VERSION=v0.2.5
All published go.mod files reference v0.2.5 for axonops/audit deps.
```

## Test plan

- [x] `make test-release-scripts` — 123/123 pass (7 new under `update-deps.bats`).
- [x] Empirical against main's actual root go.mod — all stale refs rewrote, invariants pass.
- [ ] CI green on this PR.
- [ ] v0.2.5 dispatch produces full GitHub Release + cosign bundle (AC #5b).

Closes #984.