### PR TITLE
fix(release): bump preflight-tidy poll → 30min, configurable (#988)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,15 @@ on:
         required: false
         type: number
         default: 45
+      # #988 fix: full PR CI (BDD + cross-platform) is ~25 min, so
+      # the previous 5-min poll always timed out on the first post-
+      # drift dispatch (v0.2.4, v0.2.5). Expose the deadline as an
+      # input so an operator can stretch it during slow CI windows.
+      preflight_tidy_timeout_minutes:
+        description: "Minutes preflight-tidy polls the auto-merge PR before timing out (default 30)"
+        required: false
+        type: number
+        default: 30
       # #967 escape hatch: when true, skips the preflight-tidy job
       # entirely. Use ONLY when an independent investigation has
       # confirmed go.sum drift is benign and sum.golang.org is
@@ -193,7 +202,12 @@ jobs:
   preflight-tidy:
     name: Preflight Tidy (#967)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # #988 fix: 40-min ceiling = ~5 min pre-poll work + 30-min poll
+    # default + 5-min buffer. Letting bash own the timeout via its
+    # deadline-based loop produces a well-formed "PR did not merge
+    # within N minutes" error; a too-tight ceiling races the bash
+    # deadline and surfaces a generic "operation was canceled".
+    timeout-minutes: 40
     needs: [preflight]
     if: github.event_name == 'workflow_dispatch'
     permissions:
@@ -323,6 +337,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           PUBLISH_VERSION: ${{ needs.preflight.outputs.version }}
+          # #988: poll budget — configurable via workflow_dispatch
+          # input. Full PR CI is ~25 min (BDD + cross-platform), so
+          # the 5-min default in #967 always timed out on the first
+          # post-drift dispatch. Default 30 covers the envelope.
+          PREFLIGHT_TIDY_TIMEOUT_MINUTES: ${{ inputs.preflight_tidy_timeout_minutes || 30 }}
         run: |
           set -euo pipefail
           BRANCH="chore/preflight-tidy-${PUBLISH_VERSION}"
@@ -366,17 +385,29 @@ jobs:
           # AC #4 exact string.
           echo "preflight-tidy: PR opened"
           echo "preflight-tidy: PR opened" >> "$GITHUB_STEP_SUMMARY"
-          # Brief poll loop — caps at 5 minutes so the rest of the
-          # release dispatch isn't blocked indefinitely on a stuck PR.
-          for i in $(seq 1 30); do
+          # #988 fix: deadline-based poll loop. Flat 30s cadence
+          # (matches the typical CI-check polling rate; no human in
+          # the loop so no need for the exponential backoff that
+          # wait-for-pr-merge uses). Short-circuit on CLOSED so a
+          # manually-closed PR surfaces an explicit error instead
+          # of silently consuming the full budget (mirrors
+          # wait-for-pr-merge's CLOSED handling).
+          deadline=$(( $(date +%s) + PREFLIGHT_TIDY_TIMEOUT_MINUTES * 60 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
             state=$(gh pr view "$NUM" --json state --jq '.state')
-            if [ "$state" = "MERGED" ]; then
-              echo "preflight-tidy: PR #$NUM merged"
-              exit 0
-            fi
-            sleep 10
+            case "$state" in
+              MERGED)
+                echo "preflight-tidy: PR #$NUM merged"
+                exit 0
+                ;;
+              CLOSED)
+                echo "::error::preflight-tidy: PR #$NUM was closed without merging"
+                exit 1
+                ;;
+            esac
+            sleep 30
           done
-          echo "::error::preflight-tidy: PR #$NUM not merged within 5 minutes"
+          echo "::error::preflight-tidy: PR #$NUM not merged within $PREFLIGHT_TIDY_TIMEOUT_MINUTES minutes"
           exit 1
 
   # =====================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **preflight-tidy now waits 30 min for its auto-merge PR by default,
+  configurable via `preflight_tidy_timeout_minutes` (#988).** Full PR
+  CI (BDD + cross-platform) takes ~25 min, so the previous 5-min poll
+  (`for i in $(seq 1 30); do … sleep 10; done`) always timed out on
+  the first post-drift dispatch — v0.2.4 and v0.2.5 hit this exact
+  failure mode and both required a manual re-dispatch. The poll loop
+  is now deadline-based (60 × 30s by default, configurable via the
+  new workflow_dispatch input), short-circuits on `CLOSED` state
+  (mirrors the `wait-for-pr-merge` pattern), and the job-level
+  `timeout-minutes` is lifted from 15 → 40 so the bash deadline owns
+  the failure mode and produces a well-formed "PR did not merge
+  within N minutes" error instead of a generic
+  "operation was canceled". Two new bats anchors in
+  `tests/release-scripts/release-yml-grep.bats` lock the wiring
+  (input declaration + env-var pattern). Recovery playbook in
+  `docs/releasing.md` documents the new override.
 - **#957 release-PR-tolerant carve-out regex now matches series
   branches (#983).** The release-tool creates `release/v<MAJOR>.<MINOR>.x`
   series branches (literal `x` patch component), but #957's

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -668,6 +668,7 @@ every write operation; it does not consume a personal access token.
 | `version` | string | _(required)_ | Always — must be a valid `vX.Y.Z[-PRE]` tag |
 | `api_check_blocking` | bool | `false` | Flip to `true` after v1.0 (see "`api-check` transition" below) |
 | `merge_timeout_minutes` | number | `45` | Stretch when a slow reviewer window is expected during a high-stakes release. The `wait-for-pr-merge` job polls every 30s with exponential backoff to 120s; the timeout is the total budget. Operator-facing recovery snippet in the job summary uses the same value. (#927 MAJOR-3) |
+| `preflight_tidy_timeout_minutes` | number | `30` | Stretch when CI is unusually slow. The `preflight-tidy` job polls its auto-merge PR every 30s; total budget is this value. Default covers the typical ~25-min BDD + cross-platform CI envelope. Bumped from `5` (the v0.2.4 / v0.2.5 default that always timed out on the first post-drift dispatch). (#988) |
 
 ### `api-check` transition (advisory → blocking)
 
@@ -846,6 +847,15 @@ release workflow will pick up the merge and continue.
 ```bash
 gh pr review --approve <PR_NUMBER>
 ```
+
+#### preflight-tidy timed out waiting for its own auto-merge PR (30 min)
+
+The preflight-tidy auto-merge PR is still pending CI. Wait for it to
+merge, then re-dispatch `release.yml` with the same `version` — the
+second dispatch sees a tidy main and the preflight-tidy job exits with
+`preflight-tidy: no drift to absorb`. Alternatively, re-dispatch with
+`preflight_tidy_timeout_minutes=60` (or higher) for the slow-CI case.
+(#988)
 
 #### `wait-for-pr-merge` timed out (45 min) but the PR is still open
 

--- a/tests/release-scripts/release-yml-grep.bats
+++ b/tests/release-scripts/release-yml-grep.bats
@@ -413,6 +413,17 @@ setup() {
     echo "$body" | grep -qF -- '--auto --squash'
     echo "$body" | grep -qF 'preflight-tidy: PR opened'
     echo "$body" | grep -qF 'preflight-tidy: PR auto-merge refused — aborting'
+    # #988: poll-budget input declared at workflow scope (asserted
+    # against $RELEASE_YML, not $body — the input block is OUTSIDE
+    # the preflight-tidy job awk range).
+    grep -qF 'preflight_tidy_timeout_minutes:' "$RELEASE_YML"
+    # #988: poll uses the configurable env var (not hardcoded 5min).
+    # Asserts both the env-var name AND the fallback default to lock
+    # the wiring; the literal poll-iteration count is intentionally
+    # NOT asserted so a future operator default-bump doesn't break
+    # the test.
+    echo "$body" | grep -qF 'PREFLIGHT_TIDY_TIMEOUT_MINUTES'
+    echo "$body" | grep -qF 'inputs.preflight_tidy_timeout_minutes || 30'
 }
 
 @test "test_release_yml_preflight_tidy_honours_skip_input" {


### PR DESCRIPTION
## Summary

- Bumps the preflight-tidy auto-merge poll loop from 5 min → 30 min default.
- New \`inputs.preflight_tidy_timeout_minutes\` workflow_dispatch input for operator stretch.
- Job-level \`timeout-minutes\` lifted 15 → 40 so the bash deadline owns the failure mode (devops finding).
- Adds CLOSED-state short-circuit (mirrors wait-for-pr-merge pattern).
- 2 new bats assertions, doc table row + recovery playbook subsection, CHANGELOG.

## Why

v0.2.4 and v0.2.5 both timed out at preflight-tidy on the first post-drift dispatch because the 5-min poll couldn't outwait the ~25-min full CI cycle. Operator had to manually re-dispatch each time.

## Test plan

- [x] \`make test-release-scripts\` — 125/125.
- [x] \`goreleaser check\` valid.
- [x] YAML syntactic validity.
- [ ] CI green on this PR.
- [ ] v0.2.6 dispatch confirms preflight-tidy waits the full budget without aborting prematurely.

Closes #988.