### PR TITLE
fix(ci): #957 carve-out regex match release/vX.Y.x series (#983)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **#957 release-PR-tolerant carve-out regex now matches series
+  branches (#983).** The release-tool creates `release/v<MAJOR>.<MINOR>.x`
+  series branches (literal `x` patch component), but #957's
+  regex `^release/v[0-9]+\.[0-9]+\.[0-9]+` required three integers
+  and missed this shape. Every release-prep PR's Hygiene check
+  failed `regen-schema-artifacts-check` / `ta-diff-check` and
+  required admin-merge. v0.2.4's release-prep PR (#982) hit this
+  exact failure mid-dispatch. The relaxed regex
+  `^release/v[0-9]+\.[0-9]+(\.[0-9]+|\.x)` matches both shapes.
+  New `test_*_skips_on_release_series_head_ref` bats anchors for
+  both Makefile targets.
 - **Root `go.mod` is now rewritten by the release `update-deps.sh`
   script (#984).** Previously the script skipped the core module
   (`scripts/release/update-deps.sh:53` carried

--- a/Makefile
+++ b/Makefile
@@ -1139,7 +1139,7 @@ regen-schema-artifacts:
 # in full. See `docs/releasing.md` § Troubleshooting.
 .PHONY: regen-schema-artifacts-check
 regen-schema-artifacts-check:
-	@if echo "$${GITHUB_HEAD_REF:-}" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+'; then \
+	@if echo "$${GITHUB_HEAD_REF:-}" | grep -qE '^release/v[0-9]+\.[0-9]+(\.[0-9]+|\.x)'; then \
 		echo "regen-schema-artifacts-check: skipping on release PR head ref $$GITHUB_HEAD_REF (#957)"; \
 		exit 0; \
 	fi; \
@@ -1207,7 +1207,7 @@ ta:
 # safe. The non-release path still runs the check.
 .PHONY: ta-diff-check
 ta-diff-check:
-	@if echo "$${GITHUB_HEAD_REF:-}" | grep -qE '^release/v[0-9]+\.[0-9]+\.[0-9]+'; then \
+	@if echo "$${GITHUB_HEAD_REF:-}" | grep -qE '^release/v[0-9]+\.[0-9]+(\.[0-9]+|\.x)'; then \
 		echo "ta-diff-check: skipping on release PR head ref $$GITHUB_HEAD_REF (#957)"; \
 		exit 0; \
 	fi

--- a/tests/release-scripts/check-static-release-pr-tolerant.bats
+++ b/tests/release-scripts/check-static-release-pr-tolerant.bats
@@ -38,6 +38,17 @@ setup() {
     [[ "$output" == *"skipping on release PR head ref release/v1.0.0-rc.1"* ]]
 }
 
+# #983: the release-tool creates SERIES branches named
+# `release/v<MAJOR>.<MINOR>.x` (literal `x` for the patch). The
+# original #957 regex required three integers and missed this shape,
+# blocking every release-prep PR's Hygiene check with admin-merge
+# required. The relaxed regex now matches both shapes.
+@test "test_regen_schema_artifacts_check_skips_on_release_series_head_ref" {
+    GITHUB_HEAD_REF=release/v0.2.x run make -s regen-schema-artifacts-check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping on release PR head ref release/v0.2.x"* ]]
+}
+
 @test "test_regen_schema_artifacts_check_runs_on_unset_head_ref" {
     # Unset GITHUB_HEAD_REF (the GHA value on push, on dispatch,
     # or in a local invocation). The target must run the full check.
@@ -82,6 +93,14 @@ setup() {
     GITHUB_HEAD_REF=release/v1.0.0-rc.1 run make -s ta-diff-check
     [ "$status" -eq 0 ]
     [[ "$output" == *"skipping on release PR head ref release/v1.0.0-rc.1"* ]]
+}
+
+# #983: see regen-schema-artifacts-check counterpart above. Series
+# branch shape (`release/v<MAJOR>.<MINOR>.x`) must also skip.
+@test "test_ta_diff_check_skips_on_release_series_head_ref" {
+    GITHUB_HEAD_REF=release/v0.2.x run make -s ta-diff-check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping on release PR head ref release/v0.2.x"* ]]
 }
 
 @test "test_ta_diff_check_runs_on_unset_head_ref" {


### PR DESCRIPTION
## Summary

Two-line regex relaxation:  → . Matches both `release/v0.2.x` (release-tool series default) and `release/v0.2.5` (dispatched-version alt).

#957's regex required three integers and missed the series shape entirely. Every release-prep PR's Hygiene check failed; v0.2.4's #982 had to be admin-merged manually mid-dispatch. v0.2.5 would hit it again without this fix.

## Test plan

- [x] `make test-release-scripts` — 125/125 (2 new).
- [x] Manual: `GITHUB_HEAD_REF=release/v0.2.x make regen-schema-artifacts-check` → skips correctly.
- [x] Manual: same for `ta-diff-check`.
- [ ] CI green on this PR.

Closes #983.